### PR TITLE
feat(aggregate): ingest-owned template miner with immutable IDs

### DIFF
--- a/internal/aggregate/template_miner.go
+++ b/internal/aggregate/template_miner.go
@@ -1,0 +1,890 @@
+package aggregate
+
+// TemplateMiner — the ingest-owned log template miner (issue #163).
+//
+// Drain-style fixed-depth prefix-tree clustering (He et al., 2017), rewritten
+// here with aggregate identity semantics. It is NOT the GraphRAG miner: legacy
+// mode keeps `internal/graphrag`'s Drain untouched, shadow and aggregate modes
+// use this one so two template ID spaces never exist.
+//
+// What differs from the GraphRAG implementation:
+//
+//   - Immutable surrogate IDs. GraphRAG rehashes Template.ID whenever tokens
+//     generalize; that is fine for best-effort clustering and unusable as
+//     seven-day bucket identity. Here an ID is minted once through a
+//     TemplateRegistrar (dictionary kind log_template) and never changes. The
+//     template TEXT evolves under a stable ID.
+//   - Partitioned by (tenant, service). Each partition owns an independent
+//     tree and its own mutex: no global write lock on the hot path and no
+//     cross-service template mutation.
+//   - Bounded per #158. At most MaxTemplatesPerService patterns per partition;
+//     past the cap, lines route to the partition's pre-created __other__
+//     template so totals survive while identity detail collapses.
+//   - Synchronous and bounded-latency. Mine() runs on the reducer hot path:
+//     no regexp, no channels, no background goroutines, token count capped.
+//
+// Pure stdlib. Never returns an error, never blocks on anything but its own
+// partition mutex.
+//
+// Note on ID values: the miner guarantees a deterministic per-partition
+// sequence of template registrations for a given input stream. The absolute
+// uint32 values come from the registrar (in Phase 2, a database sequence), so
+// they depend on that allocator's ordering, not on the miner.
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// TemplateWildcard is the placeholder token for a generalized position.
+	TemplateWildcard = "<*>"
+
+	// TemplateOther is the rendered text of a partition's overflow template.
+	TemplateOther = "__other__"
+
+	// DefaultMaxLogTemplatesPerService is the #158 per-service log-template
+	// cap, wired to AGGREGATE_MAX_LOG_TEMPLATES_PER_SERVICE.
+	DefaultMaxLogTemplatesPerService = 10
+
+	defaultTemplateDepth       = 4
+	defaultTemplateSimilarity  = 0.4
+	defaultTemplateMaxChildren = 100
+	defaultTemplateMaxTokens   = 128
+
+	tmMaskNum   = "<NUM>"
+	tmMaskUUID  = "<UUID>"
+	tmMaskIP    = "<IP>"
+	tmMaskHex   = "<HEX>"
+	tmMaskTS    = "<TS>"
+	tmMaskEmail = "<EMAIL>"
+	tmMaskTrunc = "<TRUNC>"
+
+	tmMaxAliasHops = 8
+)
+
+// --- registration contract ---
+
+// TemplateRegistration is the request handed to a TemplateRegistrar when the
+// miner mints a new template identity. It mirrors the dictionary registration
+// contract for kind=log_template (#159, amended by #163): the value written to
+// the dictionary is a surrogate identity whose presentation text may later
+// change without the ID changing.
+type TemplateRegistration struct {
+	Tenant   string
+	Service  string
+	Template string // rendered template text at registration time
+	IsOther  bool   // true for a partition's pre-created __other__ identity
+}
+
+// TemplateRegistrar allocates immutable surrogate template IDs. Phase 1 uses
+// an in-memory allocator; Phase 2 replaces it with the durable aggregate
+// dictionary, where registration commits atomically with the first referencing
+// delta.
+//
+// Implementations must be safe for concurrent use and bounded in latency: the
+// miner calls RegisterTemplate while holding a partition lock. A returned
+// error, or a zero ID, is treated as "no identity available" — the miner then
+// routes the line to the partition's overflow template and never fails.
+type TemplateRegistrar interface {
+	RegisterTemplate(TemplateRegistration) (uint32, error)
+}
+
+// TemplateRegistrarFunc adapts a plain function to TemplateRegistrar.
+type TemplateRegistrarFunc func(TemplateRegistration) (uint32, error)
+
+// RegisterTemplate implements TemplateRegistrar.
+func (f TemplateRegistrarFunc) RegisterTemplate(r TemplateRegistration) (uint32, error) {
+	return f(r)
+}
+
+// inMemoryTemplateRegistrar hands out sequential IDs starting at 1. ID 0 is
+// reserved for "no identity assigned".
+type inMemoryTemplateRegistrar struct{ next atomic.Uint32 }
+
+// NewInMemoryTemplateRegistrar returns the Phase 1 provisional allocator.
+// IDs are process-local and do not survive a restart.
+func NewInMemoryTemplateRegistrar() TemplateRegistrar { return &inMemoryTemplateRegistrar{} }
+
+func (r *inMemoryTemplateRegistrar) RegisterTemplate(TemplateRegistration) (uint32, error) {
+	return r.next.Add(1), nil
+}
+
+// --- facts ---
+
+// TemplateFact is the per-log-line record handed to GraphRAG. GraphRAG does no
+// mining of its own in shadow and aggregate modes; it consumes these.
+type TemplateFact struct {
+	Tenant     string
+	Service    string
+	Severity   string
+	TemplateID uint32
+	Template   string
+	Timestamp  time.Time
+	IsOther    bool
+}
+
+// --- configuration ---
+
+// TemplateMinerConfig configures a TemplateMiner. Zero values take defaults.
+type TemplateMinerConfig struct {
+	// MaxTemplatesPerService caps distinct mined templates per
+	// (tenant, service). The overflow template is reserved capacity and does
+	// not count against it. Default DefaultMaxLogTemplatesPerService.
+	MaxTemplatesPerService int
+
+	// Depth is the prefix-tree depth below the token-length layer.
+	// Default 4, minimum 1.
+	Depth int
+
+	// SimilarityThreshold is Drain's simSeq threshold in (0, 1]. Default 0.4.
+	SimilarityThreshold float64
+
+	// MaxChildren caps distinct children per tree node; overflow tokens route
+	// through the wildcard child. Default 100.
+	MaxChildren int
+
+	// MaxTokens bounds tokens taken from one log body, keeping Mine() latency
+	// independent of body size. Default 128.
+	MaxTokens int
+
+	// Registrar allocates template IDs. Default NewInMemoryTemplateRegistrar().
+	Registrar TemplateRegistrar
+
+	// OnFact, when set, is called synchronously for every mined line —
+	// including overflow lines — outside the partition lock. Keep it cheap.
+	OnFact func(TemplateFact)
+}
+
+// --- miner ---
+
+// TemplateMiner mines log templates, partitioned by (tenant, service).
+// The zero value is not usable; construct one with NewTemplateMiner.
+type TemplateMiner struct {
+	maxTemplates int
+	depth        int
+	similarity   float64
+	maxChildren  int
+	maxTokens    int
+
+	reg    TemplateRegistrar
+	onFact func(TemplateFact)
+
+	// mu guards the partition map only. It is taken for writing exactly once
+	// per new (tenant, service) pair; mining an existing partition takes it
+	// for reading.
+	mu    sync.RWMutex
+	parts map[tmPartKey]*tmPartition
+
+	// idxMu guards the presentation index. Lock order is always
+	// partition mutex -> idxMu, never the reverse.
+	idxMu sync.RWMutex
+	text  map[uint32]string
+	alias map[uint32]uint32
+}
+
+// NewTemplateMiner builds a miner from cfg, applying defaults.
+func NewTemplateMiner(cfg TemplateMinerConfig) *TemplateMiner {
+	m := &TemplateMiner{
+		maxTemplates: cfg.MaxTemplatesPerService,
+		depth:        cfg.Depth,
+		similarity:   cfg.SimilarityThreshold,
+		maxChildren:  cfg.MaxChildren,
+		maxTokens:    cfg.MaxTokens,
+		reg:          cfg.Registrar,
+		onFact:       cfg.OnFact,
+		parts:        make(map[tmPartKey]*tmPartition),
+		text:         make(map[uint32]string),
+		alias:        make(map[uint32]uint32),
+	}
+	if m.maxTemplates <= 0 {
+		m.maxTemplates = DefaultMaxLogTemplatesPerService
+	}
+	if m.depth <= 0 {
+		m.depth = defaultTemplateDepth
+	}
+	if m.similarity <= 0 || m.similarity > 1 {
+		m.similarity = defaultTemplateSimilarity
+	}
+	if m.maxChildren <= 0 {
+		m.maxChildren = defaultTemplateMaxChildren
+	}
+	if m.maxTokens <= 0 {
+		m.maxTokens = defaultTemplateMaxTokens
+	}
+	if m.reg == nil {
+		m.reg = NewInMemoryTemplateRegistrar()
+	}
+	return m
+}
+
+// Mine clusters one log body and returns its template ID. isOther is true when
+// the line was absorbed by the partition's overflow template — the caller must
+// still count it, only the identity detail is gone. Mine never fails; a
+// registrar that cannot allocate yields (0, true).
+func (m *TemplateMiner) Mine(tenant, service, severity, body string) (id uint32, isOther bool) {
+	return m.MineAt(tenant, service, severity, body, time.Now())
+}
+
+// MineAt is Mine with an explicit arrival time — the reducer captures one
+// timestamp per Export request and passes it for every point in that request.
+func (m *TemplateMiner) MineAt(tenant, service, severity, body string, at time.Time) (id uint32, isOther bool) {
+	p := m.partition(tenant, service)
+	tokens := tmSplitTokens(body, m.maxTokens)
+
+	wantText := m.onFact != nil
+	id, isOther, text := m.mine(p, tokens, body, at, wantText)
+
+	if m.onFact != nil {
+		m.onFact(TemplateFact{
+			Tenant:     tenant,
+			Service:    service,
+			Severity:   severity,
+			TemplateID: id,
+			Template:   text,
+			Timestamp:  at,
+			IsOther:    isOther,
+		})
+	}
+	return id, isOther
+}
+
+// TemplateText returns the current rendered text for a template ID, following
+// convergence aliases. IDs issued in the past always resolve: a retired ID
+// resolves to its survivor's text, never to nothing.
+func (m *TemplateMiner) TemplateText(id uint32) (string, bool) {
+	m.idxMu.RLock()
+	defer m.idxMu.RUnlock()
+	for i := 0; i < tmMaxAliasHops; i++ {
+		if t, ok := m.text[id]; ok {
+			return t, true
+		}
+		next, ok := m.alias[id]
+		if !ok || next == id {
+			break
+		}
+		id = next
+	}
+	return "", false
+}
+
+// TemplatePartitionStats is a point-in-time view of one (tenant, service)
+// partition.
+type TemplatePartitionStats struct {
+	Tenant            string
+	Service           string
+	Templates         int    // live mined templates (excludes __other__)
+	OtherID           uint32 // 0 when the overflow identity is not allocated
+	Overflow          uint64 // lines absorbed by __other__
+	Converged         uint64 // templates retired into a surviving twin
+	RegistrarFailures uint64
+}
+
+// Stats returns per-partition statistics, sorted by tenant then service.
+func (m *TemplateMiner) Stats() []TemplatePartitionStats {
+	m.mu.RLock()
+	parts := make([]*tmPartition, 0, len(m.parts))
+	for _, p := range m.parts {
+		parts = append(parts, p)
+	}
+	m.mu.RUnlock()
+
+	out := make([]TemplatePartitionStats, 0, len(parts))
+	for _, p := range parts {
+		out = append(out, p.stats())
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Tenant != out[j].Tenant {
+			return out[i].Tenant < out[j].Tenant
+		}
+		return out[i].Service < out[j].Service
+	})
+	return out
+}
+
+// PartitionStats returns statistics for one partition, if it exists.
+func (m *TemplateMiner) PartitionStats(tenant, service string) (TemplatePartitionStats, bool) {
+	m.mu.RLock()
+	p := m.parts[tmPartKey{tenant: tenant, service: service}]
+	m.mu.RUnlock()
+	if p == nil {
+		return TemplatePartitionStats{}, false
+	}
+	return p.stats(), true
+}
+
+// --- partitions ---
+
+type tmPartKey struct {
+	tenant  string
+	service string
+}
+
+type tmPartition struct {
+	tenant  string
+	service string
+
+	mu        sync.Mutex
+	byLen     map[int]*tmNode
+	templates map[uint32]*tmTemplate
+	nextSeq   uint64
+	otherID   uint32
+
+	overflow          uint64
+	converged         uint64
+	registrarFailures uint64
+}
+
+func (p *tmPartition) stats() TemplatePartitionStats {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return TemplatePartitionStats{
+		Tenant:            p.tenant,
+		Service:           p.service,
+		Templates:         len(p.templates),
+		OtherID:           p.otherID,
+		Overflow:          p.overflow,
+		Converged:         p.converged,
+		RegistrarFailures: p.registrarFailures,
+	}
+}
+
+func (m *TemplateMiner) partition(tenant, service string) *tmPartition {
+	k := tmPartKey{tenant: tenant, service: service}
+
+	m.mu.RLock()
+	p := m.parts[k]
+	m.mu.RUnlock()
+	if p != nil {
+		return p
+	}
+
+	m.mu.Lock()
+	if p = m.parts[k]; p == nil {
+		p = &tmPartition{
+			tenant:    tenant,
+			service:   service,
+			byLen:     make(map[int]*tmNode),
+			templates: make(map[uint32]*tmTemplate),
+		}
+		m.parts[k] = p
+	}
+	m.mu.Unlock()
+	return p
+}
+
+// --- templates and tree ---
+
+type tmTemplate struct {
+	id     uint32
+	seq    uint64 // partition-local creation ordinal; lower survives convergence
+	tokens []string
+
+	count     uint64
+	firstSeen time.Time
+	lastSeen  time.Time
+	sample    string
+
+	leaf *tmNode
+	// aliasOf, when set, makes this entry a forwarder: it stays in its leaf so
+	// matching keeps working, but every match resolves to the survivor.
+	aliasOf *tmTemplate
+}
+
+type tmNode struct {
+	children map[string]*tmNode
+	groups   []*tmTemplate
+}
+
+func newTmNode() *tmNode { return &tmNode{children: make(map[string]*tmNode)} }
+
+// descend walks the length layer and prefix tree, creating nodes as needed and
+// routing through the wildcard child once a node hits the child cap.
+func (p *tmPartition) descend(tokens []string, depth, maxChildren int) *tmNode {
+	n := len(tokens)
+	root, ok := p.byLen[n]
+	if !ok {
+		root = newTmNode()
+		p.byLen[n] = root
+	}
+
+	eff := depth
+	if eff > n {
+		eff = n
+	}
+
+	cur := root
+	for i := 0; i < eff; i++ {
+		tok := tokens[i]
+		if child, ok := cur.children[tok]; ok {
+			cur = child
+			continue
+		}
+		if tok == TemplateWildcard || len(cur.children) >= maxChildren {
+			cur = tmChild(cur, TemplateWildcard)
+			continue
+		}
+		cur = tmChild(cur, tok)
+	}
+	return cur
+}
+
+func tmChild(n *tmNode, key string) *tmNode {
+	if c, ok := n.children[key]; ok {
+		return c
+	}
+	c := newTmNode()
+	n.children[key] = c
+	return c
+}
+
+// mine does the whole clustering decision under the partition lock.
+func (m *TemplateMiner) mine(p *tmPartition, tokens []string, raw string, at time.Time, wantText bool) (uint32, bool, string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	m.ensureOtherLocked(p)
+
+	// An empty body has no pattern; it still counts, so it becomes overflow.
+	if len(tokens) == 0 {
+		p.overflow++
+		return p.otherID, true, TemplateOther
+	}
+
+	leaf := p.descend(tokens, m.depth, m.maxChildren)
+
+	if best, sim := tmBestMatch(leaf, tokens); best != nil && sim >= m.similarity {
+		best = tmResolveAlias(best)
+		// Lengths are equal by construction (the length layer plus the
+		// survivor keeping its twin's pattern); the bound is defensive.
+		changed := false
+		for i := 0; i < len(tokens) && i < len(best.tokens); i++ {
+			if best.tokens[i] == TemplateWildcard {
+				continue
+			}
+			if best.tokens[i] != tokens[i] {
+				best.tokens[i] = TemplateWildcard
+				changed = true
+			}
+		}
+		if changed {
+			// The ID does not move — only the text under it.
+			m.setText(best.id, tmJoin(best.tokens))
+			if twin := p.findTwinLocked(best); twin != nil {
+				best = m.convergeLocked(p, best, twin)
+			}
+		}
+		best.count++
+		best.lastSeen = at
+
+		if !wantText {
+			return best.id, false, ""
+		}
+		return best.id, false, tmJoin(best.tokens)
+	}
+
+	// New pattern.
+	if len(p.templates) >= m.maxTemplates {
+		p.overflow++
+		return p.otherID, true, TemplateOther
+	}
+
+	text := tmJoin(tokens)
+	id, err := m.reg.RegisterTemplate(TemplateRegistration{
+		Tenant:   p.tenant,
+		Service:  p.service,
+		Template: text,
+	})
+	if err != nil || id == 0 {
+		p.registrarFailures++
+		p.overflow++
+		return p.otherID, true, TemplateOther
+	}
+	if _, dup := p.templates[id]; dup || id == p.otherID {
+		// A registrar that reissues a live ID would silently merge unrelated
+		// series. Refuse the identity rather than corrupt it.
+		p.registrarFailures++
+		p.overflow++
+		return p.otherID, true, TemplateOther
+	}
+
+	t := &tmTemplate{
+		id:        id,
+		seq:       p.nextSeq,
+		tokens:    append([]string(nil), tokens...),
+		count:     1,
+		firstSeen: at,
+		lastSeen:  at,
+		sample:    raw,
+		leaf:      leaf,
+	}
+	p.nextSeq++
+	leaf.groups = append(leaf.groups, t)
+	p.templates[id] = t
+	m.setText(id, text)
+	return id, false, text
+}
+
+// ensureOtherLocked allocates the partition's overflow identity. It is
+// pre-created on first use and retried on later calls if the registrar was
+// unavailable.
+func (m *TemplateMiner) ensureOtherLocked(p *tmPartition) {
+	if p.otherID != 0 {
+		return
+	}
+	id, err := m.reg.RegisterTemplate(TemplateRegistration{
+		Tenant:   p.tenant,
+		Service:  p.service,
+		Template: TemplateOther,
+		IsOther:  true,
+	})
+	if err != nil || id == 0 {
+		p.registrarFailures++
+		return
+	}
+	p.otherID = id
+	m.setText(id, TemplateOther)
+}
+
+// tmBestMatch scores the leaf's templates by Drain's simSeq. Ties go to the
+// earlier entry in the slice, which is creation order — deterministic.
+func tmBestMatch(leaf *tmNode, tokens []string) (*tmTemplate, float64) {
+	var best *tmTemplate
+	bestSim := -1.0
+	for _, g := range leaf.groups {
+		if len(g.tokens) != len(tokens) {
+			continue
+		}
+		if sim := tmSimilarity(g.tokens, tokens); sim > bestSim {
+			bestSim = sim
+			best = g
+		}
+	}
+	return best, bestSim
+}
+
+// tmSimilarity is matching token positions over token count. Wildcards in the
+// template count as matches.
+func tmSimilarity(template, tokens []string) float64 {
+	if len(template) != len(tokens) || len(tokens) == 0 {
+		return 0
+	}
+	matches := 0
+	for i, t := range template {
+		if t == TemplateWildcard || t == tokens[i] {
+			matches++
+		}
+	}
+	return float64(matches) / float64(len(tokens))
+}
+
+func tmResolveAlias(t *tmTemplate) *tmTemplate {
+	for i := 0; i < tmMaxAliasHops && t.aliasOf != nil; i++ {
+		t = t.aliasOf
+	}
+	return t
+}
+
+// findTwinLocked looks for another live template with an identical pattern.
+// Bounded by the per-partition cap, so this is a handful of comparisons and
+// only runs when a template actually generalized.
+func (p *tmPartition) findTwinLocked(t *tmTemplate) *tmTemplate {
+	for _, other := range p.templates {
+		if other == t || other.aliasOf != nil {
+			continue
+		}
+		if tmTokensEqual(other.tokens, t.tokens) {
+			return other
+		}
+	}
+	return nil
+}
+
+// convergeLocked folds two identical patterns into one. The older template
+// (lower partition-local sequence) survives; the retired ID keeps resolving
+// through the alias index and its tree entry becomes a forwarder, so lines
+// that used to match it now return the survivor. No issued ID is ever
+// rewritten or reused.
+func (m *TemplateMiner) convergeLocked(p *tmPartition, a, b *tmTemplate) *tmTemplate {
+	survivor, retired := a, b
+	if b.seq < a.seq {
+		survivor, retired = b, a
+	}
+
+	survivor.count += retired.count
+	if !retired.firstSeen.IsZero() && retired.firstSeen.Before(survivor.firstSeen) {
+		survivor.firstSeen = retired.firstSeen
+	}
+	if retired.lastSeen.After(survivor.lastSeen) {
+		survivor.lastSeen = retired.lastSeen
+	}
+	retired.count = 0
+	retired.aliasOf = survivor
+
+	delete(p.templates, retired.id)
+	p.converged++
+
+	m.aliasID(retired.id, survivor.id)
+	return survivor
+}
+
+// --- presentation index ---
+
+func (m *TemplateMiner) setText(id uint32, text string) {
+	if id == 0 {
+		return
+	}
+	m.idxMu.Lock()
+	m.text[id] = text
+	m.idxMu.Unlock()
+}
+
+// aliasID points a retired ID at its survivor, keeping alias chains flat.
+func (m *TemplateMiner) aliasID(from, to uint32) {
+	if from == 0 || to == 0 || from == to {
+		return
+	}
+	m.idxMu.Lock()
+	delete(m.text, from)
+	m.alias[from] = to
+	for k, v := range m.alias {
+		if v == from {
+			m.alias[k] = to
+		}
+	}
+	m.idxMu.Unlock()
+}
+
+// --- tokenization and masking ---
+
+// tmSplitTokens splits a body on whitespace, masks variable-looking tokens,
+// and stops after max tokens so a pathological line cannot stretch Mine().
+func tmSplitTokens(body string, max int) []string {
+	if body == "" {
+		return nil
+	}
+	out := make([]string, 0, 16)
+	start := -1
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\v' || c == '\f' {
+			if start >= 0 {
+				out = append(out, tmMaskToken(body[start:i]))
+				start = -1
+				if len(out) >= max {
+					return append(out, tmMaskTrunc)
+				}
+			}
+			continue
+		}
+		if start < 0 {
+			start = i
+		}
+	}
+	if start >= 0 {
+		out = append(out, tmMaskToken(body[start:]))
+	}
+	return out
+}
+
+// tmMaskToken replaces a variable-looking token with a stable placeholder.
+// Hand-rolled rather than regexp-driven: this runs per token on the ingest hot
+// path, and the classification stays deterministic.
+func tmMaskToken(tok string) string {
+	switch {
+	case tmIsUUID(tok):
+		return tmMaskUUID
+	case tmIsHex(tok):
+		return tmMaskHex
+	case tmIsIPv4(tok):
+		return tmMaskIP
+	case tmIsTimestamp(tok):
+		return tmMaskTS
+	case tmIsEmail(tok):
+		return tmMaskEmail
+	case tmIsNumber(tok):
+		return tmMaskNum
+	}
+	if !tmHasDigit(tok) {
+		return tok
+	}
+	return tmMaskDigitRuns(tok)
+}
+
+func tmHasDigit(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= '0' && s[i] <= '9' {
+			return true
+		}
+	}
+	return false
+}
+
+func tmIsHexDigit(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
+func tmIsUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i := 0; i < 36; i++ {
+		switch i {
+		case 8, 13, 18, 23:
+			if s[i] != '-' {
+				return false
+			}
+		default:
+			if !tmIsHexDigit(s[i]) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// tmIsHex matches 0x-prefixed hex and long bare hex runs (>= 16 chars), which
+// in practice are IDs, hashes, and encoded keys.
+func tmIsHex(s string) bool {
+	if len(s) > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X') {
+		for i := 2; i < len(s); i++ {
+			if !tmIsHexDigit(s[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	if len(s) < 16 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if !tmIsHexDigit(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func tmIsIPv4(s string) bool {
+	if len(s) < 7 {
+		return false
+	}
+	if i := strings.IndexByte(s, ':'); i >= 0 {
+		if !tmIsDigits(s[i+1:]) {
+			return false
+		}
+		s = s[:i]
+	}
+	groups := 0
+	for {
+		i := strings.IndexByte(s, '.')
+		var part string
+		if i < 0 {
+			part = s
+		} else {
+			part = s[:i]
+		}
+		if len(part) == 0 || len(part) > 3 || !tmIsDigits(part) {
+			return false
+		}
+		groups++
+		if i < 0 {
+			break
+		}
+		s = s[i+1:]
+	}
+	return groups == 4
+}
+
+// tmIsTimestamp matches a leading ISO-8601 date, with or without a time part.
+func tmIsTimestamp(s string) bool {
+	if len(s) < 10 {
+		return false
+	}
+	if s[4] != '-' || s[7] != '-' {
+		return false
+	}
+	return tmIsDigits(s[0:4]) && tmIsDigits(s[5:7]) && tmIsDigits(s[8:10])
+}
+
+func tmIsEmail(s string) bool {
+	at := strings.IndexByte(s, '@')
+	if at <= 0 || at >= len(s)-3 {
+		return false
+	}
+	return strings.IndexByte(s[at+1:], '.') > 0
+}
+
+func tmIsDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// tmIsNumber matches a signed integer or decimal.
+func tmIsNumber(s string) bool {
+	if s == "" {
+		return false
+	}
+	if s[0] == '-' || s[0] == '+' {
+		s = s[1:]
+	}
+	dot := false
+	digits := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= '0' && c <= '9':
+			digits++
+		case c == '.' && !dot:
+			dot = true
+		default:
+			return false
+		}
+	}
+	return digits > 0
+}
+
+// tmMaskDigitRuns replaces every maximal digit run inside a token, which is
+// what turns "/api/users/42/orders" into "/api/users/<NUM>/orders".
+func tmMaskDigitRuns(tok string) string {
+	var b strings.Builder
+	b.Grow(len(tok))
+	for i := 0; i < len(tok); {
+		if tok[i] >= '0' && tok[i] <= '9' {
+			j := i
+			for j < len(tok) && tok[j] >= '0' && tok[j] <= '9' {
+				j++
+			}
+			b.WriteString(tmMaskNum)
+			i = j
+			continue
+		}
+		b.WriteByte(tok[i])
+		i++
+	}
+	return b.String()
+}
+
+func tmJoin(tokens []string) string { return strings.Join(tokens, " ") }
+
+func tmTokensEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/aggregate/template_miner_test.go
+++ b/internal/aggregate/template_miner_test.go
@@ -1,0 +1,658 @@
+package aggregate
+
+import (
+	"fmt"
+	"hash/fnv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// partitionScopedRegistrar allocates IDs from a per-(tenant, service) counter
+// so ID values do not depend on how partitions interleave. The miner's own
+// guarantee is a deterministic per-partition registration sequence; this
+// registrar turns that into comparable absolute IDs.
+type partitionScopedRegistrar struct {
+	mu    sync.Mutex
+	bases map[string]uint32
+	next  map[string]uint32
+}
+
+func newPartitionScopedRegistrar() *partitionScopedRegistrar {
+	return &partitionScopedRegistrar{
+		bases: make(map[string]uint32),
+		next:  make(map[string]uint32),
+	}
+}
+
+func (r *partitionScopedRegistrar) RegisterTemplate(reg TemplateRegistration) (uint32, error) {
+	key := reg.Tenant + "\x00" + reg.Service
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	base, ok := r.bases[key]
+	if !ok {
+		// Deterministic per-partition ID space, derived from the partition key
+		// so it does not depend on which partition registered first.
+		h := fnv.New32a()
+		_, _ = h.Write([]byte(key))
+		base = 1_000_000 + (h.Sum32()%1000)*1000
+		r.bases[key] = base
+	}
+	r.next[key]++
+	return base + r.next[key], nil
+}
+
+func testMiner(t *testing.T, cfg TemplateMinerConfig) *TemplateMiner {
+	t.Helper()
+	return NewTemplateMiner(cfg)
+}
+
+var testTime = time.Date(2026, 8, 21, 10, 0, 0, 0, time.UTC)
+
+// --- determinism ---
+
+func TestTemplateMinerDeterministicAcrossInterleavings(t *testing.T) {
+	type line struct{ service, body string }
+
+	svcA := []string{
+		"checkout order 1001 failed for shard alpha",
+		"checkout order 1002 failed for shard alpha",
+		"cart item 44 added by user 9001",
+		"payment gateway timeout after 250 ms",
+		"checkout order 1003 failed for shard bravo",
+		"cart item 45 added by user 9002",
+	}
+	svcB := []string{
+		"index rebuild started for tenant acme",
+		"index rebuild finished in 1200 ms",
+		"query 0xdeadbeefcafe returned 17 rows",
+		"index rebuild started for tenant globex",
+		"query 0xfeedface returned 3 rows",
+	}
+
+	sequential := make([]line, 0, len(svcA)+len(svcB))
+	for _, b := range svcA {
+		sequential = append(sequential, line{"checkout", b})
+	}
+	for _, b := range svcB {
+		sequential = append(sequential, line{"search", b})
+	}
+
+	interleaved := make([]line, 0, len(svcA)+len(svcB))
+	for i := 0; i < len(svcA) || i < len(svcB); i++ {
+		if i < len(svcB) {
+			interleaved = append(interleaved, line{"search", svcB[i]})
+		}
+		if i < len(svcA) {
+			interleaved = append(interleaved, line{"checkout", svcA[i]})
+		}
+	}
+
+	run := func(lines []line) (map[string]uint32, map[string]string) {
+		m := testMiner(t, TemplateMinerConfig{Registrar: newPartitionScopedRegistrar()})
+		ids := make(map[string]uint32)
+		texts := make(map[string]string)
+		for _, l := range lines {
+			id, isOther := m.MineAt("acme", l.service, "INFO", l.body, testTime)
+			if isOther {
+				t.Fatalf("unexpected overflow for %q", l.body)
+			}
+			ids[l.service+"|"+l.body] = id
+		}
+		for k, id := range ids {
+			txt, ok := m.TemplateText(id)
+			if !ok {
+				t.Fatalf("no text for id %d (%s)", id, k)
+			}
+			texts[k] = txt
+		}
+		return ids, texts
+	}
+
+	idsSeq, textSeq := run(sequential)
+	idsInt, textInt := run(interleaved)
+
+	if len(idsSeq) != len(idsInt) {
+		t.Fatalf("id map sizes differ: %d vs %d", len(idsSeq), len(idsInt))
+	}
+	for k, want := range idsSeq {
+		if got := idsInt[k]; got != want {
+			t.Errorf("%s: id %d != %d across interleavings", k, got, want)
+		}
+		if got, want := textInt[k], textSeq[k]; got != want {
+			t.Errorf("%s: text %q != %q across interleavings", k, got, want)
+		}
+	}
+}
+
+func TestTemplateMinerSameStreamSameIDs(t *testing.T) {
+	bodies := []string{
+		"GET /api/users/12345/orders took 34ms",
+		"GET /api/users/999/orders took 7ms",
+		"worker pool saturated queue depth 4096",
+		"worker pool saturated queue depth 8192",
+	}
+	first := make([]uint32, len(bodies))
+	m1 := testMiner(t, TemplateMinerConfig{Registrar: newPartitionScopedRegistrar()})
+	for i, b := range bodies {
+		first[i], _ = m1.MineAt("acme", "api", "INFO", b, testTime)
+	}
+	m2 := testMiner(t, TemplateMinerConfig{Registrar: newPartitionScopedRegistrar()})
+	for i, b := range bodies {
+		got, _ := m2.MineAt("acme", "api", "INFO", b, testTime)
+		if got != first[i] {
+			t.Errorf("body %q: id %d on rerun, want %d", b, got, first[i])
+		}
+	}
+}
+
+// --- immutability ---
+
+func TestTemplateIDStableWhileTextGeneralizes(t *testing.T) {
+	m := testMiner(t, TemplateMinerConfig{})
+
+	id1, isOther := m.MineAt("acme", "checkout", "ERROR", "checkout order failed for shard alpha", testTime)
+	if isOther {
+		t.Fatal("first line overflowed")
+	}
+	txt1, _ := m.TemplateText(id1)
+	if txt1 != "checkout order failed for shard alpha" {
+		t.Fatalf("initial text = %q", txt1)
+	}
+
+	id2, _ := m.MineAt("acme", "checkout", "ERROR", "checkout order failed for shard bravo", testTime)
+	if id2 != id1 {
+		t.Fatalf("id changed on generalization: %d -> %d", id1, id2)
+	}
+	txt2, _ := m.TemplateText(id1)
+	if txt2 != "checkout order failed for shard "+TemplateWildcard {
+		t.Fatalf("generalized text = %q", txt2)
+	}
+
+	// Further generalization still keeps the identity.
+	id3, _ := m.MineAt("acme", "checkout", "ERROR", "checkout order failed for zone bravo", testTime)
+	if id3 != id1 {
+		t.Fatalf("id changed on second generalization: %d -> %d", id1, id3)
+	}
+	txt3, _ := m.TemplateText(id1)
+	if txt3 == txt2 {
+		t.Fatalf("text did not evolve: %q", txt3)
+	}
+	if !strings.Contains(txt3, TemplateWildcard) {
+		t.Fatalf("expected wildcards in %q", txt3)
+	}
+
+	st, ok := m.PartitionStats("acme", "checkout")
+	if !ok || st.Templates != 1 {
+		t.Fatalf("stats = %+v, ok=%v", st, ok)
+	}
+}
+
+func TestTemplateConvergenceKeepsSurvivorID(t *testing.T) {
+	// Convergence is not reachable through best-match dynamics: a template
+	// that dominates another always wins the match, so a merge can never
+	// produce a pattern that already exists in the same leaf. The path exists
+	// because durable identity must survive it if it ever does happen (a
+	// different depth, threshold, or masking table changes the reachability
+	// argument), so it is exercised directly.
+	m := testMiner(t, TemplateMinerConfig{})
+
+	older, _ := m.MineAt("acme", "search", "INFO", "index rebuild started alpha", testTime)
+	newer, _ := m.MineAt("acme", "search", "INFO", "query planner rejected beta", testTime)
+	if older == newer {
+		t.Fatal("expected two distinct templates")
+	}
+
+	p := m.partition("acme", "search")
+	p.mu.Lock()
+	a, b := p.templates[older], p.templates[newer]
+	if a == nil || b == nil {
+		p.mu.Unlock()
+		t.Fatalf("templates missing: %v %v", a, b)
+	}
+	// Force the identical pattern, then converge from the newer side. Both
+	// sides render the same text, which is what an actual convergence means.
+	a.tokens = append([]string(nil), b.tokens...)
+	survivor := m.convergeLocked(p, b, a)
+	p.mu.Unlock()
+
+	if survivor.id != older {
+		t.Fatalf("survivor = %d, want the older id %d", survivor.id, older)
+	}
+
+	// The retired ID stays valid and resolves to the survivor's text.
+	wantText, _ := m.TemplateText(older)
+	gotText, ok := m.TemplateText(newer)
+	if !ok || gotText != wantText {
+		t.Fatalf("retired id text = %q (ok=%v), want %q", gotText, ok, wantText)
+	}
+
+	// Lines that used to match the retired template now return the survivor.
+	got, isOther := m.MineAt("acme", "search", "INFO", "query planner rejected beta", testTime)
+	if isOther {
+		t.Fatal("post-convergence line overflowed")
+	}
+	if got != older {
+		t.Fatalf("post-convergence id = %d, want survivor %d", got, older)
+	}
+
+	st, _ := m.PartitionStats("acme", "search")
+	if st.Converged != 1 {
+		t.Fatalf("converged = %d, want 1", st.Converged)
+	}
+	if st.Templates != 1 {
+		t.Fatalf("templates = %d, want 1", st.Templates)
+	}
+}
+
+func TestTemplateIDsNeverRemapped(t *testing.T) {
+	m := testMiner(t, TemplateMinerConfig{MaxTemplatesPerService: 4})
+	seen := make(map[uint32]string)
+
+	bodies := []string{
+		"alpha task 1 done in 5ms",
+		"alpha task 2 done in 9ms",
+		"bravo cache miss for key abc",
+		"bravo cache miss for key xyz",
+		"charlie flush wrote 12 pages",
+		"delta connection reset by peer",
+		"echo shard 3 rebalanced",
+		"foxtrot lease expired for node 7",
+	}
+	for _, b := range bodies {
+		id, isOther := m.MineAt("acme", "svc", "INFO", b, testTime)
+		if isOther {
+			continue
+		}
+		if prev, ok := seen[id]; ok && prev != b {
+			// Same ID for a different body is fine (that is clustering); the
+			// invariant under test is the reverse direction below.
+			_ = prev
+		}
+		seen[id] = b
+	}
+
+	// Every ID ever issued must still resolve.
+	for id := range seen {
+		if _, ok := m.TemplateText(id); !ok {
+			t.Errorf("issued id %d no longer resolves", id)
+		}
+	}
+
+	// Re-mining a body must return the same ID it first got.
+	firstIDs := make(map[string]uint32)
+	for _, b := range bodies {
+		id, _ := m.MineAt("acme", "svc", "INFO", b, testTime)
+		firstIDs[b] = id
+	}
+	for _, b := range bodies {
+		id, _ := m.MineAt("acme", "svc", "INFO", b, testTime)
+		if id != firstIDs[b] {
+			t.Errorf("body %q remapped from %d to %d", b, firstIDs[b], id)
+		}
+	}
+}
+
+// --- partition isolation ---
+
+func TestTemplatePartitionIsolation(t *testing.T) {
+	m := testMiner(t, TemplateMinerConfig{})
+	body := "connection pool exhausted for shard alpha"
+
+	idA, _ := m.MineAt("acme", "checkout", "WARN", body, testTime)
+	idB, _ := m.MineAt("acme", "search", "WARN", body, testTime)
+	idT, _ := m.MineAt("globex", "checkout", "WARN", body, testTime)
+
+	if idA == idB || idA == idT || idB == idT {
+		t.Fatalf("partitions share identity: %d %d %d", idA, idB, idT)
+	}
+	for _, id := range []uint32{idA, idB, idT} {
+		txt, ok := m.TemplateText(id)
+		if !ok || txt != body {
+			t.Fatalf("id %d text = %q ok=%v", id, txt, ok)
+		}
+	}
+
+	// Generalizing one partition must not touch the others.
+	m.MineAt("acme", "checkout", "WARN", "connection pool exhausted for shard bravo", testTime)
+	if txt, _ := m.TemplateText(idA); !strings.Contains(txt, TemplateWildcard) {
+		t.Fatalf("checkout template did not generalize: %q", txt)
+	}
+	if txt, _ := m.TemplateText(idB); txt != body {
+		t.Fatalf("search template mutated: %q", txt)
+	}
+	if txt, _ := m.TemplateText(idT); txt != body {
+		t.Fatalf("globex template mutated: %q", txt)
+	}
+
+	stats := m.Stats()
+	if len(stats) != 3 {
+		t.Fatalf("stats len = %d, want 3", len(stats))
+	}
+	if stats[0].Tenant != "acme" || stats[0].Service != "checkout" {
+		t.Fatalf("stats not sorted: %+v", stats)
+	}
+	if stats[2].Tenant != "globex" {
+		t.Fatalf("stats not sorted: %+v", stats)
+	}
+}
+
+func TestTemplateMinerConcurrentMine(t *testing.T) {
+	m := testMiner(t, TemplateMinerConfig{
+		MaxTemplatesPerService: 6,
+		OnFact:                 func(TemplateFact) {},
+	})
+
+	const goroutines = 16
+	const perGoroutine = 200
+	services := []string{"checkout", "search", "cart", "payments"}
+	tenants := []string{"acme", "globex"}
+
+	var wg sync.WaitGroup
+	var overflow atomic.Uint64
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(g int) {
+			defer wg.Done()
+			svc := services[g%len(services)]
+			ten := tenants[g%len(tenants)]
+			for i := 0; i < perGoroutine; i++ {
+				body := fmt.Sprintf("worker %d handled request %d in %d ms path /api/v1/items/%d", g, i, i%97, i)
+				if _, isOther := m.MineAt(ten, svc, "INFO", body, testTime); isOther {
+					overflow.Add(1)
+				}
+				m.TemplateText(uint32(i%32) + 1)
+				m.Stats()
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	total := uint64(0)
+	for _, st := range m.Stats() {
+		if st.Templates > 6 {
+			t.Errorf("%s/%s: %d templates over cap", st.Tenant, st.Service, st.Templates)
+		}
+		total += st.Overflow
+	}
+	if total != overflow.Load() {
+		t.Errorf("overflow accounting: stats %d, callers %d", total, overflow.Load())
+	}
+}
+
+// --- cap behavior ---
+
+func TestTemplateCapRoutesToOther(t *testing.T) {
+	m := testMiner(t, TemplateMinerConfig{MaxTemplatesPerService: 10})
+
+	words := []string{
+		"alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+		"india", "juliet", "kilo", "lima", "mike", "november", "oscar",
+	}
+	ids := make([]uint32, 0, 10)
+	for i := 0; i < 10; i++ {
+		body := fmt.Sprintf("%s shard rotated cleanly", words[i])
+		id, isOther := m.MineAt("acme", "svc", "INFO", body, testTime)
+		if isOther {
+			t.Fatalf("pattern %d overflowed early", i)
+		}
+		ids = append(ids, id)
+	}
+
+	st, _ := m.PartitionStats("acme", "svc")
+	if st.Templates != 10 {
+		t.Fatalf("templates = %d, want 10", st.Templates)
+	}
+	otherID := st.OtherID
+	if otherID == 0 {
+		t.Fatal("overflow template was not pre-created")
+	}
+	for _, id := range ids {
+		if id == otherID {
+			t.Fatalf("mined id %d collides with __other__", id)
+		}
+	}
+	if txt, ok := m.TemplateText(otherID); !ok || txt != TemplateOther {
+		t.Fatalf("__other__ text = %q ok=%v", txt, ok)
+	}
+
+	// Templates 11..15 collapse into __other__, totals preserved via isOther.
+	for i := 10; i < 15; i++ {
+		body := fmt.Sprintf("%s shard rotated cleanly", words[i])
+		id, isOther := m.MineAt("acme", "svc", "INFO", body, testTime)
+		if !isOther {
+			t.Fatalf("pattern %d was admitted past the cap", i)
+		}
+		if id != otherID {
+			t.Fatalf("pattern %d: id %d, want __other__ %d", i, id, otherID)
+		}
+	}
+
+	st, _ = m.PartitionStats("acme", "svc")
+	if st.Templates != 10 {
+		t.Fatalf("templates = %d after overflow, want 10", st.Templates)
+	}
+	if st.Overflow != 5 {
+		t.Fatalf("overflow = %d, want 5", st.Overflow)
+	}
+
+	// Admitted templates keep working after the cap is hit.
+	id, isOther := m.MineAt("acme", "svc", "INFO", words[3]+" shard rotated cleanly", testTime)
+	if isOther || id != ids[3] {
+		t.Fatalf("admitted template regressed: id=%d isOther=%v want %d", id, isOther, ids[3])
+	}
+
+	// A different service has its own budget.
+	if _, isOther := m.MineAt("acme", "other-svc", "INFO", words[14]+" shard rotated cleanly", testTime); isOther {
+		t.Fatal("cap leaked across partitions")
+	}
+}
+
+func TestTemplateEmptyBodyIsOverflow(t *testing.T) {
+	m := testMiner(t, TemplateMinerConfig{})
+	id, isOther := m.MineAt("acme", "svc", "INFO", "   ", testTime)
+	if !isOther {
+		t.Fatal("blank body should be overflow")
+	}
+	st, _ := m.PartitionStats("acme", "svc")
+	if id != st.OtherID || st.Overflow != 1 {
+		t.Fatalf("id=%d stats=%+v", id, st)
+	}
+}
+
+func TestTemplateRegistrarFailureDegrades(t *testing.T) {
+	var fail atomic.Bool
+	fail.Store(true)
+	var seq atomic.Uint32
+	m := testMiner(t, TemplateMinerConfig{
+		Registrar: TemplateRegistrarFunc(func(TemplateRegistration) (uint32, error) {
+			if fail.Load() {
+				return 0, fmt.Errorf("dictionary unavailable")
+			}
+			return seq.Add(1), nil
+		}),
+	})
+
+	id, isOther := m.MineAt("acme", "svc", "INFO", "shard alpha went offline", testTime)
+	if !isOther || id != 0 {
+		t.Fatalf("expected (0, true) while the registrar is down, got (%d, %v)", id, isOther)
+	}
+	st, _ := m.PartitionStats("acme", "svc")
+	if st.RegistrarFailures == 0 || st.Overflow != 1 {
+		t.Fatalf("stats = %+v", st)
+	}
+
+	// Recovery: the overflow identity is retried on the next call.
+	fail.Store(false)
+	id, isOther = m.MineAt("acme", "svc", "INFO", "shard alpha went offline", testTime)
+	if isOther || id == 0 {
+		t.Fatalf("expected a real identity after recovery, got (%d, %v)", id, isOther)
+	}
+	st, _ = m.PartitionStats("acme", "svc")
+	if st.OtherID == 0 {
+		t.Fatal("overflow identity not allocated after recovery")
+	}
+}
+
+func TestTemplateRegistrarDuplicateIDRefused(t *testing.T) {
+	m := testMiner(t, TemplateMinerConfig{
+		Registrar: TemplateRegistrarFunc(func(r TemplateRegistration) (uint32, error) {
+			if r.IsOther {
+				return 1, nil
+			}
+			return 2, nil // always the same live ID
+		}),
+	})
+	if _, isOther := m.MineAt("acme", "svc", "INFO", "alpha bravo charlie delta echo", testTime); isOther {
+		t.Fatal("first template should be admitted")
+	}
+	id, isOther := m.MineAt("acme", "svc", "INFO", "zulu yankee xray whiskey victor", testTime)
+	if !isOther || id != 1 {
+		t.Fatalf("duplicate id should degrade to __other__, got (%d, %v)", id, isOther)
+	}
+	st, _ := m.PartitionStats("acme", "svc")
+	if st.RegistrarFailures != 1 {
+		t.Fatalf("registrar failures = %d, want 1", st.RegistrarFailures)
+	}
+}
+
+// --- facts ---
+
+func TestTemplateFactHook(t *testing.T) {
+	var facts []TemplateFact
+	var mu sync.Mutex
+	m := testMiner(t, TemplateMinerConfig{
+		MaxTemplatesPerService: 1,
+		OnFact: func(f TemplateFact) {
+			mu.Lock()
+			facts = append(facts, f)
+			mu.Unlock()
+		},
+	})
+
+	id, _ := m.MineAt("acme", "checkout", "ERROR", "order 42 rejected by risk engine", testTime)
+	m.MineAt("acme", "checkout", "WARN", "totally different shape here now", testTime)
+
+	if len(facts) != 2 {
+		t.Fatalf("facts = %d, want 2", len(facts))
+	}
+	f := facts[0]
+	if f.Tenant != "acme" || f.Service != "checkout" || f.Severity != "ERROR" {
+		t.Fatalf("fact identity = %+v", f)
+	}
+	if f.TemplateID != id || f.IsOther {
+		t.Fatalf("fact id = %d isOther=%v, want %d false", f.TemplateID, f.IsOther, id)
+	}
+	if f.Template != "order "+tmMaskNum+" rejected by risk engine" {
+		t.Fatalf("fact template = %q", f.Template)
+	}
+	if !f.Timestamp.Equal(testTime) {
+		t.Fatalf("fact timestamp = %v", f.Timestamp)
+	}
+	if !facts[1].IsOther || facts[1].Template != TemplateOther {
+		t.Fatalf("overflow fact = %+v", facts[1])
+	}
+}
+
+// --- masking ---
+
+func TestTemplateMasking(t *testing.T) {
+	cases := []struct {
+		body string
+		want string
+	}{
+		{"user 12345 logged in", "user " + tmMaskNum + " logged in"},
+		{"latency -1.5 ms", "latency " + tmMaskNum + " ms"},
+		{"GET /api/users/42/orders", "GET /api/users/" + tmMaskNum + "/orders"},
+		{"took 34ms", "took " + tmMaskNum + "ms"},
+		{"peer 10.0.0.7:5432 closed", "peer " + tmMaskIP + " closed"},
+		{"trace 3f2504e0-4f89-11d3-9a0c-0305e82c3301 ended", "trace " + tmMaskUUID + " ended"},
+		{"span 0xdeadbeef parent cafebabedeadbeef99", "span " + tmMaskHex + " parent " + tmMaskHex},
+		{"at 2026-08-21T10:00:00Z boom", "at " + tmMaskTS + " boom"},
+		{"mail ops@example.com bounced", "mail " + tmMaskEmail + " bounced"},
+		{"  padded   spacing  ", "padded spacing"},
+		{"no variables here", "no variables here"},
+	}
+	for _, c := range cases {
+		got := tmJoin(tmSplitTokens(c.body, defaultTemplateMaxTokens))
+		if got != c.want {
+			t.Errorf("mask(%q) = %q, want %q", c.body, got, c.want)
+		}
+	}
+}
+
+func TestTemplateTokenCapBoundsWork(t *testing.T) {
+	body := strings.Repeat("tok ", 5000)
+	tokens := tmSplitTokens(body, defaultTemplateMaxTokens)
+	if len(tokens) != defaultTemplateMaxTokens+1 {
+		t.Fatalf("tokens = %d, want %d", len(tokens), defaultTemplateMaxTokens+1)
+	}
+	if tokens[len(tokens)-1] != tmMaskTrunc {
+		t.Fatalf("last token = %q", tokens[len(tokens)-1])
+	}
+
+	m := testMiner(t, TemplateMinerConfig{})
+	if _, isOther := m.MineAt("acme", "svc", "INFO", body, testTime); isOther {
+		t.Fatal("truncated line should still get an identity")
+	}
+}
+
+func TestTemplateUnknownIDDoesNotResolve(t *testing.T) {
+	m := testMiner(t, TemplateMinerConfig{})
+	if _, ok := m.TemplateText(4242); ok {
+		t.Fatal("unknown id resolved")
+	}
+}
+
+// --- benchmarks ---
+
+var benchBodies = []string{
+	"GET /api/v1/orders/847362/items returned 200 in 34ms",
+	"checkout order 847362 failed for shard alpha: downstream timeout",
+	"connection to 10.4.12.9:5432 reset by peer after 1200 ms",
+	"trace 3f2504e0-4f89-11d3-9a0c-0305e82c3301 span 0xdeadbeefcafe0001 ended",
+	"cache miss for key user:847362:profile, refilling from postgres",
+	"worker pool saturated: queue depth 4096, dropping healthy batch",
+}
+
+func BenchmarkTemplateMinerMine(b *testing.B) {
+	m := NewTemplateMiner(TemplateMinerConfig{MaxTemplatesPerService: 10})
+	for _, body := range benchBodies {
+		m.MineAt("acme", "checkout", "INFO", body, testTime)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.MineAt("acme", "checkout", "INFO", benchBodies[i%len(benchBodies)], testTime)
+	}
+}
+
+func BenchmarkTemplateMinerMineParallel(b *testing.B) {
+	m := NewTemplateMiner(TemplateMinerConfig{MaxTemplatesPerService: 10})
+	services := []string{"checkout", "search", "cart", "payments", "shipping", "auth"}
+	for _, svc := range services {
+		for _, body := range benchBodies {
+			m.MineAt("acme", svc, "INFO", body, testTime)
+		}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	var n atomic.Uint64
+	b.RunParallel(func(pb *testing.PB) {
+		i := int(n.Add(1))
+		svc := services[i%len(services)]
+		for pb.Next() {
+			i++
+			m.MineAt("acme", svc, "INFO", benchBodies[i%len(benchBodies)], testTime)
+		}
+	})
+}
+
+func BenchmarkTemplateMinerTokenize(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		tmSplitTokens(benchBodies[i%len(benchBodies)], defaultTemplateMaxTokens)
+	}
+}


### PR DESCRIPTION
Part of #172 (Phase 1 aggregate engine core). Implements the ingest-owned
`TemplateMiner` decided in #163's resolution, as new files in a new
`internal/aggregate` package. Sibling PRs add the other Phase 1 components to
the same package; this one touches only `template_miner.go` and its tests.

## What lands

`internal/aggregate/template_miner.go` — Drain-style fixed-depth prefix-tree
template mining, fresh implementation, stdlib only. `internal/graphrag/drain.go`
is untouched: legacy mode keeps its miner, shadow/aggregate use this one so two
template ID spaces never exist.

Identity semantics that differ from the GraphRAG miner:

- **Immutable surrogate IDs.** `Mine(tenant, service, severity, body) (id uint32, isOther bool)`.
  An ID is minted once through a `TemplateRegistrar` (dictionary kind
  `log_template`, per #159 as amended by #163) and never changes. Token
  generalization evolves the template *text* under the same ID. Phase 1 ships
  an in-memory sequential allocator; the interface boundary is what Phase 2
  makes durable (registration atomic with the first referencing delta).
- **Convergence keeps a survivor.** If two templates end up with the same
  pattern, the older (lower partition-local sequence) survives; the retired
  template stays in its tree as a forwarder so future matches return the
  survivor, and the retired ID keeps resolving through an alias index. No
  issued ID is ever rewritten or reused.
- **Partitioned by (tenant, service).** Independent trees, one mutex each. The
  partition map's write lock is taken once per new pair; mining an existing
  partition never takes a global write lock and never mutates another service's
  templates.
- **Bounded per #158.** `MaxTemplatesPerService` (default 10 =
  `AGGREGATE_MAX_LOG_TEMPLATES_PER_SERVICE`). Past the cap, lines route to the
  partition's pre-created `__other__` identity with `isOther=true` — totals
  survive, identity detail collapses, overflow is counted per partition. The
  overflow template is reserved capacity and does not consume the cap.
- **Hot-path shaped.** No regexp (hand-rolled deterministic token masking for
  NUM/UUID/IP/HEX/TS/EMAIL and embedded digit runs), token count capped so a
  pathological body cannot stretch `Mine()`, no goroutines, no channels, never
  returns an error. A registrar outage degrades to overflow and retries.

Also exposed: `TemplateText(id)` for presentation, `Stats()` /
`PartitionStats()` (template count, overflow, converged, registrar failures),
and an optional `OnFact` callback emitting
`{tenant, service, severity, template_id, template, timestamp, is_other}`
for GraphRAG — a plain synchronous callback, no channel machinery.

## Verification

```
go vet ./internal/aggregate/          # clean
golangci-lint run ./internal/aggregate/...   # clean
go test ./internal/aggregate/ -count=1 -race # 15 tests, all pass
```

Benchmarks (AMD EPYC 9354P, `-benchtime 200000x`):

| Benchmark | ns/op | B/op | allocs/op |
|---|---|---|---|
| `TemplateMinerMine` | 551.7 | 268 | 1 |
| `TemplateMinerMineParallel` (6 partitions) | 249.0 | 268 | 1 |
| `TemplateMinerTokenize` | 438.9 | 268 | 1 |

Tokenization dominates; the tree walk and match are the cheap part.

## Notes for review

- **Convergence is not reachable through best-match dynamics.** A template
  that dominates another (same literals, more wildcards) always scores at least
  as high, so a merge can never produce a pattern that already exists in the
  same leaf. The path is kept because durable identity has to survive it if a
  future depth/threshold/masking change makes it reachable, and it is tested
  directly rather than through a contrived stream. Called out here so nobody
  reads the test as white-box for its own sake.
- `TemplateFact` carries `Tenant` in addition to the field set named in #163;
  a fact without it is ambiguous across tenants.
- `MineAt(..., at time.Time)` is provided alongside `Mine` so the reducer can
  pass the single per-Export arrival time instead of taking `time.Now()` per
  point.
- Unexported identifiers are `tm`-prefixed to stay out of the way of the
  sibling Phase 1 files landing in this package (route normalization also wants
  `isUUID`-shaped helpers).
- Not wired into ingest, no config plumbing, no `doc.go` — those belong to the
  sibling changes.
