### PR TITLE
feat(aggregate): engine core — reducer, shards, temporality, cardinality, shadow wiring

### DIFF
--- a/internal/aggregate/cardinality.go
+++ b/internal/aggregate/cardinality.go
@@ -1,0 +1,476 @@
+package aggregate
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Cardinality enforcement per issue #158.
+//
+// The budget allocates MATERIALIZED ACTIVE SERIES — full SeriesKeys present in
+// at least one mutable window — not semantic objects. One operation legitimately
+// yields several trace series once method, HTTP class, status and span kind are
+// multiplied out, and pretending otherwise is how a 6,000-series budget silently
+// becomes a 30,000-series one.
+//
+// The enforcement order is FROZEN:
+//
+//	tenant fraction -> per-service cap -> signal sub-cap -> global cap
+//
+// Blame localizes before the shared pool is touched: a single noisy service
+// hits its own ceiling first, so the global cap stays a backstop rather than
+// becoming the policy by accident.
+//
+// Nothing is ever dropped. Past a cap, telemetry merges into the per-(service,
+// signal) __other__ series, which preserves StatusClass — error visibility must
+// survive overflow — while collapsing Method to OTHER, HTTPClass to NONE, the
+// dimension tuple to none and the name to the dictionary's __other__ entry.
+// Overflow series draw on reserved capacity: a cap can never block creation of
+// the series whose job is to absorb violations of that cap.
+
+// Platform default caps, matching the #158 resolution and the AGGREGATE_*
+// defaults in internal/config.
+const (
+	DefaultMaxSeries        = 6000
+	DefaultMaxSeriesMetrics = 2400
+	DefaultMaxSeriesTraces  = 2400
+	DefaultMaxSeriesEdges   = 500
+	DefaultMaxSeriesLogs    = 500
+	DefaultMaxSeriesSystem  = 200
+
+	DefaultMaxOperationsPerService   = 20
+	DefaultMaxTraceSeriesPerService  = 50
+	DefaultMaxMetricSeriesPerService = 50
+
+	DefaultMaxProducerBaselinesPerSeries = 8
+)
+
+// OverflowReason names the cap that forced a series into its __other__ series.
+// The strings are metric label values and are part of the contract.
+type OverflowReason uint8
+
+// OverflowReason values, in enforcement order.
+const (
+	OverflowNone OverflowReason = iota
+	// OverflowTenant — the tenant's fraction of the global budget is full.
+	OverflowTenant
+	// OverflowServiceNames — the service has too many distinct names
+	// (operations for traces, log templates for logs).
+	OverflowServiceNames
+	// OverflowServiceSeries — the service has too many materialized series.
+	OverflowServiceSeries
+	// OverflowSignal — the signal's sub-cap is full.
+	OverflowSignal
+	// OverflowGlobal — the instance-wide backstop is full.
+	OverflowGlobal
+)
+
+// String implements fmt.Stringer.
+func (r OverflowReason) String() string {
+	switch r {
+	case OverflowTenant:
+		return "tenant"
+	case OverflowServiceNames:
+		return "service_names"
+	case OverflowServiceSeries:
+		return "service_series"
+	case OverflowSignal:
+		return "signal"
+	case OverflowGlobal:
+		return "global"
+	default:
+		return "none"
+	}
+}
+
+// LimiterConfig holds the cardinality budget. Zero values take the platform
+// defaults; a negative value disables that cap.
+type LimiterConfig struct {
+	MaxSeries        int
+	MaxSeriesMetrics int
+	MaxSeriesTraces  int
+	MaxSeriesEdges   int
+	MaxSeriesLogs    int
+	MaxSeriesSystem  int
+
+	MaxOperationsPerService   int
+	MaxLogTemplatesPerService int
+	MaxTraceSeriesPerService  int
+	MaxMetricSeriesPerService int
+
+	// SeriesPerTenantFraction is the fraction of MaxSeries one tenant may
+	// hold. 0 disables the tenant cap (the single-tenant default).
+	SeriesPerTenantFraction float64
+
+	// OtherNameID resolves the dictionary __other__ ID for the name kind of a
+	// signal, which is what an overflow series uses as its NameID. Required.
+	OtherNameID func(tenantID uint32, signal Signal) uint32
+}
+
+// Validate reports a budget that cannot hold: sum of sub-caps above the global
+// cap, or a tenant fraction outside [0,1]. config.Load() performs the same
+// checks at startup (fail-closed); this exists so an engine constructed
+// directly in a test cannot quietly run an impossible budget.
+func (c LimiterConfig) Validate() error {
+	if c.SeriesPerTenantFraction < 0 || c.SeriesPerTenantFraction > 1 {
+		return fmt.Errorf("aggregate: series-per-tenant fraction %v outside [0,1]", c.SeriesPerTenantFraction)
+	}
+	sum := c.MaxSeriesMetrics + c.MaxSeriesTraces + c.MaxSeriesEdges + c.MaxSeriesLogs + c.MaxSeriesSystem
+	if sum > c.MaxSeries {
+		return fmt.Errorf("aggregate: sum of signal sub-caps (%d) exceeds global cap (%d)", sum, c.MaxSeries)
+	}
+	return nil
+}
+
+// withDefaults fills unset caps.
+func (c LimiterConfig) withDefaults() LimiterConfig {
+	if c.MaxSeries == 0 {
+		c.MaxSeries = DefaultMaxSeries
+	}
+	if c.MaxSeriesMetrics == 0 {
+		c.MaxSeriesMetrics = DefaultMaxSeriesMetrics
+	}
+	if c.MaxSeriesTraces == 0 {
+		c.MaxSeriesTraces = DefaultMaxSeriesTraces
+	}
+	if c.MaxSeriesEdges == 0 {
+		c.MaxSeriesEdges = DefaultMaxSeriesEdges
+	}
+	if c.MaxSeriesLogs == 0 {
+		c.MaxSeriesLogs = DefaultMaxSeriesLogs
+	}
+	if c.MaxSeriesSystem == 0 {
+		c.MaxSeriesSystem = DefaultMaxSeriesSystem
+	}
+	if c.MaxOperationsPerService == 0 {
+		c.MaxOperationsPerService = DefaultMaxOperationsPerService
+	}
+	if c.MaxLogTemplatesPerService == 0 {
+		c.MaxLogTemplatesPerService = DefaultMaxLogTemplatesPerService
+	}
+	if c.MaxTraceSeriesPerService == 0 {
+		c.MaxTraceSeriesPerService = DefaultMaxTraceSeriesPerService
+	}
+	if c.MaxMetricSeriesPerService == 0 {
+		c.MaxMetricSeriesPerService = DefaultMaxMetricSeriesPerService
+	}
+	return c
+}
+
+// serviceScope is the (service, signal) scope of the per-service caps.
+type serviceScope struct {
+	tenant  uint32
+	service uint32
+	signal  Signal
+}
+
+// SeriesWindowKey identifies one series inside one mutable window. Window starts
+// are UTC-aligned Unix seconds.
+type SeriesWindowKey struct {
+	Key         SeriesKey
+	WindowStart int64
+}
+
+// Admission is the outcome of evaluating one series against the budget.
+type Admission struct {
+	// Key is the series to record under. It differs from the requested key
+	// when a cap forced overflow routing.
+	Key SeriesKey
+	// Overflowed reports that a cap was hit and Key is an __other__ series.
+	Overflowed bool
+	// Reason names the cap that triggered overflow.
+	Reason OverflowReason
+}
+
+// LimiterStats is a snapshot of Limiter occupancy.
+type LimiterStats struct {
+	// Active is the number of distinct series present in a mutable window.
+	Active int
+	// ActiveBySignal breaks Active down per signal.
+	ActiveBySignal map[Signal]int
+	// Overflow counts admissions routed to an __other__ series, per reason.
+	Overflow map[OverflowReason]uint64
+	// OverflowSeries is the number of live __other__ series.
+	OverflowSeries int
+}
+
+// Limiter owns the active-series census and enforces the budget. It is safe for
+// concurrent use.
+//
+// The engine calls Admit before taking any shard lock and Release during window
+// rollover. The limiter never takes a shard lock, so the lock order is always
+// engine -> limiter and can never invert.
+type Limiter struct {
+	cfg LimiterConfig
+
+	mu sync.Mutex
+	// present records which (series, window) pairs exist. It is the definition
+	// of "active": a series is active while it appears in a mutable window.
+	present map[SeriesWindowKey]struct{}
+	// windows counts how many mutable windows hold each series, so a series
+	// leaving one window does not release budget it still occupies elsewhere.
+	windows map[SeriesKey]int
+
+	total     int
+	bySignal  map[Signal]int
+	byService map[serviceScope]int
+	names     map[serviceScope]map[uint32]struct{}
+	byTenant  map[uint32]int
+	overflow  map[SeriesKey]struct{}
+
+	overflowCounts map[OverflowReason]uint64
+}
+
+// NewLimiter returns a Limiter for cfg.
+func NewLimiter(cfg LimiterConfig) *Limiter {
+	return &Limiter{
+		cfg:            cfg.withDefaults(),
+		present:        make(map[SeriesWindowKey]struct{}),
+		windows:        make(map[SeriesKey]int),
+		bySignal:       make(map[Signal]int),
+		byService:      make(map[serviceScope]int),
+		names:          make(map[serviceScope]map[uint32]struct{}),
+		byTenant:       make(map[uint32]int),
+		overflow:       make(map[SeriesKey]struct{}),
+		overflowCounts: make(map[OverflowReason]uint64),
+	}
+}
+
+// Admit evaluates key against the budget for the given window and returns the
+// series to record under. The full materialized key is evaluated before
+// admission; nothing is ever refused, only redirected.
+func (l *Limiter) Admit(key SeriesKey, window int64) Admission {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if _, ok := l.present[SeriesWindowKey{Key: key, WindowStart: window}]; ok {
+		return Admission{Key: key}
+	}
+	if l.windows[key] > 0 {
+		// Already active in another mutable window: it holds budget already.
+		l.addLocked(key, window, false)
+		return Admission{Key: key}
+	}
+	if reason := l.checkLocked(key); reason != OverflowNone {
+		l.overflowCounts[reason]++
+		other := l.overflowKey(key)
+		l.admitOverflowLocked(other, window)
+		return Admission{Key: other, Overflowed: true, Reason: reason}
+	}
+	l.addLocked(key, window, false)
+	return Admission{Key: key}
+}
+
+// checkLocked applies the frozen enforcement order and returns the first cap
+// that key violates. l.mu must be held.
+func (l *Limiter) checkLocked(key SeriesKey) OverflowReason {
+	// 1. Tenant fraction.
+	if l.cfg.SeriesPerTenantFraction > 0 {
+		limit := int(l.cfg.SeriesPerTenantFraction * float64(l.cfg.MaxSeries))
+		if limit < 1 {
+			limit = 1
+		}
+		if l.byTenant[key.TenantID] >= limit {
+			return OverflowTenant
+		}
+	}
+
+	scope := serviceScope{tenant: key.TenantID, service: key.ServiceID, signal: key.Signal}
+
+	// 2a. Per-service distinct-name cap (operations for traces and edges, log
+	// templates for logs). #159: the per-service operation cap counts distinct
+	// names; the sub-caps and global cap count full SeriesKeys.
+	if limit := l.nameCap(key.Signal); limit > 0 {
+		if names := l.names[scope]; len(names) >= limit {
+			if _, known := names[key.NameID]; !known {
+				return OverflowServiceNames
+			}
+		}
+	}
+
+	// 2b. Per-service materialized-series cap. Per-service caps are isolation
+	// ceilings, not reservations: 150 services x 50 may exceed the sub-cap,
+	// and the instance-wide cap remains the final shared bound.
+	if limit := l.seriesCap(key.Signal); limit > 0 && l.byService[scope] >= limit {
+		return OverflowServiceSeries
+	}
+
+	// 3. Signal sub-cap.
+	if limit := l.signalCap(key.Signal); limit > 0 && l.bySignal[key.Signal] >= limit {
+		return OverflowSignal
+	}
+
+	// 4. Global backstop.
+	if l.cfg.MaxSeries > 0 && l.total >= l.cfg.MaxSeries {
+		return OverflowGlobal
+	}
+	return OverflowNone
+}
+
+// admitOverflowLocked records an __other__ series. It bypasses every cap: the
+// series that absorbs quota violations can never be blocked by a quota. It is
+// still counted in the totals, so an operator sees the true occupancy — which
+// means the active count can exceed the global cap by the number of live
+// overflow series, bounded by (services x signals x status classes).
+func (l *Limiter) admitOverflowLocked(other SeriesKey, window int64) {
+	if _, ok := l.present[SeriesWindowKey{Key: other, WindowStart: window}]; ok {
+		return
+	}
+	l.addLocked(other, window, true)
+}
+
+// addLocked records presence of key in window and, on the series' first window,
+// charges it against the budget. l.mu must be held.
+func (l *Limiter) addLocked(key SeriesKey, window int64, isOverflow bool) {
+	l.present[SeriesWindowKey{Key: key, WindowStart: window}] = struct{}{}
+	l.windows[key]++
+	if l.windows[key] > 1 {
+		return
+	}
+	l.total++
+	l.bySignal[key.Signal]++
+	scope := serviceScope{tenant: key.TenantID, service: key.ServiceID, signal: key.Signal}
+	l.byService[scope]++
+	l.byTenant[key.TenantID]++
+	if l.nameCap(key.Signal) > 0 {
+		names := l.names[scope]
+		if names == nil {
+			names = make(map[uint32]struct{})
+			l.names[scope] = names
+		}
+		names[key.NameID] = struct{}{}
+	}
+	if isOverflow {
+		l.overflow[key] = struct{}{}
+	}
+}
+
+// Release drops one series' presence in one window. When the series leaves its
+// last mutable window it stops consuming budget: historical series are free
+// (#158), only active ones are charged.
+func (l *Limiter) Release(key SeriesKey, window int64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.releaseLocked(key, window)
+}
+
+func (l *Limiter) releaseLocked(key SeriesKey, window int64) {
+	swk := SeriesWindowKey{Key: key, WindowStart: window}
+	if _, ok := l.present[swk]; !ok {
+		return
+	}
+	delete(l.present, swk)
+	l.windows[key]--
+	if l.windows[key] > 0 {
+		return
+	}
+	delete(l.windows, key)
+	l.total--
+	l.bySignal[key.Signal]--
+	scope := serviceScope{tenant: key.TenantID, service: key.ServiceID, signal: key.Signal}
+	l.byService[scope]--
+	if l.byService[scope] <= 0 {
+		delete(l.byService, scope)
+	}
+	l.byTenant[key.TenantID]--
+	if l.byTenant[key.TenantID] <= 0 {
+		delete(l.byTenant, key.TenantID)
+	}
+	if names := l.names[scope]; names != nil {
+		delete(names, key.NameID)
+		if len(names) == 0 {
+			delete(l.names, scope)
+		}
+	}
+	delete(l.overflow, key)
+}
+
+// overflowKey builds the per-(service, signal) __other__ series for key.
+// StatusClass survives — an error that overflows is still an error — while the
+// name, dimensions, method, HTTP class and span kind collapse, which is what
+// bounds the number of overflow series.
+func (l *Limiter) overflowKey(key SeriesKey) SeriesKey {
+	other := SeriesKey{
+		TenantID:    key.TenantID,
+		ServiceID:   key.ServiceID,
+		DimsID:      0,
+		Signal:      key.Signal,
+		StatusClass: key.StatusClass,
+		HTTPClass:   HTTPClassNone,
+		Variant:     SpanKindUnspecified,
+	}
+	if key.Signal == SignalTraceOp || key.Signal == SignalServiceEdge {
+		other.Method = MethodOther
+	}
+	if l.cfg.OtherNameID != nil {
+		other.NameID = l.cfg.OtherNameID(key.TenantID, key.Signal)
+	}
+	return other
+}
+
+func (l *Limiter) nameCap(s Signal) int {
+	switch s {
+	case SignalTraceOp, SignalServiceEdge:
+		return l.cfg.MaxOperationsPerService
+	case SignalLog:
+		return l.cfg.MaxLogTemplatesPerService
+	default:
+		return 0
+	}
+}
+
+func (l *Limiter) seriesCap(s Signal) int {
+	switch s {
+	case SignalTraceOp, SignalServiceEdge:
+		return l.cfg.MaxTraceSeriesPerService
+	case SignalMetric:
+		return l.cfg.MaxMetricSeriesPerService
+	default:
+		return 0
+	}
+}
+
+func (l *Limiter) signalCap(s Signal) int {
+	switch s {
+	case SignalTraceOp:
+		return l.cfg.MaxSeriesTraces
+	case SignalServiceEdge:
+		return l.cfg.MaxSeriesEdges
+	case SignalLog:
+		return l.cfg.MaxSeriesLogs
+	case SignalMetric:
+		return l.cfg.MaxSeriesMetrics
+	default:
+		return l.cfg.MaxSeriesSystem
+	}
+}
+
+// IsOverflowSeries reports whether key is a live __other__ series.
+func (l *Limiter) IsOverflowSeries(key SeriesKey) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	_, ok := l.overflow[key]
+	return ok
+}
+
+// Stats returns a snapshot of occupancy and overflow counters.
+func (l *Limiter) Stats() LimiterStats {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	bySignal := make(map[Signal]int, len(l.bySignal))
+	for s, n := range l.bySignal {
+		if n > 0 {
+			bySignal[s] = n
+		}
+	}
+	overflow := make(map[OverflowReason]uint64, len(l.overflowCounts))
+	for r, n := range l.overflowCounts {
+		overflow[r] = n
+	}
+	return LimiterStats{
+		Active:         l.total,
+		ActiveBySignal: bySignal,
+		Overflow:       overflow,
+		OverflowSeries: len(l.overflow),
+	}
+}

--- a/internal/aggregate/cardinality_test.go
+++ b/internal/aggregate/cardinality_test.go
@@ -1,0 +1,335 @@
+package aggregate
+
+import (
+	"testing"
+	"time"
+)
+
+// otherNameStub stands in for the dictionary's __other__ entry.
+const otherNameStub uint32 = 999999
+
+func newTestLimiter(cfg LimiterConfig) *Limiter {
+	cfg.OtherNameID = func(uint32, Signal) uint32 { return otherNameStub }
+	return NewLimiter(cfg)
+}
+
+func capTraceKey(service, name uint32, m Method, status StatusClass) SeriesKey {
+	return SeriesKey{
+		TenantID:    1,
+		ServiceID:   service,
+		NameID:      name,
+		Signal:      SignalTraceOp,
+		StatusClass: status,
+		Method:      m,
+	}
+}
+
+const testWindow int64 = 1_000_000_000
+
+// --- enforcement order: each tier must fire first in its own scenario ---
+
+func TestEnforcementOrderTenantFirst(t *testing.T) {
+	// Tenant fraction is the tightest: 2% of 100 = 2 series. Every other cap
+	// is wide open, so only the tenant rule can trigger.
+	l := newTestLimiter(LimiterConfig{
+		MaxSeries: 100, MaxSeriesTraces: 100,
+		MaxOperationsPerService: 100, MaxTraceSeriesPerService: 100,
+		SeriesPerTenantFraction: 0.02,
+	})
+	l.Admit(capTraceKey(1, 1, MethodGet, StatusOK), testWindow)
+	l.Admit(capTraceKey(1, 2, MethodGet, StatusOK), testWindow)
+
+	adm := l.Admit(capTraceKey(1, 3, MethodGet, StatusOK), testWindow)
+	if !adm.Overflowed || adm.Reason != OverflowTenant {
+		t.Fatalf("admission = %+v, want overflow with reason tenant", adm)
+	}
+}
+
+func TestEnforcementOrderServiceNamesBeforeServiceSeries(t *testing.T) {
+	// Two operations allowed per service; the materialized per-service cap is
+	// wide, so the distinct-name rule must be what fires.
+	l := newTestLimiter(LimiterConfig{
+		MaxSeries: 1000, MaxSeriesTraces: 1000,
+		MaxOperationsPerService: 2, MaxTraceSeriesPerService: 1000,
+	})
+	l.Admit(capTraceKey(1, 1, MethodGet, StatusOK), testWindow)
+	l.Admit(capTraceKey(1, 2, MethodGet, StatusOK), testWindow)
+
+	// A third distinct operation overflows...
+	adm := l.Admit(capTraceKey(1, 3, MethodGet, StatusOK), testWindow)
+	if !adm.Overflowed || adm.Reason != OverflowServiceNames {
+		t.Fatalf("admission = %+v, want overflow with reason service_names", adm)
+	}
+	// ...but another materialization of a KNOWN operation is admitted: the
+	// name cap counts distinct names, not full keys (#159).
+	known := l.Admit(capTraceKey(1, 1, MethodPost, StatusError), testWindow)
+	if known.Overflowed {
+		t.Fatalf("a new materialization of a known operation was rejected: %+v", known)
+	}
+}
+
+func TestEnforcementOrderServiceSeriesBeforeSignal(t *testing.T) {
+	// One operation, but only two materialized series per service. The name
+	// cap can never fire here, and the signal sub-cap is far away.
+	l := newTestLimiter(LimiterConfig{
+		MaxSeries: 1000, MaxSeriesTraces: 1000,
+		MaxOperationsPerService: 100, MaxTraceSeriesPerService: 2,
+	})
+	l.Admit(capTraceKey(1, 1, MethodGet, StatusOK), testWindow)
+	l.Admit(capTraceKey(1, 1, MethodPost, StatusOK), testWindow)
+
+	adm := l.Admit(capTraceKey(1, 1, MethodPut, StatusOK), testWindow)
+	if !adm.Overflowed || adm.Reason != OverflowServiceSeries {
+		t.Fatalf("admission = %+v, want overflow with reason service_series", adm)
+	}
+}
+
+func TestEnforcementOrderSignalSubCap(t *testing.T) {
+	// Per-service caps are wide; the signal sub-cap is two. Two different
+	// services each take one slot, so no per-service rule can fire.
+	l := newTestLimiter(LimiterConfig{
+		MaxSeries: 1000, MaxSeriesTraces: 2, MaxSeriesLogs: 100,
+		MaxOperationsPerService: 100, MaxTraceSeriesPerService: 100,
+	})
+	l.Admit(capTraceKey(1, 1, MethodGet, StatusOK), testWindow)
+	l.Admit(capTraceKey(2, 1, MethodGet, StatusOK), testWindow)
+
+	adm := l.Admit(capTraceKey(3, 1, MethodGet, StatusOK), testWindow)
+	if !adm.Overflowed || adm.Reason != OverflowSignal {
+		t.Fatalf("admission = %+v, want overflow with reason signal", adm)
+	}
+
+	// A different signal is unaffected: sub-caps are independent.
+	logAdm := l.Admit(SeriesKey{TenantID: 1, ServiceID: 9, NameID: 1, Signal: SignalLog, StatusClass: SeverityTierInfo}, testWindow)
+	if logAdm.Overflowed {
+		t.Fatalf("log series overflowed on the trace sub-cap: %+v", logAdm)
+	}
+}
+
+// TestEnforcementOrderGlobalBackstop drives the last tier directly. In a
+// VALID configuration the global cap is unreachable — LimiterConfig.Validate
+// requires sum(sub-caps) <= global, so a signal sub-cap always fires first.
+// That is the point of the backstop: it exists for the misconfigured and the
+// overflow-inflated case, and it is evaluated last.
+func TestEnforcementOrderGlobalBackstop(t *testing.T) {
+	l := newTestLimiter(LimiterConfig{
+		MaxSeries: 2, MaxSeriesTraces: 1000, MaxSeriesLogs: 1000,
+		MaxOperationsPerService: 100, MaxTraceSeriesPerService: 100,
+	})
+	l.Admit(capTraceKey(1, 1, MethodGet, StatusOK), testWindow)
+	l.Admit(capTraceKey(2, 1, MethodGet, StatusOK), testWindow)
+
+	adm := l.Admit(capTraceKey(3, 1, MethodGet, StatusOK), testWindow)
+	if !adm.Overflowed || adm.Reason != OverflowGlobal {
+		t.Fatalf("admission = %+v, want overflow with reason global", adm)
+	}
+}
+
+func TestLimiterConfigValidateRejectsImpossibleBudgets(t *testing.T) {
+	over := LimiterConfig{MaxSeries: 100, MaxSeriesMetrics: 60, MaxSeriesTraces: 60}
+	if err := over.Validate(); err == nil {
+		t.Error("sum of sub-caps above the global cap was accepted")
+	}
+	badFraction := LimiterConfig{MaxSeries: 100, MaxSeriesTraces: 10, SeriesPerTenantFraction: 1.5}
+	if err := badFraction.Validate(); err == nil {
+		t.Error("tenant fraction above 1 was accepted")
+	}
+	ok := LimiterConfig{MaxSeries: 100, MaxSeriesTraces: 50, MaxSeriesLogs: 50}
+	if err := ok.Validate(); err != nil {
+		t.Errorf("valid budget rejected: %v", err)
+	}
+}
+
+func TestNewEngineRejectsImpossibleBudget(t *testing.T) {
+	_, err := NewEngine(EngineConfig{
+		Limiter: LimiterConfig{MaxSeries: 10, MaxSeriesTraces: 9, MaxSeriesLogs: 9},
+	})
+	if err == nil {
+		t.Fatal("engine accepted a budget whose sub-caps exceed the global cap")
+	}
+}
+
+// --- overflow behavior ---
+
+func TestOverflowSeriesPreservesStatusAndCollapsesTheRest(t *testing.T) {
+	l := newTestLimiter(LimiterConfig{
+		MaxSeries: 1000, MaxSeriesTraces: 1000,
+		MaxOperationsPerService: 1, MaxTraceSeriesPerService: 1000,
+	})
+	l.Admit(capTraceKey(1, 1, MethodGet, StatusOK), testWindow)
+
+	errored := l.Admit(SeriesKey{
+		TenantID: 1, ServiceID: 1, NameID: 42, Signal: SignalTraceOp,
+		StatusClass: StatusError, Method: MethodPost, HTTPClass: HTTPClass5xx,
+		Variant: SpanKindServer,
+	}, testWindow)
+	if !errored.Overflowed {
+		t.Fatal("expected overflow")
+	}
+	// Error visibility must survive overflow.
+	if errored.Key.StatusClass != StatusError {
+		t.Errorf("overflow status = %d, want StatusError", errored.Key.StatusClass)
+	}
+	if errored.Key.Method != MethodOther {
+		t.Errorf("overflow method = %v, want OTHER", errored.Key.Method)
+	}
+	if errored.Key.HTTPClass != HTTPClassNone {
+		t.Errorf("overflow http class = %v, want none", errored.Key.HTTPClass)
+	}
+	if errored.Key.NameID != otherNameStub {
+		t.Errorf("overflow name = %d, want the dictionary __other__ entry", errored.Key.NameID)
+	}
+	if errored.Key.Variant != SpanKindUnspecified || errored.Key.DimsID != 0 {
+		t.Errorf("overflow key kept identity detail: %+v", errored.Key)
+	}
+	if err := errored.Key.Validate(); err != nil {
+		t.Errorf("overflow key is not a valid series key: %v", err)
+	}
+
+	// A healthy overflow lands on a DIFFERENT overflow series than the error
+	// one — collapsing errors into the healthy bucket would hide outages.
+	healthy := l.Admit(capTraceKey(1, 43, MethodPut, StatusOK), testWindow)
+	if healthy.Key == errored.Key {
+		t.Error("error and healthy overflow collapsed into one series")
+	}
+}
+
+func TestOverflowSeriesCreationIsImmuneToEveryCap(t *testing.T) {
+	// Every cap is at its floor: one series globally, one per signal, one per
+	// service, one operation, and a tenant fraction that resolves to one.
+	l := newTestLimiter(LimiterConfig{
+		MaxSeries: 1, MaxSeriesTraces: 1,
+		MaxOperationsPerService: 1, MaxTraceSeriesPerService: 1,
+		SeriesPerTenantFraction: 0.01,
+	})
+	l.Admit(capTraceKey(1, 1, MethodGet, StatusOK), testWindow)
+
+	adm := l.Admit(capTraceKey(1, 2, MethodGet, StatusOK), testWindow)
+	if !adm.Overflowed {
+		t.Fatal("expected overflow")
+	}
+	if !l.IsOverflowSeries(adm.Key) {
+		t.Fatal("the __other__ series was not created: a cap blocked the series meant to absorb cap violations")
+	}
+	if got := l.Stats().OverflowSeries; got != 1 {
+		t.Errorf("live overflow series = %d, want 1", got)
+	}
+}
+
+func TestOverflowPreservesTotals(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e, err := NewEngine(EngineConfig{
+		Mode: ModeShadow,
+		Now:  func() time.Time { return now },
+		Limiter: LimiterConfig{
+			MaxSeries: 1000, MaxSeriesTraces: 500, MaxSeriesLogs: 100,
+			MaxSeriesMetrics: 100, MaxSeriesEdges: 100, MaxSeriesSystem: 100,
+			// Three operations per service: everything past that overflows.
+			MaxOperationsPerService: 3, MaxTraceSeriesPerService: 1000,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	const operations = 50
+	const perOperation = 7
+	r := e.NewReducer(now)
+	wantErrors := uint64(0)
+	for op := 0; op < operations; op++ {
+		for i := 0; i < perOperation; i++ {
+			isErr := op%5 == 0
+			status := int32(1)
+			if isErr {
+				status = 2
+				wantErrors++
+			}
+			r.ReduceSpan(SpanInput{
+				Tenant: "t", Service: "svc",
+				SpanName:   string(rune('a'+op%26)) + string(rune('a'+op/26)),
+				Timestamp:  now,
+				StatusCode: status, DurationMicros: float64(i + 1),
+			})
+		}
+	}
+	e.ApplyReducer(r)
+
+	snap := e.Snapshot()
+	count, errors := snap.Totals(SignalTraceOp)
+	if count != operations*perOperation {
+		t.Errorf("total count = %d, want %d — overflow must never lose a point", count, operations*perOperation)
+	}
+	if errors != wantErrors {
+		t.Errorf("total errors = %d, want %d", errors, wantErrors)
+	}
+	if snap.Overflow[OverflowServiceNames] == 0 {
+		t.Error("no service_names overflow was recorded despite exceeding the operation cap")
+	}
+	// Identity detail collapsed: far fewer series than operations.
+	if snap.ActiveSeries >= operations {
+		t.Errorf("active series = %d, want well under %d — overflow must collapse identity", snap.ActiveSeries, operations)
+	}
+}
+
+// TestActiveSeriesReleasedAcrossWindows proves budget accounting is per-series,
+// not per-(series, window): a series in two windows costs one slot, and giving
+// up one window does not free it.
+func TestActiveSeriesCountedOncePerSeries(t *testing.T) {
+	l := newTestLimiter(LimiterConfig{MaxSeries: 100, MaxSeriesTraces: 100})
+	key := capTraceKey(1, 1, MethodGet, StatusOK)
+
+	l.Admit(key, testWindow)
+	l.Admit(key, testWindow+300)
+	if got := l.Stats().Active; got != 1 {
+		t.Fatalf("active = %d, want 1 — one series in two windows is one series", got)
+	}
+
+	l.Release(key, testWindow)
+	if got := l.Stats().Active; got != 1 {
+		t.Fatalf("active = %d after releasing one of two windows, want 1", got)
+	}
+	l.Release(key, testWindow+300)
+	if got := l.Stats().Active; got != 0 {
+		t.Fatalf("active = %d after releasing every window, want 0", got)
+	}
+}
+
+func TestLogTemplateCapDrivesLogSeriesOverflow(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e, err := NewEngine(EngineConfig{
+		Mode: ModeShadow,
+		Now:  func() time.Time { return now },
+		Limiter: LimiterConfig{
+			MaxSeries: 1000, MaxSeriesLogs: 500, MaxSeriesTraces: 100,
+			MaxSeriesMetrics: 100, MaxSeriesEdges: 100, MaxSeriesSystem: 100,
+			MaxLogTemplatesPerService: 2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	r := e.NewReducer(now)
+	bodies := []string{
+		"alpha connection refused",
+		"beta disk quota exceeded",
+		"gamma certificate expired",
+		"delta upstream unavailable",
+		"epsilon handshake failed",
+	}
+	for _, b := range bodies {
+		r.ReduceLog(LogInput{Tenant: "t", Service: "svc", Severity: "ERROR", Body: b, Timestamp: now})
+	}
+	e.ApplyReducer(r)
+
+	count, errors := e.Snapshot().Totals(SignalLog)
+	if count != uint64(len(bodies)) || errors != uint64(len(bodies)) {
+		t.Errorf("log totals = (%d, %d), want (%d, %d) — totals survive template overflow",
+			count, errors, len(bodies), len(bodies))
+	}
+	// The miner caps templates per service; the __other__ template absorbs the
+	// rest, so the series count stays bounded.
+	if got := e.Snapshot().ActiveSeries; got > 3 {
+		t.Errorf("active log series = %d, want at most 3 (2 templates + __other__)", got)
+	}
+}

--- a/internal/aggregate/delta.go
+++ b/internal/aggregate/delta.go
@@ -1,0 +1,223 @@
+package aggregate
+
+import "time"
+
+// AggregateDelta is the compact aggregate contribution of one Export request to
+// one series in one window (CONTEXT.md, "Delta"). It is what request-local
+// reduction produces and what the engine applies; finalized buckets are built
+// from deltas, never the other way round.
+//
+// Every field is additive or order-independent so two deltas for the same
+// (series, window) merge without consulting the points that produced them. That
+// is what lets the Phase 2 group-commit writer (#173) pre-merge deltas inside a
+// transaction, and what lets Phase 1 apply them straight to the shards.
+//
+// A delta is not safe for concurrent use. Reducers are request-local and each
+// owns its deltas until they are handed to the engine.
+type AggregateDelta struct {
+	// Count is the number of accepted points that contributed to this series:
+	// spans for traces, log records for logs, data points for metrics. It is
+	// accepted telemetry, never sampled telemetry (#153 §8).
+	Count uint64
+	// ErrorCount is the subset of Count classified as an error: span status
+	// ERROR for traces, severity ERROR/FATAL for logs. Metrics never set it.
+	ErrorCount uint64
+
+	// --- durations (traces) ---
+
+	// DurationCount is the number of duration observations. It tracks Count
+	// for trace series and stays zero elsewhere, so a merged delta can still
+	// tell "no spans" from "spans with zero duration".
+	DurationCount uint64
+	// DurationSum is the sum of observed durations, in microseconds.
+	DurationSum float64
+	// DurationMin and DurationMax are the extremes of the observed durations
+	// in microseconds. They are only meaningful when DurationCount > 0.
+	DurationMin float64
+	DurationMax float64
+	// Sketch holds the quantile contribution of the observed durations. It is
+	// allocated on the first duration observation and stays nil for series
+	// that carry no latency (logs, metrics), which keeps the common delta
+	// small — a Sketch is ~2 KiB of dense bins.
+	Sketch *Sketch
+
+	// --- gauge-like metrics ---
+	//
+	// Populated by gauges and by cumulative non-monotonic sums, which #166
+	// aggregates gauge-like: last/min/max/sum-of-samples/count, never
+	// reset-detected.
+
+	GaugeCount uint64
+	GaugeSum   float64
+	GaugeMin   float64
+	GaugeMax   float64
+	// GaugeLast is the sample with the highest GaugeLastTime seen so far.
+	// Merging picks the later timestamp so the result does not depend on the
+	// order in which deltas were merged. Two samples of one series carrying
+	// the IDENTICAL timestamp are ambiguous about which is last, and that tie
+	// resolves by arrival order — no merge rule can fix a producer that
+	// timestamps two values the same.
+	GaugeLast     float64
+	GaugeLastTime time.Time
+
+	// --- cumulative counters ---
+
+	// CounterDelta is the increase attributed to this window: the sum of
+	// per-point deltas computed by the baseline tracker for cumulative sums,
+	// or the raw values of delta-temporality points.
+	CounterDelta float64
+	// ResetCount is the number of counter resets observed in this window
+	// (start-time change or value regression, per #166).
+	ResetCount uint64
+
+	// --- logs ---
+
+	// LogCount is the number of log records in this series. It is redundant
+	// with Count for log series and zero everywhere else; it exists so a
+	// merged multi-signal view can still answer "how many logs" without
+	// carrying the SeriesKey alongside.
+	LogCount uint64
+	// FirstTimestamp and LastTimestamp bound the log records that contributed.
+	// Zero when LogCount is zero.
+	FirstTimestamp time.Time
+	LastTimestamp  time.Time
+}
+
+// ObserveSpan records one span: its count, its error classification and its
+// duration in microseconds. Negative durations are recorded in the counters but
+// clamped to zero for the sketch, which is what Sketch.Observe does with them
+// anyway (latency is non-negative by construction).
+func (d *AggregateDelta) ObserveSpan(durationMicros float64, isError bool) {
+	d.Count++
+	if isError {
+		d.ErrorCount++
+	}
+	d.observeDuration(durationMicros)
+}
+
+// observeDuration folds one duration observation into the duration statistics
+// and the sketch, allocating the sketch on first use.
+func (d *AggregateDelta) observeDuration(micros float64) {
+	if d.DurationCount == 0 || micros < d.DurationMin {
+		d.DurationMin = micros
+	}
+	if d.DurationCount == 0 || micros > d.DurationMax {
+		d.DurationMax = micros
+	}
+	d.DurationCount++
+	d.DurationSum += micros
+	if d.Sketch == nil {
+		d.Sketch = NewSketch()
+	}
+	d.Sketch.Observe(micros)
+}
+
+// ObserveLog records one log record at ts. isError marks ERROR/FATAL severity.
+func (d *AggregateDelta) ObserveLog(ts time.Time, isError bool) {
+	d.Count++
+	d.LogCount++
+	if isError {
+		d.ErrorCount++
+	}
+	if d.FirstTimestamp.IsZero() || ts.Before(d.FirstTimestamp) {
+		d.FirstTimestamp = ts
+	}
+	if ts.After(d.LastTimestamp) {
+		d.LastTimestamp = ts
+	}
+}
+
+// ObserveGauge records one gauge-like sample at ts.
+func (d *AggregateDelta) ObserveGauge(value float64, ts time.Time) {
+	d.Count++
+	if d.GaugeCount == 0 || value < d.GaugeMin {
+		d.GaugeMin = value
+	}
+	if d.GaugeCount == 0 || value > d.GaugeMax {
+		d.GaugeMax = value
+	}
+	d.GaugeCount++
+	d.GaugeSum += value
+	if d.GaugeLastTime.IsZero() || !ts.Before(d.GaugeLastTime) {
+		d.GaugeLast = value
+		d.GaugeLastTime = ts
+	}
+}
+
+// ObserveCounter records one counter increase already converted to a delta by
+// the baseline tracker. reset marks that the increase followed a counter reset.
+func (d *AggregateDelta) ObserveCounter(delta float64, reset bool) {
+	d.Count++
+	d.CounterDelta += delta
+	if reset {
+		d.ResetCount++
+	}
+}
+
+// Merge folds other into d. Every field is additive or order-independent, so
+// merging is associative and commutative: the result depends only on the
+// multiset of observations, never on the order they arrived in.
+func (d *AggregateDelta) Merge(other *AggregateDelta) {
+	if other == nil {
+		return
+	}
+	d.Count += other.Count
+	d.ErrorCount += other.ErrorCount
+
+	if other.DurationCount > 0 {
+		if d.DurationCount == 0 || other.DurationMin < d.DurationMin {
+			d.DurationMin = other.DurationMin
+		}
+		if d.DurationCount == 0 || other.DurationMax > d.DurationMax {
+			d.DurationMax = other.DurationMax
+		}
+		d.DurationCount += other.DurationCount
+		d.DurationSum += other.DurationSum
+	}
+	if other.Sketch != nil {
+		if d.Sketch == nil {
+			d.Sketch = NewSketch()
+		}
+		d.Sketch.Merge(other.Sketch)
+	}
+
+	if other.GaugeCount > 0 {
+		if d.GaugeCount == 0 || other.GaugeMin < d.GaugeMin {
+			d.GaugeMin = other.GaugeMin
+		}
+		if d.GaugeCount == 0 || other.GaugeMax > d.GaugeMax {
+			d.GaugeMax = other.GaugeMax
+		}
+		d.GaugeCount += other.GaugeCount
+		d.GaugeSum += other.GaugeSum
+		if d.GaugeLastTime.IsZero() || other.GaugeLastTime.After(d.GaugeLastTime) {
+			d.GaugeLast = other.GaugeLast
+			d.GaugeLastTime = other.GaugeLastTime
+		}
+	}
+
+	d.CounterDelta += other.CounterDelta
+	d.ResetCount += other.ResetCount
+
+	d.LogCount += other.LogCount
+	if !other.FirstTimestamp.IsZero() && (d.FirstTimestamp.IsZero() || other.FirstTimestamp.Before(d.FirstTimestamp)) {
+		d.FirstTimestamp = other.FirstTimestamp
+	}
+	if other.LastTimestamp.After(d.LastTimestamp) {
+		d.LastTimestamp = other.LastTimestamp
+	}
+}
+
+// Clone returns a deep copy, including the sketch. Used by Snapshot so a caller
+// can read a consistent view without holding a shard lock.
+func (d *AggregateDelta) Clone() *AggregateDelta {
+	if d == nil {
+		return nil
+	}
+	cp := *d
+	if d.Sketch != nil {
+		s := *d.Sketch
+		cp.Sketch = &s
+	}
+	return &cp
+}

--- a/internal/aggregate/dict.go
+++ b/internal/aggregate/dict.go
@@ -204,6 +204,13 @@ func (c *Cache) register(scope dictScope, value []byte) uint32 {
 	return id
 }
 
+// OtherID returns the pre-created overflow ID for (tenantID, kind). Cardinality
+// overflow routing needs it directly, not just as a miss fallback: an overflow
+// series carries the __other__ entry as its NameID.
+func (c *Cache) OtherID(tenantID uint32, kind Kind) uint32 {
+	return c.reg.OtherID(tenantID, kind)
+}
+
 // Len returns the number of cached entries across every scope. Diagnostic only.
 func (c *Cache) Len() int {
 	c.mu.RLock()

--- a/internal/aggregate/engine.go
+++ b/internal/aggregate/engine.go
@@ -1,0 +1,556 @@
+package aggregate
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// The engine: mutable windows, four mutex-guarded shards, and the apply path.
+//
+// Time bounds are fixed by #160 and #153 §6: five-minute UTC tumbling windows,
+// ten minutes of allowed lateness, two minutes of tolerated future skew. The
+// mutable set is the current window plus the windows still inside the lateness
+// horizon; everything older is finalized and never re-enters memory.
+//
+// PHASE 1 LOSS, STATED PLAINLY: there is no durable store yet (#173). A window
+// that rolls out of the mutable set is DISCARDED, not finalized — its counts
+// are gone. That is acceptable only because Phase 1 runs in shadow mode, where
+// the legacy path remains the source of truth and the aggregate numbers exist
+// to be compared, not queried. Nothing in this package may be presented to a
+// user as authoritative until the group-commit writer lands.
+//
+// Shards are four plain mutex-guarded maps (hash & 3). No shard goroutines, no
+// channels. Two shard locks are NEVER held at once: a delta touches exactly one
+// shard, and the apply path walks the shards one at a time. The limiter is the
+// only other lock in play and it never reaches back for a shard, so the order
+// is always shard -> limiter.
+
+// Engine time bounds.
+const (
+	// WindowSize is the tumbling window width. Windows are aligned to UTC.
+	WindowSize = 5 * time.Minute
+	// AllowedLateness is how long after a window closes its points are still
+	// accepted. Later points are excluded from aggregates and counted.
+	AllowedLateness = 10 * time.Minute
+	// MaxFutureSkew is how far ahead of arrival a point may be timestamped.
+	// Future windows are never created.
+	MaxFutureSkew = 2 * time.Minute
+	// NumShards is the shard count. Fixed at four per #160.
+	NumShards = 4
+)
+
+// Modes. Phase 1 ships legacy and aggregate-shadow; ModeAggregate is accepted
+// by config but the read path does not switch over until a later phase.
+const (
+	ModeLegacy    = "legacy"
+	ModeShadow    = "aggregate-shadow"
+	ModeAggregate = "aggregate"
+)
+
+// PointDisposition classifies a point against the mutable-window horizon.
+type PointDisposition uint8
+
+// PointDisposition values. The non-accepted strings are metric label values.
+const (
+	// PointAccepted — the point belongs to a mutable window.
+	PointAccepted PointDisposition = iota
+	// PointLate — the point is older than the lateness horizon. It is excluded
+	// from aggregates and counted; the raw/exemplar path still sees it, because
+	// a late error trace is still evidence (#160).
+	PointLate
+	// PointFuture — the point is timestamped beyond the tolerated skew.
+	PointFuture
+)
+
+// String implements fmt.Stringer.
+func (d PointDisposition) String() string {
+	switch d {
+	case PointLate:
+		return "late"
+	case PointFuture:
+		return "future"
+	default:
+		return "accepted"
+	}
+}
+
+// DeltaMap is one reducer's output: the deltas of one Export request, keyed by
+// series and window.
+type DeltaMap map[SeriesWindowKey]*AggregateDelta
+
+// Applier applies deltas to the engine's shards. Phase 1 wires the direct
+// applier, which mutates the shards inline. Phase 2 (#173) interposes the
+// group-commit writer here: it batches deltas from many Export requests into
+// one SQLite transaction and calls ApplyCommitted only after the COMMIT, making
+// the shards a projection of committed state. No caller changes when it does.
+type Applier interface {
+	Apply(DeltaMap) uint64
+}
+
+// EngineConfig configures an Engine. Zero values take platform defaults.
+type EngineConfig struct {
+	// Mode is the aggregate mode (AGGREGATE_MODE). An Engine is only
+	// constructed for a non-legacy mode.
+	Mode string
+
+	// Limiter holds the cardinality budget.
+	Limiter LimiterConfig
+
+	// MaxProducerBaselinesPerSeries and MaxBaselines bound the cumulative
+	// baseline tracker.
+	MaxProducerBaselinesPerSeries int
+	MaxBaselines                  int
+
+	// Registrar mints dictionary IDs. Defaults to an in-memory registrar
+	// whose IDs are provisional and vanish on restart (#173 replaces it).
+	Registrar Registrar
+
+	// Miner is the ingest-owned template miner (#163). Defaults to one built
+	// from the log-template cap.
+	Miner *TemplateMiner
+
+	// Metrics is the Prometheus recorder. nil disables metric recording.
+	Metrics MetricsRecorder
+
+	// Now is the clock, injectable for tests. Defaults to time.Now.
+	Now func() time.Time
+}
+
+// Engine is the aggregate accounting engine.
+type Engine struct {
+	mode string
+	now  func() time.Time
+
+	cache     *Cache
+	miner     *TemplateMiner
+	limiter   *Limiter
+	baselines *BaselineTracker
+	metrics   MetricsRecorder
+
+	shards [NumShards]shard
+
+	applier  atomic.Pointer[Applier]
+	revision atomic.Uint64
+
+	windowsDiscarded atomic.Uint64
+	seriesDiscarded  atomic.Uint64
+}
+
+// shard is one mutex-guarded slice of the mutable window set.
+type shard struct {
+	mu      sync.Mutex
+	windows map[int64]map[SeriesKey]*AggregateDelta
+}
+
+// NewEngine builds an Engine. It fails on a budget that cannot hold — a
+// misconfigured cap must stop startup, not silently become policy.
+func NewEngine(cfg EngineConfig) (*Engine, error) {
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.Mode == "" {
+		cfg.Mode = ModeShadow
+	}
+	limCfg := cfg.Limiter.withDefaults()
+	if err := limCfg.Validate(); err != nil {
+		return nil, err
+	}
+	reg := cfg.Registrar
+	if reg == nil {
+		reg = NewMemRegistrar(nil)
+	}
+	e := &Engine{
+		mode:    cfg.Mode,
+		now:     cfg.Now,
+		cache:   NewCache(reg),
+		miner:   cfg.Miner,
+		metrics: cfg.Metrics,
+	}
+	if e.metrics == nil {
+		e.metrics = noopRecorder{}
+	}
+	limCfg.OtherNameID = e.otherNameID
+	e.limiter = NewLimiter(limCfg)
+	e.baselines = NewBaselineTracker(BaselineTrackerConfig{
+		MaxProducersPerSeries: cfg.MaxProducerBaselinesPerSeries,
+		MaxBaselines:          cfg.MaxBaselines,
+		GapThreshold:          AllowedLateness,
+	})
+	if e.miner == nil {
+		// The miner's IDs ARE the log series NameIDs, so they must be minted
+		// in the same dictionary namespace the overflow __other__ ID comes
+		// from (#159 as amended by #163). A private counter would let an
+		// ordinary template collide with an unrelated dictionary entry.
+		e.miner = NewTemplateMiner(TemplateMinerConfig{
+			MaxTemplatesPerService: limCfg.MaxLogTemplatesPerService,
+			Registrar:              TemplateRegistrarFunc(e.registerTemplate),
+		})
+	}
+	for i := range e.shards {
+		e.shards[i].windows = make(map[int64]map[SeriesKey]*AggregateDelta)
+	}
+	var a Applier = directApplier{e}
+	e.applier.Store(&a)
+	return e, nil
+}
+
+// Mode returns the configured aggregate mode.
+func (e *Engine) Mode() string { return e.mode }
+
+// Cache returns the dictionary cache.
+func (e *Engine) Cache() *Cache { return e.cache }
+
+// Miner returns the ingest-owned template miner.
+func (e *Engine) Miner() *TemplateMiner { return e.miner }
+
+// Limiter returns the cardinality limiter.
+func (e *Engine) Limiter() *Limiter { return e.limiter }
+
+// Baselines returns the cumulative baseline tracker.
+func (e *Engine) Baselines() *BaselineTracker { return e.baselines }
+
+// Revision returns the current revision. It increases by one on every applied
+// batch and never decreases, so a consumer can tell "nothing changed" from
+// "changed back to the same numbers" (#163's replacement-by-revision topology).
+func (e *Engine) Revision() uint64 { return e.revision.Load() }
+
+// SetApplier replaces the apply path. Phase 2 uses it to insert the
+// group-commit writer between the reducer and the shards.
+func (e *Engine) SetApplier(a Applier) {
+	if a == nil {
+		return
+	}
+	e.applier.Store(&a)
+}
+
+// otherNameID resolves the dictionary __other__ entry for a signal's name
+// namespace, which is what an overflow series carries as its NameID.
+func (e *Engine) otherNameID(tenantID uint32, signal Signal) uint32 {
+	kind, ok := NameKind(signal)
+	if !ok {
+		return 0
+	}
+	return e.cache.OtherID(tenantID, kind)
+}
+
+// registerTemplate mints a template identity in the log_template dictionary
+// namespace. The registered value pairs the service with the template text at
+// registration time: that pair is the immutable surrogate identity, and the
+// text may evolve under the same ID later without the ID moving (#163).
+func (e *Engine) registerTemplate(r TemplateRegistration) (uint32, error) {
+	tenantID := e.cache.InternTenant(r.Tenant)
+	if r.IsOther {
+		return e.cache.OtherID(tenantID, KindLogTemplate), nil
+	}
+	var sb strings.Builder
+	sb.Grow(len(r.Service) + 1 + len(r.Template))
+	sb.WriteString(r.Service)
+	sb.WriteByte(0)
+	sb.WriteString(r.Template)
+	return e.cache.Intern(tenantID, KindLogTemplate, sb.String()), nil
+}
+
+// WindowStart returns the UTC-aligned start of the window containing t, as Unix
+// seconds. Alignment is computed arithmetically rather than with Truncate so it
+// is obviously independent of the local zone.
+func WindowStart(t time.Time) int64 {
+	const w = int64(WindowSize / time.Second)
+	sec := t.Unix()
+	rem := sec % w
+	if rem < 0 {
+		rem += w
+	}
+	return sec - rem
+}
+
+// Classify places a point in a window relative to one Export's arrival time.
+// A single arrivalTime is captured per Export request and used for every point
+// in it (#160): lateness must not depend on where in the batch a point sits.
+func Classify(arrival, pointTime time.Time) (int64, PointDisposition) {
+	if pointTime.Sub(arrival) > MaxFutureSkew {
+		return 0, PointFuture
+	}
+	start := WindowStart(pointTime)
+	// A window stays mutable until lateness expires after it closes.
+	if arrival.Unix() >= start+int64(WindowSize/time.Second)+int64(AllowedLateness/time.Second) {
+		return start, PointLate
+	}
+	return start, PointAccepted
+}
+
+// ApplyReducer records the reduction metrics for one Export request and applies
+// its deltas. This is the entry point the OTLP servers call.
+func (e *Engine) ApplyReducer(r *Reducer) uint64 {
+	if r == nil {
+		return e.revision.Load()
+	}
+	e.recordReduction(r)
+	return e.ApplyDeltas(r.Deltas())
+}
+
+// ApplyDeltas applies one reducer's output through the configured applier.
+func (e *Engine) ApplyDeltas(m DeltaMap) uint64 {
+	if len(m) == 0 {
+		return e.revision.Load()
+	}
+	a := *e.applier.Load()
+	return a.Apply(m)
+}
+
+// directApplier is the Phase 1 apply path: no durability, no batching.
+type directApplier struct{ e *Engine }
+
+// Apply implements Applier.
+func (d directApplier) Apply(m DeltaMap) uint64 { return d.e.ApplyCommitted(m) }
+
+// ApplyCommitted admits the deltas against the cardinality budget and folds
+// them into the mutable windows. Phase 2's writer calls it after its COMMIT;
+// Phase 1 calls it inline.
+//
+// Admission happens first, with no shard lock held, because a series pushed
+// past a cap is rerouted to an __other__ series that may hash to a different
+// shard. Resolving identity before touching any shard is what keeps the rule
+// "never hold two shard locks" trivially true.
+func (e *Engine) ApplyCommitted(m DeltaMap) uint64 {
+	if len(m) == 0 {
+		return e.revision.Load()
+	}
+	e.Rollover(e.now())
+
+	cutoff := e.now().Unix() - int64(WindowSize/time.Second) - int64(AllowedLateness/time.Second)
+	resolved := make(DeltaMap, len(m))
+	for swk, d := range m {
+		if swk.WindowStart <= cutoff {
+			// The window's lateness horizon expired between reduction and
+			// apply. Recreating it here would only have it discarded at the
+			// next rollover.
+			e.seriesDiscarded.Add(1)
+			continue
+		}
+		adm := e.limiter.Admit(swk.Key, swk.WindowStart)
+		if adm.Overflowed {
+			e.metrics.RecordOverflow(swk.Key.Signal, adm.Reason)
+		}
+		target := SeriesWindowKey{Key: adm.Key, WindowStart: swk.WindowStart}
+		if existing, ok := resolved[target]; ok {
+			// Two source series collapsed onto the same overflow series.
+			// Totals are preserved; only identity detail is gone.
+			existing.Merge(d)
+			continue
+		}
+		resolved[target] = d
+	}
+
+	for i := range e.shards {
+		e.applyShard(i, resolved)
+	}
+
+	rev := e.revision.Add(1)
+	e.publishActiveSeries()
+	return rev
+}
+
+// applyShard folds every entry belonging to shard i into it, under that shard's
+// lock and no other.
+func (e *Engine) applyShard(i int, resolved DeltaMap) {
+	sh := &e.shards[i]
+	locked := false
+	defer func() {
+		if locked {
+			sh.mu.Unlock()
+		}
+	}()
+	for swk, d := range resolved {
+		if shardIndex(swk.Key) != i {
+			continue
+		}
+		if !locked {
+			sh.mu.Lock()
+			locked = true
+		}
+		w := sh.windows[swk.WindowStart]
+		if w == nil {
+			w = make(map[SeriesKey]*AggregateDelta)
+			sh.windows[swk.WindowStart] = w
+		}
+		if cur, ok := w[swk.Key]; ok {
+			cur.Merge(d)
+			continue
+		}
+		w[swk.Key] = d.Clone()
+	}
+}
+
+// Rollover discards every window whose lateness horizon has expired and returns
+// how many it dropped.
+//
+// Phase 1 DISCARDS. There is no delta log to finalize from and no bucket table
+// to materialize into, so the counts in an expiring window are lost. See the
+// file header: this is shadow-mode behavior, not the durability contract.
+func (e *Engine) Rollover(now time.Time) int {
+	cutoff := now.Unix() - int64(WindowSize/time.Second) - int64(AllowedLateness/time.Second)
+	dropped := 0
+	var released []SeriesWindowKey
+	for i := range e.shards {
+		sh := &e.shards[i]
+		sh.mu.Lock()
+		for start, w := range sh.windows {
+			if start > cutoff {
+				continue
+			}
+			for key := range w {
+				released = append(released, SeriesWindowKey{Key: key, WindowStart: start})
+			}
+			delete(sh.windows, start)
+			dropped++
+		}
+		sh.mu.Unlock()
+	}
+	for _, swk := range released {
+		e.limiter.Release(swk.Key, swk.WindowStart)
+	}
+	if dropped > 0 {
+		e.windowsDiscarded.Add(uint64(dropped))
+		e.seriesDiscarded.Add(uint64(len(released)))
+		e.publishActiveSeries()
+	}
+	return dropped
+}
+
+// publishActiveSeries pushes the limiter's occupancy into the active-series
+// gauge.
+func (e *Engine) publishActiveSeries() {
+	e.metrics.SetActiveSeries(e.limiter.Stats().ActiveBySignal)
+}
+
+// recordReduction publishes one Export request's reduction accounting.
+func (e *Engine) recordReduction(r *Reducer) {
+	e.metrics.RecordReduction(r.stats, r.deltaCountBySignal())
+}
+
+// WindowSnapshot is one mutable window's contents.
+type WindowSnapshot struct {
+	// Start is the window's UTC start.
+	Start time.Time
+	// Series maps each active series in the window to a copy of its delta.
+	Series map[SeriesKey]*AggregateDelta
+}
+
+// Snapshot is a consistent-enough view of the engine for tests and metrics.
+//
+// It walks the shards one at a time, so it is not a single atomic instant
+// across shards. That is deliberate: an atomic cross-shard snapshot would need
+// all four locks held at once, which is the one thing the shard design forbids.
+type Snapshot struct {
+	// Revision is the revision at the end of the walk.
+	Revision uint64
+	// Windows are the mutable windows, oldest first.
+	Windows []WindowSnapshot
+	// ActiveSeries and ActiveBySignal mirror the limiter's census.
+	ActiveSeries   int
+	ActiveBySignal map[Signal]int
+	// Overflow counts admissions rerouted to an __other__ series, per reason.
+	Overflow map[OverflowReason]uint64
+	// WindowsDiscarded and SeriesDiscarded count Phase 1 rollover loss.
+	WindowsDiscarded uint64
+	SeriesDiscarded  uint64
+}
+
+// Snapshot returns a copy of the mutable window set.
+func (e *Engine) Snapshot() Snapshot {
+	byWindow := make(map[int64]map[SeriesKey]*AggregateDelta)
+	for i := range e.shards {
+		sh := &e.shards[i]
+		sh.mu.Lock()
+		for start, w := range sh.windows {
+			dst := byWindow[start]
+			if dst == nil {
+				dst = make(map[SeriesKey]*AggregateDelta, len(w))
+				byWindow[start] = dst
+			}
+			for key, d := range w {
+				dst[key] = d.Clone()
+			}
+		}
+		sh.mu.Unlock()
+	}
+
+	starts := make([]int64, 0, len(byWindow))
+	for start := range byWindow {
+		starts = append(starts, start)
+	}
+	sort.Slice(starts, func(i, j int) bool { return starts[i] < starts[j] })
+
+	windows := make([]WindowSnapshot, 0, len(starts))
+	for _, start := range starts {
+		windows = append(windows, WindowSnapshot{
+			Start:  time.Unix(start, 0).UTC(),
+			Series: byWindow[start],
+		})
+	}
+
+	ls := e.limiter.Stats()
+	return Snapshot{
+		Revision:         e.revision.Load(),
+		Windows:          windows,
+		ActiveSeries:     ls.Active,
+		ActiveBySignal:   ls.ActiveBySignal,
+		Overflow:         ls.Overflow,
+		WindowsDiscarded: e.windowsDiscarded.Load(),
+		SeriesDiscarded:  e.seriesDiscarded.Load(),
+	}
+}
+
+// Totals sums one signal's counters across every mutable window. It is the
+// shadow-mode comparison primitive: the same input stream must produce the same
+// totals regardless of the sampling rate.
+func (s Snapshot) Totals(signal Signal) (count, errors uint64) {
+	for _, w := range s.Windows {
+		for key, d := range w.Series {
+			if key.Signal != signal {
+				continue
+			}
+			count += d.Count
+			errors += d.ErrorCount
+		}
+	}
+	return count, errors
+}
+
+// String implements fmt.Stringer for test failures.
+func (s Snapshot) String() string {
+	return fmt.Sprintf("Snapshot{revision=%d windows=%d active=%d discarded_windows=%d}",
+		s.Revision, len(s.Windows), s.ActiveSeries, s.WindowsDiscarded)
+}
+
+// shardIndex maps a series to its shard. FNV-1a over the identity fields,
+// unrolled so it stays allocation-free and inlinable.
+func shardIndex(k SeriesKey) int {
+	const (
+		offset = uint32(2166136261)
+		prime  = uint32(16777619)
+	)
+	h := offset
+	for _, v := range [...]uint32{
+		k.TenantID,
+		k.ServiceID,
+		k.NameID,
+		k.DimsID,
+		uint32(k.Signal)<<24 | uint32(k.StatusClass)<<16 | uint32(k.HTTPClass)<<8 | uint32(k.Method),
+		uint32(k.Variant),
+	} {
+		h ^= v & 0xff
+		h *= prime
+		h ^= (v >> 8) & 0xff
+		h *= prime
+		h ^= (v >> 16) & 0xff
+		h *= prime
+		h ^= v >> 24
+		h *= prime
+	}
+	return int(h & (NumShards - 1))
+}

--- a/internal/aggregate/engine_test.go
+++ b/internal/aggregate/engine_test.go
@@ -1,0 +1,428 @@
+package aggregate
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// testEngine builds an engine with a fixed clock and generous caps, so a test
+// that is not about cardinality never trips a cap by accident.
+func testEngine(t *testing.T, now time.Time) *Engine {
+	t.Helper()
+	e, err := NewEngine(EngineConfig{
+		Mode: ModeShadow,
+		Now:  func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	return e
+}
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return ts
+}
+
+func TestWindowStartIsUTCAligned(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"2026-08-21T12:00:00Z", "2026-08-21T12:00:00Z"},
+		{"2026-08-21T12:03:59Z", "2026-08-21T12:00:00Z"},
+		{"2026-08-21T12:04:59.999Z", "2026-08-21T12:00:00Z"},
+		{"2026-08-21T12:05:00Z", "2026-08-21T12:05:00Z"},
+		{"2026-08-21T23:59:59Z", "2026-08-21T23:55:00Z"},
+		{"1969-12-31T23:57:00Z", "1969-12-31T23:55:00Z"}, // pre-epoch: floor, not truncate-toward-zero
+	}
+	for _, c := range cases {
+		got := WindowStart(mustTime(t, c.in))
+		want := mustTime(t, c.want).Unix()
+		if got != want {
+			t.Errorf("WindowStart(%s) = %d, want %d (%s)", c.in, got, want, c.want)
+		}
+	}
+}
+
+// TestWindowStartIndependentOfLocalZone pins that alignment is UTC, not local:
+// a non-UTC location must not shift the window boundary.
+func TestWindowStartIndependentOfLocalZone(t *testing.T) {
+	utc := mustTime(t, "2026-08-21T12:03:00Z")
+	kolkata := time.FixedZone("IST", 5*3600+1800) // +05:30, a half-hour offset
+	shifted := utc.In(kolkata)
+	if WindowStart(utc) != WindowStart(shifted) {
+		t.Fatalf("window start moved with location: %d vs %d", WindowStart(utc), WindowStart(shifted))
+	}
+}
+
+func TestClassifyLateAndFuture(t *testing.T) {
+	arrival := mustTime(t, "2026-08-21T12:00:00Z")
+	cases := []struct {
+		name   string
+		offset time.Duration
+		want   PointDisposition
+	}{
+		{"current", 0, PointAccepted},
+		{"inside the lateness horizon", -9 * time.Minute, PointAccepted},
+		{"past the lateness horizon", -16 * time.Minute, PointLate},
+		{"far past", -3 * time.Hour, PointLate},
+		{"slightly ahead", time.Minute, PointAccepted},
+		{"beyond future skew", 3 * time.Minute, PointFuture},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, got := Classify(arrival, arrival.Add(c.offset))
+			if got != c.want {
+				t.Fatalf("disposition = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestReducerExcludesLateAndFuturePointsWithMetrics proves late and future
+// points are excluded from aggregates and COUNTED — never dropped silently.
+func TestReducerExcludesLateAndFuturePoints(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := testEngine(t, now)
+	r := e.NewReducer(now)
+
+	r.ReduceSpan(SpanInput{Tenant: "t", Service: "svc", SpanName: "op", Timestamp: now, DurationMicros: 100})
+	r.ReduceSpan(SpanInput{Tenant: "t", Service: "svc", SpanName: "op", Timestamp: now.Add(-30 * time.Minute), DurationMicros: 100})
+	r.ReduceSpan(SpanInput{Tenant: "t", Service: "svc", SpanName: "op", Timestamp: now.Add(10 * time.Minute), DurationMicros: 100})
+
+	st := r.Stats()
+	if st.InputPoints[SignalTraceOp] != 3 {
+		t.Errorf("input points = %d, want 3", st.InputPoints[SignalTraceOp])
+	}
+	if st.LatePoints[SignalTraceOp] != 1 {
+		t.Errorf("late points = %d, want 1", st.LatePoints[SignalTraceOp])
+	}
+	if st.FuturePoints[SignalTraceOp] != 1 {
+		t.Errorf("future points = %d, want 1", st.FuturePoints[SignalTraceOp])
+	}
+	if st.Accepted[SignalTraceOp] != 1 {
+		t.Errorf("accepted = %d, want 1", st.Accepted[SignalTraceOp])
+	}
+
+	e.ApplyReducer(r)
+	count, _ := e.Snapshot().Totals(SignalTraceOp)
+	if count != 1 {
+		t.Fatalf("aggregated count = %d, want 1 (late and future excluded)", count)
+	}
+}
+
+// TestLatePointStillLandsInItsOwnWindow: a point inside the lateness horizon
+// belongs to the window of its own timestamp, not the window of arrival.
+func TestLatePointLandsInItsOwnWindow(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := testEngine(t, now)
+	r := e.NewReducer(now)
+	r.ReduceSpan(SpanInput{Tenant: "t", Service: "svc", SpanName: "op", Timestamp: now, DurationMicros: 1})
+	r.ReduceSpan(SpanInput{Tenant: "t", Service: "svc", SpanName: "op", Timestamp: now.Add(-7 * time.Minute), DurationMicros: 1})
+	e.ApplyReducer(r)
+
+	snap := e.Snapshot()
+	if len(snap.Windows) != 2 {
+		t.Fatalf("windows = %d, want 2 (%v)", len(snap.Windows), snap)
+	}
+	if got, want := snap.Windows[0].Start, mustTime(t, "2026-08-21T11:50:00Z"); !got.Equal(want) {
+		t.Errorf("oldest window = %s, want %s", got, want)
+	}
+	if got, want := snap.Windows[1].Start, mustTime(t, "2026-08-21T12:00:00Z"); !got.Equal(want) {
+		t.Errorf("newest window = %s, want %s", got, want)
+	}
+}
+
+func TestRolloverDiscardsExpiredWindowsAndReleasesBudget(t *testing.T) {
+	base := mustTime(t, "2026-08-21T12:00:00Z")
+	clock := base
+	e, err := NewEngine(EngineConfig{Mode: ModeShadow, Now: func() time.Time { return clock }})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	r := e.NewReducer(clock)
+	r.ReduceSpan(SpanInput{Tenant: "t", Service: "svc", SpanName: "op", Timestamp: clock, DurationMicros: 1})
+	e.ApplyReducer(r)
+
+	if got := e.Snapshot().ActiveSeries; got != 1 {
+		t.Fatalf("active series = %d, want 1", got)
+	}
+
+	// Advance past the window's close plus the full lateness horizon.
+	clock = base.Add(WindowSize + AllowedLateness + time.Second)
+	if dropped := e.Rollover(clock); dropped != 1 {
+		t.Fatalf("rollover dropped %d windows, want 1", dropped)
+	}
+
+	snap := e.Snapshot()
+	if len(snap.Windows) != 0 {
+		t.Errorf("windows = %d, want 0", len(snap.Windows))
+	}
+	if snap.ActiveSeries != 0 {
+		t.Errorf("active series = %d after rollover, want 0 — budget must be released", snap.ActiveSeries)
+	}
+	// Phase 1 loses the window rather than finalizing it. The counters exist so
+	// the loss is visible instead of silent.
+	if snap.WindowsDiscarded != 1 || snap.SeriesDiscarded != 1 {
+		t.Errorf("discard counters = (%d, %d), want (1, 1)", snap.WindowsDiscarded, snap.SeriesDiscarded)
+	}
+}
+
+func TestRolloverKeepsWindowsInsideTheHorizon(t *testing.T) {
+	base := mustTime(t, "2026-08-21T12:00:00Z")
+	clock := base
+	e, err := NewEngine(EngineConfig{Mode: ModeShadow, Now: func() time.Time { return clock }})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	r := e.NewReducer(clock)
+	r.ReduceSpan(SpanInput{Tenant: "t", Service: "svc", SpanName: "op", Timestamp: clock, DurationMicros: 1})
+	e.ApplyReducer(r)
+
+	clock = base.Add(WindowSize + AllowedLateness - time.Minute)
+	if dropped := e.Rollover(clock); dropped != 0 {
+		t.Fatalf("rollover dropped %d windows while still mutable", dropped)
+	}
+	if len(e.Snapshot().Windows) != 1 {
+		t.Fatal("window disappeared while still inside the lateness horizon")
+	}
+}
+
+func TestRevisionIsMonotonic(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := testEngine(t, now)
+	prev := e.Revision()
+	for i := 0; i < 20; i++ {
+		r := e.NewReducer(now)
+		r.ReduceSpan(SpanInput{Tenant: "t", Service: "svc", SpanName: "op", Timestamp: now, DurationMicros: 1})
+		rev := e.ApplyReducer(r)
+		if rev <= prev {
+			t.Fatalf("revision %d did not advance past %d", rev, prev)
+		}
+		prev = rev
+	}
+}
+
+// TestConcurrentApplyDeltas exercises the shard locking under -race and proves
+// no delta is lost and no revision is handed out twice.
+func TestConcurrentApplyDeltas(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := testEngine(t, now)
+
+	const goroutines = 8
+	const perGoroutine = 50
+	// Enough distinct operations to spread across all four shards.
+	operations := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+
+	var wg sync.WaitGroup
+	revs := make([][]uint64, goroutines)
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			revs[g] = make([]uint64, 0, perGoroutine)
+			for i := 0; i < perGoroutine; i++ {
+				r := e.NewReducer(now)
+				for _, op := range operations {
+					r.ReduceSpan(SpanInput{
+						Tenant: "t", Service: "svc", SpanName: op,
+						Timestamp: now, DurationMicros: float64(i + 1),
+					})
+				}
+				revs[g] = append(revs[g], e.ApplyReducer(r))
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	count, _ := e.Snapshot().Totals(SignalTraceOp)
+	want := uint64(goroutines * perGoroutine * len(operations))
+	if count != want {
+		t.Errorf("aggregated count = %d, want %d", count, want)
+	}
+
+	seen := make(map[uint64]bool)
+	for _, rs := range revs {
+		for _, rev := range rs {
+			if seen[rev] {
+				t.Fatalf("revision %d handed out twice", rev)
+			}
+			seen[rev] = true
+		}
+	}
+	if got := e.Revision(); got != uint64(goroutines*perGoroutine) {
+		t.Errorf("final revision = %d, want %d", got, goroutines*perGoroutine)
+	}
+}
+
+// TestShardsAreUsed guards against a hash that collapses every series onto one
+// shard, which would make the four-shard design decorative.
+func TestShardsAreUsed(t *testing.T) {
+	used := make(map[int]bool)
+	for i := uint32(0); i < 256; i++ {
+		used[shardIndex(SeriesKey{TenantID: 1, ServiceID: 2, NameID: i, Signal: SignalTraceOp})] = true
+	}
+	if len(used) != NumShards {
+		t.Fatalf("hash reached %d of %d shards", len(used), NumShards)
+	}
+}
+
+// TestApplierInterposition proves the Phase 2 group-commit writer can slot in
+// between the reducer and the shards without touching the callers.
+func TestApplierInterposition(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := testEngine(t, now)
+
+	var calls atomic.Int64
+	e.SetApplier(applierFunc(func(m DeltaMap) uint64 {
+		calls.Add(1)
+		return e.ApplyCommitted(m) // stands in for "commit, then apply"
+	}))
+
+	r := e.NewReducer(now)
+	r.ReduceSpan(SpanInput{Tenant: "t", Service: "svc", SpanName: "op", Timestamp: now, DurationMicros: 1})
+	e.ApplyReducer(r)
+
+	if calls.Load() != 1 {
+		t.Fatalf("interposed applier called %d times, want 1", calls.Load())
+	}
+	if count, _ := e.Snapshot().Totals(SignalTraceOp); count != 1 {
+		t.Fatalf("count = %d, want 1", count)
+	}
+}
+
+type applierFunc func(DeltaMap) uint64
+
+func (f applierFunc) Apply(m DeltaMap) uint64 { return f(m) }
+
+func TestDeltaMergeIsOrderIndependent(t *testing.T) {
+	ts := mustTime(t, "2026-08-21T12:00:00Z")
+	// Distinct gauge timestamps per builder: two samples carrying the SAME
+	// timestamp for one series are genuinely ambiguous about which is "last",
+	// and no merge order can resolve that.
+	build := func(vals []float64, offset int) *AggregateDelta {
+		d := &AggregateDelta{}
+		for i, v := range vals {
+			d.ObserveSpan(v, i%3 == 0)
+			d.ObserveGauge(v, ts.Add(time.Duration(offset+i)*time.Second))
+		}
+		return d
+	}
+	a := build([]float64{1, 2, 3}, 0)
+	b := build([]float64{4, 5, 6}, 10)
+
+	ab := build([]float64{1, 2, 3}, 0)
+	ab.Merge(b)
+	ba := build([]float64{4, 5, 6}, 10)
+	ba.Merge(a)
+
+	if ab.Count != ba.Count || ab.ErrorCount != ba.ErrorCount {
+		t.Errorf("counts diverged: %+v vs %+v", ab, ba)
+	}
+	if ab.DurationSum != ba.DurationSum || ab.DurationMin != ba.DurationMin || ab.DurationMax != ba.DurationMax {
+		t.Errorf("duration stats diverged: %+v vs %+v", ab, ba)
+	}
+	if ab.GaugeLast != ba.GaugeLast || !ab.GaugeLastTime.Equal(ba.GaugeLastTime) {
+		t.Errorf("gauge last diverged: %v@%v vs %v@%v", ab.GaugeLast, ab.GaugeLastTime, ba.GaugeLast, ba.GaugeLastTime)
+	}
+	if ab.Sketch.Count() != ba.Sketch.Count() {
+		t.Errorf("sketch counts diverged: %d vs %d", ab.Sketch.Count(), ba.Sketch.Count())
+	}
+}
+
+func TestSeverityTierMapping(t *testing.T) {
+	cases := []struct {
+		text string
+		num  int32
+		want StatusClass
+	}{
+		{"", 17, SeverityTierError},
+		{"ERROR", 0, SeverityTierError},
+		{"error", 0, SeverityTierError},
+		{"WARNING", 0, SeverityTierWarn},
+		{"FATAL", 0, SeverityTierFatal},
+		{"CRITICAL", 0, SeverityTierFatal},
+		{"DEBUG", 0, SeverityTierDebug},
+		{"TRACE", 0, SeverityTierTrace},
+		{"INFO", 0, SeverityTierInfo},
+		{"something-else", 0, SeverityTierInfo},
+		{"", 0, SeverityTierUnspecified},
+	}
+	for _, c := range cases {
+		if got := SeverityTier(c.text, c.num); got != c.want {
+			t.Errorf("SeverityTier(%q, %d) = %d, want %d", c.text, c.num, got, c.want)
+		}
+	}
+}
+
+func TestReduceLogUsesTemplateIdentityAndSeverity(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := testEngine(t, now)
+	r := e.NewReducer(now)
+
+	for i := 0; i < 5; i++ {
+		r.ReduceLog(LogInput{
+			Tenant: "t", Service: "svc", Severity: "ERROR",
+			Body: "connection to db-7 failed after 30 retries", Timestamp: now,
+		})
+	}
+	r.ReduceLog(LogInput{Tenant: "t", Service: "svc", Severity: "INFO", Body: "request served", Timestamp: now})
+	e.ApplyReducer(r)
+
+	// Five identical-shape ERROR lines cluster into one template series; the
+	// INFO line is a second template AND a second severity tier.
+	if got := len(r.Deltas()); got != 2 {
+		t.Fatalf("log deltas = %d, want 2", got)
+	}
+	count, errors := e.Snapshot().Totals(SignalLog)
+	if count != 6 {
+		t.Errorf("log count = %d, want 6", count)
+	}
+	if errors != 5 {
+		t.Errorf("log error count = %d, want 5", errors)
+	}
+}
+
+func TestReduceMetricGaugeAndDelta(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := testEngine(t, now)
+	r := e.NewReducer(now)
+
+	r.ReduceMetricPoint(MetricInput{Tenant: "t", Service: "svc", Name: "queue.depth", Value: 5, Timestamp: now})
+	r.ReduceMetricPoint(MetricInput{Tenant: "t", Service: "svc", Name: "queue.depth", Value: 9, Timestamp: now.Add(time.Second)})
+	r.ReduceMetricPoint(MetricInput{Tenant: "t", Service: "svc", Name: "queue.depth", Value: 2, Timestamp: now.Add(2 * time.Second)})
+	r.ReduceMetricPoint(MetricInput{
+		Tenant: "t", Service: "svc", Name: "requests", Value: 7,
+		Timestamp: now, Temporality: TemporalityDelta, Monotonic: true,
+	})
+
+	var gauge, counter *AggregateDelta
+	for swk, d := range r.Deltas() {
+		if d.GaugeCount > 0 {
+			gauge = d
+			_ = swk
+			continue
+		}
+		counter = d
+	}
+	if gauge == nil || counter == nil {
+		t.Fatalf("expected a gauge delta and a counter delta, got %d deltas", len(r.Deltas()))
+	}
+	if gauge.GaugeCount != 3 || gauge.GaugeMin != 2 || gauge.GaugeMax != 9 || gauge.GaugeSum != 16 {
+		t.Errorf("gauge stats wrong: %+v", gauge)
+	}
+	if gauge.GaugeLast != 2 {
+		t.Errorf("gauge last = %v, want 2 (latest timestamp wins)", gauge.GaugeLast)
+	}
+	if counter.CounterDelta != 7 {
+		t.Errorf("delta-temporality counter = %v, want 7", counter.CounterDelta)
+	}
+}

--- a/internal/aggregate/metrics.go
+++ b/internal/aggregate/metrics.go
@@ -1,0 +1,91 @@
+package aggregate
+
+import "github.com/RandomCodeSpace/otelcontext/internal/telemetry"
+
+// Metric plumbing. The Prometheus collectors themselves live in
+// internal/telemetry with every other subsystem's metrics — that package owns
+// registration against the default registry via promauto, and splitting the
+// aggregate engine's metrics out into a second registration site would give
+// operators two places to look and this package a duplicate-registration panic
+// in tests.
+//
+// The indirection here is a recorder interface, not a second registry: it keeps
+// the engine testable without a live Prometheus registry and keeps a nil
+// *telemetry.Metrics (which every ingest test passes) from panicking.
+
+// MetricsRecorder is the engine's view of the metric surface.
+type MetricsRecorder interface {
+	// RecordReduction publishes one Export request's reduction accounting:
+	// input points, emitted deltas, the reduction ratio, late/future
+	// exclusions, and the shadow-comparison counters.
+	RecordReduction(stats ReducerStats, deltas map[Signal]uint64)
+	// RecordOverflow counts one admission rerouted to an __other__ series.
+	RecordOverflow(signal Signal, reason OverflowReason)
+	// SetActiveSeries publishes the active-series census per signal.
+	SetActiveSeries(active map[Signal]int)
+}
+
+// noopRecorder is the default when no metrics are wired.
+type noopRecorder struct{}
+
+func (noopRecorder) RecordReduction(ReducerStats, map[Signal]uint64) {}
+func (noopRecorder) RecordOverflow(Signal, OverflowReason)           {}
+func (noopRecorder) SetActiveSeries(map[Signal]int)                  {}
+
+// promRecorder bridges the engine onto the platform's Prometheus metrics.
+type promRecorder struct{ m *telemetry.Metrics }
+
+// NewPrometheusRecorder returns a recorder backed by the platform metrics. A
+// nil *telemetry.Metrics yields a no-op recorder rather than a panic.
+func NewPrometheusRecorder(m *telemetry.Metrics) MetricsRecorder {
+	if m == nil {
+		return noopRecorder{}
+	}
+	return promRecorder{m: m}
+}
+
+// RecordReduction implements MetricsRecorder.
+func (r promRecorder) RecordReduction(stats ReducerStats, deltas map[Signal]uint64) {
+	for i := range stats.InputPoints {
+		signal := Signal(i) // #nosec G115 -- loop index over a signal-sized array
+		in := stats.InputPoints[i]
+		if in == 0 && stats.LatePoints[i] == 0 && stats.FuturePoints[i] == 0 {
+			continue
+		}
+		label := signal.String()
+		if in > 0 {
+			out := deltas[signal]
+			r.m.AggregateInputPointsTotal.WithLabelValues(label).Add(float64(in))
+			r.m.AggregateDeltasTotal.WithLabelValues(label).Add(float64(out))
+			if out > 0 {
+				r.m.AggregateReductionRatio.WithLabelValues(label).Observe(float64(in) / float64(out))
+			}
+		}
+		if n := stats.LatePoints[i]; n > 0 {
+			r.m.AggregateLatePointsTotal.WithLabelValues(label, PointLate.String()).Add(float64(n))
+		}
+		if n := stats.FuturePoints[i]; n > 0 {
+			r.m.AggregateLatePointsTotal.WithLabelValues(label, PointFuture.String()).Add(float64(n))
+		}
+		if n := stats.Accepted[i]; n > 0 {
+			r.m.AggregateShadowAcceptedTotal.WithLabelValues(label).Add(float64(n))
+		}
+	}
+	for service, n := range stats.ErrorsByService {
+		if n > 0 {
+			r.m.AggregateShadowErrorsTotal.WithLabelValues(service).Add(float64(n))
+		}
+	}
+}
+
+// RecordOverflow implements MetricsRecorder.
+func (r promRecorder) RecordOverflow(signal Signal, reason OverflowReason) {
+	r.m.AggregateOverflowTotal.WithLabelValues(signal.String(), reason.String()).Inc()
+}
+
+// SetActiveSeries implements MetricsRecorder.
+func (r promRecorder) SetActiveSeries(active map[Signal]int) {
+	for sig := SignalTraceOp; sig <= signalMax; sig++ {
+		r.m.AggregateSeriesActive.WithLabelValues(sig.String()).Set(float64(active[sig]))
+	}
+}

--- a/internal/aggregate/reducer.go
+++ b/internal/aggregate/reducer.go
@@ -1,0 +1,347 @@
+package aggregate
+
+import (
+	"strings"
+	"time"
+)
+
+// Request-local reduction.
+//
+// One Reducer per Export call. It collapses every span, log record and metric
+// point in the request into a small map of (series, window) deltas BEFORE any
+// global aggregate state is touched: the shards are never mutated here, so an
+// Export's cost is bounded by its own batch and no ingest goroutine blocks
+// another one behind a shard lock (#160).
+//
+// "No global mutation" means no shard mutation. Reduction does intern
+// dictionary IDs and mine log templates, both of which are shared, mutex-guarded
+// and idempotent — a SeriesKey cannot be built without them, and #163 puts the
+// miner on this exact path on purpose.
+//
+// The reducer runs ahead of the sampler and the severity gates. Aggregate counts
+// describe accepted telemetry, not the sampling rate (#153 §8); that is the
+// whole point of the engine, and it is the invariant the shadow-mode tests
+// assert.
+//
+// A Reducer is NOT safe for concurrent use. Export paths that fan out over
+// resource batches build one Reducer per goroutine and merge them with
+// MergeFrom before applying — merging a handful of deltas is cheap precisely
+// because reduction already happened.
+
+// signalCount sizes the per-signal stat arrays.
+const signalCount = int(signalMax) + 1
+
+// ReducerStats is one Export request's reduction accounting.
+type ReducerStats struct {
+	// InputPoints counts points offered to the reducer, per signal, including
+	// the ones excluded as late or future.
+	InputPoints [signalCount]uint64
+	// LatePoints counts points older than the lateness horizon. They are
+	// excluded from aggregates and counted here — never dropped silently
+	// (#160). The raw/exemplar path still sees them.
+	LatePoints [signalCount]uint64
+	// FuturePoints counts points timestamped beyond the tolerated skew.
+	FuturePoints [signalCount]uint64
+	// Accepted counts points that contributed to a delta. This is the
+	// shadow-comparison numerator: it must be identical for the same input
+	// stream at any sampling rate.
+	Accepted [signalCount]uint64
+	// StaleCumulative counts cumulative points ignored as stale or duplicate
+	// against their baseline (#166 case 1).
+	StaleCumulative uint64
+	// ErrorsByService counts errors per service — the cheap invariant #165
+	// asks for on the aggregate side, and nothing more expensive.
+	ErrorsByService map[string]uint64
+}
+
+// merge folds other into s.
+func (s *ReducerStats) merge(other *ReducerStats) {
+	for i := 0; i < signalCount; i++ {
+		s.InputPoints[i] += other.InputPoints[i]
+		s.LatePoints[i] += other.LatePoints[i]
+		s.FuturePoints[i] += other.FuturePoints[i]
+		s.Accepted[i] += other.Accepted[i]
+	}
+	s.StaleCumulative += other.StaleCumulative
+	for svc, n := range other.ErrorsByService {
+		if s.ErrorsByService == nil {
+			s.ErrorsByService = make(map[string]uint64, len(other.ErrorsByService))
+		}
+		s.ErrorsByService[svc] += n
+	}
+}
+
+// SpanInput is one span, already parsed out of OTLP. Only the fields that can
+// affect series identity or aggregates are carried: IDs, URLs and messages are
+// on the permanent banned list (#153, #159) and never reach this struct.
+type SpanInput struct {
+	Tenant  string
+	Service string
+	// SpanName is the raw span name, used for operation naming when no route
+	// attribute is present.
+	SpanName string
+	// HTTPRoute is http.route, URLPath is url.path or http.target. Route
+	// normalization precedence is fixed in #159.
+	HTTPRoute string
+	URLPath   string
+	// Method is the raw HTTP method string; it collapses onto the bounded
+	// Method enum.
+	Method string
+	// HTTPStatusCode is http.response.status_code, 0 when absent.
+	HTTPStatusCode int
+	// SpanKind and StatusCode are the OTLP numeric values.
+	SpanKind   int32
+	StatusCode int32
+	// Timestamp is the span start time; it selects the window.
+	Timestamp      time.Time
+	DurationMicros float64
+}
+
+// LogInput is one log record.
+type LogInput struct {
+	Tenant  string
+	Service string
+	// Severity is the severity text; SeverityNumber is the OTLP number and
+	// wins when non-zero.
+	Severity       string
+	SeverityNumber int32
+	// Body is mined into a template. It never enters series identity itself.
+	Body      string
+	Timestamp time.Time
+}
+
+// MetricInput is one metric data point.
+type MetricInput struct {
+	Tenant  string
+	Service string
+	Name    string
+	Value   float64
+	// Timestamp selects the window; StartTime is the cumulative start time
+	// used for reset detection.
+	Timestamp time.Time
+	StartTime time.Time
+	// Temporality and Monotonic select the aggregation model (#166).
+	Temporality Temporality
+	Monotonic   bool
+	// Resource carries the stable identity used to derive the ProducerID.
+	Resource ResourceIdentity
+}
+
+// Reducer collapses one Export request into deltas.
+type Reducer struct {
+	eng     *Engine
+	arrival time.Time
+	deltas  DeltaMap
+	stats   ReducerStats
+}
+
+// NewReducer returns a reducer for one Export request. arrival is the single
+// timestamp captured for that request and used to evaluate lateness and future
+// skew for every point in it.
+func (e *Engine) NewReducer(arrival time.Time) *Reducer {
+	return &Reducer{eng: e, arrival: arrival}
+}
+
+// Arrival returns the reducer's arrival time.
+func (r *Reducer) Arrival() time.Time { return r.arrival }
+
+// Stats returns the reduction accounting.
+func (r *Reducer) Stats() ReducerStats { return r.stats }
+
+// Deltas returns the reduced deltas. The map is handed to the engine as-is; the
+// reducer must not be used afterwards.
+func (r *Reducer) Deltas() DeltaMap { return r.deltas }
+
+// Len returns the number of deltas produced so far.
+func (r *Reducer) Len() int { return len(r.deltas) }
+
+// MergeFrom folds another reducer's deltas and stats into r. Used by Export
+// paths that reduce resource batches in parallel.
+func (r *Reducer) MergeFrom(other *Reducer) {
+	if other == nil {
+		return
+	}
+	for swk, d := range other.deltas {
+		if cur, ok := r.deltas[swk]; ok {
+			cur.Merge(d)
+			continue
+		}
+		if r.deltas == nil {
+			r.deltas = make(DeltaMap, len(other.deltas))
+		}
+		r.deltas[swk] = d
+	}
+	r.stats.merge(&other.stats)
+}
+
+// deltaCountBySignal counts emitted deltas per signal — the denominator of the
+// reduction ratio.
+func (r *Reducer) deltaCountBySignal() map[Signal]uint64 {
+	out := make(map[Signal]uint64, signalCount)
+	for swk := range r.deltas {
+		out[swk.Key.Signal]++
+	}
+	return out
+}
+
+// delta returns the delta for (key, window), creating it on first use.
+func (r *Reducer) delta(key SeriesKey, window int64) *AggregateDelta {
+	swk := SeriesWindowKey{Key: key, WindowStart: window}
+	if d, ok := r.deltas[swk]; ok {
+		return d
+	}
+	if r.deltas == nil {
+		r.deltas = make(DeltaMap, 8)
+	}
+	d := &AggregateDelta{}
+	r.deltas[swk] = d
+	return d
+}
+
+// admitPoint applies the window/lateness rules and updates the per-signal
+// counters. It reports ok=false when the point is excluded.
+func (r *Reducer) admitPoint(signal Signal, ts time.Time) (int64, bool) {
+	r.stats.InputPoints[signal]++
+	window, disp := Classify(r.arrival, ts)
+	switch disp {
+	case PointLate:
+		r.stats.LatePoints[signal]++
+		return 0, false
+	case PointFuture:
+		r.stats.FuturePoints[signal]++
+		return 0, false
+	default:
+		return window, true
+	}
+}
+
+// countError records a per-service error for the shadow comparison.
+func (r *Reducer) countError(service string) {
+	if r.stats.ErrorsByService == nil {
+		r.stats.ErrorsByService = make(map[string]uint64, 4)
+	}
+	r.stats.ErrorsByService[service]++
+}
+
+// ReduceSpan folds one span into its trace-operation series.
+func (r *Reducer) ReduceSpan(in SpanInput) {
+	window, ok := r.admitPoint(SignalTraceOp, in.Timestamp)
+	if !ok {
+		return
+	}
+	tenantID := r.eng.cache.InternTenant(in.Tenant)
+	operation := NormalizeOperation(in.HTTPRoute, in.URLPath, in.SpanName)
+	key := SeriesKey{
+		TenantID:    tenantID,
+		ServiceID:   r.eng.cache.Intern(tenantID, KindService, in.Service),
+		NameID:      r.eng.cache.Intern(tenantID, KindOperation, operation),
+		Signal:      SignalTraceOp,
+		StatusClass: TraceStatusFromCode(in.StatusCode),
+		HTTPClass:   HTTPClassFromStatus(in.HTTPStatusCode),
+		Method:      ParseMethod(in.Method),
+		Variant:     VariantFromSpanKind(in.SpanKind),
+	}
+	isError := key.StatusClass == StatusError
+	r.delta(key, window).ObserveSpan(in.DurationMicros, isError)
+	r.stats.Accepted[SignalTraceOp]++
+	if isError {
+		r.countError(in.Service)
+	}
+}
+
+// ReduceLog folds one log record into its log series. The template is mined
+// synchronously by the ingest-owned miner (#163); the template ID is the
+// series' NameID, resolved through the log_template dictionary namespace.
+func (r *Reducer) ReduceLog(in LogInput) {
+	window, ok := r.admitPoint(SignalLog, in.Timestamp)
+	if !ok {
+		return
+	}
+	tenantID := r.eng.cache.InternTenant(in.Tenant)
+	templateID, _ := r.eng.miner.MineAt(in.Tenant, in.Service, in.Severity, in.Body, r.arrival)
+	tier := SeverityTier(in.Severity, in.SeverityNumber)
+	key := SeriesKey{
+		TenantID:    tenantID,
+		ServiceID:   r.eng.cache.Intern(tenantID, KindService, in.Service),
+		NameID:      templateID,
+		Signal:      SignalLog,
+		StatusClass: tier,
+	}
+	isError := tier >= SeverityTierError
+	r.delta(key, window).ObserveLog(in.Timestamp, isError)
+	r.stats.Accepted[SignalLog]++
+	if isError {
+		r.countError(in.Service)
+	}
+}
+
+// ReduceMetricPoint folds one metric data point into its metric series,
+// applying the #166 aggregation model for its temporality and monotonicity.
+func (r *Reducer) ReduceMetricPoint(in MetricInput) {
+	window, ok := r.admitPoint(SignalMetric, in.Timestamp)
+	if !ok {
+		return
+	}
+	tenantID := r.eng.cache.InternTenant(in.Tenant)
+	key := SeriesKey{
+		TenantID:  tenantID,
+		ServiceID: r.eng.cache.Intern(tenantID, KindService, in.Service),
+		NameID:    r.eng.cache.Intern(tenantID, KindMetricName, in.Name),
+		Signal:    SignalMetric,
+	}
+
+	switch {
+	// Gauges and cumulative non-monotonic sums (UpDownCounter): gauge-like,
+	// never reset-detected. Negative movement is legitimate here.
+	case IsGaugeLike(in.Temporality, in.Monotonic):
+		r.delta(key, window).ObserveGauge(in.Value, in.Timestamp)
+
+	// Delta temporality merges directly; negative deltas are legal for
+	// non-monotonic instruments.
+	case in.Temporality == TemporalityDelta:
+		r.delta(key, window).ObserveCounter(in.Value, false)
+
+	// Cumulative monotonic: convert against the producer's baseline.
+	default:
+		producer := ResolveProducerID(in.Resource)
+		out := r.eng.baselines.ObserveCumulative(key, producer, in.StartTime, in.Timestamp, in.Value)
+		if out.Ignored {
+			// Stale or duplicate: it must not move the baseline, synthesize a
+			// delta, or count as a reset.
+			r.stats.StaleCumulative++
+			return
+		}
+		d := r.delta(key, window)
+		d.ObserveCounter(out.Delta, out.Reset)
+	}
+	r.stats.Accepted[SignalMetric]++
+}
+
+// SeverityTier maps an OTLP severity onto the log StatusClass tier. The numeric
+// severity wins when present; otherwise the text is classified with the same
+// substring rules the legacy ingest gate uses, so a shadow-mode comparison is
+// not thrown off by a disagreement about what "WARNING" means.
+func SeverityTier(text string, number int32) StatusClass {
+	if number > 0 {
+		return SeverityTierFromNumber(number)
+	}
+	upper := strings.ToUpper(text)
+	switch {
+	case strings.Contains(upper, "FATAL"), strings.Contains(upper, "CRIT"):
+		return SeverityTierFatal
+	case strings.Contains(upper, "ERR"):
+		return SeverityTierError
+	case strings.Contains(upper, "WARN"):
+		return SeverityTierWarn
+	case strings.Contains(upper, "DEBUG"):
+		return SeverityTierDebug
+	case strings.Contains(upper, "TRACE"):
+		return SeverityTierTrace
+	case strings.Contains(upper, "INFO"):
+		return SeverityTierInfo
+	case upper == "":
+		return SeverityTierUnspecified
+	default:
+		return SeverityTierInfo
+	}
+}

--- a/internal/aggregate/reducer_bench_test.go
+++ b/internal/aggregate/reducer_bench_test.go
@@ -1,0 +1,150 @@
+package aggregate
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// benchOperations is the operation set the reduction benchmarks replay. Ten
+// operations is the shape #172's acceptance criterion names.
+var benchOperations = []string{
+	"GET /orders", "POST /orders", "GET /orders/{id}", "DELETE /orders/{id}",
+	"GET /users", "POST /users", "GET /health", "POST /checkout",
+	"GET /inventory", "POST /payments",
+}
+
+// benchSpans builds a batch of spans across the operation set, alternating
+// status so the batch materializes both healthy and error series.
+func benchSpans(n int, ts time.Time) []SpanInput {
+	spans := make([]SpanInput, 0, n)
+	for i := 0; i < n; i++ {
+		status := int32(1)
+		if i%13 == 0 {
+			status = 2
+		}
+		spans = append(spans, SpanInput{
+			Tenant:         "default",
+			Service:        "checkout",
+			SpanName:       benchOperations[i%len(benchOperations)],
+			Method:         "GET",
+			HTTPStatusCode: 200,
+			SpanKind:       2,
+			StatusCode:     status,
+			Timestamp:      ts,
+			DurationMicros: float64(100 + i%5000),
+		})
+	}
+	return spans
+}
+
+// TestReductionRatio is the acceptance criterion: 1,000 spans across 10
+// operations must collapse to a handful of deltas.
+func TestReductionRatio(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := testEngine(t, now)
+	spans := benchSpans(1000, now)
+
+	r := e.NewReducer(now)
+	for _, s := range spans {
+		r.ReduceSpan(s)
+	}
+
+	deltas := r.Len()
+	if deltas == 0 {
+		t.Fatal("no deltas produced")
+	}
+	if deltas > 40 {
+		t.Errorf("1000 spans over %d operations produced %d deltas, want <= 40", len(benchOperations), deltas)
+	}
+	t.Logf("reduction: 1000 spans -> %d deltas (ratio %.1f:1)", deltas, 1000.0/float64(deltas))
+
+	e.ApplyReducer(r)
+	if count, _ := e.Snapshot().Totals(SignalTraceOp); count != 1000 {
+		t.Fatalf("aggregated count = %d, want 1000 — reduction must not lose points", count)
+	}
+}
+
+// TestReducerAllocationsAreFlatInBatchSize pins the property that makes the
+// engine worth having: cost per Export is bounded by the number of distinct
+// SERIES, not by the number of points. A tenfold batch must not cost tenfold
+// allocations.
+func TestReducerAllocationsAreFlatInBatchSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocation measurement is noisy under -short")
+	}
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := testEngine(t, now)
+
+	measure := func(n int) float64 {
+		spans := benchSpans(n, now)
+		// Warm the dictionary and template caches: first-sight interning is a
+		// one-off cost, not a per-request one.
+		warm := e.NewReducer(now)
+		for _, s := range spans {
+			warm.ReduceSpan(s)
+		}
+		return testing.AllocsPerRun(20, func() {
+			r := e.NewReducer(now)
+			for _, s := range spans {
+				r.ReduceSpan(s)
+			}
+		})
+	}
+
+	small := measure(100)
+	large := measure(1000)
+	t.Logf("allocs per Export: 100 spans = %.0f, 1000 spans = %.0f", small, large)
+
+	if large > small*3 {
+		t.Errorf("allocations scaled with batch size: %.0f at 100 spans, %.0f at 1000 spans", small, large)
+	}
+	// Per-point allocation must fall as the batch grows — that is reduction.
+	if perPoint := large / 1000; perPoint > small/100 {
+		t.Errorf("per-point allocations did not improve with batch size: %.3f vs %.3f", perPoint, small/100)
+	}
+}
+
+func BenchmarkReduceSpans(b *testing.B) {
+	now := time.Unix(1787000000, 0).UTC()
+	for _, n := range []int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("spans=%d", n), func(b *testing.B) {
+			e, err := NewEngine(EngineConfig{Mode: ModeShadow, Now: func() time.Time { return now }})
+			if err != nil {
+				b.Fatalf("NewEngine: %v", err)
+			}
+			spans := benchSpans(n, now)
+			warm := e.NewReducer(now)
+			for _, s := range spans {
+				warm.ReduceSpan(s)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				r := e.NewReducer(now)
+				for _, s := range spans {
+					r.ReduceSpan(s)
+				}
+			}
+			b.ReportMetric(float64(warm.Len()), "deltas")
+		})
+	}
+}
+
+func BenchmarkApplyDeltas(b *testing.B) {
+	now := time.Unix(1787000000, 0).UTC()
+	e, err := NewEngine(EngineConfig{Mode: ModeShadow, Now: func() time.Time { return now }})
+	if err != nil {
+		b.Fatalf("NewEngine: %v", err)
+	}
+	spans := benchSpans(1000, now)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r := e.NewReducer(now)
+		for _, s := range spans {
+			r.ReduceSpan(s)
+		}
+		e.ApplyReducer(r)
+	}
+}

--- a/internal/aggregate/temporality.go
+++ b/internal/aggregate/temporality.go
@@ -1,0 +1,355 @@
+package aggregate
+
+import (
+	"hash/fnv"
+	"sync"
+	"time"
+)
+
+// Cumulative-sum handling per issue #166.
+//
+// The evaluation order below is NORMATIVE. Getting it wrong does not produce a
+// slightly wrong number, it produces fabricated rate spikes and silently
+// swallowed resets, so the order is spelled out rather than implied by control
+// flow:
+//
+//  1. stale/duplicate vs baseline.LastTimestamp -> ignore and count; never a reset
+//  2. start_time change                          -> reset, delta = current
+//  3. same start_time and current < prior        -> implicit reset, delta = current
+//  4. normal progression                         -> delta = current - prior
+//
+// Non-monotonic sums never enter this path at all: they are gauge-like, and
+// applying value-decrease reset detection to an UpDownCounter mangles it.
+//
+// Baselines are in-memory in Phase 1. Durability — upserting the baseline row
+// inside the same group commit as the deltas it justifies — is #173. Until then
+// a restart re-seeds every baseline, which is the accepted-gap fallback #166
+// documents, not the target contract.
+
+// Temporality is the OTLP aggregation temporality of a metric point.
+type Temporality uint8
+
+// Temporality values, mirroring the OTLP numbering.
+const (
+	TemporalityUnspecified Temporality = 0
+	TemporalityDelta       Temporality = 1
+	TemporalityCumulative  Temporality = 2
+)
+
+// ProducerID discriminates the concrete emitter of a cumulative series — an
+// instance, pod or process. It is internal baseline state only: it never enters
+// a SeriesKey and is never an aggregate dimension (#159's allowlist, #166's
+// producer keying). Two producers sharing one canonical series would otherwise
+// look like perpetual resets.
+type ProducerID uint64
+
+// degradedProducer is the shared baseline slot used once a series has more
+// distinct producers than the configured per-series bound. Apparent resets from
+// interleaved producers are accepted and counted rather than letting baseline
+// state grow without bound (#166).
+const degradedProducer ProducerID = 0
+
+// ResourceIdentity is the stable slice of resource attributes used to derive a
+// ProducerID. Every field is optional; the first present value per slot is used.
+// This is deliberately NOT the full resource attribute set: attributes that vary
+// per export would fragment baselines into uselessness.
+type ResourceIdentity struct {
+	// ServiceInstanceID is service.instance.id. When present it IS the
+	// producer identity — the semantic convention exists for exactly this.
+	ServiceInstanceID string
+	// ServiceNamespace is service.namespace.
+	ServiceNamespace string
+	// ServiceName is service.name.
+	ServiceName string
+	// Host is host.id, else host.name.
+	Host string
+	// Workload is k8s.pod.uid, else container.id, else process.pid.
+	Workload string
+}
+
+// ResolveProducerID returns the producer discriminator for a resource.
+// service.instance.id wins when present; otherwise the ID is a deterministic
+// FNV-1a hash of the stable tuple {service.namespace, service.name,
+// host.id|host.name, k8s.pod.uid|container.id|process.pid}.
+//
+// The hash is never zero: zero is the degraded shared slot.
+func ResolveProducerID(id ResourceIdentity) ProducerID {
+	h := fnv.New64a()
+	if id.ServiceInstanceID != "" {
+		_, _ = h.Write([]byte("i\x00"))
+		_, _ = h.Write([]byte(id.ServiceInstanceID))
+	} else {
+		_, _ = h.Write([]byte("t\x00"))
+		for _, part := range [...]string{id.ServiceNamespace, id.ServiceName, id.Host, id.Workload} {
+			_, _ = h.Write([]byte(part))
+			_, _ = h.Write([]byte{0})
+		}
+	}
+	sum := h.Sum64()
+	if sum == uint64(degradedProducer) {
+		sum = 1
+	}
+	return ProducerID(sum)
+}
+
+// Baseline is the per-(series, producer) record of the last cumulative point.
+type Baseline struct {
+	// StartTime is the point's start_time_unix_nano. A change means the
+	// producer restarted its counter.
+	StartTime time.Time
+	// LastTimestamp is the timestamp of the last accepted point. Points at or
+	// before it are stale or duplicate.
+	LastTimestamp time.Time
+	// Value is the last accepted cumulative value.
+	Value float64
+}
+
+// ResetReason names why a counter reset was recorded.
+type ResetReason uint8
+
+// ResetReason values. The strings double as metric label values.
+const (
+	ResetNone ResetReason = iota
+	// ResetStartTimeChange — the producer reported a new start_time.
+	ResetStartTimeChange
+	// ResetValueRegression — same start_time, value went backwards.
+	ResetValueRegression
+)
+
+// String implements fmt.Stringer.
+func (r ResetReason) String() string {
+	switch r {
+	case ResetStartTimeChange:
+		return "start_time_change"
+	case ResetValueRegression:
+		return "value_regression"
+	default:
+		return "none"
+	}
+}
+
+// CumulativeOutcome classifies what happened to one cumulative point. Exactly
+// one of Ignored/Seeded/Gap/Reset/Normal describes the point; Delta carries the
+// increase to attribute to the point's window.
+type CumulativeOutcome struct {
+	// Delta is the increase attributable to this point. Zero for ignored,
+	// seeded and gap outcomes.
+	Delta float64
+	// Ignored is true for a stale or duplicate point: it did not move the
+	// baseline and produced no delta (case 1).
+	Ignored bool
+	// Seeded is true when this point created a baseline. No delta is
+	// attributed: the accumulation predates our observation window and
+	// crediting it to one 5-minute window would fabricate a rate spike.
+	Seeded bool
+	// Gap is true when the point arrived more than the allowed-lateness
+	// window after the baseline's last timestamp. The computed delta is
+	// discarded and the baseline re-seeded (#166 downtime handling): totals
+	// under-count across long outages, rates never lie.
+	Gap bool
+	// Reset is true when a counter reset was detected; Reason says which.
+	Reset  bool
+	Reason ResetReason
+	// Degraded is true when the point was attributed to the per-series shared
+	// baseline because the producer bound was exhausted.
+	Degraded bool
+}
+
+// BaselineStats is a snapshot of BaselineTracker counters.
+type BaselineStats struct {
+	// Entries is the number of live baseline records.
+	Entries int
+	// Series is the number of series holding at least one baseline.
+	Series int
+	// Stale counts points ignored as stale or duplicate.
+	Stale uint64
+	// Seeded counts baselines created.
+	Seeded uint64
+	// Gaps counts baselines re-seeded after a downtime gap.
+	Gaps uint64
+	// ResetsStartTime and ResetsRegression count resets by reason.
+	ResetsStartTime  uint64
+	ResetsRegression uint64
+	// ProducerOverflow counts points routed to a degraded shared baseline
+	// because the per-series producer bound was exhausted.
+	ProducerOverflow uint64
+	// GlobalOverflow counts points that could not take a dedicated baseline
+	// because the global baseline budget was exhausted.
+	GlobalOverflow uint64
+}
+
+// BaselineTrackerConfig bounds the tracker.
+type BaselineTrackerConfig struct {
+	// MaxProducersPerSeries is the per-series producer-baseline bound
+	// (AGGREGATE_MAX_PRODUCER_BASELINES_PER_SERIES, default 8). Excess
+	// producers share one degraded baseline and never evict the first N.
+	MaxProducersPerSeries int
+	// MaxBaselines is the global baseline-entry budget
+	// (the resolved AGGREGATE_MAX_BASELINES). Past it, only the per-series
+	// degraded slot may still be created — it is reserved capacity, exactly
+	// like the __other__ series, because refusing it would strand the series.
+	MaxBaselines int
+	// GapThreshold is the downtime bound: a point more than this after the
+	// baseline's last timestamp re-seeds instead of crediting the increase.
+	// Defaults to AllowedLateness.
+	GapThreshold time.Duration
+}
+
+// BaselineTracker converts cumulative monotonic points into deltas and detects
+// resets. It is safe for concurrent use.
+type BaselineTracker struct {
+	cfg BaselineTrackerConfig
+
+	mu      sync.Mutex
+	series  map[SeriesKey]map[ProducerID]*Baseline
+	entries int
+
+	stale            uint64
+	seeded           uint64
+	gaps             uint64
+	resetsStartTime  uint64
+	resetsRegression uint64
+	producerOverflow uint64
+	globalOverflow   uint64
+}
+
+// NewBaselineTracker returns a tracker bounded by cfg. Zero or negative bounds
+// take the platform defaults.
+func NewBaselineTracker(cfg BaselineTrackerConfig) *BaselineTracker {
+	if cfg.MaxProducersPerSeries <= 0 {
+		cfg.MaxProducersPerSeries = DefaultMaxProducerBaselinesPerSeries
+	}
+	if cfg.MaxBaselines <= 0 {
+		cfg.MaxBaselines = cfg.MaxProducersPerSeries * DefaultMaxSeriesMetrics
+	}
+	if cfg.GapThreshold <= 0 {
+		cfg.GapThreshold = AllowedLateness
+	}
+	return &BaselineTracker{
+		cfg:    cfg,
+		series: make(map[SeriesKey]map[ProducerID]*Baseline),
+	}
+}
+
+// ObserveCumulative applies the normative #166 evaluation order to one
+// cumulative monotonic point and returns what to do with it.
+//
+// key must be the full canonical metric-series identity BEFORE cardinality
+// overflow routing: two series that later collapse into one __other__ series
+// still have independent counters, and merging their baselines would invent
+// resets.
+func (t *BaselineTracker) ObserveCumulative(key SeriesKey, producer ProducerID, startTime, ts time.Time, value float64) CumulativeOutcome {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	byProducer, ok := t.series[key]
+	if !ok {
+		byProducer = make(map[ProducerID]*Baseline, 1)
+		t.series[key] = byProducer
+	}
+
+	var out CumulativeOutcome
+	b, ok := byProducer[producer]
+	if !ok {
+		// The producer has no baseline. Take a dedicated slot when both the
+		// per-series bound and the global budget allow; otherwise degrade to
+		// the series' shared slot, which is reserved capacity.
+		if len(byProducer) >= t.cfg.MaxProducersPerSeries && producer != degradedProducer {
+			t.producerOverflow++
+			out.Degraded = true
+			producer = degradedProducer
+			b, ok = byProducer[producer]
+		} else if t.entries >= t.cfg.MaxBaselines && producer != degradedProducer {
+			t.globalOverflow++
+			out.Degraded = true
+			producer = degradedProducer
+			b, ok = byProducer[producer]
+		}
+	}
+
+	if !ok {
+		byProducer[producer] = &Baseline{StartTime: startTime, LastTimestamp: ts, Value: value}
+		t.entries++
+		t.seeded++
+		out.Seeded = true
+		return out
+	}
+
+	// (1) Stale or duplicate: never moves the baseline, never a reset.
+	if !ts.After(b.LastTimestamp) {
+		t.stale++
+		out.Ignored = true
+		return out
+	}
+
+	// Downtime gap: the increase spans more than the mutable-window horizon,
+	// so it cannot be attributed to any window we still own. Re-seed.
+	if ts.Sub(b.LastTimestamp) > t.cfg.GapThreshold {
+		b.StartTime = startTime
+		b.LastTimestamp = ts
+		b.Value = value
+		t.gaps++
+		out.Gap = true
+		return out
+	}
+
+	switch {
+	// (2) start_time change -> reset, delta = current.
+	case !startTime.Equal(b.StartTime):
+		t.resetsStartTime++
+		out.Reset = true
+		out.Reason = ResetStartTimeChange
+		out.Delta = value
+	// (3) same start_time, value regressed -> implicit reset, delta = current.
+	case value < b.Value:
+		t.resetsRegression++
+		out.Reset = true
+		out.Reason = ResetValueRegression
+		out.Delta = value
+	// (4) normal progression.
+	default:
+		out.Delta = value - b.Value
+	}
+
+	b.StartTime = startTime
+	b.LastTimestamp = ts
+	b.Value = value
+	return out
+}
+
+// Baseline returns a copy of the baseline for (key, producer). Tests and
+// diagnostics only.
+func (t *BaselineTracker) Baseline(key SeriesKey, producer ProducerID) (Baseline, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	b, ok := t.series[key][producer]
+	if !ok {
+		return Baseline{}, false
+	}
+	return *b, true
+}
+
+// Stats returns a snapshot of the tracker counters.
+func (t *BaselineTracker) Stats() BaselineStats {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return BaselineStats{
+		Entries:          t.entries,
+		Series:           len(t.series),
+		Stale:            t.stale,
+		Seeded:           t.seeded,
+		Gaps:             t.gaps,
+		ResetsStartTime:  t.resetsStartTime,
+		ResetsRegression: t.resetsRegression,
+		ProducerOverflow: t.producerOverflow,
+		GlobalOverflow:   t.globalOverflow,
+	}
+}
+
+// IsGaugeLike reports whether a metric point aggregates gauge-like — last, min,
+// max, sum-of-samples and count, with no reset detection. Gauges do, and so do
+// cumulative non-monotonic sums (UpDownCounter): negative movement there is
+// legitimate, not a reset (#166 case 2).
+func IsGaugeLike(temporality Temporality, monotonic bool) bool {
+	return temporality != TemporalityDelta && !monotonic
+}

--- a/internal/aggregate/temporality_test.go
+++ b/internal/aggregate/temporality_test.go
@@ -1,0 +1,348 @@
+package aggregate
+
+import (
+	"testing"
+	"time"
+)
+
+func testKey(name uint32) SeriesKey {
+	return SeriesKey{TenantID: 1, ServiceID: 2, NameID: name, Signal: SignalMetric}
+}
+
+func newTestTracker(perSeries, global int) *BaselineTracker {
+	return NewBaselineTracker(BaselineTrackerConfig{
+		MaxProducersPerSeries: perSeries,
+		MaxBaselines:          global,
+	})
+}
+
+// --- the four normative cases of #166, in order ---
+
+func TestCumulativeCase1StaleAndDuplicateIgnored(t *testing.T) {
+	base := mustTime(t, "2026-08-21T12:00:00Z")
+	start := mustTime(t, "2026-08-21T11:00:00Z")
+	tr := newTestTracker(8, 100)
+	key := testKey(1)
+
+	tr.ObserveCumulative(key, 7, start, base, 100) // seed
+	if out := tr.ObserveCumulative(key, 7, start, base.Add(time.Second), 110); out.Delta != 10 {
+		t.Fatalf("progression delta = %v, want 10", out.Delta)
+	}
+
+	// Duplicate: identical timestamp and value.
+	dup := tr.ObserveCumulative(key, 7, start, base.Add(time.Second), 110)
+	if !dup.Ignored || dup.Delta != 0 || dup.Reset {
+		t.Errorf("duplicate outcome = %+v, want ignored with no delta and no reset", dup)
+	}
+
+	// Out of order: an older timestamp, and a LOWER value — which case 3 would
+	// call a reset if the stale check did not come first.
+	old := tr.ObserveCumulative(key, 7, start, base, 100)
+	if !old.Ignored || old.Reset {
+		t.Errorf("out-of-order outcome = %+v, want ignored and NOT a reset", old)
+	}
+
+	// The baseline must not have moved.
+	b, ok := tr.Baseline(key, 7)
+	if !ok || b.Value != 110 || !b.LastTimestamp.Equal(base.Add(time.Second)) {
+		t.Fatalf("baseline moved on a stale point: %+v", b)
+	}
+	if got := tr.Stats().Stale; got != 2 {
+		t.Errorf("stale count = %d, want 2", got)
+	}
+}
+
+func TestCumulativeCase2StartTimeChangeIsAReset(t *testing.T) {
+	base := mustTime(t, "2026-08-21T12:00:00Z")
+	start := mustTime(t, "2026-08-21T11:00:00Z")
+	tr := newTestTracker(8, 100)
+	key := testKey(1)
+
+	tr.ObserveCumulative(key, 7, start, base, 500)
+	// Producer restarted: new start_time, and the value happens to be HIGHER
+	// than the prior one, so only the start-time rule can catch this.
+	out := tr.ObserveCumulative(key, 7, start.Add(time.Hour), base.Add(time.Minute), 600)
+	if !out.Reset || out.Reason != ResetStartTimeChange {
+		t.Fatalf("outcome = %+v, want reset with reason start_time_change", out)
+	}
+	if out.Delta != 600 {
+		t.Errorf("delta = %v, want 600 (the whole current value)", out.Delta)
+	}
+	if got := tr.Stats().ResetsStartTime; got != 1 {
+		t.Errorf("start-time reset count = %d, want 1", got)
+	}
+}
+
+func TestCumulativeCase3ValueRegressionIsAnImplicitReset(t *testing.T) {
+	base := mustTime(t, "2026-08-21T12:00:00Z")
+	start := mustTime(t, "2026-08-21T11:00:00Z")
+	tr := newTestTracker(8, 100)
+	key := testKey(1)
+
+	tr.ObserveCumulative(key, 7, start, base, 500)
+	out := tr.ObserveCumulative(key, 7, start, base.Add(time.Minute), 12)
+	if !out.Reset || out.Reason != ResetValueRegression {
+		t.Fatalf("outcome = %+v, want reset with reason value_regression", out)
+	}
+	if out.Delta != 12 {
+		t.Errorf("delta = %v, want 12", out.Delta)
+	}
+	if got := tr.Stats().ResetsRegression; got != 1 {
+		t.Errorf("regression reset count = %d, want 1", got)
+	}
+}
+
+func TestCumulativeCase4NormalProgression(t *testing.T) {
+	base := mustTime(t, "2026-08-21T12:00:00Z")
+	start := mustTime(t, "2026-08-21T11:00:00Z")
+	tr := newTestTracker(8, 100)
+	key := testKey(1)
+
+	seed := tr.ObserveCumulative(key, 7, start, base, 100)
+	if !seed.Seeded || seed.Delta != 0 {
+		t.Fatalf("seed outcome = %+v, want Seeded with zero delta", seed)
+	}
+	for i, want := range []float64{5, 15, 1} {
+		ts := base.Add(time.Duration(i+1) * time.Minute)
+		prev, _ := tr.Baseline(key, 7)
+		out := tr.ObserveCumulative(key, 7, start, ts, prev.Value+want)
+		if out.Reset || out.Ignored || out.Gap {
+			t.Fatalf("step %d outcome = %+v, want plain progression", i, out)
+		}
+		if out.Delta != want {
+			t.Errorf("step %d delta = %v, want %v", i, out.Delta, want)
+		}
+	}
+}
+
+// --- downtime gap ---
+
+func TestCumulativeDowntimeGapReseedsAndCounts(t *testing.T) {
+	base := mustTime(t, "2026-08-21T12:00:00Z")
+	start := mustTime(t, "2026-08-21T11:00:00Z")
+	tr := newTestTracker(8, 100)
+	key := testKey(1)
+
+	tr.ObserveCumulative(key, 7, start, base, 100)
+	// The producer went away for an hour and came back with a much larger
+	// counter. Crediting an hour of increase to one 5-minute window would
+	// fabricate a rate spike, so the delta is discarded and the baseline
+	// re-seeded.
+	out := tr.ObserveCumulative(key, 7, start, base.Add(time.Hour), 100000)
+	if !out.Gap {
+		t.Fatalf("outcome = %+v, want a gap", out)
+	}
+	if out.Delta != 0 {
+		t.Errorf("delta = %v, want 0 — a downtime increase belongs to no window we own", out.Delta)
+	}
+	if got := tr.Stats().Gaps; got != 1 {
+		t.Errorf("gap count = %d, want 1", got)
+	}
+	b, _ := tr.Baseline(key, 7)
+	if b.Value != 100000 {
+		t.Errorf("baseline value = %v, want 100000 (re-seeded)", b.Value)
+	}
+
+	// The next point continues normally from the re-seeded baseline.
+	next := tr.ObserveCumulative(key, 7, start, base.Add(time.Hour+time.Minute), 100005)
+	if next.Gap || next.Reset || next.Delta != 5 {
+		t.Errorf("post-gap outcome = %+v, want plain delta 5", next)
+	}
+}
+
+// TestCumulativeGapBoundary pins that the gap threshold is the allowed-lateness
+// horizon exactly: at the boundary it is still a normal progression.
+func TestCumulativeGapBoundary(t *testing.T) {
+	base := mustTime(t, "2026-08-21T12:00:00Z")
+	start := mustTime(t, "2026-08-21T11:00:00Z")
+	tr := newTestTracker(8, 100)
+	key := testKey(1)
+
+	tr.ObserveCumulative(key, 7, start, base, 100)
+	at := tr.ObserveCumulative(key, 7, start, base.Add(AllowedLateness), 150)
+	if at.Gap {
+		t.Errorf("exactly at the threshold reported a gap: %+v", at)
+	}
+	just := tr.ObserveCumulative(key, 7, start, base.Add(2*AllowedLateness+time.Second), 200)
+	if !just.Gap {
+		t.Errorf("past the threshold did not report a gap: %+v", just)
+	}
+}
+
+// --- producer identity and overflow ---
+
+func TestProducerIDPrefersServiceInstanceID(t *testing.T) {
+	withInstance := ResourceIdentity{ServiceInstanceID: "abc", ServiceName: "svc", Host: "h1"}
+	sameInstanceOtherHost := ResourceIdentity{ServiceInstanceID: "abc", ServiceName: "svc", Host: "h2"}
+	if ResolveProducerID(withInstance) != ResolveProducerID(sameInstanceOtherHost) {
+		t.Error("service.instance.id must fully determine the producer when present")
+	}
+
+	a := ResourceIdentity{ServiceName: "svc", Host: "h1", Workload: "pod-1"}
+	b := ResourceIdentity{ServiceName: "svc", Host: "h1", Workload: "pod-2"}
+	if ResolveProducerID(a) == ResolveProducerID(b) {
+		t.Error("distinct workloads must produce distinct producer IDs")
+	}
+	sameTuple := ResourceIdentity{ServiceName: "svc", Host: "h1", Workload: "pod-1"}
+	if ResolveProducerID(a) != ResolveProducerID(sameTuple) {
+		t.Error("producer ID is not deterministic for an identical tuple")
+	}
+	if ResolveProducerID(ResourceIdentity{}) == degradedProducer {
+		t.Error("a derived producer ID must never collide with the degraded slot")
+	}
+}
+
+func TestProducerOverflowDegradesWithoutEvicting(t *testing.T) {
+	base := mustTime(t, "2026-08-21T12:00:00Z")
+	start := mustTime(t, "2026-08-21T11:00:00Z")
+	tr := newTestTracker(2, 100)
+	key := testKey(1)
+
+	// Two producers fill the per-series bound.
+	tr.ObserveCumulative(key, 101, start, base, 10)
+	tr.ObserveCumulative(key, 102, start, base, 20)
+
+	// A third degrades to the shared slot.
+	out := tr.ObserveCumulative(key, 103, start, base, 30)
+	if !out.Degraded {
+		t.Fatalf("third producer outcome = %+v, want degraded", out)
+	}
+	if got := tr.Stats().ProducerOverflow; got != 1 {
+		t.Errorf("producer overflow count = %d, want 1", got)
+	}
+
+	// The first two baselines survive untouched — overflow never evicts a
+	// correct baseline.
+	if b, ok := tr.Baseline(key, 101); !ok || b.Value != 10 {
+		t.Errorf("first baseline was disturbed: %+v ok=%v", b, ok)
+	}
+	if b, ok := tr.Baseline(key, 102); !ok || b.Value != 20 {
+		t.Errorf("second baseline was disturbed: %+v ok=%v", b, ok)
+	}
+	if _, ok := tr.Baseline(key, degradedProducer); !ok {
+		t.Error("degraded shared baseline was not created")
+	}
+
+	// The first two producers keep converting correctly afterwards.
+	if got := tr.ObserveCumulative(key, 101, start, base.Add(time.Minute), 15); got.Delta != 5 {
+		t.Errorf("bounded producer delta = %v, want 5", got.Delta)
+	}
+}
+
+func TestGlobalBaselineCapDegradesToSharedSlot(t *testing.T) {
+	base := mustTime(t, "2026-08-21T12:00:00Z")
+	start := mustTime(t, "2026-08-21T11:00:00Z")
+	tr := newTestTracker(8, 2)
+
+	tr.ObserveCumulative(testKey(1), 101, start, base, 1)
+	tr.ObserveCumulative(testKey(2), 102, start, base, 1)
+
+	// Global budget exhausted: the next series may still take the shared slot,
+	// which is reserved capacity — refusing it would strand the series.
+	out := tr.ObserveCumulative(testKey(3), 103, start, base, 1)
+	if !out.Degraded {
+		t.Fatalf("outcome at the global cap = %+v, want degraded", out)
+	}
+	if got := tr.Stats().GlobalOverflow; got != 1 {
+		t.Errorf("global overflow count = %d, want 1", got)
+	}
+	if _, ok := tr.Baseline(testKey(3), degradedProducer); !ok {
+		t.Error("series past the global cap got no baseline at all")
+	}
+}
+
+// --- non-monotonic ---
+
+func TestNonMonotonicNeverResetDetected(t *testing.T) {
+	if IsGaugeLike(TemporalityCumulative, false) != true {
+		t.Error("cumulative non-monotonic must be gauge-like")
+	}
+	if IsGaugeLike(TemporalityCumulative, true) != false {
+		t.Error("cumulative monotonic must not be gauge-like")
+	}
+	if IsGaugeLike(TemporalityDelta, false) != false {
+		t.Error("delta temporality must merge directly, not gauge-like")
+	}
+	if IsGaugeLike(TemporalityUnspecified, false) != true {
+		t.Error("a plain gauge must be gauge-like")
+	}
+}
+
+// TestReducerNonMonotonicSumIsGaugeLike drives the whole path: an UpDownCounter
+// that goes down must not register a single reset.
+func TestReducerNonMonotonicSumIsGaugeLike(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := testEngine(t, now)
+	r := e.NewReducer(now)
+
+	for i, v := range []float64{10, 4, 9, 1} {
+		r.ReduceMetricPoint(MetricInput{
+			Tenant: "t", Service: "svc", Name: "pool.inuse", Value: v,
+			Timestamp:   now.Add(time.Duration(i) * time.Second),
+			StartTime:   now.Add(-time.Hour),
+			Temporality: TemporalityCumulative, Monotonic: false,
+		})
+	}
+	e.ApplyReducer(r)
+
+	if got := e.Baselines().Stats(); got.ResetsRegression != 0 || got.ResetsStartTime != 0 || got.Entries != 0 {
+		t.Fatalf("non-monotonic sum touched the baseline tracker: %+v", got)
+	}
+	for _, d := range r.Deltas() {
+		if d.ResetCount != 0 {
+			t.Errorf("reset recorded for a non-monotonic sum: %+v", d)
+		}
+		if d.GaugeCount != 4 || d.GaugeMin != 1 || d.GaugeMax != 10 {
+			t.Errorf("gauge-like aggregation wrong: %+v", d)
+		}
+	}
+}
+
+// TestReducerCumulativeMonotonicThroughEngine exercises the reducer's use of
+// the tracker, including the reset counter landing on the delta.
+func TestReducerCumulativeMonotonicThroughEngine(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := testEngine(t, now)
+	r := e.NewReducer(now)
+
+	start := now.Add(-time.Hour)
+	emit := func(offset time.Duration, startTime time.Time, v float64) {
+		r.ReduceMetricPoint(MetricInput{
+			Tenant: "t", Service: "svc", Name: "requests.total", Value: v,
+			Timestamp: now.Add(offset), StartTime: startTime,
+			Temporality: TemporalityCumulative, Monotonic: true,
+			Resource: ResourceIdentity{ServiceInstanceID: "inst-1"},
+		})
+	}
+	emit(0, start, 100)             // seed, delta 0
+	emit(time.Second, start, 130)   // +30
+	emit(2*time.Second, start, 125) // regression reset, delta = 125
+	emit(2*time.Second, start, 125) // duplicate, ignored
+
+	if got := r.Stats().StaleCumulative; got != 1 {
+		t.Errorf("stale cumulative count = %d, want 1", got)
+	}
+	e.ApplyReducer(r)
+
+	var found bool
+	for _, w := range e.Snapshot().Windows {
+		for key, d := range w.Series {
+			if key.Signal != SignalMetric {
+				continue
+			}
+			found = true
+			if d.CounterDelta != 155 {
+				t.Errorf("counter delta = %v, want 155 (0 + 30 + 125)", d.CounterDelta)
+			}
+			if d.ResetCount != 1 {
+				t.Errorf("reset count = %d, want 1", d.ResetCount)
+			}
+			if d.Count != 3 {
+				t.Errorf("point count = %d, want 3 (the duplicate contributes nothing)", d.Count)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no metric series recorded")
+	}
+}

--- a/internal/ingest/aggregate_bridge.go
+++ b/internal/ingest/aggregate_bridge.go
@@ -1,0 +1,120 @@
+package ingest
+
+import (
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// OTLP -> aggregate translation.
+//
+// Kept out of otlp.go so the legacy Export paths stay readable and so the
+// aggregate wiring is one nil check plus one call at each site. When
+// AGGREGATE_MODE=legacy no Engine is constructed, every reducer reference is
+// nil, and none of this runs.
+
+// aggregateSpanInput builds the reducer input for one span. It reads only the
+// attributes that can affect series identity; span/trace IDs, URLs and messages
+// are on the permanent banned list (#153, #159) and are never carried across.
+func aggregateSpanInput(tenantID, serviceName string, span *tracepb.Span, start, end time.Time) aggregate.SpanInput {
+	in := aggregate.SpanInput{
+		Tenant:         tenantID,
+		Service:        serviceName,
+		SpanName:       span.Name,
+		SpanKind:       int32(span.Kind),
+		Timestamp:      start,
+		DurationMicros: float64(end.Sub(start).Microseconds()),
+	}
+	if span.Status != nil {
+		in.StatusCode = int32(span.Status.Code)
+	}
+	for _, kv := range span.Attributes {
+		if kv == nil || kv.Value == nil {
+			continue
+		}
+		switch kv.Key {
+		case "http.route":
+			in.HTTPRoute = kv.Value.GetStringValue()
+		case "url.path":
+			in.URLPath = kv.Value.GetStringValue()
+		case "http.target":
+			if in.URLPath == "" {
+				in.URLPath = kv.Value.GetStringValue()
+			}
+		case "http.request.method":
+			in.Method = kv.Value.GetStringValue()
+		case "http.method":
+			if in.Method == "" {
+				in.Method = kv.Value.GetStringValue()
+			}
+		case "http.response.status_code":
+			in.HTTPStatusCode = int(kv.Value.GetIntValue())
+		case "http.status_code":
+			if in.HTTPStatusCode == 0 {
+				in.HTTPStatusCode = int(kv.Value.GetIntValue())
+			}
+		}
+	}
+	return in
+}
+
+// aggregateResourceIdentity extracts the stable resource identity used to
+// derive a metric producer's ProducerID (#166). Only the first-present value
+// per slot is taken: attributes that vary per export would fragment baselines.
+func aggregateResourceIdentity(attrs []*commonpb.KeyValue) aggregate.ResourceIdentity {
+	var id aggregate.ResourceIdentity
+	for _, kv := range attrs {
+		if kv == nil || kv.Value == nil {
+			continue
+		}
+		switch kv.Key {
+		case "service.instance.id":
+			id.ServiceInstanceID = kv.Value.GetStringValue()
+		case "service.namespace":
+			id.ServiceNamespace = kv.Value.GetStringValue()
+		case "service.name":
+			id.ServiceName = kv.Value.GetStringValue()
+		case "host.id":
+			id.Host = kv.Value.GetStringValue()
+		case "host.name":
+			if id.Host == "" {
+				id.Host = kv.Value.GetStringValue()
+			}
+		case "k8s.pod.uid":
+			id.Workload = kv.Value.GetStringValue()
+		case "container.id":
+			if id.Workload == "" {
+				id.Workload = kv.Value.GetStringValue()
+			}
+		case "process.pid":
+			if id.Workload == "" {
+				id.Workload = kv.Value.String()
+			}
+		}
+	}
+	return id
+}
+
+// aggregateTemporality maps the OTLP aggregation temporality of a metric onto
+// the engine's enum, along with whether the instrument is monotonic. A gauge
+// reports (unspecified, false), which is exactly the gauge-like model.
+func aggregateTemporality(m *metricspb.Metric) (aggregate.Temporality, bool) {
+	if sum := m.GetSum(); sum != nil {
+		switch sum.AggregationTemporality {
+		case metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA:
+			return aggregate.TemporalityDelta, sum.IsMonotonic
+		case metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE:
+			return aggregate.TemporalityCumulative, sum.IsMonotonic
+		default:
+			// Unspecified temporality on a Sum is a broken producer. It is
+			// passed through as unspecified so the reducer picks the model
+			// from monotonicity alone: gauge-like when non-monotonic,
+			// baseline conversion when monotonic.
+			return aggregate.TemporalityUnspecified, sum.IsMonotonic
+		}
+	}
+	return aggregate.TemporalityUnspecified, false
+}

--- a/internal/ingest/aggregate_wiring_test.go
+++ b/internal/ingest/aggregate_wiring_test.go
@@ -1,0 +1,264 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/config"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"gorm.io/gorm"
+)
+
+// newAggregateEngine builds a shadow-mode engine with the platform default
+// budget and a fixed clock, so window placement in these tests is deterministic.
+func newAggregateEngine(t *testing.T, now time.Time) *aggregate.Engine {
+	t.Helper()
+	e, err := aggregate.NewEngine(aggregate.EngineConfig{
+		Mode: aggregate.ModeShadow,
+		Now:  func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	return e
+}
+
+// newAggregateTestRepo returns an in-memory repository on the synchronous
+// persist path, so one Export() leaves everything readable when it returns.
+func newAggregateTestRepo(t *testing.T) (*storage.Repository, *gorm.DB) {
+	t.Helper()
+	db, err := storage.NewDatabase("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	if err := storage.AutoMigrateModels(db, "sqlite"); err != nil {
+		t.Fatalf("AutoMigrateModels: %v", err)
+	}
+	repo := storage.NewRepositoryFromDB(db, "sqlite")
+	t.Cleanup(func() { _ = repo.Close() })
+	return repo, db
+}
+
+func aggTestConfig() *config.Config {
+	return &config.Config{
+		IngestMinSeverity:          "INFO",
+		DefaultTenant:              storage.DefaultTenantID,
+		SamplingLatencyThresholdMs: 500,
+	}
+}
+
+// aggSpanRequest builds an export request of healthy spans spread over a few
+// services and operations. Every span is fast and OK, so the sampler's
+// always-keep rules for errors and slow spans cannot rescue any of them —
+// which is exactly what makes the sampling-invariant test meaningful.
+func aggSpanRequest(spansPerService int, ts time.Time) *coltracepb.ExportTraceServiceRequest {
+	services := []string{"checkout", "orders", "payments"}
+	operations := []string{"GET /a", "GET /b", "POST /c"}
+
+	req := &coltracepb.ExportTraceServiceRequest{}
+	for si, svc := range services {
+		spans := make([]*tracepb.Span, 0, spansPerService)
+		for i := 0; i < spansPerService; i++ {
+			status := &tracepb.Status{Code: tracepb.Status_STATUS_CODE_OK}
+			spans = append(spans, &tracepb.Span{
+				TraceId:           []byte(fmt.Sprintf("%016d%016d", si, i)),
+				SpanId:            []byte(fmt.Sprintf("%08d", i)),
+				Name:              operations[i%len(operations)],
+				Kind:              tracepb.Span_SPAN_KIND_SERVER,
+				StartTimeUnixNano: uint64(ts.UnixNano()), // #nosec G115 -- test timestamps are positive
+				EndTimeUnixNano:   uint64(ts.Add(time.Millisecond).UnixNano()),
+				Status:            status,
+				Attributes: []*commonpb.KeyValue{
+					{Key: "http.request.method", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "GET"}}},
+					{Key: "http.response.status_code", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 200}}},
+				},
+			})
+		}
+		req.ResourceSpans = append(req.ResourceSpans, &tracepb.ResourceSpans{
+			Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
+				{Key: "service.name", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: svc}}},
+			}},
+			ScopeSpans: []*tracepb.ScopeSpans{{Spans: spans}},
+		})
+	}
+	return req
+}
+
+func countAggSpans(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+	var n int64
+	if err := db.Model(&storage.Span{}).Count(&n).Error; err != nil {
+		t.Fatalf("count spans: %v", err)
+	}
+	return n
+}
+
+// TestAggregateCountsIdenticalAcrossSamplingRates is THE invariant of the
+// aggregate-first design (#153 §8): the same input stream must produce the same
+// aggregate counts at SAMPLING_RATE=1.0 and at 0.05. If this test ever fails,
+// the reducer has drifted behind the sampler and the engine is measuring the
+// sampling rate instead of the traffic.
+func TestAggregateCountsIdenticalAcrossSamplingRates(t *testing.T) {
+	now := time.Now().UTC() // Export captures arrival from the wall clock; test data must sit in the live window
+	const spansPerService = 200
+
+	run := func(rate float64) (aggregate.Snapshot, int64) {
+		repo, db := newAggregateTestRepo(t)
+		srv := NewTraceServer(repo, nil, aggTestConfig())
+		srv.SetSampler(NewSampler(rate, true, 500))
+		engine := newAggregateEngine(t, now)
+		srv.SetAggregateEngine(engine)
+
+		if _, err := srv.Export(context.Background(), aggSpanRequest(spansPerService, now)); err != nil {
+			t.Fatalf("Export at rate %v: %v", rate, err)
+		}
+		return engine.Snapshot(), countAggSpans(t, db)
+	}
+
+	full, fullPersisted := run(1.0)
+	sampled, sampledPersisted := run(0.05)
+
+	const total = spansPerService * 3
+	if fullPersisted != total {
+		t.Fatalf("unsampled run persisted %d spans, want %d", fullPersisted, total)
+	}
+	// Guard against a vacuous test: sampling must actually be dropping spans.
+	if sampledPersisted >= fullPersisted {
+		t.Fatalf("sampling dropped nothing (%d vs %d persisted) — the invariant would be untested",
+			sampledPersisted, fullPersisted)
+	}
+	t.Logf("persisted spans: rate=1.0 -> %d, rate=0.05 -> %d", fullPersisted, sampledPersisted)
+
+	fullCount, fullErrors := full.Totals(aggregate.SignalTraceOp)
+	sampledCount, sampledErrors := sampled.Totals(aggregate.SignalTraceOp)
+
+	if fullCount != total || sampledCount != total {
+		t.Fatalf("aggregate counts = %d (rate 1.0) and %d (rate 0.05), want %d for both",
+			fullCount, sampledCount, total)
+	}
+	if fullErrors != sampledErrors {
+		t.Errorf("aggregate error counts diverged: %d vs %d", fullErrors, sampledErrors)
+	}
+	if full.ActiveSeries != sampled.ActiveSeries {
+		t.Errorf("active series diverged: %d vs %d", full.ActiveSeries, sampled.ActiveSeries)
+	}
+}
+
+// TestAggregateShadowModeDoesNotAlterPersistedOutput: turning the engine on
+// must change nothing about what reaches the database.
+func TestAggregateShadowModeDoesNotAlterPersistedOutput(t *testing.T) {
+	now := time.Now().UTC() // Export captures arrival from the wall clock; test data must sit in the live window
+	req := aggSpanRequest(25, now)
+
+	legacyRepo, legacyDB := newAggregateTestRepo(t)
+	legacy := NewTraceServer(legacyRepo, nil, aggTestConfig())
+	if _, err := legacy.Export(context.Background(), req); err != nil {
+		t.Fatalf("legacy Export: %v", err)
+	}
+
+	shadowRepo, shadowDB := newAggregateTestRepo(t)
+	shadow := NewTraceServer(shadowRepo, nil, aggTestConfig())
+	engine := newAggregateEngine(t, now)
+	shadow.SetAggregateEngine(engine)
+	if _, err := shadow.Export(context.Background(), req); err != nil {
+		t.Fatalf("shadow Export: %v", err)
+	}
+
+	if got, want := countAggSpans(t, shadowDB), countAggSpans(t, legacyDB); got != want {
+		t.Fatalf("shadow mode persisted %d spans, legacy persisted %d", got, want)
+	}
+
+	var legacyTraces, shadowTraces int64
+	if err := legacyDB.Model(&storage.Trace{}).Count(&legacyTraces).Error; err != nil {
+		t.Fatalf("count legacy traces: %v", err)
+	}
+	if err := shadowDB.Model(&storage.Trace{}).Count(&shadowTraces).Error; err != nil {
+		t.Fatalf("count shadow traces: %v", err)
+	}
+	if legacyTraces != shadowTraces {
+		t.Fatalf("shadow mode persisted %d traces, legacy persisted %d", shadowTraces, legacyTraces)
+	}
+
+	if count, _ := engine.Snapshot().Totals(aggregate.SignalTraceOp); count != 75 {
+		t.Fatalf("aggregate count = %d, want 75", count)
+	}
+}
+
+// TestLegacyModeRunsNoAggregateCode is the "nothing changed" guard: with no
+// engine wired, Export takes the identical path it always did.
+func TestLegacyModeRunsNoAggregateCode(t *testing.T) {
+	now := time.Now().UTC() // Export captures arrival from the wall clock; test data must sit in the live window
+	repo, db := newAggregateTestRepo(t)
+	srv := NewTraceServer(repo, nil, aggTestConfig())
+	if _, err := srv.Export(context.Background(), aggSpanRequest(10, now)); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if got := countAggSpans(t, db); got != 30 {
+		t.Fatalf("persisted %d spans, want 30", got)
+	}
+}
+
+// TestAggregateAccountsLogsBelowTheSeverityGate: a DEBUG log that is dropped
+// before it ever reaches the database is still accepted telemetry and must be
+// accounted.
+func TestAggregateAccountsLogsBelowTheSeverityGate(t *testing.T) {
+	now := time.Now().UTC() // Export captures arrival from the wall clock; test data must sit in the live window
+	repo, db := newAggregateTestRepo(t)
+	srv := NewLogsServer(repo, nil, aggTestConfig()) // INGEST_MIN_SEVERITY=INFO
+	engine := newAggregateEngine(t, now)
+	srv.SetAggregateEngine(engine)
+
+	records := []struct {
+		severity string
+		body     string
+	}{
+		{"DEBUG", "cache lookup for key 91 took 3ms"},
+		{"DEBUG", "cache lookup for key 92 took 4ms"},
+		{"INFO", "request served in 12ms"},
+		{"ERROR", "upstream payments timed out after 30s"},
+	}
+	req := &collogspb.ExportLogsServiceRequest{}
+	logRecords := make([]*logspb.LogRecord, 0, len(records))
+	for _, r := range records {
+		logRecords = append(logRecords, &logspb.LogRecord{
+			TimeUnixNano: uint64(now.UnixNano()), // #nosec G115 -- test timestamps are positive
+			SeverityText: r.severity,
+			Body:         &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: r.body}},
+		})
+	}
+	req.ResourceLogs = append(req.ResourceLogs, &logspb.ResourceLogs{
+		Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
+			{Key: "service.name", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "checkout"}}},
+		}},
+		ScopeLogs: []*logspb.ScopeLogs{{LogRecords: logRecords}},
+	})
+
+	if _, err := srv.Export(context.Background(), req); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	var persisted int64
+	if err := db.Model(&storage.Log{}).Count(&persisted).Error; err != nil {
+		t.Fatalf("count logs: %v", err)
+	}
+	if persisted != 2 {
+		t.Fatalf("persisted %d logs, want 2 (the DEBUG pair is gated out)", persisted)
+	}
+
+	count, errors := engine.Snapshot().Totals(aggregate.SignalLog)
+	if count != 4 {
+		t.Errorf("aggregate log count = %d, want 4 — accounting precedes the severity gate", count)
+	}
+	if errors != 1 {
+		t.Errorf("aggregate log error count = %d, want 1", errors)
+	}
+}

--- a/internal/ingest/otlp.go
+++ b/internal/ingest/otlp.go
@@ -11,6 +11,7 @@ import (
 
 	"runtime"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/config"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"github.com/RandomCodeSpace/otelcontext/internal/telemetry"
@@ -110,7 +111,12 @@ type TraceServer struct {
 	// sampler's keep/drop decision so cross-service call topology survives
 	// sampling (see graphrag.GraphRAG.ObserveSpanTopology). Args:
 	// tenant, traceID, spanID, parentSpanID, service. nil = disabled.
-	topologyObserver    func(tenant, traceID, spanID, parentSpanID, service string)
+	topologyObserver func(tenant, traceID, spanID, parentSpanID, service string)
+	// aggregateEngine, when set (AGGREGATE_MODE != legacy), runs request-local
+	// aggregate reduction BEFORE the sampler so aggregate counts describe
+	// accepted telemetry rather than the sampling rate (#153 §8). nil leaves
+	// the legacy path untouched.
+	aggregateEngine     *aggregate.Engine
 	minSeverity         int
 	allowedServices     map[string]bool
 	excludedServices    map[string]bool
@@ -123,9 +129,12 @@ type TraceServer struct {
 }
 
 type LogsServer struct {
-	repo                *storage.Repository
-	metrics             *telemetry.Metrics
-	logCallback         func(storage.Log)
+	repo        *storage.Repository
+	metrics     *telemetry.Metrics
+	logCallback func(storage.Log)
+	// aggregateEngine — see TraceServer.aggregateEngine. Reduction runs before
+	// the severity gate.
+	aggregateEngine     *aggregate.Engine
 	minSeverity         int
 	allowedServices     map[string]bool
 	excludedServices    map[string]bool
@@ -136,10 +145,12 @@ type LogsServer struct {
 }
 
 type MetricsServer struct {
-	repo                *storage.Repository
-	metrics             *telemetry.Metrics
-	aggregator          *tsdb.Aggregator
-	metricCallback      func(tsdb.RawMetric)
+	repo           *storage.Repository
+	metrics        *telemetry.Metrics
+	aggregator     *tsdb.Aggregator
+	metricCallback func(tsdb.RawMetric)
+	// aggregateEngine — see TraceServer.aggregateEngine.
+	aggregateEngine     *aggregate.Engine
 	allowedServices     map[string]bool
 	excludedServices    map[string]bool
 	defaultTenant       string
@@ -197,6 +208,23 @@ func (s *LogsServer) SetPipeline(p *Pipeline) {
 	s.pipeline = p
 }
 
+// SetAggregateEngine enables aggregate accounting on this server. The reducer
+// runs inside Export() ahead of the sampler and severity gates; passing nil
+// (the AGGREGATE_MODE=legacy case) leaves the export path unchanged.
+func (s *TraceServer) SetAggregateEngine(e *aggregate.Engine) {
+	s.aggregateEngine = e
+}
+
+// SetAggregateEngine — see TraceServer.SetAggregateEngine.
+func (s *LogsServer) SetAggregateEngine(e *aggregate.Engine) {
+	s.aggregateEngine = e
+}
+
+// SetAggregateEngine — see TraceServer.SetAggregateEngine.
+func (s *MetricsServer) SetAggregateEngine(e *aggregate.Engine) {
+	s.aggregateEngine = e
+}
+
 func NewLogsServer(repo *storage.Repository, metrics *telemetry.Metrics, cfg *config.Config) *LogsServer {
 	return &LogsServer{
 		repo:                repo,
@@ -235,6 +263,16 @@ func (s *MetricsServer) SetMetricCallback(cb func(tsdb.RawMetric)) {
 func (s *MetricsServer) Export(ctx context.Context, req *colmetricspb.ExportMetricsServiceRequest) (*colmetricspb.ExportMetricsServiceResponse, error) {
 	start := time.Now()
 	defer func() { s.metrics.ObserveIngestDuration("metrics", time.Since(start)) }()
+
+	// Aggregate accounting. One reducer, one arrival time for the whole
+	// request (#160): lateness must not depend on a point's position in the
+	// batch. nil engine = AGGREGATE_MODE=legacy = nothing below runs.
+	var reducer *aggregate.Reducer
+	if s.aggregateEngine != nil {
+		reducer = s.aggregateEngine.NewReducer(start)
+		defer func() { s.aggregateEngine.ApplyReducer(reducer) }()
+	}
+
 	for _, resourceMetrics := range req.ResourceMetrics {
 		serviceName := getServiceName(resourceMetrics.Resource.Attributes)
 
@@ -243,6 +281,11 @@ func (s *MetricsServer) Export(ctx context.Context, req *colmetricspb.ExportMetr
 		}
 
 		tenantID := resolveTenant(ctx, resourceMetrics.Resource.Attributes, s.defaultTenant, s.trustResourceTenant)
+
+		var producerIdentity aggregate.ResourceIdentity
+		if reducer != nil {
+			producerIdentity = aggregateResourceIdentity(resourceMetrics.Resource.Attributes)
+		}
 
 		for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
 			for _, m := range scopeMetrics.Metrics {
@@ -281,6 +324,22 @@ func (s *MetricsServer) Export(ctx context.Context, req *colmetricspb.ExportMetr
 						raw.Attributes[kv.Key] = kv.Value.String()
 					}
 
+					// 0. Aggregate accounting, ahead of every other consumer.
+					if reducer != nil {
+						temporality, monotonic := aggregateTemporality(m)
+						reducer.ReduceMetricPoint(aggregate.MetricInput{
+							Tenant:      tenantID,
+							Service:     serviceName,
+							Name:        m.Name,
+							Value:       val,
+							Timestamp:   raw.Timestamp,
+							StartTime:   time.Unix(0, int64(p.StartTimeUnixNano)), // #nosec G115 -- OTLP time in nanos: uint64 source fits int64 until year 2262
+							Temporality: temporality,
+							Monotonic:   monotonic,
+							Resource:    producerIdentity,
+						})
+					}
+
 					// 1. Process via TSDB Aggregator (for storage)
 					if s.aggregator != nil {
 						s.aggregator.Ingest(raw)
@@ -315,6 +374,10 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 		logs    []storage.Log
 		hasErr  bool // any span in this slice had STATUS_CODE_ERROR
 		hasSlow bool // any span exceeded latencyThresholdMs
+		// reducer holds this resource batch's aggregate deltas. Reduction is
+		// request-local and lock-free, so each goroutine owns its own reducer
+		// and they are merged once below.
+		reducer *aggregate.Reducer
 	}
 
 	results := make([]batchResult, len(req.ResourceSpans))
@@ -340,6 +403,13 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 			// exactly one Trace row per trace instead of one per span.
 			traceIdx := make(map[string]int)
 			var localHasErr, localHasSlow bool
+
+			// Aggregate accounting. One arrival time for the whole Export
+			// request (#160), captured above as `start`.
+			var reducer *aggregate.Reducer
+			if s.aggregateEngine != nil {
+				reducer = s.aggregateEngine.NewReducer(start)
+			}
 
 			for _, scopeSpans := range resourceSpans.ScopeSpans {
 				for _, span := range scopeSpans.Spans {
@@ -374,6 +444,14 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 							parentSpanIDHex,
 							serviceName,
 						)
+					}
+
+					// Aggregate reduction runs BEFORE the sampler. Aggregate
+					// counts must describe accepted telemetry, not the
+					// sampling rate (#153 §8) — that invariant is the entire
+					// reason the engine sits at this point in the path.
+					if reducer != nil {
+						reducer.ReduceSpan(aggregateSpanInput(tenantID, serviceName, span, startTime, endTime))
 					}
 
 					if s.sampler != nil {
@@ -506,6 +584,7 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 				logs:    localLogs,
 				hasErr:  localHasErr,
 				hasSlow: localHasSlow,
+				reducer: reducer,
 			}
 
 			return nil
@@ -519,6 +598,7 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 	var tracesToUpsert []storage.Trace
 	var synthesizedLogs []storage.Log
 	var batchHasErr, batchHasSlow bool
+	var merged *aggregate.Reducer
 	for _, r := range results {
 		spansToInsert = append(spansToInsert, r.spans...)
 		tracesToUpsert = append(tracesToUpsert, r.traces...)
@@ -529,6 +609,21 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 		if r.hasSlow {
 			batchHasSlow = true
 		}
+		if r.reducer == nil {
+			continue
+		}
+		if merged == nil {
+			merged = r.reducer
+			continue
+		}
+		merged.MergeFrom(r.reducer)
+	}
+
+	// Apply the request's aggregate deltas before the persist decision: the
+	// aggregate path has already accepted this telemetry, and a downstream
+	// queue rejection must not retroactively unaccount it.
+	if merged != nil {
+		s.aggregateEngine.ApplyReducer(merged)
 	}
 
 	// Intake metrics fire before the persist decision so operators see
@@ -611,6 +706,9 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 	// slog.Debug("📥 [LOGS] Received Request", "resource_logs", len(req.ResourceLogs))
 
 	logResults := make([][]storage.Log, len(req.ResourceLogs))
+	// One reducer per resource batch (reduction is request-local and not
+	// concurrency-safe); merged into one after the group finishes.
+	reducers := make([]*aggregate.Reducer, len(req.ResourceLogs))
 
 	g, _ := errgroup.WithContext(ctx)
 
@@ -627,6 +725,12 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 
 			localLogs := make([]storage.Log, 0)
 
+			var reducer *aggregate.Reducer
+			if s.aggregateEngine != nil {
+				reducer = s.aggregateEngine.NewReducer(start)
+				reducers[idx] = reducer
+			}
+
 			for _, scopeLogs := range resourceLogs.ScopeLogs {
 				for _, l := range scopeLogs.LogRecords {
 					severity := l.SeverityText
@@ -634,13 +738,27 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 						severity = l.SeverityNumber.String()
 					}
 
-					if !shouldIngestSeverity(severity, s.minSeverity) {
-						continue
-					}
-
 					timestamp := time.Unix(0, int64(l.TimeUnixNano)) // #nosec G115 -- OTLP time in nanos: uint64 source fits int64 until year 2262
 					if timestamp.Unix() == 0 {
 						timestamp = time.Now()
+					}
+
+					// Aggregate reduction runs BEFORE the severity gate: a
+					// DEBUG log that never reaches the DB is still accepted
+					// telemetry and must be accounted (#153 §8).
+					if reducer != nil {
+						reducer.ReduceLog(aggregate.LogInput{
+							Tenant:         tenantID,
+							Service:        serviceName,
+							Severity:       severity,
+							SeverityNumber: int32(l.SeverityNumber),
+							Body:           l.Body.GetStringValue(),
+							Timestamp:      timestamp,
+						})
+					}
+
+					if !shouldIngestSeverity(severity, s.minSeverity) {
+						continue
 					}
 
 					bodyStr := l.Body.GetStringValue()
@@ -672,6 +790,24 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 	var logsToInsert []storage.Log
 	for _, lr := range logResults {
 		logsToInsert = append(logsToInsert, lr...)
+	}
+
+	// Apply the request's aggregate deltas. This happens before the early
+	// return below: a request whose every record was filtered out still
+	// carries aggregate accounting.
+	var mergedReducer *aggregate.Reducer
+	for _, r := range reducers {
+		if r == nil {
+			continue
+		}
+		if mergedReducer == nil {
+			mergedReducer = r
+			continue
+		}
+		mergedReducer.MergeFrom(r)
+	}
+	if mergedReducer != nil {
+		s.aggregateEngine.ApplyReducer(mergedReducer)
 	}
 
 	if len(logsToInsert) == 0 {

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -152,6 +152,36 @@ type Metrics struct {
 	// --- Dashboard p99 (Task 10) ---
 	DashboardP99RowCapHitsTotal prometheus.Counter
 
+	// --- Aggregate engine (AGGREGATE_MODE != legacy) ---
+	// AggregateInputPointsTotal — points offered to the request-local reducer
+	// per signal, counted BEFORE the sampler and severity gates. This is
+	// accepted telemetry, not persisted telemetry.
+	AggregateInputPointsTotal *prometheus.CounterVec
+	// AggregateDeltasTotal — series deltas emitted by reduction. The gap
+	// between this and input points is the whole value of the engine.
+	AggregateDeltasTotal *prometheus.CounterVec
+	// AggregateReductionRatio — input points per emitted delta, per Export
+	// request. A ratio collapsing toward 1 means cardinality is exploding.
+	AggregateReductionRatio *prometheus.HistogramVec
+	// AggregateLatePointsTotal — points excluded from aggregates because they
+	// fell outside the mutable-window horizon. reason="late" (older than the
+	// allowed lateness) or reason="future" (beyond the tolerated skew).
+	AggregateLatePointsTotal *prometheus.CounterVec
+	// AggregateSeriesActive — series present in at least one mutable window,
+	// per signal. This is what the AGGREGATE_MAX_SERIES* caps bound.
+	AggregateSeriesActive *prometheus.GaugeVec
+	// AggregateOverflowTotal — admissions rerouted to an __other__ series,
+	// labeled by the cap that triggered it (tenant|service_names|
+	// service_series|signal|global). Totals are preserved; identity is not.
+	AggregateOverflowTotal *prometheus.CounterVec
+	// AggregateShadowAcceptedTotal — telemetry accounted on the aggregate
+	// side per signal. In shadow mode this is compared against the legacy
+	// path's accepted counts; it must not move with the sampling rate.
+	AggregateShadowAcceptedTotal *prometheus.CounterVec
+	// AggregateShadowErrorsTotal — errors accounted on the aggregate side per
+	// service. Cheap invariant only (#165): no per-series comparison.
+	AggregateShadowErrorsTotal *prometheus.CounterVec
+
 	// Atomic counters for JSON health endpoint (avoids scraping Prometheus)
 	totalIngested  atomic.Int64
 	activeConns    atomic.Int64
@@ -424,6 +454,39 @@ func New() *Metrics {
 		Name: "otelcontext_dashboard_p99_row_cap_hits_total",
 		Help: "Number of dashboard p99 computations that hit the SQLite row cap (200k). Indicates the dataset is too large for in-memory p99 — use Postgres for prod.",
 	})
+	m.AggregateInputPointsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_input_points_total",
+		Help: "Points offered to the aggregate reducer, per signal, counted before sampling and severity gates.",
+	}, []string{"signal"})
+	m.AggregateDeltasTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_deltas_total",
+		Help: "Series deltas emitted by aggregate reduction, per signal.",
+	}, []string{"signal"})
+	m.AggregateReductionRatio = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "otelcontext_aggregate_reduction_ratio",
+		Help:    "Input points per emitted delta, per Export request. Falling toward 1 means cardinality is exploding.",
+		Buckets: []float64{1, 2, 5, 10, 25, 50, 100, 250, 500, 1000},
+	}, []string{"signal"})
+	m.AggregateLatePointsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_late_points_total",
+		Help: "Points excluded from aggregates for falling outside the mutable-window horizon. reason=late|future.",
+	}, []string{"signal", "reason"})
+	m.AggregateSeriesActive = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "otelcontext_aggregate_series_active",
+		Help: "Series present in at least one mutable window, per signal. Bounded by the AGGREGATE_MAX_SERIES* caps.",
+	}, []string{"signal"})
+	m.AggregateOverflowTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_overflow_total",
+		Help: "Admissions rerouted to an __other__ series, by the cap that triggered it. Totals are preserved; identity detail is not.",
+	}, []string{"signal", "reason"})
+	m.AggregateShadowAcceptedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_shadow_accepted_total",
+		Help: "Telemetry accounted on the aggregate side, per signal. Must not move with SAMPLING_RATE.",
+	}, []string{"signal"})
+	m.AggregateShadowErrorsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_shadow_errors_total",
+		Help: "Errors accounted on the aggregate side, per service. Cheap shadow-mode invariant only.",
+	}, []string{"service"})
 	return m
 }
 

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/ai"
 	"github.com/RandomCodeSpace/otelcontext/internal/api"
 	"github.com/RandomCodeSpace/otelcontext/internal/config"
@@ -454,6 +455,45 @@ func main() {
 	traceServer := ingest.NewTraceServer(repo, metrics, cfg)
 	logsServer := ingest.NewLogsServer(repo, metrics, cfg)
 	metricsServer := ingest.NewMetricsServer(repo, metrics, tsdbAgg, cfg)
+
+	// Aggregate engine (AGGREGATE_MODE != legacy). Phase 1 is accounting only:
+	// the reducer runs inside Export() ahead of the sampler, the read path
+	// stays legacy, and mutable windows are discarded rather than persisted
+	// until the durable store lands (#173). AGGREGATE_MODE=legacy constructs
+	// nothing and leaves every ingest path byte-for-byte unchanged.
+	if cfg.AggregateMode != aggregate.ModeLegacy {
+		aggEngine, err := aggregate.NewEngine(aggregate.EngineConfig{
+			Mode: cfg.AggregateMode,
+			Limiter: aggregate.LimiterConfig{
+				MaxSeries:                 cfg.AggregateMaxSeries,
+				MaxSeriesMetrics:          cfg.AggregateMaxSeriesMetrics,
+				MaxSeriesTraces:           cfg.AggregateMaxSeriesTraces,
+				MaxSeriesEdges:            cfg.AggregateMaxSeriesEdges,
+				MaxSeriesLogs:             cfg.AggregateMaxSeriesLogs,
+				MaxSeriesSystem:           cfg.AggregateMaxSeriesSystem,
+				MaxOperationsPerService:   cfg.AggregateMaxOperationsPerService,
+				MaxLogTemplatesPerService: cfg.AggregateMaxLogTemplatesPerService,
+				MaxTraceSeriesPerService:  cfg.AggregateMaxTraceSeriesPerService,
+				MaxMetricSeriesPerService: cfg.AggregateMaxMetricSeriesPerService,
+				SeriesPerTenantFraction:   cfg.AggregateSeriesPerTenantFraction,
+			},
+			MaxProducerBaselinesPerSeries: cfg.AggregateMaxProducerBaselinesPerSeries,
+			MaxBaselines:                  cfg.ResolvedAggregateMaxBaselines(),
+			Metrics:                       aggregate.NewPrometheusRecorder(metrics),
+		})
+		if err != nil {
+			fatal("❌ Aggregate engine configuration rejected", err, "mode", cfg.AggregateMode)
+		}
+		traceServer.SetAggregateEngine(aggEngine)
+		logsServer.SetAggregateEngine(aggEngine)
+		metricsServer.SetAggregateEngine(aggEngine)
+		slog.Info("🧮 Aggregate engine enabled",
+			"mode", cfg.AggregateMode,
+			"max_series", cfg.AggregateMaxSeries,
+			"max_baselines", cfg.ResolvedAggregateMaxBaselines(),
+			"note", "Phase 1: accounting only, windows are not persisted",
+		)
+	}
 
 	// Wire adaptive sampler (only when rate < 1.0 to avoid unnecessary overhead)
 	if cfg.SamplingRate > 0 && cfg.SamplingRate < 1.0 {


### PR DESCRIPTION
Wave 2 of #172: the integration core that assembles the merged wave-1 components into the aggregate accounting path. In-memory only — persistence, durable ACK and the group-commit writer are #173.

## Components

| File | What it owns |
|---|---|
| `internal/aggregate/delta.go` | `AggregateDelta` — count, error count, duration sum/min/max + sketch, gauge last/min/max/sum/count, counter delta + reset count, log count + first/last timestamp. Every field additive or order-independent, so `Merge` is associative and commutative. |
| `internal/aggregate/reducer.go` | Request-local reduction. One `Reducer` per Export, collapsing spans/logs/metric points into `map[SeriesWindowKey]*AggregateDelta` before any shard is touched. Uses wave-1 APIs directly: `SeriesKey` + enum mappers from `key.go`, the dictionary `Cache`, `NormalizeOperation`, `TemplateMiner.MineAt`, `Sketch.Observe`. One arrival time per Export; late (>10 m) and future (>2 m) points excluded from aggregates and **counted**, never dropped silently. |
| `internal/aggregate/temporality.go` | Cumulative-sum handling in #166's NORMATIVE order: (1) stale/duplicate vs `LastTimestamp` → ignore + count, never a reset; (2) start-time change → reset, delta = current; (3) same start-time and regression → implicit reset, delta = current; (4) normal → current − prior. Downtime gaps (> allowed lateness) discard the delta and re-seed. Non-monotonic sums are gauge-like and never reset-detected. `ProducerID` = `service.instance.id`, else FNV-1a over `{service.namespace, service.name, host.id\|host.name, k8s.pod.uid\|container.id\|process.pid}`. Baselines bounded per series (8) and globally; overflow degrades to a shared slot and never evicts a correct baseline. |
| `internal/aggregate/cardinality.go` | Enforcement in the frozen order **tenant fraction → per-service → signal sub-cap → global**, evaluated on the full materialized key before admission. Overflow merges into the per-(service, signal) `__other__` series holding `StatusClass` while collapsing name → `__other__`, Method → OTHER, HTTPClass → NONE, span kind and dims → 0. Overflow series draw on reserved capacity — a cap can never block creating its own overflow series. Totals always preserved. |
| `internal/aggregate/engine.go` | Four mutex-guarded shards (`hash(SeriesKey) & 3`), 5 m UTC tumbling windows + 10 m lateness, `ApplyDeltas`, monotonic revision counter, `Snapshot()`. Admission is resolved with **no** shard lock held (overflow can rehash to a different shard), so "never hold two shard locks" is trivially true. `Applier` seam lets #173's group-commit writer interpose without a caller change. |
| `internal/aggregate/metrics.go` + `internal/telemetry/metrics.go` | `otelcontext_aggregate_input_points_total{signal}`, `_deltas_total{signal}`, `_reduction_ratio{signal}`, `_late_points_total{signal,reason}`, `_series_active{signal}`, `_overflow_total{signal,reason}`, plus shadow counters `_shadow_accepted_total{signal}` and `_shadow_errors_total{service}`. Registered in `internal/telemetry` via `promauto` like every other subsystem; the aggregate package holds only a nil-safe recorder. |
| `internal/ingest/otlp.go`, `aggregate_bridge.go`, `main.go` | Reduction runs inside all three `Export()` methods **before** the sampler and the severity gates (#153 §8). `AGGREGATE_MODE=legacy` constructs no engine; every reducer reference is nil and the export path is unchanged. |

### Phase 1 loss, stated plainly

There is no durable store yet. A window that rolls out of the mutable set is **DISCARDED**, not finalized — counts are gone. That is only acceptable because Phase 1 runs in shadow mode where the legacy path remains the source of truth. It is documented at the top of `engine.go`, counted (`Snapshot().WindowsDiscarded` / `SeriesDiscarded`), and tested.

## Test results

`go vet ./...` ✅ · `go build ./...` ✅ · `golangci-lint run ./internal/aggregate/... ./internal/ingest/... ./internal/telemetry/...` → 0 issues ✅

```
go test ./internal/aggregate/ ./internal/ingest/ ./internal/config/ -count=1 -race
ok  internal/aggregate  3.222s
ok  internal/ingest    14.159s
ok  internal/config     1.031s

go test ./internal/... -count=1   → all 18 packages with tests pass
```

Coverage of the #172 acceptance criteria:

- **THE invariant** — `TestAggregateCountsIdenticalAcrossSamplingRates`: identical 600-span stream at `SAMPLING_RATE=1.0` and `0.05`. Persisted spans 600 vs 63; aggregate counts 600 vs 600, identical error counts and active-series counts. The test fails loudly if sampling stops dropping, so it can never go vacuous.
- **Temporality** — all four normative cases, out-of-order/duplicate, downtime gap (re-seeds + counts), gap boundary, producer overflow degradation without eviction, global baseline cap, non-monotonic never reset-detected (both at the predicate and end-to-end through the reducer).
- **Cardinality** — one test per tier proving it fires first (tenant, service_names, service_series, signal, global backstop), `Validate` rejecting impossible budgets, overflow preserving totals (350 points across 50 operations under a 3-operation cap: every point survives, series collapse), `__other__` creation immune to every cap simultaneously at its floor, error and healthy overflow kept apart.
- **Windows** — UTC alignment incl. pre-epoch and a half-hour-offset zone, late/future exclusion with per-signal counters, a late point landing in its own window rather than arrival's, rollover discarding + releasing budget, rollover keeping windows inside the horizon.
- **Concurrency** — 8 goroutines × 50 Exports × 8 operations under `-race`: no lost deltas, no revision handed out twice, final revision exact. Plus a guard that the shard hash actually reaches all four shards.
- **Reducer benchmark** — see below.

### Reduction ratio measured

**1000 spans across 10 operations → 20 deltas (50:1).** (20 rather than 10 because the batch materializes both healthy and error status classes.)

```
BenchmarkReduceSpans/spans=10-8      21652 ns/op   10 deltas   26360 B/op   27 allocs/op
BenchmarkReduceSpans/spans=100-8     46615 ns/op   18 deltas   47769 B/op   45 allocs/op
BenchmarkReduceSpans/spans=1000-8   333978 ns/op   20 deltas   52760 B/op   49 allocs/op
BenchmarkApplyDeltas-8              318411 ns/op               54952 B/op   57 allocs/op
```

Allocations per Export are flat in batch size: a 100× larger batch costs 1.8× the allocations (2.7 → 0.049 allocs per point). Asserted in `TestReducerAllocationsAreFlatInBatchSize`, not just benchmarked.

## Deviations from the brief

1. **`ApplyDeltas` takes `map[SeriesWindowKey]*AggregateDelta`, not `map[SeriesKey]*AggregateDelta`.** Points in one Export can straddle windows — a point inside the lateness horizon belongs to the window of its own timestamp, not of arrival — so the window must be part of the delta key. Everything else about the signature is as specified.
2. **No `SignalServiceEdge` production in the reducer.** An edge needs the caller's service, which a single-span view does not have; edge derivation belongs with the topology observer. The signal, its sub-cap and its overflow path are fully implemented and tested — nothing emits into it yet.
3. **`DimsID` is always 0.** `AGGREGATE_METRIC_DIMS` is not in `internal/config` yet (it was not part of wave 1's config surface). `InternDims` is wired and ready; the parser is a config-side task.
4. **Per-service cap mapping made explicit.** #158 lists four per-service caps; two count distinct names and two count materialized series. Implemented as: traces/edges → `MAX_OPERATIONS_PER_SERVICE` (names) + `MAX_TRACE_SERIES_PER_SERVICE` (materialized); logs → `MAX_LOG_TEMPLATES_PER_SERVICE` (names, the miner enforces the same bound); metrics → `MAX_METRIC_SERIES_PER_SERVICE` (materialized). Applying a materialized cap of 10 to logs would have overflowed at 2 severity tiers × 10 templates.
5. **The global cap is unreachable in a valid configuration.** `Validate` requires sum(sub-caps) ≤ global, so a signal sub-cap always fires first; global is a genuine backstop for the misconfigured and overflow-inflated case. Tested at the `Limiter` level and documented in the test.
6. **Log template IDs are minted through the dictionary**, not the miner's private counter — `aggregate_dict(kind=log_template)` per #159 as amended by #163. Without this the miner's IDs and the `__other__` NameID would live in different ID spaces and could collide.
7. **Gauge "last" ties are order-dependent.** Two samples of one series carrying an identical timestamp are genuinely ambiguous; no merge rule fixes that. Documented in `delta.go`.
8. **No background goroutine.** Window rollover is evaluated lazily on apply and exposed as `Rollover(now)`, so there is nothing to add to the shutdown order and no lifecycle to get wrong.

Refs #172
