### PR TITLE
fix(ci): install syft in release.yml (v0.3.1 release recovery)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,15 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual re-release: run the CURRENT (default-branch) workflow against an
+  # already-pushed tag. GoReleaser's `release: mode: append` adds artifacts to
+  # the existing release WITHOUT mutating the immutable tag — used to recover a
+  # release whose original tag-push run failed.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to (re)build + sign (e.g. v0.3.1)'
+        required: true
 
 # Workflow-level default: minimum needed for actions/checkout. The release job
 # escalates to contents: write (create/append the GitHub release + upload
@@ -46,7 +55,10 @@ jobs:
         # actions/checkout v4.2.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          # Full history so goreleaser's changelog/version detection works.
+          # On workflow_dispatch, build the supplied existing tag; on a tag
+          # push, the pushed ref. Full history so goreleaser version detection
+          # works.
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -76,6 +88,13 @@ jobs:
         # sigstore/cosign-installer v3.9.2 — provides `cosign` for the keyless
         # signing step in .goreleaser.yaml (signs: cmd: cosign).
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159
+
+      - name: Install syft
+        # anchore/sbom-action v0.24.0 (download-syft sub-action) — puts `syft`
+        # on PATH for the goreleaser `sboms:` step, which shells out to syft per
+        # archive. Without this goreleaser fails: `exec: "syft": not found`.
+        # Pin reused from security.yml.
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610
 
       - name: Run GoReleaser
         # goreleaser/goreleaser-action v6.2.1


### PR DESCRIPTION
## Problem

The v0.3.1 release pipeline (first live run of #116's goreleaser+cosign workflow) **failed**: `exec: "syft": executable file not found in $PATH`. GoReleaser built all 4 binaries + archives + checksums, then the `sboms:` step (which shells out to syft) aborted — release.yml installs cosign but never installed syft. The tag, GH release notes, and `go install @v0.3.1` are intact; only the signed binaries didn't attach.

## Fix
- Install **syft** via `anchore/sbom-action/download-syft` before the goreleaser step (pin reused from `security.yml`).
- Add **`workflow_dispatch(tag)`** + `checkout ref=${{ inputs.tag || github.ref }}` so this fixed workflow can be re-run against the **already-pushed, immutable** v0.3.1 tag — goreleaser `release: mode: append` attaches artifacts to the existing release without re-cutting the tag (the proxy treats tags as immutable, so re-pushing is off the table).

## Recovery plan
After merge: `gh workflow run "Release (artifacts + signing)" --ref main -f tag=v0.3.1` → signed binaries + checksums + SBOMs append to the existing v0.3.1 release.

actionlint clean. Future tagged releases pick up the fix automatically on tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)