### PR TITLE
chore(security): reinstate SonarCloud as required gate

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,9 @@
 name: Security (OSS-CLI)
 # OSS-CLI security stack per RAN-53 AC #5 (mirrors codeiq RAN-46 path B).
-# Replaces Sonar + CodeQL + OWASP Dependency-Check.
+# Replaces CodeQL + OWASP Dependency-Check. SonarCloud was originally
+# replaced too but was reinstated as a required external gate on
+# 2026-04-28 (board reversal); it runs via the SonarCloud GitHub App,
+# not as a job in this workflow.
 #
 # Six independent jobs — fail-fast off so all signals surface on a single run.
 # All actions SHA-pinned per Scorecard `Pinned-Dependencies`. Top-level

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,7 +239,7 @@ Failure-mode gauges (prefix `OtelContext_`):
 
 ## Security & Supply Chain
 
-OtelContext targets the OpenSSF Best Practices `passing` badge (project [12646](https://www.bestpractices.dev/en/projects/12646)) and ships a six-job OSS-CLI security stack — no Sonar, no CodeQL, no NVD-direct tooling. Cost: $0.
+OtelContext targets the OpenSSF Best Practices `passing` badge (project [12646](https://www.bestpractices.dev/en/projects/12646)) and ships a six-job OSS-CLI security stack, supplemented by **SonarCloud SAST as a required gate** (board reversal 2026-04-28). No CodeQL, no NVD-direct tooling. Cost: $0 for the OSS-CLI tier; SonarCloud is free for public repos.
 
 ### OSS-CLI security stack (`.github/workflows/security.yml`)
 
@@ -255,7 +255,9 @@ OtelContext targets the OpenSSF Best Practices `passing` badge (project [12646](
 
 All actions are SHA-pinned per Scorecard `Pinned-Dependencies`. Top-level `permissions: read-all`; jobs scope up only when needed (gitleaks needs full history; sbom uploads).
 
-**Not used (do not re-introduce without an explicit board reversal):** SonarCloud / SonarQube, CodeQL (GHAS-paid for non-public repos), OWASP Dependency-Check (or any NVD-direct tool — NVD has analysis-backlog and rate-limit reliability problems).
+**Required external gate:** SonarCloud Code Analysis. Runs as the SonarCloud GitHub App (no in-repo workflow); listed in `main` branch protection's `required_status_checks` since 2026-04-28. Reinstated by board reversal — earlier docs that said "do not re-introduce" are superseded.
+
+**Not used (do not re-introduce without an explicit board reversal):** CodeQL (GHAS-paid for non-public repos), OWASP Dependency-Check (or any NVD-direct tool — NVD has analysis-backlog and rate-limit reliability problems).
 
 ### OpenSSF Scorecard (`.github/workflows/scorecard.yml`)
 


### PR DESCRIPTION
## Summary

Board reversal 2026-04-28: SonarCloud Code Analysis is now a required check on \`main\`. Documents and branch protection both updated.

## Changes

- **Branch protection**: \`SonarCloud Code Analysis\` added to \`required_status_checks\` on \`main\` (alongside the existing \`build · vet · test\` gate). Set via GitHub API; verified via \`GET /branches/main/protection\`.
- **\`CLAUDE.md\`**: removed SonarCloud from the "do not re-introduce" list, documented that it runs as the SonarCloud GitHub App (no in-repo workflow), and reframed the OSS-CLI security stack as supplemented by SonarCloud.
- **\`.github/workflows/security.yml\`**: updated the header comment so the historical "Replaces Sonar + ..." line no longer contradicts the current required-gate state.

## Notes

- This PR is the first to test SonarCloud-as-required-check. If SonarCloud fails here, that's a real signal — either configuration drift (e.g. missing token / project key) or a flagged finding worth addressing. PR #59 saw SonarCloud fail before the gate was added; if the failure mode is configuration, this PR will need the same fix before it can merge.
- No application code changes. No test changes.

## Test plan

- [x] CLAUDE.md and security.yml render correctly (no broken markdown, no contradictory statements left behind)
- [x] \`gh api .../branches/main/protection/required_status_checks/contexts\` shows both required contexts
- [x] commit signed (ED25519)

🤖 Generated with [Claude Code](https://claude.com/claude-code)