### PR TITLE
fix(ci): restore dist/.gitkeep after UI rebuild (unblock v0.4.0-beta.1 signing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,11 @@ jobs:
           npm ci
           npm run build
           test -f ../internal/ui/dist/index.html
+          # vite's emptyOutDir wipes internal/ui/dist on rebuild, deleting the
+          # committed .gitkeep placeholder that script-cut release tags carry.
+          # Restore it so the working tree matches the tag and GoReleaser's
+          # dirty-state check passes (no-op for tags that don't track .gitkeep).
+          git -C "$GITHUB_WORKSPACE" checkout -- internal/ui/dist/.gitkeep 2>/dev/null || true
 
       - name: Install cosign
         # sigstore/cosign-installer v3.9.2 — provides `cosign` for the keyless


### PR DESCRIPTION
GoReleaser's dirty-tree check aborts the release when the tag commits `internal/ui/dist/.gitkeep` (which `scripts/release.sh` does): release.yml rebuilds the UI, vite `emptyOutDir` deletes the committed `.gitkeep`, and `D internal/ui/dist/.gitkeep` trips the check. v0.4.0-beta.1 hit exactly this (run 27799006159). Restore the placeholder after the rebuild so the tree matches the tag; no-op for tags without `.gitkeep` (v0.3.1). After merge, recover beta.1 via `workflow_dispatch -f tag=v0.4.0-beta.1` (mode: append).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01LDQVJrixs2nJoea67a8pEG