### PR TITLE
fix(mcp): cap tool response size to prevent OOM

### DIFF
--- a/internal/mcp/response_cap_test.go
+++ b/internal/mcp/response_cap_test.go
@@ -1,0 +1,54 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTextResult_ResponseCap verifies the byte-cap defense for tool
+// responses. Without it, get_trace / get_graph_snapshot / correlated_signals
+// can OOM the process on adversarial input.
+func TestTextResult_ResponseCap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("UnderCapPassesThrough", func(t *testing.T) {
+		text := strings.Repeat("x", 1024) // 1 KiB
+		got := textResult(text)
+		if got.IsError {
+			t.Fatalf("expected success, got IsError=true: %+v", got)
+		}
+		if len(got.Content) != 1 || got.Content[0].Text != text {
+			t.Fatalf("payload mangled: %+v", got)
+		}
+	})
+
+	t.Run("AtCapPassesThrough", func(t *testing.T) {
+		// Exactly at the cap is allowed. The error fires only on > cap.
+		text := strings.Repeat("x", MaxToolResponseBytes)
+		got := textResult(text)
+		if got.IsError {
+			t.Fatalf("expected at-cap to pass, got IsError=true")
+		}
+	})
+
+	t.Run("OverCapErrors", func(t *testing.T) {
+		text := strings.Repeat("x", MaxToolResponseBytes+1)
+		got := textResult(text)
+		if !got.IsError {
+			t.Fatalf("expected over-cap to error, got success")
+		}
+		if len(got.Content) == 0 || !strings.Contains(got.Content[0].Text, "response too large") {
+			t.Fatalf("expected 'response too large' marker in error message, got: %+v", got)
+		}
+		if !strings.Contains(got.Content[0].Text, "narrow time range") {
+			t.Fatalf("expected actionable hint in error message, got: %+v", got)
+		}
+	})
+
+	t.Run("EmptyTextOK", func(t *testing.T) {
+		got := textResult("")
+		if got.IsError {
+			t.Fatalf("empty text should not error: %+v", got)
+		}
+	})
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -876,7 +876,27 @@ func parseTimeRange(args map[string]any, key string, since *time.Time) {
 
 // --- Helpers ---
 
+// MaxToolResponseBytes caps the rendered length of any tool response. Without
+// this, get_trace / get_graph_snapshot / correlated_signals can produce
+// 100MB+ JSON on adversarial input, OOM the process, and stall every
+// concurrent MCP call until MCP_CALL_TIMEOUT_MS fires.
+//
+// The cap is intentionally set well above any legitimate row-capped tool
+// response (search_logs at 200 rows is typically <1 MB) so it triggers only
+// on pathological cases. Operators hitting it should narrow their query
+// time range or use pagination.
+const MaxToolResponseBytes = 4 * 1024 * 1024
+
+// textResult wraps a successful tool response. Inputs over MaxToolResponseBytes
+// are converted to a structured error so callers see a clear failure mode
+// instead of a hung connection.
 func textResult(text string) ToolCallResult {
+	if len(text) > MaxToolResponseBytes {
+		return errorResult(fmt.Sprintf(
+			"response too large: %d bytes exceeds %d-byte cap; narrow time range or use pagination",
+			len(text), MaxToolResponseBytes,
+		))
+	}
 	return ToolCallResult{
 		Content: []ContentItem{{Type: "text", Text: text}},
 	}


### PR DESCRIPTION
## Summary

PR D of 6. Closes the MCP OOM vector identified by codex round 1: tools that marshal full payloads (\`get_trace\`, \`get_graph_snapshot\`, \`correlated_signals\`, \`get_system_graph\`) had no byte cap. A 50k-span trace or large snapshot would produce 100MB+ JSON, OOM the process, and stall every concurrent MCP call until \`MCP_CALL_TIMEOUT_MS\` fires.

- New constant \`MaxToolResponseBytes = 4 MiB\`
- Enforced inside \`textResult()\` so the cap covers all 22 marshal-then-textResult sites uniformly
- Over-cap responses convert to a structured error with actionable hint (\"narrow time range or use pagination\")

## Test plan

- [x] \`go test -count=1 ./internal/mcp/...\` → 68 passed (was 63, +5 new)
- [x] Coverage: under-cap pass-through, exactly-at-cap pass-through, over-cap errors with marker + hint, empty text safe
- [x] Existing tools (search_logs at 200 rows, etc.) are well under 4 MiB so no behavior change for normal traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)