### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,5 +1,8 @@
 name: Security Audit
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/RandomCodeSpace/Argus/security/code-scanning/2](https://github.com/RandomCodeSpace/Argus/security/code-scanning/2)

In general, the fix is to explicitly declare a minimal `permissions` block for the GITHUB_TOKEN, either at the workflow root (so it applies to all jobs) or per job, and grant only the scopes actually needed. For this workflow, the jobs only read repository contents to build and analyze code, so `contents: read` is sufficient.

The best minimal change without altering existing functionality is to add a workflow‑level `permissions` section right after the `name:` key. This will apply to both `vulnerability-check` and `build-check` jobs, unless overridden. No other scopes (like `issues`, `pull-requests`, or `packages`) are necessary based on the provided steps. Concretely, in `.github/workflows/audit.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Security Audit`) and line 3 (`on:`). No imports or additional definitions are required, since this is just GitHub Actions YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
