### PR TITLE
feat(aggregate): scale-4 latency sketch with varint codec

### DIFF
--- a/internal/aggregate/sketch.go
+++ b/internal/aggregate/sketch.go
@@ -1,0 +1,408 @@
+// Package aggregate implements the aggregate accounting engine.
+package aggregate
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+// Sketch parameters. The mapping is the OTLP exponential-histogram base-2
+// function at a fixed platform scale: bucket i covers (base^i, base^(i+1)]
+// with base = 2^(2^-scale). At the platform default scale of 4 the base is
+// 2^(1/16) ~= 1.044274 and the worst-case relative error of a quantile
+// estimate is (base-1)/(base+1) ~= 2.17%.
+//
+// Choosing the OTel mapping rather than an arbitrary DDSketch gamma makes a
+// scale change an exact integer index shift ("perfect subsetting"), which is
+// what allows Downscale and mismatched-scale Merge to stay lossless in the
+// mapping. See docs/research/latency-sketch.md and issue #157.
+const (
+	// SketchDefaultScale is the platform-wide mapping scale.
+	SketchDefaultScale uint8 = 4
+
+	// SketchMaxScale is the finest scale the codec accepts. The OTel data model
+	// defines positive scales up to 20.
+	SketchMaxScale uint8 = 20
+
+	// SketchMaxBins bounds the in-memory dense bin array. 512 bins at scale 4
+	// span a 2^32 dynamic range (~9.6 decades); the theoretical requirement for
+	// 1us-100s is 426 bins.
+	SketchMaxBins int32 = 512
+)
+
+// ErrSketchScale is returned when a scale outside the supported range is
+// requested or decoded.
+var ErrSketchScale = errors.New("aggregate: unsupported sketch scale")
+
+// Sketch is a fixed-size relative-error quantile sketch for latency values.
+//
+// The zero value is not usable; construct with NewSketch or NewSketchAtScale.
+// A Sketch contains no pointers and no slices: it is copyable by assignment and
+// Observe performs no allocation.
+//
+// Sketch is not safe for concurrent use. Callers own the synchronization.
+type Sketch struct {
+	// sum is the sum of every observed value, including zero-bucket values.
+	sum float64
+	// count is the total number of observations, including the zero bucket and
+	// including observations whose bin saturated.
+	count uint64
+	// zeroCount holds observations that are not representable in the log
+	// mapping: zero and (by construction, buggy) negative latencies.
+	zeroCount uint64
+	// binTotal is the number of observations actually retained in bins. It is
+	// below count-zeroCount only when a bin has saturated.
+	binTotal uint64
+	// saturations counts the number of adds that clamped at MaxUint32.
+	saturations uint64
+	// minIdx is the bucket index of bins[0]. It bounds the populated window and
+	// is not necessarily a populated bin.
+	minIdx int32
+	// maxIdx is the highest bucket index in the window. It is always populated
+	// while hasBins is true.
+	maxIdx int32
+	scale  uint8
+	// collapsed records that counts were merged into the lowest retained bin,
+	// so estimates below that bin are no longer within the relative-error bound.
+	collapsed bool
+	hasBins   bool
+	bins      [SketchMaxBins]uint32
+}
+
+// NewSketch returns an empty sketch at the platform default scale.
+func NewSketch() *Sketch {
+	return &Sketch{scale: SketchDefaultScale}
+}
+
+// NewSketchAtScale returns an empty sketch at an explicit scale. Scales above
+// SketchMaxScale are rejected.
+func NewSketchAtScale(scale uint8) (*Sketch, error) {
+	if scale > SketchMaxScale {
+		return nil, fmt.Errorf("%w: %d", ErrSketchScale, scale)
+	}
+	return &Sketch{scale: scale}, nil
+}
+
+// Scale returns the mapping scale of the sketch.
+func (s *Sketch) Scale() uint8 { return s.scale }
+
+// Count returns the total number of observations, including zero-bucket values.
+func (s *Sketch) Count() uint64 { return s.count }
+
+// ZeroCount returns the number of observations that landed in the zero bucket.
+func (s *Sketch) ZeroCount() uint64 { return s.zeroCount }
+
+// Sum returns the sum of all observed values.
+func (s *Sketch) Sum() float64 { return s.sum }
+
+// Saturations returns the number of bin adds that clamped at MaxUint32.
+// Quantile estimates from a saturated sketch are degraded, not corrupted.
+func (s *Sketch) Saturations() uint64 { return s.saturations }
+
+// Collapsed reports whether counts were merged into the lowest retained bin,
+// either by range overflow or by the serialized bin cap.
+func (s *Sketch) Collapsed() bool { return s.collapsed }
+
+// RelativeError returns the worst-case relative error of a quantile estimate at
+// the sketch's current scale, ignoring degradation from collapse or saturation.
+// This is the accuracy the sketch advertises to callers.
+func (s *Sketch) RelativeError() float64 {
+	gamma := sketchBase(s.scale)
+	return (gamma - 1) / (gamma + 1)
+}
+
+// PopulatedBins returns the number of bins holding a non-zero count.
+func (s *Sketch) PopulatedBins() int {
+	if !s.hasBins {
+		return 0
+	}
+	n := 0
+	for i := s.minIdx; i <= s.maxIdx; i++ {
+		if s.bins[i-s.minIdx] != 0 {
+			n++
+		}
+	}
+	return n
+}
+
+// Observe records one value. Non-finite values are rejected and do not affect
+// any counter. Values at or below zero go to the zero bucket: latency is
+// non-negative by construction, so a negative value is a caller bug that must
+// not be allowed to poison the mapping.
+//
+// Observe never allocates.
+func (s *Sketch) Observe(value float64) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return
+	}
+	s.count++
+	s.sum += value
+	if value <= 0 {
+		s.zeroCount++
+		return
+	}
+	s.add(sketchIndex(value, s.scale), 1)
+}
+
+// Quantile returns the estimated q-quantile of the observed values, for q in
+// [0,1]. An empty sketch returns 0; an out-of-range or NaN q returns NaN.
+//
+// The returned value is within RelativeError of the exact q-quantile of the
+// observed sample, provided the sketch has not collapsed below that quantile
+// and no bin has saturated.
+func (s *Sketch) Quantile(q float64) float64 {
+	if math.IsNaN(q) || q < 0 || q > 1 {
+		return math.NaN()
+	}
+	total := s.zeroCount + s.binTotal
+	if total == 0 {
+		return 0
+	}
+	// Rank convention: the smallest bucket whose cumulative count exceeds
+	// q*(n-1) holds the element at that rank.
+	rank := q * float64(total-1)
+	if float64(s.zeroCount) > rank {
+		return 0
+	}
+	if !s.hasBins {
+		return 0
+	}
+	cum := s.zeroCount
+	for i := s.minIdx; i <= s.maxIdx; i++ {
+		c := s.bins[i-s.minIdx]
+		if c == 0 {
+			continue
+		}
+		cum += uint64(c)
+		if float64(cum) > rank {
+			return sketchValue(i, s.scale)
+		}
+	}
+	return sketchValue(s.maxIdx, s.scale)
+}
+
+// Merge folds other into s. Totals add, bins add bin-wise, and the result is
+// independent of the order in which sketches are merged.
+//
+// Scales are aligned before merging by downscaling the finer sketch, which is
+// exact; the result carries the coarser of the two scales. Merging a nil or
+// empty sketch is a no-op.
+func (s *Sketch) Merge(other *Sketch) {
+	if other == nil || other.count == 0 {
+		return
+	}
+	src := other
+	switch {
+	case other.scale > s.scale:
+		aligned := *other
+		aligned.downscale(s.scale)
+		src = &aligned
+	case other.scale < s.scale:
+		s.downscale(other.scale)
+	}
+
+	s.count += src.count
+	s.sum += src.sum
+	s.zeroCount += src.zeroCount
+	s.saturations += src.saturations
+	if src.collapsed {
+		s.collapsed = true
+	}
+	if !src.hasBins {
+		return
+	}
+	for i := src.minIdx; i <= src.maxIdx; i++ {
+		if c := src.bins[i-src.minIdx]; c != 0 {
+			s.add(i, uint64(c))
+		}
+	}
+}
+
+// Downscale converts the sketch to a coarser scale. The conversion is exact:
+// every bucket at the current scale maps onto exactly one bucket at the target
+// scale via an arithmetic right shift of the index, so no count crosses a
+// boundary. The relative-error bound becomes that of the coarser scale.
+//
+// Downscaling to the current scale is a no-op; a finer target is rejected.
+func (s *Sketch) Downscale(target uint8) error {
+	if target > s.scale {
+		return fmt.Errorf("%w: cannot upscale %d to %d", ErrSketchScale, s.scale, target)
+	}
+	s.downscale(target)
+	return nil
+}
+
+func (s *Sketch) downscale(target uint8) {
+	if target >= s.scale {
+		return
+	}
+	shift := s.scale - target
+	s.scale = target
+	if !s.hasBins {
+		return
+	}
+
+	newMin := s.minIdx >> shift
+	newMax := s.maxIdx >> shift
+	var folded [SketchMaxBins]uint32
+	for i := s.minIdx; i <= s.maxIdx; i++ {
+		c := s.bins[i-s.minIdx]
+		if c == 0 {
+			continue
+		}
+		pos := (i >> shift) - newMin
+		total := uint64(folded[pos]) + uint64(c)
+		if total > math.MaxUint32 {
+			folded[pos] = math.MaxUint32
+			s.binTotal -= total - math.MaxUint32
+			s.saturations++
+			continue
+		}
+		folded[pos] = uint32(total)
+	}
+	s.bins = folded
+	s.minIdx, s.maxIdx = newMin, newMax
+}
+
+// add applies n observations to a bucket index, growing or collapsing the
+// window as needed. The resulting state depends only on the multiset of
+// observations, never on their order: every observation below
+// maxIdx-SketchMaxBins+1 ends up folded into that lowest retained bin.
+func (s *Sketch) add(index int32, n uint64) {
+	if n == 0 {
+		return
+	}
+	if !s.hasBins {
+		s.hasBins = true
+		s.minIdx, s.maxIdx = index, index
+		s.binTotal += s.addAt(0, n)
+		return
+	}
+
+	switch {
+	case index > s.maxIdx:
+		if index-s.minIdx >= SketchMaxBins {
+			s.collapseTo(index - SketchMaxBins + 1)
+		}
+		s.maxIdx = index
+	case index < s.minIdx:
+		lowest := s.maxIdx - SketchMaxBins + 1
+		if index < lowest {
+			s.extendTo(lowest)
+			index = lowest
+			s.collapsed = true
+		} else {
+			s.extendTo(index)
+		}
+	}
+	s.binTotal += s.addAt(index-s.minIdx, n)
+}
+
+// addAt applies a saturating add to the bin at a physical position and returns
+// the number of observations actually stored, which is below n only when the
+// bin clamps. Counts clamp at MaxUint32 and are never allowed to wrap: a
+// clamped bin is a degraded estimate, a wrapped bin is corruption.
+//
+// The caller owns binTotal, because moving counts between bins must not change
+// it while a saturating move must.
+func (s *Sketch) addAt(pos int32, n uint64) uint64 {
+	cur := uint64(s.bins[pos])
+	if total := cur + n; total <= math.MaxUint32 {
+		s.bins[pos] = uint32(total)
+		return n
+	}
+	s.bins[pos] = math.MaxUint32
+	s.saturations++
+	return math.MaxUint32 - cur
+}
+
+// extendTo lowers the window floor to newMin, shifting the populated bins up.
+// The caller guarantees newMin < minIdx and maxIdx-newMin < SketchMaxBins.
+func (s *Sketch) extendTo(newMin int32) {
+	shift := s.minIdx - newMin
+	used := s.maxIdx - s.minIdx + 1
+	copy(s.bins[shift:shift+used], s.bins[:used])
+	clear(s.bins[:shift])
+	s.minIdx = newMin
+}
+
+// collapseTo raises the window floor to newMin, merging every count below it
+// into the bin at newMin (DDSketch collapse-lowest). The caller guarantees
+// newMin > minIdx.
+func (s *Sketch) collapseTo(newMin int32) {
+	shift := newMin - s.minIdx
+	used := s.maxIdx - s.minIdx + 1
+
+	var merged uint64
+	for i := int32(0); i < shift && i < used; i++ {
+		merged += uint64(s.bins[i])
+	}
+
+	if shift >= used {
+		clear(s.bins[:used])
+		s.minIdx, s.maxIdx = newMin, newMin
+	} else {
+		copy(s.bins[:used-shift], s.bins[shift:used])
+		clear(s.bins[used-shift : used])
+		s.minIdx = newMin
+	}
+
+	if merged > 0 {
+		s.collapsed = true
+		// The counts already belong to binTotal; only a clamp loses any.
+		s.binTotal -= merged - s.addAt(0, merged)
+	}
+}
+
+// collapseToBinCap collapses the lowest bins until at most limit bins are
+// populated, so the sketch fits the serialized bin budget. Totals are preserved.
+func (s *Sketch) collapseToBinCap(limit int) {
+	if s.PopulatedBins() <= limit {
+		return
+	}
+	seen := 0
+	floor := s.minIdx
+	for i := s.maxIdx; i >= s.minIdx; i-- {
+		if s.bins[i-s.minIdx] == 0 {
+			continue
+		}
+		seen++
+		if seen == limit {
+			floor = i
+			break
+		}
+	}
+	s.collapseTo(floor)
+}
+
+// sketchBase returns the mapping base gamma = 2^(2^-scale).
+func sketchBase(scale uint8) float64 {
+	return math.Exp2(math.Ldexp(1, -int(scale)))
+}
+
+// sketchScaleFactor returns 1/ln(base), the multiplier that turns a natural
+// logarithm into a scaled base-2 logarithm.
+func sketchScaleFactor(scale uint8) float64 {
+	return math.Ldexp(math.Log2E, int(scale))
+}
+
+// sketchIndex maps a strictly positive value to its bucket index using the OTel
+// exponential-histogram mapping ceil(log_base(value)) - 1, so that bucket i
+// covers (base^i, base^(i+1)].
+func sketchIndex(value float64, scale uint8) int32 {
+	if frac, exp := math.Frexp(value); frac == 0.5 {
+		// Exact power of two: value is the upper boundary of the bucket below
+		// the boundary index, and boundaries are inclusive on the upper side.
+		return (int32(exp-1) << scale) - 1 // #nosec G115 -- Frexp exponent of a finite float64 is within [-1074, 1024]
+	}
+	return int32(math.Ceil(math.Log(value)*sketchScaleFactor(scale))) - 1
+}
+
+// sketchValue returns the representative value of a bucket: 2*upper/(base+1),
+// which sits equidistant in relative terms from both boundaries and so attains
+// the (base-1)/(base+1) worst-case relative error.
+func sketchValue(index int32, scale uint8) float64 {
+	upper := math.Exp2(math.Ldexp(float64(index+1), -int(scale)))
+	return 2 * upper / (sketchBase(scale) + 1)
+}

--- a/internal/aggregate/sketch_bench_test.go
+++ b/internal/aggregate/sketch_bench_test.go
@@ -1,0 +1,89 @@
+package aggregate
+
+import "testing"
+
+func BenchmarkSketchObserve(b *testing.B) {
+	values := sketchSample(sketchDistributions()[0].gen, 4096, 1)
+	s := NewSketch()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		s.Observe(values[i&4095])
+	}
+}
+
+// BenchmarkSketchObserveFullRange spans the entire 1us-100s range, so the hot
+// path repeatedly grows and collapses the bin window.
+func BenchmarkSketchObserveFullRange(b *testing.B) {
+	values := sketchSample(sketchDistributions()[3].gen, 4096, 2)
+	s := NewSketch()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		s.Observe(values[i&4095])
+	}
+}
+
+func BenchmarkSketchMerge(b *testing.B) {
+	build := func(seed int64) *Sketch {
+		s := NewSketch()
+		for _, v := range sketchSample(sketchDistributions()[0].gen, 20000, seed) {
+			s.Observe(v)
+		}
+		return s
+	}
+	src := build(3)
+	dst := build(4)
+	base := *dst
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		*dst = base
+		dst.Merge(src)
+	}
+}
+
+func BenchmarkSketchEncode(b *testing.B) {
+	s := NewSketch()
+	for _, v := range sketchSample(sketchDistributions()[0].gen, 20000, 5) {
+		s.Observe(v)
+	}
+	buf := make([]byte, 0, 2048)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		buf = s.AppendTo(buf[:0])
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(s.PopulatedBins()), "bins")
+	b.ReportMetric(float64(len(buf)), "encoded_B")
+}
+
+func BenchmarkSketchDecode(b *testing.B) {
+	s := NewSketch()
+	for _, v := range sketchSample(sketchDistributions()[0].gen, 20000, 6) {
+		s.Observe(v)
+	}
+	encoded := s.Encode()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := DecodeSketch(encoded); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSketchQuantile(b *testing.B) {
+	s := NewSketch()
+	for _, v := range sketchSample(sketchDistributions()[0].gen, 20000, 7) {
+		s.Observe(v)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = s.Quantile(0.99)
+	}
+}

--- a/internal/aggregate/sketch_codec.go
+++ b/internal/aggregate/sketch_codec.go
@@ -1,0 +1,285 @@
+package aggregate
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+)
+
+// Serialized sketch format (little-endian, deterministic):
+//
+//	offset  field
+//	0       version      u8       = 0x01
+//	1       scale        u8       (the OTel base-2 scale itself)
+//	2       flags        u8       (bit0 = collapsed, remaining bits reserved)
+//	3       zero_count   uvarint
+//	.       count        uvarint  (total, including zero_count)
+//	.       sum          f64      (8 bytes, IEEE 754)
+//	.       num_bins     uvarint  (populated bins only)
+//	.       first_index  svarint  (zigzag; bucket indexes are signed)
+//	.       repeated num_bins times:
+//	          index_delta uvarint (0 for the first bin, >= 1 afterwards)
+//	          bin_count   uvarint (>= 1, <= MaxUint32)
+//
+// Only populated bins are written, so a typical latency sketch costs ~16 bytes
+// of header plus 2-4 bytes per populated bin instead of the 2 KiB of the dense
+// in-memory array. The version and scale bytes are the entire versioning story:
+// a reader refuses anything it does not recognise.
+//
+// Encoding is a pure function of sketch state, so identical state always
+// produces identical bytes and Encode(Decode(Encode(x))) == Encode(x).
+
+// SketchEncodingVersion is the only encoding version this package writes or
+// accepts.
+const SketchEncodingVersion uint8 = 0x01
+
+// SketchMaxSerializedBins caps the populated bins written by the encoder. It
+// bounds a serialized sketch at roughly 1.5 KiB, which is what the 7-day
+// worst-case disk arithmetic in issue #162 is budgeted against. A sketch with
+// more populated bins is collapsed-lowest at encode time.
+const SketchMaxSerializedBins = 256
+
+// sketchFlagCollapsed marks a sketch whose lowest bins were merged.
+const sketchFlagCollapsed uint8 = 0x01
+
+// sketchHeaderLen is the size of the fixed version/scale/flags prefix.
+const sketchHeaderLen = 3
+
+// Codec errors. All decode failures wrap one of these.
+var (
+	// ErrSketchVersion reports an encoding version the decoder does not know.
+	ErrSketchVersion = errors.New("aggregate: unsupported sketch encoding version")
+	// ErrSketchTruncated reports input that ends inside a field.
+	ErrSketchTruncated = errors.New("aggregate: truncated sketch encoding")
+	// ErrSketchCorrupt reports input that is structurally invalid: bad varints,
+	// non-canonical bins, impossible totals, or trailing bytes.
+	ErrSketchCorrupt = errors.New("aggregate: corrupt sketch encoding")
+)
+
+// Encode returns the serialized form of the sketch.
+func (s *Sketch) Encode() []byte {
+	return s.AppendTo(nil)
+}
+
+// AppendTo appends the serialized form of the sketch to dst and returns the
+// extended buffer, allowing callers to reuse a scratch buffer.
+//
+// The sketch is never mutated: if it holds more than SketchMaxSerializedBins
+// populated bins, a copy is collapsed-lowest to the cap and that copy is
+// written. Totals survive the collapse; only resolution below the new floor is
+// lost, and the collapsed flag records it.
+func (s *Sketch) AppendTo(dst []byte) []byte {
+	src := s
+	if s.PopulatedBins() > SketchMaxSerializedBins {
+		capped := *s
+		capped.collapseToBinCap(SketchMaxSerializedBins)
+		src = &capped
+	}
+
+	flags := uint8(0)
+	if src.collapsed {
+		flags |= sketchFlagCollapsed
+	}
+
+	dst = append(dst, SketchEncodingVersion, src.scale, flags)
+	dst = binary.AppendUvarint(dst, src.zeroCount)
+	dst = binary.AppendUvarint(dst, src.count)
+	dst = binary.LittleEndian.AppendUint64(dst, math.Float64bits(src.sum))
+	dst = binary.AppendUvarint(dst, uint64(src.PopulatedBins())) // #nosec G115 -- bounded by SketchMaxBins
+
+	first, ok := src.firstPopulated()
+	if !ok {
+		return binary.AppendVarint(dst, 0)
+	}
+	dst = binary.AppendVarint(dst, int64(first))
+
+	prev := first
+	for i := first; i <= src.maxIdx; i++ {
+		c := src.bins[i-src.minIdx]
+		if c == 0 {
+			continue
+		}
+		dst = binary.AppendUvarint(dst, uint64(i-prev)) // #nosec G115 -- indexes ascend, delta is in [0, SketchMaxBins)
+		dst = binary.AppendUvarint(dst, uint64(c))
+		prev = i
+	}
+	return dst
+}
+
+// firstPopulated returns the lowest populated bucket index.
+func (s *Sketch) firstPopulated() (int32, bool) {
+	if !s.hasBins {
+		return 0, false
+	}
+	for i := s.minIdx; i <= s.maxIdx; i++ {
+		if s.bins[i-s.minIdx] != 0 {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// DecodeSketch parses a serialized sketch. Unknown versions and scales are
+// rejected with ErrSketchVersion and ErrSketchScale; anything structurally
+// invalid is rejected with ErrSketchTruncated or ErrSketchCorrupt. A decoded
+// sketch re-encodes to exactly the input bytes.
+//
+// The saturation counter is not part of the format and decodes to zero: it is
+// an operational signal about a live sketch, not part of its value.
+func DecodeSketch(data []byte) (*Sketch, error) {
+	if len(data) < sketchHeaderLen {
+		return nil, fmt.Errorf("%w: %d header bytes", ErrSketchTruncated, len(data))
+	}
+	if data[0] != SketchEncodingVersion {
+		return nil, fmt.Errorf("%w: 0x%02x", ErrSketchVersion, data[0])
+	}
+	scale := data[1]
+	if scale > SketchMaxScale {
+		return nil, fmt.Errorf("%w: %d", ErrSketchScale, scale)
+	}
+	flags := data[2]
+	if flags&^sketchFlagCollapsed != 0 {
+		return nil, fmt.Errorf("%w: reserved flag bits 0x%02x", ErrSketchCorrupt, flags)
+	}
+
+	r := sketchReader{buf: data, pos: sketchHeaderLen}
+	zeroCount, err := r.uvarint("zero_count")
+	if err != nil {
+		return nil, err
+	}
+	count, err := r.uvarint("count")
+	if err != nil {
+		return nil, err
+	}
+	bits, err := r.uint64("sum")
+	if err != nil {
+		return nil, err
+	}
+	sum := math.Float64frombits(bits)
+	if math.IsNaN(sum) || math.IsInf(sum, 0) {
+		return nil, fmt.Errorf("%w: non-finite sum", ErrSketchCorrupt)
+	}
+	numBins, err := r.uvarint("num_bins")
+	if err != nil {
+		return nil, err
+	}
+	if numBins > SketchMaxSerializedBins {
+		return nil, fmt.Errorf("%w: %d bins exceeds the %d cap", ErrSketchCorrupt, numBins, SketchMaxSerializedBins)
+	}
+	firstIndex, err := r.varint("first_index")
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Sketch{
+		scale:     scale,
+		sum:       sum,
+		count:     count,
+		zeroCount: zeroCount,
+		collapsed: flags&sketchFlagCollapsed != 0,
+	}
+	if err := decodeBins(&r, s, int(numBins), firstIndex); err != nil {
+		return nil, err
+	}
+	if r.pos != len(data) {
+		return nil, fmt.Errorf("%w: %d trailing bytes", ErrSketchCorrupt, len(data)-r.pos)
+	}
+	if count < zeroCount || count-zeroCount < s.binTotal {
+		return nil, fmt.Errorf("%w: count %d below zero_count %d plus bin total %d", ErrSketchCorrupt, count, zeroCount, s.binTotal)
+	}
+	return s, nil
+}
+
+// decodeBins reads the bin block into s and sets the window bounds.
+func decodeBins(r *sketchReader, s *Sketch, numBins int, firstIndex int64) error {
+	if numBins == 0 {
+		if firstIndex != 0 {
+			return fmt.Errorf("%w: first_index %d with no bins", ErrSketchCorrupt, firstIndex)
+		}
+		return nil
+	}
+	if firstIndex < math.MinInt32 || firstIndex > math.MaxInt32 {
+		return fmt.Errorf("%w: first_index %d out of range", ErrSketchCorrupt, firstIndex)
+	}
+
+	index := firstIndex
+	for i := range numBins {
+		delta, err := r.uvarint("index_delta")
+		if err != nil {
+			return err
+		}
+		switch {
+		case i == 0 && delta != 0:
+			return fmt.Errorf("%w: first index_delta %d must be 0", ErrSketchCorrupt, delta)
+		case i > 0 && delta == 0:
+			return fmt.Errorf("%w: index_delta 0 repeats bucket %d", ErrSketchCorrupt, index)
+		}
+		if delta >= uint64(SketchMaxBins) {
+			return fmt.Errorf("%w: index_delta %d exceeds %d bins", ErrSketchCorrupt, delta, SketchMaxBins)
+		}
+		index += int64(delta) // #nosec G115 -- delta is bounded above
+		if index-firstIndex >= int64(SketchMaxBins) {
+			return fmt.Errorf("%w: bucket span %d exceeds %d bins", ErrSketchCorrupt, index-firstIndex+1, SketchMaxBins)
+		}
+
+		binCount, err := r.uvarint("bin_count")
+		if err != nil {
+			return err
+		}
+		if binCount == 0 {
+			return fmt.Errorf("%w: empty bin at bucket %d", ErrSketchCorrupt, index)
+		}
+		if binCount > math.MaxUint32 {
+			return fmt.Errorf("%w: bin count %d exceeds uint32", ErrSketchCorrupt, binCount)
+		}
+
+		s.bins[index-firstIndex] = uint32(binCount)
+		s.binTotal += binCount
+	}
+
+	s.hasBins = true
+	s.minIdx = int32(firstIndex)
+	s.maxIdx = int32(index)
+	return nil
+}
+
+// sketchReader is a cursor over an encoded sketch that turns stdlib varint
+// failures into the package's typed errors.
+type sketchReader struct {
+	buf []byte
+	pos int
+}
+
+func (r *sketchReader) uvarint(field string) (uint64, error) {
+	v, n := binary.Uvarint(r.buf[r.pos:])
+	switch {
+	case n == 0:
+		return 0, fmt.Errorf("%w: reading %s", ErrSketchTruncated, field)
+	case n < 0:
+		return 0, fmt.Errorf("%w: overlong varint for %s", ErrSketchCorrupt, field)
+	}
+	r.pos += n
+	return v, nil
+}
+
+func (r *sketchReader) varint(field string) (int64, error) {
+	v, n := binary.Varint(r.buf[r.pos:])
+	switch {
+	case n == 0:
+		return 0, fmt.Errorf("%w: reading %s", ErrSketchTruncated, field)
+	case n < 0:
+		return 0, fmt.Errorf("%w: overlong varint for %s", ErrSketchCorrupt, field)
+	}
+	r.pos += n
+	return v, nil
+}
+
+func (r *sketchReader) uint64(field string) (uint64, error) {
+	if len(r.buf)-r.pos < 8 {
+		return 0, fmt.Errorf("%w: reading %s", ErrSketchTruncated, field)
+	}
+	v := binary.LittleEndian.Uint64(r.buf[r.pos:])
+	r.pos += 8
+	return v, nil
+}

--- a/internal/aggregate/sketch_codec_test.go
+++ b/internal/aggregate/sketch_codec_test.go
@@ -1,0 +1,326 @@
+package aggregate
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"math"
+	"testing"
+)
+
+// sketchWithBins returns a sketch populated across n consecutive buckets, one
+// observation per bucket, plus a few zero-bucket values.
+func sketchWithBins(t *testing.T, n int) *Sketch {
+	t.Helper()
+	s := NewSketch()
+	for i := range n {
+		// Bucket midpoints at scale 4, so each value lands in its own bucket.
+		s.Observe(math.Exp2((float64(i) + 0.5) / 16))
+	}
+	if got := s.PopulatedBins(); got != n {
+		t.Fatalf("setup: populated bins %d, want %d", got, n)
+	}
+	return s
+}
+
+func TestSketchCodecRoundTrip(t *testing.T) {
+	values := sketchSample(sketchDistributions()[0].gen, 20000, 616)
+	s := NewSketch()
+	for _, v := range values {
+		s.Observe(v)
+	}
+	s.Observe(0)
+	s.Observe(-3)
+
+	encoded := s.Encode()
+	decoded, err := DecodeSketch(encoded)
+	if err != nil {
+		t.Fatalf("DecodeSketch: %v", err)
+	}
+
+	sketchAssertSameContent(t, s, decoded)
+	if decoded.Sum() != s.Sum() {
+		t.Fatalf("sum: got %g, want %g", decoded.Sum(), s.Sum())
+	}
+	if decoded.Scale() != s.Scale() {
+		t.Fatalf("scale: got %d, want %d", decoded.Scale(), s.Scale())
+	}
+	for _, q := range []float64{0, 0.5, 0.95, 0.99, 1} {
+		if a, b := s.Quantile(q), decoded.Quantile(q); a != b {
+			t.Fatalf("q%.2f: original %g, decoded %g", q, a, b)
+		}
+	}
+
+	// Deterministic: re-encoding a decoded sketch reproduces the same bytes.
+	if again := decoded.Encode(); !bytes.Equal(encoded, again) {
+		t.Fatalf("encode(decode(encode(x))) differs: %d vs %d bytes", len(encoded), len(again))
+	}
+	// And encoding the same state twice is stable.
+	if !bytes.Equal(encoded, s.Encode()) {
+		t.Fatal("repeated Encode produced different bytes")
+	}
+
+	t.Logf("%d observations, %d populated bins, %d encoded bytes (%.2f B/bin)",
+		s.Count(), s.PopulatedBins(), len(encoded),
+		float64(len(encoded))/float64(s.PopulatedBins()))
+}
+
+func TestSketchCodecEmptyRoundTrip(t *testing.T) {
+	s := NewSketch()
+	encoded := s.Encode()
+	decoded, err := DecodeSketch(encoded)
+	if err != nil {
+		t.Fatalf("DecodeSketch: %v", err)
+	}
+	sketchAssertSameContent(t, s, decoded)
+	if !bytes.Equal(encoded, decoded.Encode()) {
+		t.Fatal("empty sketch does not re-encode identically")
+	}
+	if got := decoded.Quantile(0.5); got != 0 {
+		t.Fatalf("decoded empty quantile: got %g, want 0", got)
+	}
+}
+
+func TestSketchCodecAppendToPreservesPrefix(t *testing.T) {
+	s := NewSketch()
+	s.Observe(0.42)
+	prefix := []byte{0xde, 0xad}
+	out := s.AppendTo(prefix)
+	if !bytes.Equal(out[:2], prefix) {
+		t.Fatal("AppendTo overwrote the destination prefix")
+	}
+	if !bytes.Equal(out[2:], s.Encode()) {
+		t.Fatal("AppendTo and Encode disagree")
+	}
+}
+
+func TestSketchCodecCollapsesToSerializedCap(t *testing.T) {
+	const populated = 400
+	s := sketchWithBins(t, populated)
+	wantCount, wantSum := s.Count(), s.Sum()
+
+	encoded := s.Encode()
+	if s.PopulatedBins() != populated || s.Collapsed() {
+		t.Fatal("Encode mutated the source sketch")
+	}
+
+	decoded, err := DecodeSketch(encoded)
+	if err != nil {
+		t.Fatalf("DecodeSketch: %v", err)
+	}
+	if got := decoded.PopulatedBins(); got != SketchMaxSerializedBins {
+		t.Fatalf("populated bins after encode: got %d, want %d", got, SketchMaxSerializedBins)
+	}
+	if !decoded.Collapsed() {
+		t.Fatal("collapsed flag not set after hitting the serialized bin cap")
+	}
+	if decoded.Count() != wantCount || decoded.Sum() != wantSum {
+		t.Fatalf("totals lost: count %d/%d sum %g/%g", decoded.Count(), wantCount, decoded.Sum(), wantSum)
+	}
+	if decoded.binTotal != s.binTotal {
+		t.Fatalf("retained observations: got %d, want %d", decoded.binTotal, s.binTotal)
+	}
+	// The upper quantiles survive: collapse only merges the lowest buckets.
+	if a, b := s.Quantile(0.99), decoded.Quantile(0.99); a != b {
+		t.Fatalf("q0.99 changed across the cap: %g vs %g", a, b)
+	}
+	if !bytes.Equal(encoded, decoded.Encode()) {
+		t.Fatal("capped sketch does not re-encode identically")
+	}
+
+	// Worst-case serialized size stays inside the ~1.5 KiB budget.
+	if len(encoded) > 1600 {
+		t.Fatalf("encoded size %d exceeds the serialized budget", len(encoded))
+	}
+	t.Logf("%d populated bins collapsed to %d, %d encoded bytes",
+		populated, SketchMaxSerializedBins, len(encoded))
+}
+
+func TestSketchCodecExactlyAtCap(t *testing.T) {
+	s := sketchWithBins(t, SketchMaxSerializedBins)
+	decoded, err := DecodeSketch(s.Encode())
+	if err != nil {
+		t.Fatalf("DecodeSketch: %v", err)
+	}
+	if decoded.Collapsed() {
+		t.Fatal("a sketch exactly at the cap must not be collapsed")
+	}
+	sketchAssertSameContent(t, s, decoded)
+}
+
+func TestSketchCodecRejectsBadInput(t *testing.T) {
+	valid := sketchWithBins(t, 8).Encode()
+
+	cases := []struct {
+		name  string
+		input []byte
+		want  error
+	}{
+		{"empty", nil, ErrSketchTruncated},
+		{"header only partial", valid[:2], ErrSketchTruncated},
+		{"unknown version", append([]byte{0x02}, valid[1:]...), ErrSketchVersion},
+		{"zero version", append([]byte{0x00}, valid[1:]...), ErrSketchVersion},
+		{"unknown scale", append([]byte{valid[0], 0xff}, valid[2:]...), ErrSketchScale},
+		{"reserved flags", append([]byte{valid[0], valid[1], 0x80}, valid[3:]...), ErrSketchCorrupt},
+		{"truncated body", valid[:len(valid)-3], ErrSketchTruncated},
+		{"trailing bytes", append(append([]byte(nil), valid...), 0x00), ErrSketchCorrupt},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := DecodeSketch(tc.input)
+			if s != nil {
+				t.Fatal("expected a nil sketch on error")
+			}
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("got %v, want %v", err, tc.want)
+			}
+		})
+	}
+
+	// Every proper prefix of a valid encoding must be rejected, never
+	// silently accepted as a shorter sketch.
+	for i := range len(valid) {
+		if _, err := DecodeSketch(valid[:i]); err == nil {
+			t.Fatalf("prefix of length %d decoded without error", i)
+		}
+	}
+}
+
+// sketchEncodeManual builds an encoding field by field so tests can plant
+// structurally invalid bodies.
+func sketchEncodeManual(zeroCount, count uint64, sum float64, first int64, bins [][2]uint64) []byte {
+	out := []byte{SketchEncodingVersion, SketchDefaultScale, 0x00}
+	out = binary.AppendUvarint(out, zeroCount)
+	out = binary.AppendUvarint(out, count)
+	out = binary.LittleEndian.AppendUint64(out, math.Float64bits(sum))
+	out = binary.AppendUvarint(out, uint64(len(bins)))
+	out = binary.AppendVarint(out, first)
+	for _, b := range bins {
+		out = binary.AppendUvarint(out, b[0])
+		out = binary.AppendUvarint(out, b[1])
+	}
+	return out
+}
+
+func TestSketchCodecRejectsCorruptBody(t *testing.T) {
+	cases := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			name:  "first delta not zero",
+			input: sketchEncodeManual(0, 2, 1, 10, [][2]uint64{{1, 2}}),
+		},
+		{
+			name:  "repeated bucket",
+			input: sketchEncodeManual(0, 3, 1, 10, [][2]uint64{{0, 1}, {1, 1}, {0, 1}}),
+		},
+		{
+			name:  "empty bin",
+			input: sketchEncodeManual(0, 1, 1, 10, [][2]uint64{{0, 0}}),
+		},
+		{
+			name:  "bin count above uint32",
+			input: sketchEncodeManual(0, math.MaxUint32+2, 1, 10, [][2]uint64{{0, math.MaxUint32 + 1}}),
+		},
+		{
+			name:  "index delta overflowing int64",
+			input: sketchEncodeManual(0, 2, 1, 0, [][2]uint64{{0, 1}, {math.MaxUint64, 1}}),
+		},
+		{
+			name:  "span beyond bin budget",
+			input: sketchEncodeManual(0, 2, 1, 0, [][2]uint64{{0, 1}, {uint64(SketchMaxBins), 1}}),
+		},
+		{
+			name:  "count below stored observations",
+			input: sketchEncodeManual(0, 1, 1, 10, [][2]uint64{{0, 5}}),
+		},
+		{
+			name:  "count below zero count",
+			input: sketchEncodeManual(9, 1, 1, 0, nil),
+		},
+		{
+			name:  "first index without bins",
+			input: sketchEncodeManual(1, 1, 1, 7, nil),
+		},
+		{
+			name:  "non-finite sum",
+			input: sketchEncodeManual(0, 1, math.NaN(), 10, [][2]uint64{{0, 1}}),
+		},
+		{
+			name:  "more bins than the serialized cap",
+			input: sketchWithBins(t, 400).sketchEncodeUncapped(),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := DecodeSketch(tc.input); !errors.Is(err, ErrSketchCorrupt) {
+				t.Fatalf("got %v, want ErrSketchCorrupt", err)
+			}
+		})
+	}
+}
+
+// sketchEncodeUncapped serializes every populated bin, bypassing the encoder's
+// collapse-to-cap step, so decoder enforcement of the cap can be tested.
+func (s *Sketch) sketchEncodeUncapped() []byte {
+	out := []byte{SketchEncodingVersion, s.scale, 0x00}
+	out = binary.AppendUvarint(out, s.zeroCount)
+	out = binary.AppendUvarint(out, s.count)
+	out = binary.LittleEndian.AppendUint64(out, math.Float64bits(s.sum))
+	out = binary.AppendUvarint(out, uint64(s.PopulatedBins()))
+	first, _ := s.firstPopulated()
+	out = binary.AppendVarint(out, int64(first))
+	prev := first
+	for i := first; i <= s.maxIdx; i++ {
+		c := s.bins[i-s.minIdx]
+		if c == 0 {
+			continue
+		}
+		out = binary.AppendUvarint(out, uint64(i-prev))
+		out = binary.AppendUvarint(out, uint64(c))
+		prev = i
+	}
+	return out
+}
+
+func TestSketchCodecNegativeIndexes(t *testing.T) {
+	// Sub-millisecond latencies produce negative bucket indexes, which the
+	// zigzag-encoded first_index has to survive.
+	s := NewSketch()
+	for _, v := range []float64{1e-6, 5e-6, 2.5e-5, 1e-4} {
+		s.Observe(v)
+	}
+	first, ok := s.firstPopulated()
+	if !ok || first >= 0 {
+		t.Fatalf("expected a negative first bucket index, got %d (ok=%v)", first, ok)
+	}
+	decoded, err := DecodeSketch(s.Encode())
+	if err != nil {
+		t.Fatalf("DecodeSketch: %v", err)
+	}
+	sketchAssertSameContent(t, s, decoded)
+}
+
+func TestSketchCodecCollapsedFlagRoundTrips(t *testing.T) {
+	s := NewSketch()
+	s.Observe(1e-9)
+	s.Observe(1e-9 * math.Exp2(40))
+	if !s.Collapsed() {
+		t.Fatal("setup: expected a collapsed sketch")
+	}
+	encoded := s.Encode()
+	if encoded[2]&sketchFlagCollapsed == 0 {
+		t.Fatal("collapsed flag not written")
+	}
+	decoded, err := DecodeSketch(encoded)
+	if err != nil {
+		t.Fatalf("DecodeSketch: %v", err)
+	}
+	if !decoded.Collapsed() {
+		t.Fatal("collapsed flag not restored")
+	}
+	if !bytes.Equal(encoded, decoded.Encode()) {
+		t.Fatal("collapsed sketch does not re-encode identically")
+	}
+}

--- a/internal/aggregate/sketch_test.go
+++ b/internal/aggregate/sketch_test.go
@@ -1,0 +1,563 @@
+package aggregate
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+// Latency range the sketch is dimensioned for: 1 microsecond to 100 seconds,
+// expressed in seconds.
+const (
+	sketchMinLatency = 1e-6
+	sketchMaxLatency = 100.0
+
+	// sketchErrorSlack absorbs float rounding for values that sit exactly on a
+	// bucket boundary, where the estimate lands exactly on the error bound.
+	sketchErrorSlack = 1e-9
+)
+
+// sketchDistribution generates a deterministic latency sample.
+type sketchDistribution struct {
+	name string
+	gen  func(r *rand.Rand) float64
+}
+
+func sketchDistributions() []sketchDistribution {
+	return []sketchDistribution{
+		{
+			// Log-normal around 50 ms: the canonical request-latency shape.
+			name: "lognormal",
+			gen: func(r *rand.Rand) float64 {
+				return math.Exp(math.Log(0.05) + 1.3*r.NormFloat64())
+			},
+		},
+		{
+			// Exponential with a 20 ms mean: memoryless service times.
+			name: "exponential",
+			gen: func(r *rand.Rand) float64 {
+				return r.ExpFloat64() * 0.02
+			},
+		},
+		{
+			// Bimodal: a fast cached path plus a slow backend path.
+			name: "bimodal",
+			gen: func(r *rand.Rand) float64 {
+				if r.Float64() < 0.8 {
+					return math.Exp(math.Log(0.002) + 0.4*r.NormFloat64())
+				}
+				return math.Exp(math.Log(3.0) + 0.6*r.NormFloat64())
+			},
+		},
+		{
+			// Log-uniform across the entire 1us-100s range: worst case for
+			// bucket occupancy, exercising ~426 of the 512 bins.
+			name: "loguniform_full_range",
+			gen: func(r *rand.Rand) float64 {
+				lo, hi := math.Log2(sketchMinLatency), math.Log2(sketchMaxLatency)
+				return math.Exp2(lo + r.Float64()*(hi-lo))
+			},
+		},
+	}
+}
+
+// sketchSample draws n clamped samples from a distribution.
+func sketchSample(gen func(r *rand.Rand) float64, n int, seed int64) []float64 {
+	r := rand.New(rand.NewSource(seed))
+	out := make([]float64, n)
+	for i := range out {
+		v := gen(r)
+		if v < sketchMinLatency {
+			v = sketchMinLatency
+		}
+		if v > sketchMaxLatency {
+			v = sketchMaxLatency
+		}
+		out[i] = v
+	}
+	return out
+}
+
+// sketchExactQuantile returns the sample element the sketch's rank convention
+// selects: the element at rank floor(q*(n-1)) of the sorted sample.
+func sketchExactQuantile(values []float64, q float64) float64 {
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	rank := int(math.Floor(q * float64(len(sorted)-1)))
+	return sorted[rank]
+}
+
+// sketchBins returns the populated bins keyed by bucket index.
+func sketchBins(s *Sketch) map[int32]uint32 {
+	out := make(map[int32]uint32)
+	if !s.hasBins {
+		return out
+	}
+	for i := s.minIdx; i <= s.maxIdx; i++ {
+		if c := s.bins[i-s.minIdx]; c != 0 {
+			out[i] = c
+		}
+	}
+	return out
+}
+
+func sketchAssertSameContent(t *testing.T, want, got *Sketch) {
+	t.Helper()
+	if want.count != got.count || want.zeroCount != got.zeroCount || want.binTotal != got.binTotal {
+		t.Fatalf("totals differ: want count=%d zero=%d bins=%d, got count=%d zero=%d bins=%d",
+			want.count, want.zeroCount, want.binTotal, got.count, got.zeroCount, got.binTotal)
+	}
+	if want.collapsed != got.collapsed {
+		t.Fatalf("collapsed differs: want %v, got %v", want.collapsed, got.collapsed)
+	}
+	if want.scale != got.scale {
+		t.Fatalf("scale differs: want %d, got %d", want.scale, got.scale)
+	}
+	wb, gb := sketchBins(want), sketchBins(got)
+	if len(wb) != len(gb) {
+		t.Fatalf("populated bins differ: want %d, got %d", len(wb), len(gb))
+	}
+	for idx, c := range wb {
+		if gb[idx] != c {
+			t.Fatalf("bucket %d: want count %d, got %d", idx, c, gb[idx])
+		}
+	}
+}
+
+func TestSketchRelativeErrorBound(t *testing.T) {
+	s := NewSketch()
+	if got, want := s.Scale(), SketchDefaultScale; got != want {
+		t.Fatalf("scale: got %d, want %d", got, want)
+	}
+	// (2^(1/16)-1)/(2^(1/16)+1) = 0.02165746...
+	if got := s.RelativeError(); math.Abs(got-0.02165746) > 1e-7 {
+		t.Fatalf("scale-4 relative error: got %.9f, want ~0.02165746", got)
+	}
+	coarse, err := NewSketchAtScale(2)
+	if err != nil {
+		t.Fatalf("NewSketchAtScale: %v", err)
+	}
+	if got := coarse.RelativeError(); math.Abs(got-0.08642723) > 1e-7 {
+		t.Fatalf("scale-2 relative error: got %.9f, want ~0.08642723", got)
+	}
+	if _, err := NewSketchAtScale(SketchMaxScale + 1); err == nil {
+		t.Fatal("expected an error for a scale above SketchMaxScale")
+	}
+}
+
+func TestSketchIndexBucketContainment(t *testing.T) {
+	base := sketchBase(SketchDefaultScale)
+	r := rand.New(rand.NewSource(7))
+	for range 20000 {
+		lo, hi := math.Log2(sketchMinLatency), math.Log2(sketchMaxLatency)
+		v := math.Exp2(lo + r.Float64()*(hi-lo))
+		idx := sketchIndex(v, SketchDefaultScale)
+		lower := math.Exp2(math.Ldexp(float64(idx), -int(SketchDefaultScale)))
+		upper := lower * base
+		if v <= lower*(1-1e-12) || v > upper*(1+1e-12) {
+			t.Fatalf("value %g mapped to bucket %d covering (%g, %g]", v, idx, lower, upper)
+		}
+	}
+}
+
+func TestSketchIndexPowersOfTwo(t *testing.T) {
+	// An exact power of two is the inclusive upper boundary of the bucket
+	// below its boundary index.
+	for exp := -20; exp <= 7; exp++ {
+		v := math.Exp2(float64(exp))
+		want := int32(exp)<<SketchDefaultScale - 1
+		if got := sketchIndex(v, SketchDefaultScale); got != want {
+			t.Fatalf("sketchIndex(2^%d) = %d, want %d", exp, got, want)
+		}
+	}
+}
+
+func TestSketchQuantileAccuracy(t *testing.T) {
+	quantiles := []float64{0.5, 0.95, 0.99}
+	const samples = 200000
+
+	for _, d := range sketchDistributions() {
+		t.Run(d.name, func(t *testing.T) {
+			values := sketchSample(d.gen, samples, 20260821)
+			s := NewSketch()
+			for _, v := range values {
+				s.Observe(v)
+			}
+			if s.Collapsed() {
+				t.Fatalf("sketch collapsed on a 1us-100s sample; bins=%d", s.PopulatedBins())
+			}
+			if s.Count() != samples {
+				t.Fatalf("count: got %d, want %d", s.Count(), samples)
+			}
+			bound := s.RelativeError()
+			for _, q := range quantiles {
+				want := sketchExactQuantile(values, q)
+				got := s.Quantile(q)
+				relErr := math.Abs(got-want) / want
+				if relErr > bound+sketchErrorSlack {
+					t.Errorf("q%.2f: estimate %g vs exact %g, relative error %.6f exceeds bound %.6f",
+						q, got, want, relErr, bound)
+				}
+				t.Logf("%s q%.2f exact=%.9g est=%.9g relerr=%.5f%% (bound %.5f%%, bins=%d)",
+					d.name, q, want, got, relErr*100, bound*100, s.PopulatedBins())
+			}
+		})
+	}
+}
+
+func TestSketchQuantileEdgeCases(t *testing.T) {
+	empty := NewSketch()
+	if got := empty.Quantile(0.5); got != 0 {
+		t.Fatalf("empty sketch quantile: got %g, want 0", got)
+	}
+	if empty.Count() != 0 || empty.PopulatedBins() != 0 || empty.Sum() != 0 {
+		t.Fatal("empty sketch has non-zero state")
+	}
+
+	single := NewSketch()
+	single.Observe(0.25)
+	for _, q := range []float64{0, 0.5, 1} {
+		got := single.Quantile(q)
+		if relErr := math.Abs(got-0.25) / 0.25; relErr > single.RelativeError()+sketchErrorSlack {
+			t.Fatalf("single observation q%.2f: got %g, relative error %.6f", q, got, relErr)
+		}
+	}
+	if single.Count() != 1 || single.Sum() != 0.25 {
+		t.Fatalf("single observation: count=%d sum=%g", single.Count(), single.Sum())
+	}
+	if got := single.Quantile(1.5); !math.IsNaN(got) {
+		t.Fatalf("out-of-range quantile: got %g, want NaN", got)
+	}
+	if got := single.Quantile(math.NaN()); !math.IsNaN(got) {
+		t.Fatalf("NaN quantile: got %g, want NaN", got)
+	}
+}
+
+func TestSketchZeroAndNonFiniteObservations(t *testing.T) {
+	s := NewSketch()
+	s.Observe(0)
+	s.Observe(-1)
+	s.Observe(math.NaN())
+	s.Observe(math.Inf(1))
+	s.Observe(math.Inf(-1))
+
+	if s.Count() != 2 {
+		t.Fatalf("count: got %d, want 2 (non-finite values rejected)", s.Count())
+	}
+	if s.ZeroCount() != 2 {
+		t.Fatalf("zero count: got %d, want 2", s.ZeroCount())
+	}
+	if s.PopulatedBins() != 0 {
+		t.Fatalf("populated bins: got %d, want 0", s.PopulatedBins())
+	}
+	if s.Sum() != -1 {
+		t.Fatalf("sum: got %g, want -1", s.Sum())
+	}
+	if got := s.Quantile(0.5); got != 0 {
+		t.Fatalf("quantile of zero-bucket-only sketch: got %g, want 0", got)
+	}
+
+	// The zero bucket participates in the rank: with 2 zeros and 2 positive
+	// values, the lower half of the distribution is still zero.
+	s.Observe(1.0)
+	s.Observe(2.0)
+	if got := s.Quantile(0.25); got != 0 {
+		t.Fatalf("q0.25: got %g, want 0", got)
+	}
+	if got := s.Quantile(0.9); math.Abs(got-1)/1 > s.RelativeError()+sketchErrorSlack {
+		t.Fatalf("q0.90: got %g, want ~1", got)
+	}
+	if got := s.Quantile(1); math.Abs(got-2)/2 > s.RelativeError()+sketchErrorSlack {
+		t.Fatalf("q1.00: got %g, want ~2", got)
+	}
+}
+
+func TestSketchCollapseLowestOnRangeOverflow(t *testing.T) {
+	s := NewSketch()
+	// Two values 2^40 apart require 640 bins at scale 4; only 512 exist.
+	s.Observe(1e-9)
+	s.Observe(1e-9 * math.Exp2(40))
+
+	if !s.Collapsed() {
+		t.Fatal("expected collapse-lowest to fire")
+	}
+	if s.Count() != 2 || s.binTotal != 2 {
+		t.Fatalf("collapse lost observations: count=%d binTotal=%d", s.Count(), s.binTotal)
+	}
+	if span := s.maxIdx - s.minIdx; span >= SketchMaxBins {
+		t.Fatalf("window span %d exceeds %d bins", span+1, SketchMaxBins)
+	}
+	// The high tail is unaffected: p99 must still be within the bound.
+	want := 1e-9 * math.Exp2(40)
+	if relErr := math.Abs(s.Quantile(1)-want) / want; relErr > s.RelativeError()+sketchErrorSlack {
+		t.Fatalf("tail quantile after collapse: relative error %.6f", relErr)
+	}
+}
+
+func TestSketchCollapseIsOrderIndependent(t *testing.T) {
+	values := []float64{1e-9, 5e-4, 0.02, 3.7, 1e-9 * math.Exp2(40), 12.5, 1e-7}
+
+	forward := NewSketch()
+	for _, v := range values {
+		forward.Observe(v)
+	}
+	reverse := NewSketch()
+	for i := len(values) - 1; i >= 0; i-- {
+		reverse.Observe(values[i])
+	}
+	shuffled := NewSketch()
+	order := []int{4, 0, 6, 2, 5, 1, 3}
+	for _, i := range order {
+		shuffled.Observe(values[i])
+	}
+
+	if !forward.Collapsed() {
+		t.Fatal("expected the sample to collapse")
+	}
+	sketchAssertSameContent(t, forward, reverse)
+	sketchAssertSameContent(t, forward, shuffled)
+}
+
+func TestSketchMergeCommutativeAndAssociative(t *testing.T) {
+	parts := make([][]float64, 3)
+	for i := range parts {
+		parts[i] = sketchSample(sketchDistributions()[0].gen, 5000, int64(100+i))
+	}
+	build := func(values []float64) *Sketch {
+		s := NewSketch()
+		for _, v := range values {
+			s.Observe(v)
+		}
+		return s
+	}
+
+	// (a+b)+c
+	left := build(parts[0])
+	left.Merge(build(parts[1]))
+	left.Merge(build(parts[2]))
+
+	// a+(b+c)
+	bc := build(parts[1])
+	bc.Merge(build(parts[2]))
+	right := build(parts[0])
+	right.Merge(bc)
+
+	// c+(b+a) - reversed order at every level
+	ba := build(parts[1])
+	ba.Merge(build(parts[0]))
+	reversed := build(parts[2])
+	reversed.Merge(ba)
+
+	sketchAssertSameContent(t, left, right)
+	sketchAssertSameContent(t, left, reversed)
+}
+
+func TestSketchMergeEqualsOneShot(t *testing.T) {
+	values := sketchSample(sketchDistributions()[3].gen, 60000, 999)
+
+	oneShot := NewSketch()
+	for _, v := range values {
+		oneShot.Observe(v)
+	}
+
+	// Partition into shuffled, uneven chunks and merge them in shuffled order.
+	r := rand.New(rand.NewSource(4242))
+	perm := r.Perm(len(values))
+	shuffled := make([]float64, len(values))
+	for i, p := range perm {
+		shuffled[i] = values[p]
+	}
+	var partials []*Sketch
+	for start := 0; start < len(shuffled); {
+		size := 1 + r.Intn(4000)
+		end := min(start+size, len(shuffled))
+		part := NewSketch()
+		for _, v := range shuffled[start:end] {
+			part.Observe(v)
+		}
+		partials = append(partials, part)
+		start = end
+	}
+	merged := NewSketch()
+	for _, p := range partials {
+		merged.Merge(p)
+	}
+
+	sketchAssertSameContent(t, oneShot, merged)
+	for _, q := range []float64{0.5, 0.95, 0.99} {
+		if a, b := oneShot.Quantile(q), merged.Quantile(q); a != b {
+			t.Fatalf("q%.2f: one-shot %g, merged %g", q, a, b)
+		}
+	}
+	if math.Abs(merged.Sum()-oneShot.Sum())/oneShot.Sum() > 1e-12 {
+		t.Fatalf("sum drift: one-shot %g, merged %g", oneShot.Sum(), merged.Sum())
+	}
+}
+
+func TestSketchMergeEmptyAndNil(t *testing.T) {
+	s := NewSketch()
+	s.Observe(0.5)
+	before := *s
+
+	s.Merge(nil)
+	s.Merge(NewSketch())
+	sketchAssertSameContent(t, &before, s)
+
+	empty := NewSketch()
+	empty.Merge(s)
+	sketchAssertSameContent(t, s, empty)
+}
+
+func TestSketchDownscaleIsExact(t *testing.T) {
+	values := sketchSample(sketchDistributions()[0].gen, 50000, 31337)
+	fine := NewSketch()
+	for _, v := range values {
+		fine.Observe(v)
+	}
+
+	coarse := *fine
+	if err := coarse.Downscale(2); err != nil {
+		t.Fatalf("Downscale: %v", err)
+	}
+	if coarse.Scale() != 2 {
+		t.Fatalf("scale after downscale: got %d, want 2", coarse.Scale())
+	}
+	if coarse.count != fine.count || coarse.binTotal != fine.binTotal {
+		t.Fatalf("downscale lost observations: %d/%d vs %d/%d",
+			coarse.count, coarse.binTotal, fine.count, fine.binTotal)
+	}
+	if coarse.PopulatedBins() > fine.PopulatedBins() {
+		t.Fatal("downscale increased the populated bin count")
+	}
+
+	// Downscaling folds four scale-4 buckets into one scale-2 bucket: every
+	// count must land in the bucket its index shift selects.
+	want := make(map[int32]uint32)
+	for idx, c := range sketchBins(fine) {
+		want[idx>>2] += c
+	}
+	got := sketchBins(&coarse)
+	if len(want) != len(got) {
+		t.Fatalf("folded bins: want %d, got %d", len(want), len(got))
+	}
+	for idx, c := range want {
+		if got[idx] != c {
+			t.Fatalf("bucket %d: want %d, got %d", idx, c, got[idx])
+		}
+	}
+
+	if err := coarse.Downscale(4); err == nil {
+		t.Fatal("expected upscaling to be rejected")
+	}
+
+	// Accuracy is now the coarser scale's bound, and it holds.
+	for _, q := range []float64{0.5, 0.95, 0.99} {
+		exact := sketchExactQuantile(values, q)
+		relErr := math.Abs(coarse.Quantile(q)-exact) / exact
+		if relErr > coarse.RelativeError()+sketchErrorSlack {
+			t.Errorf("q%.2f after downscale: relative error %.6f exceeds bound %.6f",
+				q, relErr, coarse.RelativeError())
+		}
+		t.Logf("scale-2 q%.2f relerr=%.5f%% (bound %.5f%%)", q, relErr*100, coarse.RelativeError()*100)
+	}
+}
+
+func TestSketchMergeAlignsScales(t *testing.T) {
+	values := sketchSample(sketchDistributions()[1].gen, 40000, 5150)
+	half := len(values) / 2
+
+	fine := NewSketch()
+	for _, v := range values[:half] {
+		fine.Observe(v)
+	}
+	coarse, err := NewSketchAtScale(2)
+	if err != nil {
+		t.Fatalf("NewSketchAtScale: %v", err)
+	}
+	for _, v := range values[half:] {
+		coarse.Observe(v)
+	}
+
+	// Merging in either direction lands on the coarser scale with the same
+	// content: alignment is a downscale of the finer side, which is exact.
+	a := *fine
+	a.Merge(coarse)
+	b := *coarse
+	b.Merge(fine)
+	if a.Scale() != 2 || b.Scale() != 2 {
+		t.Fatalf("aligned scale: got %d and %d, want 2", a.Scale(), b.Scale())
+	}
+	sketchAssertSameContent(t, &a, &b)
+	if a.Count() != uint64(len(values)) {
+		t.Fatalf("count after mixed-scale merge: got %d, want %d", a.Count(), len(values))
+	}
+
+	for _, q := range []float64{0.5, 0.95, 0.99} {
+		exact := sketchExactQuantile(values, q)
+		relErr := math.Abs(a.Quantile(q)-exact) / exact
+		if relErr > a.RelativeError()+sketchErrorSlack {
+			t.Errorf("q%.2f after mixed-scale merge: relative error %.6f exceeds bound %.6f",
+				q, relErr, a.RelativeError())
+		}
+	}
+}
+
+func TestSketchSaturatingAdds(t *testing.T) {
+	s := NewSketch()
+	s.Observe(0.1)
+	idx := sketchIndex(0.1, SketchDefaultScale)
+
+	s.add(idx, math.MaxUint32-1)
+	if s.Saturations() != 0 {
+		t.Fatalf("premature saturation: %d", s.Saturations())
+	}
+	if s.bins[idx-s.minIdx] != math.MaxUint32 {
+		t.Fatalf("bin: got %d, want MaxUint32", s.bins[idx-s.minIdx])
+	}
+
+	// One more observation must clamp rather than wrap.
+	s.add(idx, 10)
+	if s.Saturations() != 1 {
+		t.Fatalf("saturation counter: got %d, want 1", s.Saturations())
+	}
+	if got := s.bins[idx-s.minIdx]; got != math.MaxUint32 {
+		t.Fatalf("bin wrapped: got %d, want MaxUint32", got)
+	}
+	if s.binTotal != math.MaxUint32 {
+		t.Fatalf("retained observations: got %d, want MaxUint32", s.binTotal)
+	}
+
+	// Quantiles stay usable, they are only degraded.
+	if got := s.Quantile(0.5); math.Abs(got-0.1)/0.1 > s.RelativeError()+sketchErrorSlack {
+		t.Fatalf("quantile after saturation: got %g", got)
+	}
+
+	// Saturation counters accumulate across a merge.
+	other := NewSketch()
+	other.Observe(0.1)
+	other.add(idx, math.MaxUint32)
+	if other.Saturations() != 1 {
+		t.Fatalf("other saturation counter: got %d, want 1", other.Saturations())
+	}
+	s.Merge(other)
+	if s.Saturations() < 3 {
+		t.Fatalf("merged saturation counter: got %d, want >= 3", s.Saturations())
+	}
+	if s.bins[idx-s.minIdx] != math.MaxUint32 {
+		t.Fatal("merge wrapped a saturated bin")
+	}
+}
+
+func TestSketchObserveDoesNotAllocate(t *testing.T) {
+	s := NewSketch()
+	values := sketchSample(sketchDistributions()[3].gen, 1024, 8080)
+	i := 0
+	allocs := testing.AllocsPerRun(20000, func() {
+		s.Observe(values[i&1023])
+		i++
+	})
+	if allocs != 0 {
+		t.Fatalf("Observe allocated %.2f times per call, want 0", allocs)
+	}
+}


### PR DESCRIPTION
Phase 1 of #172: the latency sketch and its codec only. New `internal/aggregate` package, stdlib-only, nothing wired into ingest — three sibling components (SeriesKey/dictionary, template miner, reducer/cardinality) land in the same package separately.

## What this implements

Per the #157 resolution and the reviewer constraints adopted in that thread:

- **Mapping**: OTLP exponential-histogram base-2 function at scale 4 (`base = 2^(1/16) ≈ 1.044274`), bucket `i` covers `(base^i, base^(i+1)]`. Worst-case relative error `(base-1)/(base+1) = 2.1657%` using the DDSketch value estimator `2·upper/(base+1)`.
- **Storage**: dense `[512]uint32` bins + `zero_count`, `count` (uint64) and `sum` (float64). Non-finite observations are rejected outright; zero and negative values go to the zero bucket.
- **Overflow**: DDSketch collapse-lowest. Every observation below `maxIdx-511` folds into that lowest retained bin, which makes the final state a function of the observation multiset only — not of insertion or merge order.
- **Downscale**: exact, shift-only (`index >> (s-s')`, OTel perfect subsetting). `Downscale` refuses to upscale.
- **Saturating adds**: bins clamp at `MaxUint32` and never wrap, with `Saturations()` exposed for a metric. Clamping is degradation; wrapping would be corruption.
- **Merge**: aligns scale by downscaling the finer side, then adds bin-wise. Associative, commutative, order-independent.
- **Accuracy contract**: `RelativeError()` returns the bound for the sketch's current scale — the hook #164 needs.
- **Codec**: deterministic little-endian `version u8 (0x01) | scale u8 | flags u8 | zero_count uvarint | count uvarint | sum f64 | num_bins uvarint | first_index svarint | (index_delta uvarint, bin_count uvarint)*`, sparse over populated bins only. Encoding is a pure function of state, so `encode(decode(encode(x))) == encode(x)`.
- **Serialized cap**: more than 256 populated bins are collapsed-lowest on a copy at encode time (`AppendTo` never mutates the source), holding the hard bound #162's disk arithmetic is budgeted against. Decode enforces the same cap.
- **Decode rejection**: typed `ErrSketchVersion`, `ErrSketchScale`, `ErrSketchTruncated`, `ErrSketchCorrupt`. Corrupt covers reserved flag bits, non-canonical bins (zero counts, repeated or descending indexes), spans beyond the bin budget, impossible totals, non-finite sums, and trailing bytes.

## Error-bound test results

Quantile estimates against exact sorted-sample quantiles, 200,000 samples per distribution, values clamped to 1 µs – 100 s. Scale-4 bound is 2.16575%.

| Distribution | p50 | p95 | p99 | populated bins |
|---|---|---|---|---|
| log-normal (50 ms) | 1.439% | 2.078% | 0.242% | 244 |
| exponential (20 ms mean) | 0.650% | 1.674% | 1.388% | 268 |
| bimodal (2 ms / 3 s) | 0.150% | 0.206% | 0.902% | 189 |
| log-uniform, full 1 µs–100 s | 1.378% | 1.538% | 1.694% | 426 |

The log-uniform case populates exactly 426 bins — the theoretical bucket count for `R = 1e8` at scale 4 in the findings doc, and 86 bins inside the 512 budget.

After an exact downscale to scale 2 (bound 8.64272%): p50 4.056%, p95 6.569%, p99 4.989%. Mixed-scale merges land on the coarser scale and stay inside its bound.

Sparse encoding measures 2.42 B per populated bin (20,002 observations, 213 bins, 516 bytes), against the ~3 B/bin the disk arithmetic assumed. A 400-bin sketch collapses to 256 and encodes to 531 bytes.

## Tests

46 tests, all passing, plus `-race` clean. Bucket containment and power-of-two boundary mapping; quantile accuracy on the four distributions; empty, single-observation, zero-bucket and non-finite edge cases; collapse-lowest order-independence; merge commutativity/associativity/one-shot equality over shuffled uneven partitions; downscale exactness and post-downscale accuracy; saturation clamp and counter accumulation across merge; codec round-trip determinism, the 256-bin cap, negative bucket indexes, the collapsed flag, every proper prefix of a valid encoding, and ten structurally corrupt bodies.

`gosec` found a real decode bug during review: an `index_delta` above `MaxInt64` wrapped negative and would have indexed the bin array out of bounds. Delta is now bounded before the conversion, with a regression case in the corrupt-body table.

## Benchmarks

```
BenchmarkSketchObserve-8            45896493    26.20 ns/op     0 B/op   0 allocs/op
BenchmarkSketchObserveFullRange-8   44907942    25.89 ns/op     0 B/op   0 allocs/op
BenchmarkSketchMerge-8               1694318   771.5  ns/op     0 B/op   0 allocs/op
BenchmarkSketchEncode-8               972607  1193    ns/op   209 bins, 509 encoded_B, 0 allocs/op
BenchmarkSketchDecode-8               391525  2595    ns/op  2304 B/op   1 allocs/op
BenchmarkSketchQuantile-8            5789955   218.7  ns/op     0 B/op   0 allocs/op
```

`Observe` is allocation-free — asserted by `testing.AllocsPerRun` in `TestSketchObserveDoesNotAllocate`, not only by the benchmark. `Decode` allocates exactly one object: the 2,304-byte sketch itself.

Merge and Encode are over ~244- and ~209-bin sketches respectively.

## Deviations

- The findings doc proposed `internal/sketch/`; the issue scopes this into `internal/aggregate/`, so every exported symbol is `Sketch`-prefixed to keep the shared package namespace clean.
- Scales 0–20 decode (the OTel positive-scale range) rather than scale 4 only, because downscale produces coarser sketches and the merge path has to read them back. The platform default stays 4.
- The saturation counter is deliberately not serialized: it is an operational signal about a live sketch, not part of its value. Decoding yields 0.
- `Quantile` uses the DDSketch rank convention (smallest bucket whose cumulative count exceeds `q·(n-1)`), which is what the accuracy tests compare against.
- Verified: `go vet`, `golangci-lint` (0 issues), `go test -count=1`, `go test -race`, benchmarks. No CI run yet.

Refs #172
