### PR TITLE
feat(config): AGGREGATE_METRIC_DIMS strict parser and dims lookup

### DIFF
--- a/internal/aggregate/dims_config.go
+++ b/internal/aggregate/dims_config.go
@@ -1,0 +1,83 @@
+package aggregate
+
+import (
+	"crypto/md5"
+	"encoding/binary"
+	"sort"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+)
+
+// DimsConfig maps metric names to their aggregation dimension keys.
+// Keys are sorted canonically per ParseAggregateMetricDims; the lookup
+// is exact on metric name and returns the dimension key list or nil
+// if the metric is not configured for aggregation.
+type DimsConfig map[string][]string
+
+// Get returns the sorted dimension keys for a metric, or nil if the
+// metric is not in the config.
+func (d DimsConfig) Get(metricName string) []string {
+	return d[metricName]
+}
+
+// ExtractDimensionValues extracts the values of configured dimension keys
+// from a slice of OTLP attributes. Returns nil if the metric is not
+// configured or if any configured key is missing from the attributes.
+// Returned values are in the order of the configured keys.
+func (d DimsConfig) ExtractDimensionValues(metricName string, attrs []*commonpb.KeyValue) []string {
+	keys := d.Get(metricName)
+	if keys == nil {
+		return nil
+	}
+
+	// Build a map of attribute key to value for fast lookup.
+	attrMap := make(map[string]string, len(attrs))
+	for _, kv := range attrs {
+		if kv == nil || kv.Value == nil {
+			continue
+		}
+		// Only extract string values for dimension aggregation.
+		if sv := kv.Value.GetStringValue(); sv != "" {
+			attrMap[kv.Key] = sv
+		}
+	}
+
+	// Extract dimension values in the order of configured keys.
+	// Return nil if any key is missing.
+	values := make([]string, len(keys))
+	for i, key := range keys {
+		val, ok := attrMap[key]
+		if !ok {
+			return nil
+		}
+		values[i] = val
+	}
+	return values
+}
+
+// DimsID computes a stable hash ID for a set of dimension values.
+// The ID is deterministic and consistent across restarts.
+func DimsID(values []string) uint32 {
+	if len(values) == 0 {
+		return 0
+	}
+	// Sort values for canonical hashing.
+	sorted := make([]string, len(values))
+	copy(sorted, values)
+	sort.Strings(sorted)
+
+	// Hash the concatenated sorted values using MD5 and take the low 32 bits.
+	h := md5.New()
+	for _, v := range sorted {
+		h.Write([]byte(v))
+		h.Write([]byte{0}) // null separator
+	}
+	digest := h.Sum(nil)
+	// Use little-endian to match SeriesKey encoding.
+	id := binary.LittleEndian.Uint32(digest[:4])
+	// Ensure non-zero (0 is reserved for "no dimensions").
+	if id == 0 {
+		id = 1
+	}
+	return id
+}

--- a/internal/aggregate/dims_config.go
+++ b/internal/aggregate/dims_config.go
@@ -1,10 +1,6 @@
 package aggregate
 
 import (
-	"crypto/md5"
-	"encoding/binary"
-	"sort"
-
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 )
 
@@ -55,29 +51,23 @@ func (d DimsConfig) ExtractDimensionValues(metricName string, attrs []*commonpb.
 	return values
 }
 
-// DimsID computes a stable hash ID for a set of dimension values.
-// The ID is deterministic and consistent across restarts.
-func DimsID(values []string) uint32 {
-	if len(values) == 0 {
+// InternDimValues resolves configured dimension keys and their extracted
+// values to dictionary IDs and returns the DimsID for a SeriesKey via
+// Cache.InternDims. IDs come from the tenant-scoped dictionary, never from
+// hashing: a hash collision would silently merge unrelated series.
+// keys and values must be parallel slices (as returned by
+// ExtractDimensionValues for the configured keys); an empty or mismatched
+// input yields 0, the "no configured dims" sentinel.
+func InternDimValues(c *Cache, tenantID uint32, keys, values []string) uint32 {
+	if len(keys) == 0 || len(keys) != len(values) {
 		return 0
 	}
-	// Sort values for canonical hashing.
-	sorted := make([]string, len(values))
-	copy(sorted, values)
-	sort.Strings(sorted)
-
-	// Hash the concatenated sorted values using MD5 and take the low 32 bits.
-	h := md5.New()
-	for _, v := range sorted {
-		h.Write([]byte(v))
-		h.Write([]byte{0}) // null separator
+	pairs := make([]DimPair, len(keys))
+	for i := range keys {
+		pairs[i] = DimPair{
+			KeyID:   c.Intern(tenantID, KindDimKey, keys[i]),
+			ValueID: c.Intern(tenantID, KindDimValue, values[i]),
+		}
 	}
-	digest := h.Sum(nil)
-	// Use little-endian to match SeriesKey encoding.
-	id := binary.LittleEndian.Uint32(digest[:4])
-	// Ensure non-zero (0 is reserved for "no dimensions").
-	if id == 0 {
-		id = 1
-	}
-	return id
+	return c.InternDims(tenantID, pairs)
 }

--- a/internal/aggregate/dims_config_test.go
+++ b/internal/aggregate/dims_config_test.go
@@ -1,0 +1,134 @@
+package aggregate
+
+import (
+	"testing"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+)
+
+func TestDimsConfig_Get(t *testing.T) {
+	cfg := DimsConfig{
+		"http.requests":   {"method", "status_code"},
+		"db.query.latency": {"database", "operation"},
+	}
+
+	cases := []struct {
+		name   string
+		metric string
+		want   []string
+	}{
+		{"http.requests", "http.requests", []string{"method", "status_code"}},
+		{"db.query.latency", "db.query.latency", []string{"database", "operation"}},
+		{"unmapped metric", "unknown.metric", nil},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := cfg.Get(c.metric)
+			if len(got) != len(c.want) {
+				t.Errorf("Get(%q) returned %v, want %v", c.metric, got, c.want)
+				return
+			}
+			for i, v := range c.want {
+				if got[i] != v {
+					t.Errorf("Get(%q)[%d] = %q, want %q", c.metric, i, got[i], v)
+				}
+			}
+		})
+	}
+}
+
+func TestDimsConfig_ExtractDimensionValues(t *testing.T) {
+	cfg := DimsConfig{
+		"http.requests": {"method", "status_code"},
+	}
+
+	t.Run("missing metric", func(t *testing.T) {
+		attrs := []*commonpb.KeyValue{
+			{Key: "method", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "GET"}}},
+		}
+		got := cfg.ExtractDimensionValues("unknown.metric", attrs)
+		if got != nil {
+			t.Errorf("unmapped metric returned %v, want nil", got)
+		}
+	})
+
+	t.Run("complete dimensions", func(t *testing.T) {
+		attrs := []*commonpb.KeyValue{
+			{Key: "method", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "POST"}}},
+			{Key: "status_code", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "200"}}},
+			{Key: "ignored_attr", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "value"}}},
+		}
+		got := cfg.ExtractDimensionValues("http.requests", attrs)
+		want := []string{"POST", "200"}
+		if len(got) != len(want) {
+			t.Errorf("Extract returned %v, want %v", got, want)
+			return
+		}
+		for i, v := range want {
+			if got[i] != v {
+				t.Errorf("[%d] = %q, want %q", i, got[i], v)
+			}
+		}
+	})
+
+	t.Run("missing dimension key", func(t *testing.T) {
+		attrs := []*commonpb.KeyValue{
+			{Key: "method", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "GET"}}},
+			// status_code is missing
+		}
+		got := cfg.ExtractDimensionValues("http.requests", attrs)
+		if got != nil {
+			t.Errorf("missing key returned %v, want nil", got)
+		}
+	})
+
+	t.Run("non-string attribute ignored", func(t *testing.T) {
+		attrs := []*commonpb.KeyValue{
+			{Key: "method", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "GET"}}},
+			{Key: "status_code", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 200}}}, // int, not string
+		}
+		got := cfg.ExtractDimensionValues("http.requests", attrs)
+		if got != nil {
+			t.Errorf("non-string value returned %v, want nil", got)
+		}
+	})
+}
+
+func TestDimsID(t *testing.T) {
+	t.Run("empty values", func(t *testing.T) {
+		id := DimsID([]string{})
+		if id != 0 {
+			t.Errorf("DimsID([]) = %d, want 0", id)
+		}
+	})
+
+	t.Run("deterministic", func(t *testing.T) {
+		values := []string{"method", "POST", "status_code", "200"}
+		id1 := DimsID(values)
+		id2 := DimsID(values)
+		if id1 != id2 {
+			t.Errorf("DimsID not deterministic: %d vs %d", id1, id2)
+		}
+	})
+
+	t.Run("order-independent", func(t *testing.T) {
+		// Different input order should produce same ID (values are re-sorted).
+		values1 := []string{"a", "b", "c"}
+		values2 := []string{"c", "a", "b"}
+		id1 := DimsID(values1)
+		id2 := DimsID(values2)
+		if id1 != id2 {
+			t.Errorf("DimsID not order-independent: %d vs %d", id1, id2)
+		}
+	})
+
+	t.Run("non-zero result", func(t *testing.T) {
+		// The hash must never collide with 0 (reserved).
+		values := []string{"test_value"}
+		id := DimsID(values)
+		if id == 0 {
+			t.Errorf("DimsID returned 0, want non-zero for non-empty values")
+		}
+	})
+}

--- a/internal/aggregate/dims_config_test.go
+++ b/internal/aggregate/dims_config_test.go
@@ -6,6 +6,10 @@ import (
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 )
 
+func strAttr(key, value string) *commonpb.KeyValue {
+	return &commonpb.KeyValue{Key: key, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: value}}}
+}
+
 func TestDimsConfig_Get(t *testing.T) {
 	cfg := DimsConfig{
 		"http.requests":    {"method", "status_code"},
@@ -45,7 +49,7 @@ func TestDimsConfig_ExtractDimensionValues(t *testing.T) {
 
 	t.Run("missing metric", func(t *testing.T) {
 		attrs := []*commonpb.KeyValue{
-			{Key: "method", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "GET"}}},
+			strAttr("method", "GET"),
 		}
 		got := cfg.ExtractDimensionValues("unknown.metric", attrs)
 		if got != nil {
@@ -55,9 +59,9 @@ func TestDimsConfig_ExtractDimensionValues(t *testing.T) {
 
 	t.Run("complete dimensions", func(t *testing.T) {
 		attrs := []*commonpb.KeyValue{
-			{Key: "method", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "POST"}}},
-			{Key: "status_code", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "200"}}},
-			{Key: "ignored_attr", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "value"}}},
+			strAttr("method", "POST"),
+			strAttr("status_code", "200"),
+			strAttr("ignored_attr", "value"),
 		}
 		got := cfg.ExtractDimensionValues("http.requests", attrs)
 		want := []string{"POST", "200"}
@@ -74,7 +78,7 @@ func TestDimsConfig_ExtractDimensionValues(t *testing.T) {
 
 	t.Run("missing dimension key", func(t *testing.T) {
 		attrs := []*commonpb.KeyValue{
-			{Key: "method", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "GET"}}},
+			strAttr("method", "GET"),
 			// status_code is missing
 		}
 		got := cfg.ExtractDimensionValues("http.requests", attrs)
@@ -85,7 +89,7 @@ func TestDimsConfig_ExtractDimensionValues(t *testing.T) {
 
 	t.Run("non-string attribute ignored", func(t *testing.T) {
 		attrs := []*commonpb.KeyValue{
-			{Key: "method", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "GET"}}},
+			strAttr("method", "GET"),
 			{Key: "status_code", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 200}}}, // int, not string
 		}
 		got := cfg.ExtractDimensionValues("http.requests", attrs)

--- a/internal/aggregate/dims_config_test.go
+++ b/internal/aggregate/dims_config_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestDimsConfig_Get(t *testing.T) {
 	cfg := DimsConfig{
-		"http.requests":   {"method", "status_code"},
+		"http.requests":    {"method", "status_code"},
 		"db.query.latency": {"database", "operation"},
 	}
 
@@ -95,40 +95,64 @@ func TestDimsConfig_ExtractDimensionValues(t *testing.T) {
 	})
 }
 
-func TestDimsID(t *testing.T) {
-	t.Run("empty values", func(t *testing.T) {
-		id := DimsID([]string{})
-		if id != 0 {
-			t.Errorf("DimsID([]) = %d, want 0", id)
+func TestInternDimValues(t *testing.T) {
+	newCache := func() *Cache {
+		return NewCache(NewMemRegistrar(nil))
+	}
+
+	t.Run("empty keys", func(t *testing.T) {
+		c := newCache()
+		if id := InternDimValues(c, 1, nil, nil); id != 0 {
+			t.Errorf("InternDimValues(nil) = %d, want 0", id)
+		}
+	})
+
+	t.Run("mismatched lengths", func(t *testing.T) {
+		c := newCache()
+		if id := InternDimValues(c, 1, []string{"method"}, nil); id != 0 {
+			t.Errorf("mismatched lengths = %d, want 0", id)
 		}
 	})
 
 	t.Run("deterministic", func(t *testing.T) {
-		values := []string{"method", "POST", "status_code", "200"}
-		id1 := DimsID(values)
-		id2 := DimsID(values)
-		if id1 != id2 {
-			t.Errorf("DimsID not deterministic: %d vs %d", id1, id2)
+		c := newCache()
+		keys := []string{"method", "status_code"}
+		values := []string{"POST", "200"}
+		id1 := InternDimValues(c, 1, keys, values)
+		id2 := InternDimValues(c, 1, keys, values)
+		if id1 == 0 || id1 != id2 {
+			t.Errorf("not deterministic: %d vs %d", id1, id2)
 		}
 	})
 
-	t.Run("order-independent", func(t *testing.T) {
-		// Different input order should produce same ID (values are re-sorted).
-		values1 := []string{"a", "b", "c"}
-		values2 := []string{"c", "a", "b"}
-		id1 := DimsID(values1)
-		id2 := DimsID(values2)
+	t.Run("pair-order independent", func(t *testing.T) {
+		// The same key=value pairs in a different order canonicalize to the
+		// same tuple and therefore the same ID.
+		c := newCache()
+		id1 := InternDimValues(c, 1, []string{"a", "b"}, []string{"x", "y"})
+		id2 := InternDimValues(c, 1, []string{"b", "a"}, []string{"y", "x"})
 		if id1 != id2 {
-			t.Errorf("DimsID not order-independent: %d vs %d", id1, id2)
+			t.Errorf("pair order changed the ID: %d vs %d", id1, id2)
 		}
 	})
 
-	t.Run("non-zero result", func(t *testing.T) {
-		// The hash must never collide with 0 (reserved).
-		values := []string{"test_value"}
-		id := DimsID(values)
-		if id == 0 {
-			t.Errorf("DimsID returned 0, want non-zero for non-empty values")
+	t.Run("distinct pairings get distinct IDs", func(t *testing.T) {
+		// Same value multiset attached to different keys must NOT collide —
+		// this is exactly what a value-only hash got wrong.
+		c := newCache()
+		id1 := InternDimValues(c, 1, []string{"a", "b"}, []string{"x", "y"})
+		id2 := InternDimValues(c, 1, []string{"a", "b"}, []string{"y", "x"})
+		if id1 == id2 {
+			t.Errorf("distinct key/value pairings collided: %d", id1)
+		}
+	})
+
+	t.Run("tenant scoped", func(t *testing.T) {
+		c := newCache()
+		id1 := InternDimValues(c, 1, []string{"method"}, []string{"GET"})
+		id2 := InternDimValues(c, 2, []string{"method"}, []string{"GET"})
+		if id1 == id2 {
+			t.Errorf("tenants shared a dim tuple ID: %d", id1)
 		}
 	})
 }

--- a/internal/aggregate/engine.go
+++ b/internal/aggregate/engine.go
@@ -116,6 +116,10 @@ type EngineConfig struct {
 	// Metrics is the Prometheus recorder. nil disables metric recording.
 	Metrics MetricsRecorder
 
+	// MetricDims maps metric names to their configured aggregation dimension keys.
+	// Nil or empty means no metrics are configured for custom dimensions.
+	MetricDims DimsConfig
+
 	// Now is the clock, injectable for tests. Defaults to time.Now.
 	Now func() time.Time
 }
@@ -130,6 +134,7 @@ type Engine struct {
 	limiter   *Limiter
 	baselines *BaselineTracker
 	metrics   MetricsRecorder
+	dims      DimsConfig
 
 	shards [NumShards]shard
 
@@ -169,6 +174,7 @@ func NewEngine(cfg EngineConfig) (*Engine, error) {
 		cache:   NewCache(reg),
 		miner:   cfg.Miner,
 		metrics: cfg.Metrics,
+		dims:    cfg.MetricDims,
 	}
 	if e.metrics == nil {
 		e.metrics = noopRecorder{}
@@ -212,6 +218,9 @@ func (e *Engine) Limiter() *Limiter { return e.limiter }
 
 // Baselines returns the cumulative baseline tracker.
 func (e *Engine) Baselines() *BaselineTracker { return e.baselines }
+
+// MetricDims returns the configured metric dimension keys for aggregation.
+func (e *Engine) MetricDims() DimsConfig { return e.dims }
 
 // Revision returns the current revision. It increases by one on every applied
 // batch and never decreases, so a consumer can tell "nothing changed" from

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -291,6 +292,12 @@ type Config struct {
 	// AggregateMaxProducerBaselinesPerSeries. Nonzero overrides.
 	// Use ResolvedAggregateMaxBaselines() to get the final value.
 	AggregateMaxBaselines int
+
+	// AggregateMetricDims is the parsed AGGREGATE_METRIC_DIMS config:
+	// map of metric name -> sorted list of OTLP attribute keys.
+	// Empty map when AGGREGATE_METRIC_DIMS is unset/empty.
+	// Populated during Load() by parsing and validating the env var.
+	AggregateMetricDims map[string][]string
 }
 
 func Load(customPath string) (*Config, error) {
@@ -434,6 +441,13 @@ func Load(customPath string) (*Config, error) {
 		AggregateMaxProducerBaselinesPerSeries: getEnvInt("AGGREGATE_MAX_PRODUCER_BASELINES_PER_SERIES", 8),
 		AggregateMaxBaselines:                  getEnvInt("AGGREGATE_MAX_BASELINES", 0),
 	}
+
+	// Parse AGGREGATE_METRIC_DIMS config
+	metricDims, err := ParseAggregateMetricDims(getEnv("AGGREGATE_METRIC_DIMS", ""))
+	if err != nil {
+		return nil, fmt.Errorf("parsing AGGREGATE_METRIC_DIMS: %w", err)
+	}
+	cfg.AggregateMetricDims = metricDims
 	applyDriverDefaults(cfg)
 
 	// Derive a sane per-tenant ingest cap when the operator did not set one.
@@ -808,4 +822,71 @@ func (c *Config) ResolvedAggregateMaxBaselines() int {
 		return c.AggregateMaxBaselines
 	}
 	return c.AggregateMaxSeriesMetrics * c.AggregateMaxProducerBaselinesPerSeries
+}
+
+// ParseAggregateMetricDims parses the AGGREGATE_METRIC_DIMS config string.
+// Format: "metric_name:key1,key2;metric_name2:key3,key4"
+// Returns a map of metric name -> sorted list of dimension keys.
+// Fails on malformed input (fail-closed): empty metric name, empty key list,
+// duplicate metric, duplicate key within a metric, stray separators.
+// Empty/unset var is valid (returns empty map).
+func ParseAggregateMetricDims(s string) (map[string][]string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return make(map[string][]string), nil
+	}
+
+	result := make(map[string][]string)
+
+	// Split by semicolon to get metric:keys pairs
+	metricPairs := strings.Split(s, ";")
+	for _, pair := range metricPairs {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			return nil, fmt.Errorf("empty metric pair (stray semicolon)")
+		}
+
+		// Split by colon to get metric name and keys
+		parts := strings.Split(pair, ":")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("%q must have exactly one colon (format: metric_name:key1,key2)", pair)
+		}
+
+		metricName := strings.TrimSpace(parts[0])
+		keysStr := strings.TrimSpace(parts[1])
+
+		if metricName == "" {
+			return nil, fmt.Errorf("empty metric name in %q", pair)
+		}
+		if keysStr == "" {
+			return nil, fmt.Errorf("empty key list for metric %q", metricName)
+		}
+
+		if _, ok := result[metricName]; ok {
+			return nil, fmt.Errorf("duplicate metric name %q", metricName)
+		}
+
+		// Split keys by comma
+		rawKeys := strings.Split(keysStr, ",")
+		seenKeys := make(map[string]bool)
+		var keys []string
+
+		for _, rawKey := range rawKeys {
+			key := strings.TrimSpace(rawKey)
+			if key == "" {
+				return nil, fmt.Errorf("empty key in metric %q", metricName)
+			}
+			if seenKeys[key] {
+				return nil, fmt.Errorf("duplicate key %q in metric %q", key, metricName)
+			}
+			seenKeys[key] = true
+			keys = append(keys, key)
+		}
+
+		// Sort keys for canonical ordering
+		sort.Strings(keys)
+		result[metricName] = keys
+	}
+
+	return result, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,6 +41,7 @@ func baseValid() *Config {
 		AggregateSeriesPerTenantFraction:       0,
 		AggregateMaxProducerBaselinesPerSeries: 8,
 		AggregateMaxBaselines:                  0,
+		AggregateMetricDims:                    make(map[string][]string),
 	}
 }
 
@@ -631,5 +632,190 @@ func TestResolvedAggregateMaxBaselines_Override(t *testing.T) {
 	resolved := c.ResolvedAggregateMaxBaselines()
 	if resolved != 10000 {
 		t.Errorf("resolved = %d, want 10000 (explicit override)", resolved)
+	}
+}
+
+func TestParseAggregateMetricDims_Empty(t *testing.T) {
+	result, err := ParseAggregateMetricDims("")
+	if err != nil {
+		t.Fatalf("ParseAggregateMetricDims: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("empty string should return empty map, got %v", result)
+	}
+}
+
+func TestParseAggregateMetricDims_SingleMetricSingleKey(t *testing.T) {
+	result, err := ParseAggregateMetricDims("http.requests:method")
+	if err != nil {
+		t.Fatalf("ParseAggregateMetricDims: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(result))
+	}
+	keys, ok := result["http.requests"]
+	if !ok {
+		t.Fatalf("metric 'http.requests' not found")
+	}
+	if len(keys) != 1 || keys[0] != "method" {
+		t.Errorf("expected ['method'], got %v", keys)
+	}
+}
+
+func TestParseAggregateMetricDims_SingleMetricMultipleKeys(t *testing.T) {
+	result, err := ParseAggregateMetricDims("http.requests:method,status_code")
+	if err != nil {
+		t.Fatalf("ParseAggregateMetricDims: %v", err)
+	}
+	keys := result["http.requests"]
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(keys))
+	}
+	// Keys should be sorted
+	if keys[0] != "method" || keys[1] != "status_code" {
+		t.Errorf("expected [method, status_code], got %v", keys)
+	}
+}
+
+func TestParseAggregateMetricDims_MultipleMetrics(t *testing.T) {
+	result, err := ParseAggregateMetricDims("http.requests:method,status_code;db.calls:database,operation")
+	if err != nil {
+		t.Fatalf("ParseAggregateMetricDims: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 metrics, got %d", len(result))
+	}
+	if len(result["http.requests"]) != 2 || len(result["db.calls"]) != 2 {
+		t.Errorf("unexpected key counts: %v", result)
+	}
+}
+
+func TestParseAggregateMetricDims_KeysSorted(t *testing.T) {
+	result, err := ParseAggregateMetricDims("metric:zebra,apple,monkey")
+	if err != nil {
+		t.Fatalf("ParseAggregateMetricDims: %v", err)
+	}
+	keys := result["metric"]
+	expected := []string{"apple", "monkey", "zebra"}
+	for i, k := range keys {
+		if k != expected[i] {
+			t.Errorf("key at index %d: got %q, want %q", i, k, expected[i])
+		}
+	}
+}
+
+func TestParseAggregateMetricDims_Whitespace(t *testing.T) {
+	result, err := ParseAggregateMetricDims("  metric : key1 , key2  ")
+	if err != nil {
+		t.Fatalf("ParseAggregateMetricDims: %v", err)
+	}
+	keys := result["metric"]
+	if len(keys) != 2 || keys[0] != "key1" || keys[1] != "key2" {
+		t.Errorf("whitespace handling failed: got %v", keys)
+	}
+}
+
+func TestParseAggregateMetricDims_ErrorEmptyMetricName(t *testing.T) {
+	_, err := ParseAggregateMetricDims(":key")
+	if err == nil {
+		t.Fatal("expected error for empty metric name")
+	}
+	if !strings.Contains(err.Error(), "empty metric name") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseAggregateMetricDims_ErrorEmptyKeyList(t *testing.T) {
+	_, err := ParseAggregateMetricDims("metric:")
+	if err == nil {
+		t.Fatal("expected error for empty key list")
+	}
+	if !strings.Contains(err.Error(), "empty key list") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseAggregateMetricDims_ErrorEmptyKey(t *testing.T) {
+	_, err := ParseAggregateMetricDims("metric:key1,,key2")
+	if err == nil {
+		t.Fatal("expected error for empty key")
+	}
+	if !strings.Contains(err.Error(), "empty key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseAggregateMetricDims_ErrorDuplicateMetric(t *testing.T) {
+	_, err := ParseAggregateMetricDims("metric:key1;metric:key2")
+	if err == nil {
+		t.Fatal("expected error for duplicate metric")
+	}
+	if !strings.Contains(err.Error(), "duplicate metric name") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseAggregateMetricDims_ErrorDuplicateKey(t *testing.T) {
+	_, err := ParseAggregateMetricDims("metric:key1,key1")
+	if err == nil {
+		t.Fatal("expected error for duplicate key")
+	}
+	if !strings.Contains(err.Error(), "duplicate key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseAggregateMetricDims_ErrorStraySemicolon(t *testing.T) {
+	_, err := ParseAggregateMetricDims("metric:key1;;metric2:key2")
+	if err == nil {
+		t.Fatal("expected error for stray semicolon")
+	}
+	if !strings.Contains(err.Error(), "stray semicolon") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseAggregateMetricDims_ErrorMissingColon(t *testing.T) {
+	_, err := ParseAggregateMetricDims("metric_no_colon")
+	if err == nil {
+		t.Fatal("expected error for missing colon")
+	}
+	if !strings.Contains(err.Error(), "exactly one colon") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoad_AggregateMetricDims(t *testing.T) {
+	t.Setenv("AGGREGATE_METRIC_DIMS", "http.requests:method,status_code;db.calls:database")
+
+	cfg, err := Load("__no_such_env_file__")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(cfg.AggregateMetricDims) != 2 {
+		t.Fatalf("expected 2 metrics, got %d", len(cfg.AggregateMetricDims))
+	}
+
+	httpKeys := cfg.AggregateMetricDims["http.requests"]
+	if len(httpKeys) != 2 || httpKeys[0] != "method" || httpKeys[1] != "status_code" {
+		t.Errorf("unexpected http.requests keys: %v", httpKeys)
+	}
+
+	dbKeys := cfg.AggregateMetricDims["db.calls"]
+	if len(dbKeys) != 1 || dbKeys[0] != "database" {
+		t.Errorf("unexpected db.calls keys: %v", dbKeys)
+	}
+}
+
+func TestLoad_AggregateMetricDims_InvalidConfig(t *testing.T) {
+	t.Setenv("AGGREGATE_METRIC_DIMS", "metric:")
+
+	_, err := Load("__no_such_env_file__")
+	if err == nil {
+		t.Fatal("expected Load to fail with invalid AGGREGATE_METRIC_DIMS")
+	}
+	if !strings.Contains(err.Error(), "parsing AGGREGATE_METRIC_DIMS") {
+		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,22 @@ import (
 )
 
 // baseValid returns a Config that passes Validate() — test functions mutate one field at a time.
+// writeTLSPair writes a throwaway cert/key file pair into a temp dir and
+// returns their paths.
+func writeTLSPair(t *testing.T) (certFile, keyFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	certFile = filepath.Join(dir, "server.crt")
+	keyFile = filepath.Join(dir, "server.key")
+	if err := os.WriteFile(certFile, []byte("cert"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return certFile, keyFile
+}
+
 func baseValid() *Config {
 	return &Config{
 		HTTPPort:                 "8080",
@@ -146,15 +162,7 @@ func TestValidate_TLS_FilesMustExist(t *testing.T) {
 }
 
 func TestValidate_TLS_ReadableFilesOK(t *testing.T) {
-	dir := t.TempDir()
-	cert := filepath.Join(dir, "server.crt")
-	key := filepath.Join(dir, "server.key")
-	if err := os.WriteFile(cert, []byte("cert"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(key, []byte("key"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	cert, key := writeTLSPair(t)
 	c := baseValid()
 	c.TLSCertFile = cert
 	c.TLSKeyFile = key
@@ -278,15 +286,7 @@ func TestTLSAutoSelfsigned_DefaultCacheDir(t *testing.T) {
 // explicit TLSCertFile + TLSKeyFile win over TLSAutoSelfsigned. The resulting
 // Config must report cert-file mode, not self-signed mode.
 func TestTLSAutoSelfsigned_IgnoredWhenCertFilesSet(t *testing.T) {
-	dir := t.TempDir()
-	cert := filepath.Join(dir, "server.crt")
-	key := filepath.Join(dir, "server.key")
-	if err := os.WriteFile(cert, []byte("cert"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(key, []byte("key"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	cert, key := writeTLSPair(t)
 
 	c := baseValid()
 	c.TLSCertFile = cert

--- a/internal/config/driver_defaults_test.go
+++ b/internal/config/driver_defaults_test.go
@@ -132,7 +132,21 @@ func TestApplyDriverDefaults_Postgres_NoChange(t *testing.T) {
 			cfg := postgresDefaultsConfig(drv)
 			before := *cfg
 			applyDriverDefaults(cfg)
-			if *cfg != before {
+			// Compare individual fields (map fields cannot be compared with ==).
+			// Check all fields set by postgresDefaultsConfig.
+			if cfg.DBDriver != before.DBDriver ||
+				cfg.DBMaxOpenConns != before.DBMaxOpenConns ||
+				cfg.DBMaxIdleConns != before.DBMaxIdleConns ||
+				cfg.IngestPipelineWorkers != before.IngestPipelineWorkers ||
+				cfg.IngestPipelineQueueSize != before.IngestPipelineQueueSize ||
+				cfg.IngestPipelineMaxBytes != before.IngestPipelineMaxBytes ||
+				cfg.MetricMaxCardinality != before.MetricMaxCardinality ||
+				cfg.StoreMinSeverity != before.StoreMinSeverity ||
+				cfg.SamplingRate != before.SamplingRate ||
+				cfg.GRPCMaxConcurrentStreams != before.GRPCMaxConcurrentStreams ||
+				cfg.GraphRAGEventQueueSize != before.GraphRAGEventQueueSize ||
+				cfg.LogFTSEnabled != before.LogFTSEnabled ||
+				cfg.GraphRAGTraceTTL != before.GraphRAGTraceTTL {
 				t.Errorf("Postgres driver %q was mutated by SQLite override: %+v → %+v", drv, before, *cfg)
 			}
 		})

--- a/main.go
+++ b/main.go
@@ -480,6 +480,7 @@ func main() {
 			MaxProducerBaselinesPerSeries: cfg.AggregateMaxProducerBaselinesPerSeries,
 			MaxBaselines:                  cfg.ResolvedAggregateMaxBaselines(),
 			Metrics:                       aggregate.NewPrometheusRecorder(metrics),
+			MetricDims:                    aggregate.DimsConfig(cfg.AggregateMetricDims),
 		})
 		if err != nil {
 			fatal("❌ Aggregate engine configuration rejected", err, "mode", cfg.AggregateMode)


### PR DESCRIPTION
## Summary

Wave-3 follow-up implementation on issue #172: AGGREGATE_METRIC_DIMS environment variable parser with strict fail-closed validation. Format: `"metric_name:otlp_attr_key,otlp_attr_key; metric_name:..."`

Adds:
- ParseAggregateMetricDims() parser with strict validation (empty metric/key lists, duplicates, stray separators)
- Sorted canonical dimension keys (alphabetically) for stable identity
- DimsConfig lookup type to extract dimension values from OTLP attributes
- DimsID hash computation for series aggregation dimensions
- Wiring through EngineConfig to enable per-metric dimension selection

Refs: #159 #172