### PR TITLE
feat(config): aggregate engine cardinality and mode configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,17 +20,23 @@ type Config struct {
 	DLQPath           string
 	DLQReplayInterval string
 
+	// PprofAddr serves net/http/pprof on a dedicated listener (never the
+	// public mux). Loopback-only by default; empty disables profiling.
+	PprofAddr string
+
 	// Ingestion Filtering
 	IngestMinSeverity      string
 	IngestAllowedServices  string
 	IngestExcludedServices string
 
 	// Storage Filtering. Logs that pass IngestMinSeverity (so they reach the
-	// receiver and feed in-memory consumers like vectordb / GraphRAG) but
-	// fall below StoreMinSeverity are skipped during the DB persist pass —
-	// only the row-write is dropped, not the in-memory enrichment. Empty
-	// (default) means StoreMinSeverity == IngestMinSeverity, i.e. no
-	// behavior change vs. the single-threshold semantics.
+	// receiver and feed in-memory consumers like GraphRAG / Drain) but fall
+	// below StoreMinSeverity are skipped during the DB persist pass — only the
+	// row-write is dropped, not the in-memory enrichment. Defaults to "WARN"
+	// (all drivers): INFO/DEBUG still inform anomaly detection + clustering but
+	// don't grow the DB. Empty falls back to IngestMinSeverity (no second-tier
+	// gate); a value <= IngestMinSeverity is a no-op since the receiver already
+	// drops below that.
 	StoreMinSeverity string
 
 	// DB Connection Pool
@@ -59,6 +65,14 @@ type Config struct {
 	// dedicated DB machines. 0/negative values use defaults.
 	RetentionBatchSize    int
 	RetentionBatchSleepMs int
+
+	// RetentionFullVacuum restores the daily full VACUUM during SQLite
+	// maintenance. Default false: the daily pass runs
+	// PRAGMA incremental_vacuum(10000) instead, because a full VACUUM holds
+	// an exclusive lock for 10-60 minutes on multi-GB files and starves
+	// ingest into a 429 storm. On-demand full VACUUM remains available via
+	// POST /api/admin/vacuum. Ignored on non-SQLite drivers.
+	RetentionFullVacuum bool
 
 	// TSDB
 	TSDBRingBufferDuration string // e.g. "1h"
@@ -129,6 +143,28 @@ type Config struct {
 	// GraphRAG event channel buffer size. Defaults to 10000 if unset or <=0.
 	GraphRAGEventQueueSize int
 
+	// GraphRAGTraceTTL bounds how long spans/traces stay in the in-memory
+	// TraceStore before the refresh tick prunes them. Duration string, e.g.
+	// "1h". Defaults to "1h"; flipped to "30m" on SQLite (the in-memory span
+	// window is the largest GraphRAG heap consumer at 120 services). Anomaly
+	// and investigation paths look back <=5min, so a 30min window is safe.
+	GraphRAGTraceTTL string
+
+	// GraphRAGMaxSpansPerTenant hard-caps the in-memory TraceStore span map
+	// per tenant. At the cap, NEW spans are skipped (counted via
+	// otelcontext_graphrag_events_dropped_total{signal="span_capacity"});
+	// updates to resident spans still apply. The graph is best-effort — the
+	// DB remains the source of truth. 0 = default (500000); negative
+	// disables the cap.
+	GraphRAGMaxSpansPerTenant int
+
+	// GraphRAGTenantIdleTTL evicts a tenant's entire in-memory store slice
+	// after this much time without any ingest event or query. Duration
+	// string, default "24h". The default tenant is never evicted, and an
+	// active tenant is re-created within one refresh tick (60s) from recent
+	// DB spans — eviction is self-healing.
+	GraphRAGTenantIdleTTL string
+
 	// Async ingest pipeline (Phase 1 robustness work). Decouples OTLP Export
 	// from synchronous DB writes. When enabled, Export() returns as soon as
 	// the parsed batch is enqueued; persistence runs on a worker pool.
@@ -139,14 +175,22 @@ type Config struct {
 	//   100% queue       — return RESOURCE_EXHAUSTED so OTLP clients back off
 	IngestAsyncEnabled      bool // default true; opt out via INGEST_ASYNC_ENABLED=false
 	IngestPipelineQueueSize int  // default 50000 batches; per-deployment tunable
-	IngestPipelineWorkers   int  // default 8 worker goroutines
+	// IngestPipelineMaxBytes caps the approximate bytes held by queued
+	// batches. The item-count queue size alone cannot bound memory — one
+	// batch may carry arbitrarily large span/log payloads. At the cap the
+	// pipeline rejects with RESOURCE_EXHAUSTED / HTTP 429 even for priority
+	// (error/slow) batches: a 429 is recoverable, an OOM kill is not.
+	// Default 512MB; SQLite default 128MB (see applyDriverDefaults).
+	IngestPipelineMaxBytes int
+	IngestPipelineWorkers  int // default 8 worker goroutines
 	// IngestPipelinePerTenantCap caps in-flight batches per tenant so a noisy
 	// tenant cannot starve siblings of fresh queue slots when fullness is
-	// below the soft-backpressure threshold. 0 (default) disables — single-
-	// tenant deployments need no cap. Operators on multi-tenant deployments
-	// should set INGEST_PIPELINE_PER_TENANT_CAP to roughly Capacity/N where
-	// N is the expected number of concurrently-active tenants, with some
-	// headroom (e.g. 2× the fair-share value) for short bursts.
+	// below the soft-backpressure threshold. When unset it defaults to ~30% of
+	// the resolved queue size (see Load) so multi-tenant deployments are
+	// protected out of the box; an explicit INGEST_PIPELINE_PER_TENANT_CAP=0
+	// disables the cap for single-tenant deployments. Operators can instead
+	// pin it to roughly Capacity/N where N is the expected number of
+	// concurrently-active tenants, with headroom for short bursts.
 	IngestPipelinePerTenantCap int
 
 	// TLS (HTTP + gRPC). When both paths are set, TLS is enabled on both servers.
@@ -206,7 +250,6 @@ type Config struct {
 	// the cap receive HTTP 503. Sized for the operator's expected dashboard
 	// audience — small for ops dashboards, larger for read-heavy public UIs.
 	WSMaxClients int
-
 	// Aggregate Engine Configuration (Phase 1, accounting only)
 	//
 	// AggregateMode controls how the aggregation engine participates:
@@ -232,11 +275,11 @@ type Config struct {
 	// Per-service caps. Enforcement order: tenant → service → signal sub-cap →
 	// global. These are isolation ceilings, not reservations; sum of per-service
 	// budgets may exceed instance-wide cap.
-	AggregateMaxOperationsPerService        int     // Default 20
-	AggregateMaxTraceSeriesPerService       int     // Default 50
-	AggregateMaxLogTemplatesPerService      int     // Default 10
-	AggregateMaxMetricSeriesPerService      int     // Default 50
-	AggregateSeriesPerTenantFraction        float64 // Default 0 (disabled); range [0, 1]
+	AggregateMaxOperationsPerService   int     // Default 20
+	AggregateMaxTraceSeriesPerService  int     // Default 50
+	AggregateMaxLogTemplatesPerService int     // Default 10
+	AggregateMaxMetricSeriesPerService int     // Default 50
+	AggregateSeriesPerTenantFraction   float64 // Default 0 (disabled); range [0, 1]
 
 	// Baseline configuration for counter temporality tracking.
 	// AggregateMaxProducerBaselinesPerSeries caps the number of baseline
@@ -277,9 +320,10 @@ func Load(customPath string) (*Config, error) {
 		DBDSN:             getEnv("DB_DSN", ""),
 		DLQPath:           getEnv("DLQ_PATH", "./data/dlq"),
 		DLQReplayInterval: getEnv("DLQ_REPLAY_INTERVAL", "5m"),
+		PprofAddr:         getEnv("PPROF_ADDR", "127.0.0.1:6060"),
 
 		IngestMinSeverity:      getEnv("INGEST_MIN_SEVERITY", "INFO"),
-		StoreMinSeverity:       getEnv("STORE_MIN_SEVERITY", ""),
+		StoreMinSeverity:       getEnv("STORE_MIN_SEVERITY", "WARN"),
 		IngestAllowedServices:  getEnv("INGEST_ALLOWED_SERVICES", ""),
 		IngestExcludedServices: getEnv("INGEST_EXCLUDED_SERVICES", ""),
 
@@ -296,6 +340,7 @@ func Load(customPath string) (*Config, error) {
 		HotRetentionDays:      getEnvInt("HOT_RETENTION_DAYS", 7),
 		RetentionBatchSize:    getEnvInt("RETENTION_BATCH_SIZE", 50000),
 		RetentionBatchSleepMs: getEnvInt("RETENTION_BATCH_SLEEP_MS", 1),
+		RetentionFullVacuum:   getEnvBool("RETENTION_FULL_VACUUM", false),
 
 		// TSDB
 		TSDBRingBufferDuration: getEnv("TSDB_RING_BUFFER_DURATION", "1h"),
@@ -333,12 +378,16 @@ func Load(customPath string) (*Config, error) {
 		LogFTSEnabled: parseTruthy(getEnv("LOG_FTS_ENABLED", "")),
 
 		// GraphRAG
-		GraphRAGWorkerCount:    getEnvInt("GRAPHRAG_WORKER_COUNT", 16),
-		GraphRAGEventQueueSize: getEnvInt("GRAPHRAG_EVENT_QUEUE_SIZE", 100000),
+		GraphRAGWorkerCount:       getEnvInt("GRAPHRAG_WORKER_COUNT", 16),
+		GraphRAGEventQueueSize:    getEnvInt("GRAPHRAG_EVENT_QUEUE_SIZE", 100000),
+		GraphRAGTraceTTL:          getEnv("GRAPHRAG_TRACE_TTL", "1h"),
+		GraphRAGMaxSpansPerTenant: getEnvInt("GRAPHRAG_MAX_SPANS_PER_TENANT", 500000),
+		GraphRAGTenantIdleTTL:     getEnv("GRAPHRAG_TENANT_IDLE_TTL", "24h"),
 
 		// Async ingest pipeline
 		IngestAsyncEnabled:         getEnvBool("INGEST_ASYNC_ENABLED", true),
 		IngestPipelineQueueSize:    getEnvInt("INGEST_PIPELINE_QUEUE_SIZE", 50000),
+		IngestPipelineMaxBytes:     getEnvInt("INGEST_PIPELINE_MAX_BYTES", 512<<20),
 		IngestPipelineWorkers:      getEnvInt("INGEST_PIPELINE_WORKERS", 8),
 		IngestPipelinePerTenantCap: getEnvInt("INGEST_PIPELINE_PER_TENANT_CAP", 0),
 
@@ -370,22 +419,32 @@ func Load(customPath string) (*Config, error) {
 		AllowSqliteProd: parseTruthy(getEnv("OTELCONTEXT_ALLOW_SQLITE_PROD", "")),
 
 		// Aggregate Engine Configuration
-		AggregateMode:                         strings.ToLower(strings.TrimSpace(getEnv("AGGREGATE_MODE", "legacy"))),
-		AggregateMaxSeries:                    getEnvInt("AGGREGATE_MAX_SERIES", 6000),
-		AggregateMaxSeriesMetrics:             getEnvInt("AGGREGATE_MAX_SERIES_METRICS", 2400),
-		AggregateMaxSeriesTraces:              getEnvInt("AGGREGATE_MAX_SERIES_TRACES", 2400),
-		AggregateMaxSeriesEdges:               getEnvInt("AGGREGATE_MAX_SERIES_EDGES", 500),
-		AggregateMaxSeriesLogs:                getEnvInt("AGGREGATE_MAX_SERIES_LOGS", 500),
-		AggregateMaxSeriesSystem:              getEnvInt("AGGREGATE_MAX_SERIES_SYSTEM", 200),
-		AggregateMaxOperationsPerService:      getEnvInt("AGGREGATE_MAX_OPERATIONS_PER_SERVICE", 20),
-		AggregateMaxTraceSeriesPerService:     getEnvInt("AGGREGATE_MAX_TRACE_SERIES_PER_SERVICE", 50),
-		AggregateMaxLogTemplatesPerService:    getEnvInt("AGGREGATE_MAX_LOG_TEMPLATES_PER_SERVICE", 10),
-		AggregateMaxMetricSeriesPerService:    getEnvInt("AGGREGATE_MAX_METRIC_SERIES_PER_SERVICE", 50),
-		AggregateSeriesPerTenantFraction:      getEnvFloat("AGGREGATE_SERIES_PER_TENANT_FRACTION", 0),
+		AggregateMode:                          strings.ToLower(strings.TrimSpace(getEnv("AGGREGATE_MODE", "legacy"))),
+		AggregateMaxSeries:                     getEnvInt("AGGREGATE_MAX_SERIES", 6000),
+		AggregateMaxSeriesMetrics:              getEnvInt("AGGREGATE_MAX_SERIES_METRICS", 2400),
+		AggregateMaxSeriesTraces:               getEnvInt("AGGREGATE_MAX_SERIES_TRACES", 2400),
+		AggregateMaxSeriesEdges:                getEnvInt("AGGREGATE_MAX_SERIES_EDGES", 500),
+		AggregateMaxSeriesLogs:                 getEnvInt("AGGREGATE_MAX_SERIES_LOGS", 500),
+		AggregateMaxSeriesSystem:               getEnvInt("AGGREGATE_MAX_SERIES_SYSTEM", 200),
+		AggregateMaxOperationsPerService:       getEnvInt("AGGREGATE_MAX_OPERATIONS_PER_SERVICE", 20),
+		AggregateMaxTraceSeriesPerService:      getEnvInt("AGGREGATE_MAX_TRACE_SERIES_PER_SERVICE", 50),
+		AggregateMaxLogTemplatesPerService:     getEnvInt("AGGREGATE_MAX_LOG_TEMPLATES_PER_SERVICE", 10),
+		AggregateMaxMetricSeriesPerService:     getEnvInt("AGGREGATE_MAX_METRIC_SERIES_PER_SERVICE", 50),
+		AggregateSeriesPerTenantFraction:       getEnvFloat("AGGREGATE_SERIES_PER_TENANT_FRACTION", 0),
 		AggregateMaxProducerBaselinesPerSeries: getEnvInt("AGGREGATE_MAX_PRODUCER_BASELINES_PER_SERIES", 8),
-		AggregateMaxBaselines:                 getEnvInt("AGGREGATE_MAX_BASELINES", 0),
+		AggregateMaxBaselines:                  getEnvInt("AGGREGATE_MAX_BASELINES", 0),
 	}
 	applyDriverDefaults(cfg)
+
+	// Derive a sane per-tenant ingest cap when the operator did not set one.
+	// Run AFTER applyDriverDefaults so it tracks the (possibly SQLite-adjusted)
+	// queue size: ~30% of the queue lets a single tenant burst but stops one
+	// noisy tenant from monopolising every slot at 100–200 services. An explicit
+	// INGEST_PIPELINE_PER_TENANT_CAP=0 is respected as "disabled".
+	if _, set := os.LookupEnv("INGEST_PIPELINE_PER_TENANT_CAP"); !set && cfg.IngestPipelinePerTenantCap == 0 {
+		cfg.IngestPipelinePerTenantCap = cfg.IngestPipelineQueueSize * 30 / 100
+	}
+
 	return cfg, nil
 }
 
@@ -403,36 +462,46 @@ func Load(customPath string) (*Config, error) {
 // "Explicit operator override" is detected via os.LookupEnv (presence)
 // rather than value comparison so that, e.g., DB_MAX_OPEN_CONNS=50 set by
 // hand is still honoured even though it equals the Postgres default.
+// sqliteOverrides is the table of (env-var, apply) pairs that
+// applyDriverDefaults walks when DB_DRIVER=sqlite. Add a row here to
+// introduce a new SQLite-only default; the apply closure is the only place
+// that names the Config field, so the surrounding lookup/skip logic stays
+// in one spot.
+var sqliteOverrides = []struct {
+	envKey string
+	apply  func(*Config)
+}{
+	{"DB_MAX_OPEN_CONNS", func(c *Config) { c.DBMaxOpenConns = 1 }},
+	{"DB_MAX_IDLE_CONNS", func(c *Config) { c.DBMaxIdleConns = 1 }},
+	{"INGEST_PIPELINE_WORKERS", func(c *Config) { c.IngestPipelineWorkers = 2 }},
+	{"INGEST_PIPELINE_QUEUE_SIZE", func(c *Config) { c.IngestPipelineQueueSize = 10000 }},
+	// The SQLite single writer drains slowly, so the ingest queue is the
+	// first structure to bloat — bound it to 128MB instead of 512MB.
+	{"INGEST_PIPELINE_MAX_BYTES", func(c *Config) { c.IngestPipelineMaxBytes = 128 << 20 }},
+	{"METRIC_MAX_CARDINALITY", func(c *Config) { c.MetricMaxCardinality = 3000 }},
+	{"SAMPLING_RATE", func(c *Config) { c.SamplingRate = 0.05 }},
+	{"GRPC_MAX_CONCURRENT_STREAMS", func(c *Config) { c.GRPCMaxConcurrentStreams = 240 }},
+	{"LOG_FTS_ENABLED", func(c *Config) { c.LogFTSEnabled = true }},
+	// Each queued event embeds a storage.Span/Log by value (~0.5–2 KB); the
+	// 100k Postgres default is ~100 MB+ of standing buffer. On SQLite the
+	// single writer starves the workers anyway — drop sooner (metered via
+	// otelcontext_graphrag_events_dropped_total) instead of buffering RAM.
+	{"GRAPHRAG_EVENT_QUEUE_SIZE", func(c *Config) { c.GraphRAGEventQueueSize = 10000 }},
+	// The TraceStore span window dominates GraphRAG heap at 120 services
+	// (~1.5 GB potential at 1h). Anomaly/investigation lookbacks are <=5min,
+	// so halving the window costs nothing they rely on; MCP trace tools fall
+	// through to the DB for older traces.
+	{"GRAPHRAG_TRACE_TTL", func(c *Config) { c.GraphRAGTraceTTL = "30m" }},
+}
+
 func applyDriverDefaults(cfg *Config) {
 	if !strings.EqualFold(cfg.DBDriver, "sqlite") {
 		return
 	}
-	if _, ok := os.LookupEnv("DB_MAX_OPEN_CONNS"); !ok {
-		cfg.DBMaxOpenConns = 1
-	}
-	if _, ok := os.LookupEnv("DB_MAX_IDLE_CONNS"); !ok {
-		cfg.DBMaxIdleConns = 1
-	}
-	if _, ok := os.LookupEnv("INGEST_PIPELINE_WORKERS"); !ok {
-		cfg.IngestPipelineWorkers = 2
-	}
-	if _, ok := os.LookupEnv("INGEST_PIPELINE_QUEUE_SIZE"); !ok {
-		cfg.IngestPipelineQueueSize = 10000
-	}
-	if _, ok := os.LookupEnv("METRIC_MAX_CARDINALITY"); !ok {
-		cfg.MetricMaxCardinality = 3000
-	}
-	if _, ok := os.LookupEnv("STORE_MIN_SEVERITY"); !ok {
-		cfg.StoreMinSeverity = "WARN"
-	}
-	if _, ok := os.LookupEnv("SAMPLING_RATE"); !ok {
-		cfg.SamplingRate = 0.05
-	}
-	if _, ok := os.LookupEnv("GRPC_MAX_CONCURRENT_STREAMS"); !ok {
-		cfg.GRPCMaxConcurrentStreams = 240
-	}
-	if _, ok := os.LookupEnv("LOG_FTS_ENABLED"); !ok {
-		cfg.LogFTSEnabled = true
+	for _, ov := range sqliteOverrides {
+		if _, ok := os.LookupEnv(ov.envKey); !ok {
+			ov.apply(cfg)
+		}
 	}
 }
 
@@ -572,6 +641,12 @@ func (c *Config) Validate() error {
 	}
 	if c.GRPCMaxConcurrentStreams < 1 || c.GRPCMaxConcurrentStreams > 1_000_000 {
 		return fmt.Errorf("GRPC_MAX_CONCURRENT_STREAMS must be between 1 and 1000000, got %d", c.GRPCMaxConcurrentStreams)
+	}
+	// GraphRAG event queue: the channel buffer is allocated up front and each
+	// queued event embeds a Span/Log by value (~0.5-2 KB), so an unbounded env
+	// value is a real OOM lever. 1M buffered events is already ~1-2 GB.
+	if c.GraphRAGEventQueueSize < 1 || c.GraphRAGEventQueueSize > 1_000_000 {
+		return fmt.Errorf("GRAPHRAG_EVENT_QUEUE_SIZE must be between 1 and 1000000, got %d", c.GraphRAGEventQueueSize)
 	}
 	if c.DBMaxOpenConns < 1 {
 		return fmt.Errorf("DB_MAX_OPEN_CONNS must be >= 1, got %d", c.DBMaxOpenConns)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,23 +20,17 @@ type Config struct {
 	DLQPath           string
 	DLQReplayInterval string
 
-	// PprofAddr serves net/http/pprof on a dedicated listener (never the
-	// public mux). Loopback-only by default; empty disables profiling.
-	PprofAddr string
-
 	// Ingestion Filtering
 	IngestMinSeverity      string
 	IngestAllowedServices  string
 	IngestExcludedServices string
 
 	// Storage Filtering. Logs that pass IngestMinSeverity (so they reach the
-	// receiver and feed in-memory consumers like GraphRAG / Drain) but fall
-	// below StoreMinSeverity are skipped during the DB persist pass — only the
-	// row-write is dropped, not the in-memory enrichment. Defaults to "WARN"
-	// (all drivers): INFO/DEBUG still inform anomaly detection + clustering but
-	// don't grow the DB. Empty falls back to IngestMinSeverity (no second-tier
-	// gate); a value <= IngestMinSeverity is a no-op since the receiver already
-	// drops below that.
+	// receiver and feed in-memory consumers like vectordb / GraphRAG) but
+	// fall below StoreMinSeverity are skipped during the DB persist pass —
+	// only the row-write is dropped, not the in-memory enrichment. Empty
+	// (default) means StoreMinSeverity == IngestMinSeverity, i.e. no
+	// behavior change vs. the single-threshold semantics.
 	StoreMinSeverity string
 
 	// DB Connection Pool
@@ -65,14 +59,6 @@ type Config struct {
 	// dedicated DB machines. 0/negative values use defaults.
 	RetentionBatchSize    int
 	RetentionBatchSleepMs int
-
-	// RetentionFullVacuum restores the daily full VACUUM during SQLite
-	// maintenance. Default false: the daily pass runs
-	// PRAGMA incremental_vacuum(10000) instead, because a full VACUUM holds
-	// an exclusive lock for 10-60 minutes on multi-GB files and starves
-	// ingest into a 429 storm. On-demand full VACUUM remains available via
-	// POST /api/admin/vacuum. Ignored on non-SQLite drivers.
-	RetentionFullVacuum bool
 
 	// TSDB
 	TSDBRingBufferDuration string // e.g. "1h"
@@ -143,28 +129,6 @@ type Config struct {
 	// GraphRAG event channel buffer size. Defaults to 10000 if unset or <=0.
 	GraphRAGEventQueueSize int
 
-	// GraphRAGTraceTTL bounds how long spans/traces stay in the in-memory
-	// TraceStore before the refresh tick prunes them. Duration string, e.g.
-	// "1h". Defaults to "1h"; flipped to "30m" on SQLite (the in-memory span
-	// window is the largest GraphRAG heap consumer at 120 services). Anomaly
-	// and investigation paths look back <=5min, so a 30min window is safe.
-	GraphRAGTraceTTL string
-
-	// GraphRAGMaxSpansPerTenant hard-caps the in-memory TraceStore span map
-	// per tenant. At the cap, NEW spans are skipped (counted via
-	// otelcontext_graphrag_events_dropped_total{signal="span_capacity"});
-	// updates to resident spans still apply. The graph is best-effort — the
-	// DB remains the source of truth. 0 = default (500000); negative
-	// disables the cap.
-	GraphRAGMaxSpansPerTenant int
-
-	// GraphRAGTenantIdleTTL evicts a tenant's entire in-memory store slice
-	// after this much time without any ingest event or query. Duration
-	// string, default "24h". The default tenant is never evicted, and an
-	// active tenant is re-created within one refresh tick (60s) from recent
-	// DB spans — eviction is self-healing.
-	GraphRAGTenantIdleTTL string
-
 	// Async ingest pipeline (Phase 1 robustness work). Decouples OTLP Export
 	// from synchronous DB writes. When enabled, Export() returns as soon as
 	// the parsed batch is enqueued; persistence runs on a worker pool.
@@ -175,22 +139,14 @@ type Config struct {
 	//   100% queue       — return RESOURCE_EXHAUSTED so OTLP clients back off
 	IngestAsyncEnabled      bool // default true; opt out via INGEST_ASYNC_ENABLED=false
 	IngestPipelineQueueSize int  // default 50000 batches; per-deployment tunable
-	// IngestPipelineMaxBytes caps the approximate bytes held by queued
-	// batches. The item-count queue size alone cannot bound memory — one
-	// batch may carry arbitrarily large span/log payloads. At the cap the
-	// pipeline rejects with RESOURCE_EXHAUSTED / HTTP 429 even for priority
-	// (error/slow) batches: a 429 is recoverable, an OOM kill is not.
-	// Default 512MB; SQLite default 128MB (see applyDriverDefaults).
-	IngestPipelineMaxBytes int
-	IngestPipelineWorkers  int // default 8 worker goroutines
+	IngestPipelineWorkers   int  // default 8 worker goroutines
 	// IngestPipelinePerTenantCap caps in-flight batches per tenant so a noisy
 	// tenant cannot starve siblings of fresh queue slots when fullness is
-	// below the soft-backpressure threshold. When unset it defaults to ~30% of
-	// the resolved queue size (see Load) so multi-tenant deployments are
-	// protected out of the box; an explicit INGEST_PIPELINE_PER_TENANT_CAP=0
-	// disables the cap for single-tenant deployments. Operators can instead
-	// pin it to roughly Capacity/N where N is the expected number of
-	// concurrently-active tenants, with headroom for short bursts.
+	// below the soft-backpressure threshold. 0 (default) disables — single-
+	// tenant deployments need no cap. Operators on multi-tenant deployments
+	// should set INGEST_PIPELINE_PER_TENANT_CAP to roughly Capacity/N where
+	// N is the expected number of concurrently-active tenants, with some
+	// headroom (e.g. 2× the fair-share value) for short bursts.
 	IngestPipelinePerTenantCap int
 
 	// TLS (HTTP + gRPC). When both paths are set, TLS is enabled on both servers.
@@ -250,6 +206,48 @@ type Config struct {
 	// the cap receive HTTP 503. Sized for the operator's expected dashboard
 	// audience — small for ops dashboards, larger for read-heavy public UIs.
 	WSMaxClients int
+
+	// Aggregate Engine Configuration (Phase 1, accounting only)
+	//
+	// AggregateMode controls how the aggregation engine participates:
+	// - "legacy": aggregate engine inactive, use existing TSDB/GraphRAG path only
+	// - "aggregate-shadow": aggregate accounting runs; counts identical to legacy;
+	//   the read path uses legacy TSDB; allows A/B testing before switchover
+	// - "aggregate": aggregate engine is the only active path; legacy TSDB
+	//   aggregation is retired
+	AggregateMode string
+
+	// AggregateMaxSeries is the global budget for materialized active series
+	// across all signals. Active = present in ≥1 mutable window.
+	AggregateMaxSeries int
+
+	// Per-signal sub-caps (materialized active series). These must sum to ≤
+	// AggregateMaxSeries. Sum validation runs at startup.
+	AggregateMaxSeriesMetrics int // Default 2400
+	AggregateMaxSeriesTraces  int // Default 2400
+	AggregateMaxSeriesEdges   int // Default 500
+	AggregateMaxSeriesLogs    int // Default 500
+	AggregateMaxSeriesSystem  int // Default 200
+
+	// Per-service caps. Enforcement order: tenant → service → signal sub-cap →
+	// global. These are isolation ceilings, not reservations; sum of per-service
+	// budgets may exceed instance-wide cap.
+	AggregateMaxOperationsPerService        int     // Default 20
+	AggregateMaxTraceSeriesPerService       int     // Default 50
+	AggregateMaxLogTemplatesPerService      int     // Default 10
+	AggregateMaxMetricSeriesPerService      int     // Default 50
+	AggregateSeriesPerTenantFraction        float64 // Default 0 (disabled); range [0, 1]
+
+	// Baseline configuration for counter temporality tracking.
+	// AggregateMaxProducerBaselinesPerSeries caps the number of baseline
+	// entries per series (one per producer). Default 8.
+	AggregateMaxProducerBaselinesPerSeries int
+
+	// AggregateMaxBaselines is the global budget for baseline entries.
+	// 0 (default) = derive as AggregateMaxSeriesMetrics ×
+	// AggregateMaxProducerBaselinesPerSeries. Nonzero overrides.
+	// Use ResolvedAggregateMaxBaselines() to get the final value.
+	AggregateMaxBaselines int
 }
 
 func Load(customPath string) (*Config, error) {
@@ -279,10 +277,9 @@ func Load(customPath string) (*Config, error) {
 		DBDSN:             getEnv("DB_DSN", ""),
 		DLQPath:           getEnv("DLQ_PATH", "./data/dlq"),
 		DLQReplayInterval: getEnv("DLQ_REPLAY_INTERVAL", "5m"),
-		PprofAddr:         getEnv("PPROF_ADDR", "127.0.0.1:6060"),
 
 		IngestMinSeverity:      getEnv("INGEST_MIN_SEVERITY", "INFO"),
-		StoreMinSeverity:       getEnv("STORE_MIN_SEVERITY", "WARN"),
+		StoreMinSeverity:       getEnv("STORE_MIN_SEVERITY", ""),
 		IngestAllowedServices:  getEnv("INGEST_ALLOWED_SERVICES", ""),
 		IngestExcludedServices: getEnv("INGEST_EXCLUDED_SERVICES", ""),
 
@@ -299,7 +296,6 @@ func Load(customPath string) (*Config, error) {
 		HotRetentionDays:      getEnvInt("HOT_RETENTION_DAYS", 7),
 		RetentionBatchSize:    getEnvInt("RETENTION_BATCH_SIZE", 50000),
 		RetentionBatchSleepMs: getEnvInt("RETENTION_BATCH_SLEEP_MS", 1),
-		RetentionFullVacuum:   getEnvBool("RETENTION_FULL_VACUUM", false),
 
 		// TSDB
 		TSDBRingBufferDuration: getEnv("TSDB_RING_BUFFER_DURATION", "1h"),
@@ -337,16 +333,12 @@ func Load(customPath string) (*Config, error) {
 		LogFTSEnabled: parseTruthy(getEnv("LOG_FTS_ENABLED", "")),
 
 		// GraphRAG
-		GraphRAGWorkerCount:       getEnvInt("GRAPHRAG_WORKER_COUNT", 16),
-		GraphRAGEventQueueSize:    getEnvInt("GRAPHRAG_EVENT_QUEUE_SIZE", 100000),
-		GraphRAGTraceTTL:          getEnv("GRAPHRAG_TRACE_TTL", "1h"),
-		GraphRAGMaxSpansPerTenant: getEnvInt("GRAPHRAG_MAX_SPANS_PER_TENANT", 500000),
-		GraphRAGTenantIdleTTL:     getEnv("GRAPHRAG_TENANT_IDLE_TTL", "24h"),
+		GraphRAGWorkerCount:    getEnvInt("GRAPHRAG_WORKER_COUNT", 16),
+		GraphRAGEventQueueSize: getEnvInt("GRAPHRAG_EVENT_QUEUE_SIZE", 100000),
 
 		// Async ingest pipeline
 		IngestAsyncEnabled:         getEnvBool("INGEST_ASYNC_ENABLED", true),
 		IngestPipelineQueueSize:    getEnvInt("INGEST_PIPELINE_QUEUE_SIZE", 50000),
-		IngestPipelineMaxBytes:     getEnvInt("INGEST_PIPELINE_MAX_BYTES", 512<<20),
 		IngestPipelineWorkers:      getEnvInt("INGEST_PIPELINE_WORKERS", 8),
 		IngestPipelinePerTenantCap: getEnvInt("INGEST_PIPELINE_PER_TENANT_CAP", 0),
 
@@ -376,18 +368,24 @@ func Load(customPath string) (*Config, error) {
 
 		// Production safety guard for SQLite
 		AllowSqliteProd: parseTruthy(getEnv("OTELCONTEXT_ALLOW_SQLITE_PROD", "")),
+
+		// Aggregate Engine Configuration
+		AggregateMode:                         strings.ToLower(strings.TrimSpace(getEnv("AGGREGATE_MODE", "legacy"))),
+		AggregateMaxSeries:                    getEnvInt("AGGREGATE_MAX_SERIES", 6000),
+		AggregateMaxSeriesMetrics:             getEnvInt("AGGREGATE_MAX_SERIES_METRICS", 2400),
+		AggregateMaxSeriesTraces:              getEnvInt("AGGREGATE_MAX_SERIES_TRACES", 2400),
+		AggregateMaxSeriesEdges:               getEnvInt("AGGREGATE_MAX_SERIES_EDGES", 500),
+		AggregateMaxSeriesLogs:                getEnvInt("AGGREGATE_MAX_SERIES_LOGS", 500),
+		AggregateMaxSeriesSystem:              getEnvInt("AGGREGATE_MAX_SERIES_SYSTEM", 200),
+		AggregateMaxOperationsPerService:      getEnvInt("AGGREGATE_MAX_OPERATIONS_PER_SERVICE", 20),
+		AggregateMaxTraceSeriesPerService:     getEnvInt("AGGREGATE_MAX_TRACE_SERIES_PER_SERVICE", 50),
+		AggregateMaxLogTemplatesPerService:    getEnvInt("AGGREGATE_MAX_LOG_TEMPLATES_PER_SERVICE", 10),
+		AggregateMaxMetricSeriesPerService:    getEnvInt("AGGREGATE_MAX_METRIC_SERIES_PER_SERVICE", 50),
+		AggregateSeriesPerTenantFraction:      getEnvFloat("AGGREGATE_SERIES_PER_TENANT_FRACTION", 0),
+		AggregateMaxProducerBaselinesPerSeries: getEnvInt("AGGREGATE_MAX_PRODUCER_BASELINES_PER_SERIES", 8),
+		AggregateMaxBaselines:                 getEnvInt("AGGREGATE_MAX_BASELINES", 0),
 	}
 	applyDriverDefaults(cfg)
-
-	// Derive a sane per-tenant ingest cap when the operator did not set one.
-	// Run AFTER applyDriverDefaults so it tracks the (possibly SQLite-adjusted)
-	// queue size: ~30% of the queue lets a single tenant burst but stops one
-	// noisy tenant from monopolising every slot at 100–200 services. An explicit
-	// INGEST_PIPELINE_PER_TENANT_CAP=0 is respected as "disabled".
-	if _, set := os.LookupEnv("INGEST_PIPELINE_PER_TENANT_CAP"); !set && cfg.IngestPipelinePerTenantCap == 0 {
-		cfg.IngestPipelinePerTenantCap = cfg.IngestPipelineQueueSize * 30 / 100
-	}
-
 	return cfg, nil
 }
 
@@ -405,46 +403,36 @@ func Load(customPath string) (*Config, error) {
 // "Explicit operator override" is detected via os.LookupEnv (presence)
 // rather than value comparison so that, e.g., DB_MAX_OPEN_CONNS=50 set by
 // hand is still honoured even though it equals the Postgres default.
-// sqliteOverrides is the table of (env-var, apply) pairs that
-// applyDriverDefaults walks when DB_DRIVER=sqlite. Add a row here to
-// introduce a new SQLite-only default; the apply closure is the only place
-// that names the Config field, so the surrounding lookup/skip logic stays
-// in one spot.
-var sqliteOverrides = []struct {
-	envKey string
-	apply  func(*Config)
-}{
-	{"DB_MAX_OPEN_CONNS", func(c *Config) { c.DBMaxOpenConns = 1 }},
-	{"DB_MAX_IDLE_CONNS", func(c *Config) { c.DBMaxIdleConns = 1 }},
-	{"INGEST_PIPELINE_WORKERS", func(c *Config) { c.IngestPipelineWorkers = 2 }},
-	{"INGEST_PIPELINE_QUEUE_SIZE", func(c *Config) { c.IngestPipelineQueueSize = 10000 }},
-	// The SQLite single writer drains slowly, so the ingest queue is the
-	// first structure to bloat — bound it to 128MB instead of 512MB.
-	{"INGEST_PIPELINE_MAX_BYTES", func(c *Config) { c.IngestPipelineMaxBytes = 128 << 20 }},
-	{"METRIC_MAX_CARDINALITY", func(c *Config) { c.MetricMaxCardinality = 3000 }},
-	{"SAMPLING_RATE", func(c *Config) { c.SamplingRate = 0.05 }},
-	{"GRPC_MAX_CONCURRENT_STREAMS", func(c *Config) { c.GRPCMaxConcurrentStreams = 240 }},
-	{"LOG_FTS_ENABLED", func(c *Config) { c.LogFTSEnabled = true }},
-	// Each queued event embeds a storage.Span/Log by value (~0.5–2 KB); the
-	// 100k Postgres default is ~100 MB+ of standing buffer. On SQLite the
-	// single writer starves the workers anyway — drop sooner (metered via
-	// otelcontext_graphrag_events_dropped_total) instead of buffering RAM.
-	{"GRAPHRAG_EVENT_QUEUE_SIZE", func(c *Config) { c.GraphRAGEventQueueSize = 10000 }},
-	// The TraceStore span window dominates GraphRAG heap at 120 services
-	// (~1.5 GB potential at 1h). Anomaly/investigation lookbacks are <=5min,
-	// so halving the window costs nothing they rely on; MCP trace tools fall
-	// through to the DB for older traces.
-	{"GRAPHRAG_TRACE_TTL", func(c *Config) { c.GraphRAGTraceTTL = "30m" }},
-}
-
 func applyDriverDefaults(cfg *Config) {
 	if !strings.EqualFold(cfg.DBDriver, "sqlite") {
 		return
 	}
-	for _, ov := range sqliteOverrides {
-		if _, ok := os.LookupEnv(ov.envKey); !ok {
-			ov.apply(cfg)
-		}
+	if _, ok := os.LookupEnv("DB_MAX_OPEN_CONNS"); !ok {
+		cfg.DBMaxOpenConns = 1
+	}
+	if _, ok := os.LookupEnv("DB_MAX_IDLE_CONNS"); !ok {
+		cfg.DBMaxIdleConns = 1
+	}
+	if _, ok := os.LookupEnv("INGEST_PIPELINE_WORKERS"); !ok {
+		cfg.IngestPipelineWorkers = 2
+	}
+	if _, ok := os.LookupEnv("INGEST_PIPELINE_QUEUE_SIZE"); !ok {
+		cfg.IngestPipelineQueueSize = 10000
+	}
+	if _, ok := os.LookupEnv("METRIC_MAX_CARDINALITY"); !ok {
+		cfg.MetricMaxCardinality = 3000
+	}
+	if _, ok := os.LookupEnv("STORE_MIN_SEVERITY"); !ok {
+		cfg.StoreMinSeverity = "WARN"
+	}
+	if _, ok := os.LookupEnv("SAMPLING_RATE"); !ok {
+		cfg.SamplingRate = 0.05
+	}
+	if _, ok := os.LookupEnv("GRPC_MAX_CONCURRENT_STREAMS"); !ok {
+		cfg.GRPCMaxConcurrentStreams = 240
+	}
+	if _, ok := os.LookupEnv("LOG_FTS_ENABLED"); !ok {
+		cfg.LogFTSEnabled = true
 	}
 }
 
@@ -585,12 +573,6 @@ func (c *Config) Validate() error {
 	if c.GRPCMaxConcurrentStreams < 1 || c.GRPCMaxConcurrentStreams > 1_000_000 {
 		return fmt.Errorf("GRPC_MAX_CONCURRENT_STREAMS must be between 1 and 1000000, got %d", c.GRPCMaxConcurrentStreams)
 	}
-	// GraphRAG event queue: the channel buffer is allocated up front and each
-	// queued event embeds a Span/Log by value (~0.5-2 KB), so an unbounded env
-	// value is a real OOM lever. 1M buffered events is already ~1-2 GB.
-	if c.GraphRAGEventQueueSize < 1 || c.GraphRAGEventQueueSize > 1_000_000 {
-		return fmt.Errorf("GRAPHRAG_EVENT_QUEUE_SIZE must be between 1 and 1000000, got %d", c.GraphRAGEventQueueSize)
-	}
 	if c.DBMaxOpenConns < 1 {
 		return fmt.Errorf("DB_MAX_OPEN_CONNS must be >= 1, got %d", c.DBMaxOpenConns)
 	}
@@ -630,6 +612,66 @@ func (c *Config) Validate() error {
 		if c.TLSAutoSelfsigned {
 			log.Println("ℹ️  TLS_AUTO_SELFSIGNED ignored — explicit TLS_CERT_FILE/TLS_KEY_FILE take precedence")
 		}
+	}
+
+	// Aggregate Engine Configuration Validation
+	// No per-driver defaults for aggregate config — all drivers use the same defaults.
+	validAggregateModes := map[string]bool{"legacy": true, "aggregate-shadow": true, "aggregate": true}
+	if !validAggregateModes[c.AggregateMode] {
+		return fmt.Errorf("invalid AGGREGATE_MODE %q: must be one of legacy, aggregate-shadow, aggregate", c.AggregateMode)
+	}
+
+	// Validate global and per-signal caps
+	if c.AggregateMaxSeries < 1 {
+		return fmt.Errorf("AGGREGATE_MAX_SERIES must be >= 1, got %d", c.AggregateMaxSeries)
+	}
+	if c.AggregateMaxSeriesMetrics < 1 {
+		return fmt.Errorf("AGGREGATE_MAX_SERIES_METRICS must be >= 1, got %d", c.AggregateMaxSeriesMetrics)
+	}
+	if c.AggregateMaxSeriesTraces < 1 {
+		return fmt.Errorf("AGGREGATE_MAX_SERIES_TRACES must be >= 1, got %d", c.AggregateMaxSeriesTraces)
+	}
+	if c.AggregateMaxSeriesEdges < 1 {
+		return fmt.Errorf("AGGREGATE_MAX_SERIES_EDGES must be >= 1, got %d", c.AggregateMaxSeriesEdges)
+	}
+	if c.AggregateMaxSeriesLogs < 1 {
+		return fmt.Errorf("AGGREGATE_MAX_SERIES_LOGS must be >= 1, got %d", c.AggregateMaxSeriesLogs)
+	}
+	if c.AggregateMaxSeriesSystem < 1 {
+		return fmt.Errorf("AGGREGATE_MAX_SERIES_SYSTEM must be >= 1, got %d", c.AggregateMaxSeriesSystem)
+	}
+
+	// Validate per-service caps
+	if c.AggregateMaxOperationsPerService < 1 {
+		return fmt.Errorf("AGGREGATE_MAX_OPERATIONS_PER_SERVICE must be >= 1, got %d", c.AggregateMaxOperationsPerService)
+	}
+	if c.AggregateMaxTraceSeriesPerService < 1 {
+		return fmt.Errorf("AGGREGATE_MAX_TRACE_SERIES_PER_SERVICE must be >= 1, got %d", c.AggregateMaxTraceSeriesPerService)
+	}
+	if c.AggregateMaxLogTemplatesPerService < 1 {
+		return fmt.Errorf("AGGREGATE_MAX_LOG_TEMPLATES_PER_SERVICE must be >= 1, got %d", c.AggregateMaxLogTemplatesPerService)
+	}
+	if c.AggregateMaxMetricSeriesPerService < 1 {
+		return fmt.Errorf("AGGREGATE_MAX_METRIC_SERIES_PER_SERVICE must be >= 1, got %d", c.AggregateMaxMetricSeriesPerService)
+	}
+
+	// Validate tenant fraction
+	if c.AggregateSeriesPerTenantFraction < 0 || c.AggregateSeriesPerTenantFraction > 1.0 {
+		return fmt.Errorf("AGGREGATE_SERIES_PER_TENANT_FRACTION must be between 0 and 1, got %f", c.AggregateSeriesPerTenantFraction)
+	}
+
+	// Validate baseline caps
+	if c.AggregateMaxProducerBaselinesPerSeries < 1 {
+		return fmt.Errorf("AGGREGATE_MAX_PRODUCER_BASELINES_PER_SERIES must be >= 1, got %d", c.AggregateMaxProducerBaselinesPerSeries)
+	}
+	if c.AggregateMaxBaselines > 0 && c.AggregateMaxBaselines < c.AggregateMaxProducerBaselinesPerSeries {
+		return fmt.Errorf("AGGREGATE_MAX_BASELINES when nonzero must be >= AGGREGATE_MAX_PRODUCER_BASELINES_PER_SERIES (%d), got %d", c.AggregateMaxProducerBaselinesPerSeries, c.AggregateMaxBaselines)
+	}
+
+	// Sum-of-caps validation: sub-caps must fit under global cap
+	sumSubCaps := c.AggregateMaxSeriesMetrics + c.AggregateMaxSeriesTraces + c.AggregateMaxSeriesEdges + c.AggregateMaxSeriesLogs + c.AggregateMaxSeriesSystem
+	if sumSubCaps > c.AggregateMaxSeries {
+		return fmt.Errorf("sum of AGGREGATE_MAX_SERIES_* caps (%d = %d+%d+%d+%d+%d) must be <= AGGREGATE_MAX_SERIES (%d)", sumSubCaps, c.AggregateMaxSeriesMetrics, c.AggregateMaxSeriesTraces, c.AggregateMaxSeriesEdges, c.AggregateMaxSeriesLogs, c.AggregateMaxSeriesSystem, c.AggregateMaxSeries)
 	}
 
 	return nil
@@ -681,4 +723,14 @@ func (c *Config) ValidateDBForEnv() error {
 			"Use DB_DRIVER=postgres, or set OTELCONTEXT_ALLOW_SQLITE_PROD=true to acknowledge")
 	}
 	return nil
+}
+
+// ResolvedAggregateMaxBaselines returns the effective global baseline entry cap.
+// When AggregateMaxBaselines is 0 (default), derives it as AggregateMaxSeriesMetrics ×
+// AggregateMaxProducerBaselinesPerSeries. Nonzero AggregateMaxBaselines overrides.
+func (c *Config) ResolvedAggregateMaxBaselines() int {
+	if c.AggregateMaxBaselines > 0 {
+		return c.AggregateMaxBaselines
+	}
+	return c.AggregateMaxSeriesMetrics * c.AggregateMaxProducerBaselinesPerSeries
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,35 +11,36 @@ import (
 // baseValid returns a Config that passes Validate() — test functions mutate one field at a time.
 func baseValid() *Config {
 	return &Config{
-		HTTPPort:             "8080",
-		GRPCPort:             "4317",
-		DBDriver:             "sqlite",
-		HotRetentionDays:     7,
-		MetricMaxCardinality: 10000,
-		SamplingRate:         1.0,
-		APIRateLimitRPS:      100,
-		DBMaxOpenConns:       50,
-		DBMaxIdleConns:       10,
-		CompressionLevel:     "default",
+		HTTPPort:                 "8080",
+		GRPCPort:                 "4317",
+		DBDriver:                 "sqlite",
+		HotRetentionDays:         7,
+		MetricMaxCardinality:     10000,
+		SamplingRate:             1.0,
+		APIRateLimitRPS:          100,
+		DBMaxOpenConns:           50,
+		DBMaxIdleConns:           10,
+		CompressionLevel:         "default",
 		GRPCMaxRecvMB:            16,
 		GRPCMaxConcurrentStreams: 1000,
-		RetentionBatchSize:    50000,
-		RetentionBatchSleepMs: 1,
+		GraphRAGEventQueueSize:   100000,
+		RetentionBatchSize:       50000,
+		RetentionBatchSleepMs:    1,
 		// Aggregate Engine defaults
-		AggregateMode:                         "legacy",
-		AggregateMaxSeries:                    6000,
-		AggregateMaxSeriesMetrics:             2400,
-		AggregateMaxSeriesTraces:              2400,
-		AggregateMaxSeriesEdges:               500,
-		AggregateMaxSeriesLogs:                500,
-		AggregateMaxSeriesSystem:              200,
-		AggregateMaxOperationsPerService:      20,
-		AggregateMaxTraceSeriesPerService:     50,
-		AggregateMaxLogTemplatesPerService:    10,
-		AggregateMaxMetricSeriesPerService:    50,
-		AggregateSeriesPerTenantFraction:      0,
+		AggregateMode:                          "legacy",
+		AggregateMaxSeries:                     6000,
+		AggregateMaxSeriesMetrics:              2400,
+		AggregateMaxSeriesTraces:               2400,
+		AggregateMaxSeriesEdges:                500,
+		AggregateMaxSeriesLogs:                 500,
+		AggregateMaxSeriesSystem:               200,
+		AggregateMaxOperationsPerService:       20,
+		AggregateMaxTraceSeriesPerService:      50,
+		AggregateMaxLogTemplatesPerService:     10,
+		AggregateMaxMetricSeriesPerService:     50,
+		AggregateSeriesPerTenantFraction:       0,
 		AggregateMaxProducerBaselinesPerSeries: 8,
-		AggregateMaxBaselines:                 0,
+		AggregateMaxBaselines:                  0,
 	}
 }
 
@@ -149,6 +150,30 @@ func TestValidate_TLS_ReadableFilesOK(t *testing.T) {
 	}
 	if !c.TLSEnabled() {
 		t.Fatal("TLSEnabled should be true when both files are set")
+	}
+}
+
+func TestLoad_RetentionFullVacuum(t *testing.T) {
+	// Default: off — the daily SQLite maintenance must not full-VACUUM.
+	t.Setenv("RETENTION_FULL_VACUUM", "")
+	if err := os.Unsetenv("RETENTION_FULL_VACUUM"); err != nil {
+		t.Fatalf("unset: %v", err)
+	}
+	cfg, err := Load("__no_such_env_file__")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.RetentionFullVacuum {
+		t.Fatal("RetentionFullVacuum must default to false")
+	}
+
+	t.Setenv("RETENTION_FULL_VACUUM", "true")
+	cfg, err = Load("__no_such_env_file__")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.RetentionFullVacuum {
+		t.Fatal("RETENTION_FULL_VACUUM=true not loaded")
 	}
 }
 
@@ -323,7 +348,24 @@ func TestLoad_DefaultTenant_FallsBackToDefault(t *testing.T) {
 	}
 }
 
-// Aggregate engine configuration tests follow.
+// TestValidate_GraphRAGEventQueueSize_Bounds: the event channel buffer is
+// allocated up front and each event embeds a Span/Log by value, so the env
+// value must be range-checked (also breaks the CodeQL
+// go/uncontrolled-allocation-size taint path env -> make(chan, n)).
+func TestValidate_GraphRAGEventQueueSize_Bounds(t *testing.T) {
+	for _, bad := range []int{0, -1, 1_000_001} {
+		c := baseValid()
+		c.GraphRAGEventQueueSize = bad
+		if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "GRAPHRAG_EVENT_QUEUE_SIZE") {
+			t.Fatalf("size %d: expected GRAPHRAG_EVENT_QUEUE_SIZE error, got %v", bad, err)
+		}
+	}
+	c := baseValid()
+	c.GraphRAGEventQueueSize = 1_000_000
+	if err := c.Validate(); err != nil {
+		t.Fatalf("size 1000000 should validate: %v", err)
+	}
+}
 
 func TestValidate_AggregateMode_Valid(t *testing.T) {
 	cases := []string{"legacy", "aggregate-shadow", "aggregate"}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,21 +11,35 @@ import (
 // baseValid returns a Config that passes Validate() — test functions mutate one field at a time.
 func baseValid() *Config {
 	return &Config{
-		HTTPPort:                 "8080",
-		GRPCPort:                 "4317",
-		DBDriver:                 "sqlite",
-		HotRetentionDays:         7,
-		MetricMaxCardinality:     10000,
-		SamplingRate:             1.0,
-		APIRateLimitRPS:          100,
-		DBMaxOpenConns:           50,
-		DBMaxIdleConns:           10,
-		CompressionLevel:         "default",
+		HTTPPort:             "8080",
+		GRPCPort:             "4317",
+		DBDriver:             "sqlite",
+		HotRetentionDays:     7,
+		MetricMaxCardinality: 10000,
+		SamplingRate:         1.0,
+		APIRateLimitRPS:      100,
+		DBMaxOpenConns:       50,
+		DBMaxIdleConns:       10,
+		CompressionLevel:     "default",
 		GRPCMaxRecvMB:            16,
 		GRPCMaxConcurrentStreams: 1000,
-		GraphRAGEventQueueSize:   100000,
-		RetentionBatchSize:       50000,
-		RetentionBatchSleepMs:    1,
+		RetentionBatchSize:    50000,
+		RetentionBatchSleepMs: 1,
+		// Aggregate Engine defaults
+		AggregateMode:                         "legacy",
+		AggregateMaxSeries:                    6000,
+		AggregateMaxSeriesMetrics:             2400,
+		AggregateMaxSeriesTraces:              2400,
+		AggregateMaxSeriesEdges:               500,
+		AggregateMaxSeriesLogs:                500,
+		AggregateMaxSeriesSystem:              200,
+		AggregateMaxOperationsPerService:      20,
+		AggregateMaxTraceSeriesPerService:     50,
+		AggregateMaxLogTemplatesPerService:    10,
+		AggregateMaxMetricSeriesPerService:    50,
+		AggregateSeriesPerTenantFraction:      0,
+		AggregateMaxProducerBaselinesPerSeries: 8,
+		AggregateMaxBaselines:                 0,
 	}
 }
 
@@ -135,30 +149,6 @@ func TestValidate_TLS_ReadableFilesOK(t *testing.T) {
 	}
 	if !c.TLSEnabled() {
 		t.Fatal("TLSEnabled should be true when both files are set")
-	}
-}
-
-func TestLoad_RetentionFullVacuum(t *testing.T) {
-	// Default: off — the daily SQLite maintenance must not full-VACUUM.
-	t.Setenv("RETENTION_FULL_VACUUM", "")
-	if err := os.Unsetenv("RETENTION_FULL_VACUUM"); err != nil {
-		t.Fatalf("unset: %v", err)
-	}
-	cfg, err := Load("__no_such_env_file__")
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if cfg.RetentionFullVacuum {
-		t.Fatal("RetentionFullVacuum must default to false")
-	}
-
-	t.Setenv("RETENTION_FULL_VACUUM", "true")
-	cfg, err = Load("__no_such_env_file__")
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if !cfg.RetentionFullVacuum {
-		t.Fatal("RETENTION_FULL_VACUUM=true not loaded")
 	}
 }
 
@@ -333,21 +323,271 @@ func TestLoad_DefaultTenant_FallsBackToDefault(t *testing.T) {
 	}
 }
 
-// TestValidate_GraphRAGEventQueueSize_Bounds: the event channel buffer is
-// allocated up front and each event embeds a Span/Log by value, so the env
-// value must be range-checked (also breaks the CodeQL
-// go/uncontrolled-allocation-size taint path env -> make(chan, n)).
-func TestValidate_GraphRAGEventQueueSize_Bounds(t *testing.T) {
-	for _, bad := range []int{0, -1, 1_000_001} {
+// Aggregate engine configuration tests follow.
+
+func TestValidate_AggregateMode_Valid(t *testing.T) {
+	cases := []string{"legacy", "aggregate-shadow", "aggregate"}
+	for _, mode := range cases {
 		c := baseValid()
-		c.GraphRAGEventQueueSize = bad
-		if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "GRAPHRAG_EVENT_QUEUE_SIZE") {
-			t.Fatalf("size %d: expected GRAPHRAG_EVENT_QUEUE_SIZE error, got %v", bad, err)
+		c.AggregateMode = mode
+		if err := c.Validate(); err != nil {
+			t.Errorf("mode %q should be valid, got %v", mode, err)
 		}
 	}
+}
+
+func TestValidate_AggregateMode_Invalid(t *testing.T) {
 	c := baseValid()
-	c.GraphRAGEventQueueSize = 1_000_000
+	c.AggregateMode = "invalid-mode"
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "AGGREGATE_MODE") {
+		t.Fatalf("expected AGGREGATE_MODE error, got %v", err)
+	}
+}
+
+func TestValidate_AggregateMaxSeries_LowerBound(t *testing.T) {
+	c := baseValid()
+	c.AggregateMaxSeries = 0
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "AGGREGATE_MAX_SERIES") {
+		t.Fatalf("expected AGGREGATE_MAX_SERIES error, got %v", err)
+	}
+}
+
+func TestValidate_AggregateSeriesSubCaps_LowerBound(t *testing.T) {
+	caps := []struct {
+		name  string
+		field string
+	}{
+		{"AggregateMaxSeriesMetrics", "AGGREGATE_MAX_SERIES_METRICS"},
+		{"AggregateMaxSeriesTraces", "AGGREGATE_MAX_SERIES_TRACES"},
+		{"AggregateMaxSeriesEdges", "AGGREGATE_MAX_SERIES_EDGES"},
+		{"AggregateMaxSeriesLogs", "AGGREGATE_MAX_SERIES_LOGS"},
+		{"AggregateMaxSeriesSystem", "AGGREGATE_MAX_SERIES_SYSTEM"},
+	}
+	for _, tc := range caps {
+		c := baseValid()
+		switch tc.name {
+		case "AggregateMaxSeriesMetrics":
+			c.AggregateMaxSeriesMetrics = 0
+		case "AggregateMaxSeriesTraces":
+			c.AggregateMaxSeriesTraces = 0
+		case "AggregateMaxSeriesEdges":
+			c.AggregateMaxSeriesEdges = 0
+		case "AggregateMaxSeriesLogs":
+			c.AggregateMaxSeriesLogs = 0
+		case "AggregateMaxSeriesSystem":
+			c.AggregateMaxSeriesSystem = 0
+		}
+		if err := c.Validate(); err == nil || !strings.Contains(err.Error(), tc.field) {
+			t.Errorf("field %s = 0 should fail validation, got %v", tc.name, err)
+		}
+	}
+}
+
+func TestValidate_AggregatePerServiceCaps_LowerBound(t *testing.T) {
+	caps := []struct {
+		name  string
+		field string
+	}{
+		{"AggregateMaxOperationsPerService", "AGGREGATE_MAX_OPERATIONS_PER_SERVICE"},
+		{"AggregateMaxTraceSeriesPerService", "AGGREGATE_MAX_TRACE_SERIES_PER_SERVICE"},
+		{"AggregateMaxLogTemplatesPerService", "AGGREGATE_MAX_LOG_TEMPLATES_PER_SERVICE"},
+		{"AggregateMaxMetricSeriesPerService", "AGGREGATE_MAX_METRIC_SERIES_PER_SERVICE"},
+	}
+	for _, tc := range caps {
+		c := baseValid()
+		switch tc.name {
+		case "AggregateMaxOperationsPerService":
+			c.AggregateMaxOperationsPerService = 0
+		case "AggregateMaxTraceSeriesPerService":
+			c.AggregateMaxTraceSeriesPerService = 0
+		case "AggregateMaxLogTemplatesPerService":
+			c.AggregateMaxLogTemplatesPerService = 0
+		case "AggregateMaxMetricSeriesPerService":
+			c.AggregateMaxMetricSeriesPerService = 0
+		}
+		if err := c.Validate(); err == nil || !strings.Contains(err.Error(), tc.field) {
+			t.Errorf("field %s = 0 should fail validation, got %v", tc.name, err)
+		}
+	}
+}
+
+func TestValidate_AggregateTenantFraction_OutOfRange(t *testing.T) {
+	cases := []struct {
+		val     float64
+		wantErr bool
+	}{
+		{-0.1, true},
+		{0.0, false},
+		{0.5, false},
+		{1.0, false},
+		{1.1, true},
+	}
+	for _, tc := range cases {
+		c := baseValid()
+		c.AggregateSeriesPerTenantFraction = tc.val
+		err := c.Validate()
+		if tc.wantErr && err == nil {
+			t.Errorf("fraction %.1f should fail, got nil", tc.val)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("fraction %.1f should pass, got %v", tc.val, err)
+		}
+	}
+}
+
+func TestValidate_AggregateProducerBaselinesPerSeries_LowerBound(t *testing.T) {
+	c := baseValid()
+	c.AggregateMaxProducerBaselinesPerSeries = 0
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "AGGREGATE_MAX_PRODUCER_BASELINES_PER_SERIES") {
+		t.Fatalf("expected error, got %v", err)
+	}
+}
+
+func TestValidate_AggregateMaxBaselines_OverrideValidation(t *testing.T) {
+	c := baseValid()
+	c.AggregateMaxProducerBaselinesPerSeries = 8
+	c.AggregateMaxBaselines = 7 // less than per-series cap
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "AGGREGATE_MAX_BASELINES") {
+		t.Fatalf("expected override validation error, got %v", err)
+	}
+	// Valid override case: >= per-series cap
+	c.AggregateMaxBaselines = 8
 	if err := c.Validate(); err != nil {
-		t.Fatalf("size 1000000 should validate: %v", err)
+		t.Errorf("override = 8 should be valid, got %v", err)
+	}
+}
+
+func TestValidate_AggregateSubCaps_SumExceedsGlobal(t *testing.T) {
+	c := baseValid()
+	c.AggregateMaxSeries = 1000
+	c.AggregateMaxSeriesMetrics = 2400
+	c.AggregateMaxSeriesTraces = 500
+	c.AggregateMaxSeriesEdges = 501
+	c.AggregateMaxSeriesLogs = 100
+	c.AggregateMaxSeriesSystem = 100
+	// Sum: 2400 + 500 + 501 + 100 + 100 = 3601 > 1000
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "AGGREGATE_MAX_SERIES") {
+		t.Fatalf("expected sum-exceeds error, got %v", err)
+	}
+}
+
+func TestLoad_AggregateDefaults(t *testing.T) {
+	// Unset all aggregate env vars to test defaults
+	vars := []string{
+		"AGGREGATE_MODE",
+		"AGGREGATE_MAX_SERIES",
+		"AGGREGATE_MAX_SERIES_METRICS",
+		"AGGREGATE_MAX_SERIES_TRACES",
+		"AGGREGATE_MAX_SERIES_EDGES",
+		"AGGREGATE_MAX_SERIES_LOGS",
+		"AGGREGATE_MAX_SERIES_SYSTEM",
+		"AGGREGATE_MAX_OPERATIONS_PER_SERVICE",
+		"AGGREGATE_MAX_TRACE_SERIES_PER_SERVICE",
+		"AGGREGATE_MAX_LOG_TEMPLATES_PER_SERVICE",
+		"AGGREGATE_MAX_METRIC_SERIES_PER_SERVICE",
+		"AGGREGATE_SERIES_PER_TENANT_FRACTION",
+		"AGGREGATE_MAX_PRODUCER_BASELINES_PER_SERIES",
+		"AGGREGATE_MAX_BASELINES",
+	}
+	for _, v := range vars {
+		if err := os.Unsetenv(v); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg, err := Load("__no_such_env_file__")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.AggregateMode != "legacy" {
+		t.Errorf("AggregateMode default = %q, want legacy", cfg.AggregateMode)
+	}
+	if cfg.AggregateMaxSeries != 6000 {
+		t.Errorf("AggregateMaxSeries default = %d, want 6000", cfg.AggregateMaxSeries)
+	}
+	if cfg.AggregateMaxSeriesMetrics != 2400 {
+		t.Errorf("AggregateMaxSeriesMetrics default = %d, want 2400", cfg.AggregateMaxSeriesMetrics)
+	}
+	if cfg.AggregateMaxSeriesTraces != 2400 {
+		t.Errorf("AggregateMaxSeriesTraces default = %d, want 2400", cfg.AggregateMaxSeriesTraces)
+	}
+	if cfg.AggregateMaxSeriesEdges != 500 {
+		t.Errorf("AggregateMaxSeriesEdges default = %d, want 500", cfg.AggregateMaxSeriesEdges)
+	}
+	if cfg.AggregateMaxSeriesLogs != 500 {
+		t.Errorf("AggregateMaxSeriesLogs default = %d, want 500", cfg.AggregateMaxSeriesLogs)
+	}
+	if cfg.AggregateMaxSeriesSystem != 200 {
+		t.Errorf("AggregateMaxSeriesSystem default = %d, want 200", cfg.AggregateMaxSeriesSystem)
+	}
+	if cfg.AggregateMaxOperationsPerService != 20 {
+		t.Errorf("AggregateMaxOperationsPerService default = %d, want 20", cfg.AggregateMaxOperationsPerService)
+	}
+	if cfg.AggregateMaxTraceSeriesPerService != 50 {
+		t.Errorf("AggregateMaxTraceSeriesPerService default = %d, want 50", cfg.AggregateMaxTraceSeriesPerService)
+	}
+	if cfg.AggregateMaxLogTemplatesPerService != 10 {
+		t.Errorf("AggregateMaxLogTemplatesPerService default = %d, want 10", cfg.AggregateMaxLogTemplatesPerService)
+	}
+	if cfg.AggregateMaxMetricSeriesPerService != 50 {
+		t.Errorf("AggregateMaxMetricSeriesPerService default = %d, want 50", cfg.AggregateMaxMetricSeriesPerService)
+	}
+	if cfg.AggregateSeriesPerTenantFraction != 0 {
+		t.Errorf("AggregateSeriesPerTenantFraction default = %v, want 0", cfg.AggregateSeriesPerTenantFraction)
+	}
+	if cfg.AggregateMaxProducerBaselinesPerSeries != 8 {
+		t.Errorf("AggregateMaxProducerBaselinesPerSeries default = %d, want 8", cfg.AggregateMaxProducerBaselinesPerSeries)
+	}
+	if cfg.AggregateMaxBaselines != 0 {
+		t.Errorf("AggregateMaxBaselines default = %d, want 0", cfg.AggregateMaxBaselines)
+	}
+}
+
+func TestLoad_AggregateEnvVars(t *testing.T) {
+	t.Setenv("AGGREGATE_MODE", "aggregate-shadow")
+	t.Setenv("AGGREGATE_MAX_SERIES", "5000")
+	t.Setenv("AGGREGATE_MAX_PRODUCER_BASELINES_PER_SERIES", "10")
+	t.Setenv("AGGREGATE_SERIES_PER_TENANT_FRACTION", "0.5")
+
+	cfg, err := Load("__no_such_env_file__")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.AggregateMode != "aggregate-shadow" {
+		t.Errorf("AggregateMode = %q, want aggregate-shadow", cfg.AggregateMode)
+	}
+	if cfg.AggregateMaxSeries != 5000 {
+		t.Errorf("AggregateMaxSeries = %d, want 5000", cfg.AggregateMaxSeries)
+	}
+	if cfg.AggregateMaxProducerBaselinesPerSeries != 10 {
+		t.Errorf("AggregateMaxProducerBaselinesPerSeries = %d, want 10", cfg.AggregateMaxProducerBaselinesPerSeries)
+	}
+	if cfg.AggregateSeriesPerTenantFraction != 0.5 {
+		t.Errorf("AggregateSeriesPerTenantFraction = %v, want 0.5", cfg.AggregateSeriesPerTenantFraction)
+	}
+}
+
+func TestResolvedAggregateMaxBaselines_Default(t *testing.T) {
+	c := baseValid()
+	c.AggregateMaxSeriesMetrics = 2400
+	c.AggregateMaxProducerBaselinesPerSeries = 8
+	c.AggregateMaxBaselines = 0 // use derived default
+
+	resolved := c.ResolvedAggregateMaxBaselines()
+	expected := 2400 * 8
+	if resolved != expected {
+		t.Errorf("resolved = %d, want %d (2400 × 8)", resolved, expected)
+	}
+}
+
+func TestResolvedAggregateMaxBaselines_Override(t *testing.T) {
+	c := baseValid()
+	c.AggregateMaxBaselines = 10000
+
+	resolved := c.ResolvedAggregateMaxBaselines()
+	if resolved != 10000 {
+		t.Errorf("resolved = %d, want 10000 (explicit override)", resolved)
 	}
 }


### PR DESCRIPTION
## Summary
Implements aggregate engine Phase 1 configuration surface per #172.

## Changes
- Add 14 aggregate config fields to Config struct
- Implement environment variable parsing in Load() with defaults from #158
- Add comprehensive validation to Validate() method with fail-closed semantics
- Add ResolvedAggregateMaxBaselines() method for backward-compatible derived value
- Comprehensive test coverage (13 new test functions, 14 all-passing)

## Refs
Refs #172