### PR TITLE
feat(ingest): bounded exemplar retention replacing sampler in aggregate mode

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -291,6 +291,27 @@ type Config struct {
 	// AggregateMaxProducerBaselinesPerSeries. Nonzero overrides.
 	// Use ResolvedAggregateMaxBaselines() to get the final value.
 	AggregateMaxBaselines int
+
+	// Bounded exemplar retention (#176; budgets frozen in #161).
+	//
+	// These apply ONLY when AggregateMode == "aggregate", where the adaptive
+	// Sampler is retired and the exemplar policy is the sole raw-retention
+	// gate. In legacy and aggregate-shadow the Sampler is untouched and none of
+	// these values are read.
+	//
+	// Counts AND bytes bind; first breach wins. SamplingLatencyThresholdMs
+	// stays the shared definition of "slow" in every mode.
+	ExemplarTracesPerServiceWindow    int     // Default 25, unified budget with priority fill
+	ExemplarTracesGlobalWindow        int     // Default 1500
+	ExemplarBytesPerServiceWindow     int     // Default 524288 (512 KiB)
+	ExemplarBytesGlobalWindow         int     // Default 8388608 (8 MiB)
+	ExemplarHealthyRate               float64 // Default 0.005 (0.5% eligibility target)
+	ExemplarStratumTopK               int     // Default 5, per (operation × status class)
+	ExemplarLogsErrorPerServiceWindow int     // Default 50
+	ExemplarLogsWarnEnabled           bool    // Default false — WARN is opt-in
+	ExemplarLogsWarnPerServiceWindow  int     // Default 20
+	ExemplarMaxSpansPerTrace          int     // Default 500
+	ExemplarMaxBytesPerTrace          int     // Default 262144 (256 KiB)
 }
 
 func Load(customPath string) (*Config, error) {
@@ -433,6 +454,19 @@ func Load(customPath string) (*Config, error) {
 		AggregateSeriesPerTenantFraction:       getEnvFloat("AGGREGATE_SERIES_PER_TENANT_FRACTION", 0),
 		AggregateMaxProducerBaselinesPerSeries: getEnvInt("AGGREGATE_MAX_PRODUCER_BASELINES_PER_SERIES", 8),
 		AggregateMaxBaselines:                  getEnvInt("AGGREGATE_MAX_BASELINES", 0),
+
+		// Bounded exemplar retention (aggregate mode only)
+		ExemplarTracesPerServiceWindow:    getEnvInt("EXEMPLAR_TRACES_PER_SERVICE_WINDOW", 25),
+		ExemplarTracesGlobalWindow:        getEnvInt("EXEMPLAR_TRACES_GLOBAL_WINDOW", 1500),
+		ExemplarBytesPerServiceWindow:     getEnvInt("EXEMPLAR_BYTES_PER_SERVICE_WINDOW", 512*1024),
+		ExemplarBytesGlobalWindow:         getEnvInt("EXEMPLAR_BYTES_GLOBAL_WINDOW", 8*1024*1024),
+		ExemplarHealthyRate:               getEnvFloat("EXEMPLAR_HEALTHY_RATE", 0.005),
+		ExemplarStratumTopK:               getEnvInt("EXEMPLAR_STRATUM_TOP_K", 5),
+		ExemplarLogsErrorPerServiceWindow: getEnvInt("EXEMPLAR_LOGS_ERROR_PER_SERVICE_WINDOW", 50),
+		ExemplarLogsWarnEnabled:           getEnvBool("EXEMPLAR_LOGS_WARN_ENABLED", false),
+		ExemplarLogsWarnPerServiceWindow:  getEnvInt("EXEMPLAR_LOGS_WARN_PER_SERVICE_WINDOW", 20),
+		ExemplarMaxSpansPerTrace:          getEnvInt("EXEMPLAR_MAX_SPANS_PER_TRACE", 500),
+		ExemplarMaxBytesPerTrace:          getEnvInt("EXEMPLAR_MAX_BYTES_PER_TRACE", 256*1024),
 	}
 	applyDriverDefaults(cfg)
 
@@ -741,6 +775,40 @@ func (c *Config) Validate() error {
 	}
 	if c.AggregateMaxBaselines > 0 && c.AggregateMaxBaselines < c.AggregateMaxProducerBaselinesPerSeries {
 		return fmt.Errorf("AGGREGATE_MAX_BASELINES when nonzero must be >= AGGREGATE_MAX_PRODUCER_BASELINES_PER_SERIES (%d), got %d", c.AggregateMaxProducerBaselinesPerSeries, c.AggregateMaxBaselines)
+	}
+
+	// Bounded exemplar retention validation (#176). Validated in every mode so
+	// a typo is caught at startup rather than the day the operator flips
+	// AGGREGATE_MODE=aggregate during an incident.
+	if c.ExemplarTracesPerServiceWindow < 1 {
+		return fmt.Errorf("EXEMPLAR_TRACES_PER_SERVICE_WINDOW must be >= 1, got %d", c.ExemplarTracesPerServiceWindow)
+	}
+	if c.ExemplarTracesGlobalWindow < c.ExemplarTracesPerServiceWindow {
+		return fmt.Errorf("EXEMPLAR_TRACES_GLOBAL_WINDOW (%d) must be >= EXEMPLAR_TRACES_PER_SERVICE_WINDOW (%d): a global cap below the per-service cap makes the per-service budget unreachable", c.ExemplarTracesGlobalWindow, c.ExemplarTracesPerServiceWindow)
+	}
+	if c.ExemplarBytesPerServiceWindow < 1024 {
+		return fmt.Errorf("EXEMPLAR_BYTES_PER_SERVICE_WINDOW must be >= 1024, got %d", c.ExemplarBytesPerServiceWindow)
+	}
+	if c.ExemplarBytesGlobalWindow < c.ExemplarBytesPerServiceWindow {
+		return fmt.Errorf("EXEMPLAR_BYTES_GLOBAL_WINDOW (%d) must be >= EXEMPLAR_BYTES_PER_SERVICE_WINDOW (%d)", c.ExemplarBytesGlobalWindow, c.ExemplarBytesPerServiceWindow)
+	}
+	if c.ExemplarHealthyRate < 0 || c.ExemplarHealthyRate > 1.0 {
+		return fmt.Errorf("EXEMPLAR_HEALTHY_RATE must be between 0 and 1, got %f", c.ExemplarHealthyRate)
+	}
+	if c.ExemplarStratumTopK < 1 {
+		return fmt.Errorf("EXEMPLAR_STRATUM_TOP_K must be >= 1, got %d", c.ExemplarStratumTopK)
+	}
+	if c.ExemplarLogsErrorPerServiceWindow < 1 {
+		return fmt.Errorf("EXEMPLAR_LOGS_ERROR_PER_SERVICE_WINDOW must be >= 1, got %d", c.ExemplarLogsErrorPerServiceWindow)
+	}
+	if c.ExemplarLogsWarnPerServiceWindow < 1 {
+		return fmt.Errorf("EXEMPLAR_LOGS_WARN_PER_SERVICE_WINDOW must be >= 1, got %d", c.ExemplarLogsWarnPerServiceWindow)
+	}
+	if c.ExemplarMaxSpansPerTrace < 1 {
+		return fmt.Errorf("EXEMPLAR_MAX_SPANS_PER_TRACE must be >= 1, got %d", c.ExemplarMaxSpansPerTrace)
+	}
+	if c.ExemplarMaxBytesPerTrace < 1024 {
+		return fmt.Errorf("EXEMPLAR_MAX_BYTES_PER_TRACE must be >= 1024, got %d", c.ExemplarMaxBytesPerTrace)
 	}
 
 	// Sum-of-caps validation: sub-caps must fit under global cap

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,6 +41,18 @@ func baseValid() *Config {
 		AggregateSeriesPerTenantFraction:       0,
 		AggregateMaxProducerBaselinesPerSeries: 8,
 		AggregateMaxBaselines:                  0,
+		// Bounded exemplar retention defaults (#161)
+		ExemplarTracesPerServiceWindow:    25,
+		ExemplarTracesGlobalWindow:        1500,
+		ExemplarBytesPerServiceWindow:     512 * 1024,
+		ExemplarBytesGlobalWindow:         8 * 1024 * 1024,
+		ExemplarHealthyRate:               0.005,
+		ExemplarStratumTopK:               5,
+		ExemplarLogsErrorPerServiceWindow: 50,
+		ExemplarLogsWarnEnabled:           false,
+		ExemplarLogsWarnPerServiceWindow:  20,
+		ExemplarMaxSpansPerTrace:          500,
+		ExemplarMaxBytesPerTrace:          256 * 1024,
 	}
 }
 
@@ -631,5 +643,94 @@ func TestResolvedAggregateMaxBaselines_Override(t *testing.T) {
 	resolved := c.ResolvedAggregateMaxBaselines()
 	if resolved != 10000 {
 		t.Errorf("resolved = %d, want 10000 (explicit override)", resolved)
+	}
+}
+
+// --- Bounded exemplar retention (#176) ---
+
+func TestValidate_ExemplarBudgets_LowerBounds(t *testing.T) {
+	cases := []struct {
+		name  string
+		field string
+		mut   func(*Config)
+	}{
+		{"traces per service", "EXEMPLAR_TRACES_PER_SERVICE_WINDOW", func(c *Config) { c.ExemplarTracesPerServiceWindow = 0 }},
+		{"bytes per service", "EXEMPLAR_BYTES_PER_SERVICE_WINDOW", func(c *Config) { c.ExemplarBytesPerServiceWindow = 512 }},
+		{"stratum top k", "EXEMPLAR_STRATUM_TOP_K", func(c *Config) { c.ExemplarStratumTopK = 0 }},
+		{"error log budget", "EXEMPLAR_LOGS_ERROR_PER_SERVICE_WINDOW", func(c *Config) { c.ExemplarLogsErrorPerServiceWindow = 0 }},
+		{"warn log budget", "EXEMPLAR_LOGS_WARN_PER_SERVICE_WINDOW", func(c *Config) { c.ExemplarLogsWarnPerServiceWindow = 0 }},
+		{"max spans per trace", "EXEMPLAR_MAX_SPANS_PER_TRACE", func(c *Config) { c.ExemplarMaxSpansPerTrace = 0 }},
+		{"max bytes per trace", "EXEMPLAR_MAX_BYTES_PER_TRACE", func(c *Config) { c.ExemplarMaxBytesPerTrace = 1 }},
+	}
+	for _, tc := range cases {
+		c := baseValid()
+		tc.mut(c)
+		if err := c.Validate(); err == nil || !strings.Contains(err.Error(), tc.field) {
+			t.Errorf("%s should fail validation with %s, got %v", tc.name, tc.field, err)
+		}
+	}
+}
+
+// A global cap below the per-service cap makes the per-service budget
+// unreachable — a misconfiguration worth refusing at startup rather than
+// debugging during an incident.
+func TestValidate_ExemplarGlobalBudgetsMustCoverPerService(t *testing.T) {
+	c := baseValid()
+	c.ExemplarTracesGlobalWindow = 10 // below the 25 per-service default
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "EXEMPLAR_TRACES_GLOBAL_WINDOW") {
+		t.Errorf("expected global trace cap error, got %v", err)
+	}
+
+	c = baseValid()
+	c.ExemplarBytesGlobalWindow = 4096
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "EXEMPLAR_BYTES_GLOBAL_WINDOW") {
+		t.Errorf("expected global byte cap error, got %v", err)
+	}
+}
+
+func TestValidate_ExemplarHealthyRate_Range(t *testing.T) {
+	for _, tc := range []struct {
+		val     float64
+		wantErr bool
+	}{{-0.1, true}, {0, false}, {0.005, false}, {1.0, false}, {1.1, true}} {
+		c := baseValid()
+		c.ExemplarHealthyRate = tc.val
+		err := c.Validate()
+		if tc.wantErr && err == nil {
+			t.Errorf("healthy rate %.3f should fail, got nil", tc.val)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("healthy rate %.3f should pass, got %v", tc.val, err)
+		}
+	}
+}
+
+func TestLoad_ExemplarDefaultsMatchResolution(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	checks := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"EXEMPLAR_TRACES_PER_SERVICE_WINDOW", cfg.ExemplarTracesPerServiceWindow, 25},
+		{"EXEMPLAR_TRACES_GLOBAL_WINDOW", cfg.ExemplarTracesGlobalWindow, 1500},
+		{"EXEMPLAR_BYTES_PER_SERVICE_WINDOW", cfg.ExemplarBytesPerServiceWindow, 512 * 1024},
+		{"EXEMPLAR_BYTES_GLOBAL_WINDOW", cfg.ExemplarBytesGlobalWindow, 8 * 1024 * 1024},
+		{"EXEMPLAR_LOGS_ERROR_PER_SERVICE_WINDOW", cfg.ExemplarLogsErrorPerServiceWindow, 50},
+		{"EXEMPLAR_LOGS_WARN_PER_SERVICE_WINDOW", cfg.ExemplarLogsWarnPerServiceWindow, 20},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %d, want %d", c.name, c.got, c.want)
+		}
+	}
+	if cfg.ExemplarHealthyRate != 0.005 {
+		t.Errorf("EXEMPLAR_HEALTHY_RATE = %v, want 0.005", cfg.ExemplarHealthyRate)
+	}
+	if cfg.ExemplarLogsWarnEnabled {
+		t.Error("EXEMPLAR_LOGS_WARN_ENABLED should default off — WARN raw retention is opt-in")
 	}
 }

--- a/internal/ingest/exemplar.go
+++ b/internal/ingest/exemplar.go
@@ -1,0 +1,837 @@
+package ingest
+
+import (
+	"hash/fnv"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+// Bounded exemplar retention (#176, policy frozen in #161, quality contract in
+// #163).
+//
+// In AGGREGATE_MODE=aggregate the adaptive Sampler is retired and this policy
+// is the ONLY gate on raw persistence. It sits AFTER aggregate reduction so the
+// invariant that matters during an outage holds unconditionally:
+//
+//	aggregate counts : 100% of accepted telemetry
+//	raw exemplars    : bounded by count AND bytes, regardless of severity
+//
+// An error storm therefore raises aggregate error counts and leaves raw
+// persistence flat. "Always eligible" never means "always persisted".
+//
+// Selection properties (all four are load-bearing, #161):
+//
+//   - Deterministic: the verdict is a pure function of hash(traceID) and the
+//     window's bounded selection state. No RNG, no clock.
+//   - Arrival-order independent: healthy traces use a stateless hash threshold;
+//     errors/slow use per-stratum top-K by SMALLEST hash, so the set that wins a
+//     window is the same set regardless of the order the spans showed up in.
+//   - Retry-stable: #160's at-least-once redelivery re-derives the same verdict.
+//   - Duplicate-safe: a duplicate re-selects the same slot instead of consuming
+//     a second one.
+//
+// Boundary behaviour, stated honestly: selection state is bounded, so a
+// later-arriving trace with a smaller hash can displace an already-selected
+// trace. Spans of the displaced trace that were ALREADY handed to persistence
+// are not deleted — the policy has no delete path and would not use one if it
+// had. The effect is bounded OVER-retention (at most one extra trace's already
+// persisted spans per eviction), never under-retention of a better-ranked
+// trace's future spans. Every displacement is counted as
+// otelcontext_exemplar_eviction_total so operators can see the slack.
+
+// Exemplar priority classes. Lower value = higher priority when the unified
+// per-service budget is under pressure: ERROR/FATAL displaces slow, slow
+// displaces healthy, and nothing displaces an error (#161).
+const (
+	exemplarClassError   = 0
+	exemplarClassSlow    = 1
+	exemplarClassHealthy = 2
+	exemplarClassCount   = 3
+)
+
+// exemplarClassName maps a class to its metric label.
+func exemplarClassName(class int) string {
+	switch class {
+	case exemplarClassError:
+		return "error"
+	case exemplarClassSlow:
+		return "slow"
+	default:
+		return "healthy"
+	}
+}
+
+// Drop reasons, published as otelcontext_exemplar_dropped_total{reason}.
+const (
+	exemplarReasonBudgetCount = "budget_count"
+	exemplarReasonBudgetBytes = "budget_bytes"
+	exemplarReasonStratum     = "stratum"
+)
+
+// ExemplarMetrics is the policy's view of the metric surface. It mirrors the
+// aggregate package's recorder indirection so tests (and any caller passing a
+// nil *telemetry.Metrics) do not need a live Prometheus registry.
+type ExemplarMetrics interface {
+	RecordExemplarEligible(signal, class string)
+	RecordExemplarDropped(signal, reason string)
+	RecordExemplarEviction()
+	RecordExemplarTruncation()
+}
+
+// noopExemplarMetrics is the default when no recorder is wired.
+type noopExemplarMetrics struct{}
+
+func (noopExemplarMetrics) RecordExemplarEligible(string, string) {}
+func (noopExemplarMetrics) RecordExemplarDropped(string, string)  {}
+func (noopExemplarMetrics) RecordExemplarEviction()               {}
+func (noopExemplarMetrics) RecordExemplarTruncation()             {}
+
+// ExemplarConfig carries the frozen #161 budgets. Zero fields fall back to the
+// defaults so tests can construct a policy with one or two overrides.
+type ExemplarConfig struct {
+	// TracesPerServiceWindow is the unified per-service/window trace budget
+	// filled by priority ERROR/FATAL > slow > healthy. Default 25.
+	TracesPerServiceWindow int
+	// TracesGlobalWindow bounds selected traces across all services in one
+	// window. Default 1500.
+	TracesGlobalWindow int
+	// BytesPerServiceWindow / BytesGlobalWindow bound the bytes actually handed
+	// to persistence. Counts and bytes both bind; first breach wins.
+	BytesPerServiceWindow int64 // Default 512 KiB
+	BytesGlobalWindow     int64 // Default 8 MiB
+	// HealthyRate is the stateless hash-threshold eligibility target for
+	// healthy traces. Caps dominate under load. Default 0.005 (0.5%).
+	HealthyRate float64
+	// StratumTopK bounds how many exemplars one (operation × status class)
+	// stratum may hold, so a single repeated failure cannot monopolize the
+	// per-service budget. Default 5.
+	StratumTopK int
+	// LatencyThresholdMs is the shared definition of "slow"
+	// (SAMPLING_LATENCY_THRESHOLD_MS). A predicate, not a policy — it survives
+	// the sampler's retirement in every mode (#161).
+	LatencyThresholdMs float64
+	// LogsErrorPerServiceWindow is the raw ERROR/FATAL log budget per
+	// service/window. Default 50.
+	LogsErrorPerServiceWindow int
+	// LogsWarnEnabled opts WARN logs into raw retention. Off by default.
+	LogsWarnEnabled bool
+	// LogsWarnPerServiceWindow is the WARN budget when enabled. Default 20.
+	LogsWarnPerServiceWindow int
+	// MaxSpansPerTrace / MaxBytesPerTrace bound one retained trace so the
+	// complete-retained-trace contract (#163) cannot be turned into an
+	// unbounded write by a pathological trace. Breaching either forces
+	// truncation, which is persisted as truncated=true plus retained/observed
+	// span counts.
+	MaxSpansPerTrace int   // Default 500
+	MaxBytesPerTrace int64 // Default 256 KiB
+
+	// WindowSize is the tumbling budget window. Defaults to the aggregate
+	// engine's window so exemplar budgets and aggregate buckets share edges.
+	WindowSize time.Duration
+	// Metrics receives the policy's counters. nil = no-op.
+	Metrics ExemplarMetrics
+}
+
+// Exemplar budget defaults, frozen in #161's resolution.
+const (
+	DefaultExemplarTracesPerServiceWindow    = 25
+	DefaultExemplarTracesGlobalWindow        = 1500
+	DefaultExemplarBytesPerServiceWindow     = 512 * 1024
+	DefaultExemplarBytesGlobalWindow         = 8 * 1024 * 1024
+	DefaultExemplarHealthyRate               = 0.005
+	DefaultExemplarStratumTopK               = 5
+	DefaultExemplarLogsErrorPerServiceWindow = 50
+	DefaultExemplarLogsWarnPerServiceWindow  = 20
+	DefaultExemplarMaxSpansPerTrace          = 500
+	DefaultExemplarMaxBytesPerTrace          = 256 * 1024
+)
+
+func (c *ExemplarConfig) applyDefaults() {
+	if c.TracesPerServiceWindow <= 0 {
+		c.TracesPerServiceWindow = DefaultExemplarTracesPerServiceWindow
+	}
+	if c.TracesGlobalWindow <= 0 {
+		c.TracesGlobalWindow = DefaultExemplarTracesGlobalWindow
+	}
+	if c.BytesPerServiceWindow <= 0 {
+		c.BytesPerServiceWindow = DefaultExemplarBytesPerServiceWindow
+	}
+	if c.BytesGlobalWindow <= 0 {
+		c.BytesGlobalWindow = DefaultExemplarBytesGlobalWindow
+	}
+	if c.HealthyRate < 0 {
+		c.HealthyRate = 0
+	}
+	if c.HealthyRate > 1 {
+		c.HealthyRate = 1
+	}
+	if c.StratumTopK <= 0 {
+		c.StratumTopK = DefaultExemplarStratumTopK
+	}
+	if c.LogsErrorPerServiceWindow <= 0 {
+		c.LogsErrorPerServiceWindow = DefaultExemplarLogsErrorPerServiceWindow
+	}
+	if c.LogsWarnPerServiceWindow <= 0 {
+		c.LogsWarnPerServiceWindow = DefaultExemplarLogsWarnPerServiceWindow
+	}
+	if c.MaxSpansPerTrace <= 0 {
+		c.MaxSpansPerTrace = DefaultExemplarMaxSpansPerTrace
+	}
+	if c.MaxBytesPerTrace <= 0 {
+		c.MaxBytesPerTrace = DefaultExemplarMaxBytesPerTrace
+	}
+	if c.WindowSize <= 0 {
+		c.WindowSize = aggregate.WindowSize
+	}
+	if c.Metrics == nil {
+		c.Metrics = noopExemplarMetrics{}
+	}
+}
+
+// traceState is the per-selected-trace accounting behind the
+// complete-retained-trace contract (#163). Only SELECTED traces get one, so the
+// map is bounded by the per-service budget.
+type traceState struct {
+	hash      uint64
+	class     int
+	stratum   string
+	observed  int   // spans of this trace seen by the policy
+	retained  int   // spans actually handed to persistence
+	bytes     int64 // bytes actually handed to persistence
+	truncated bool
+	evicted   bool // displaced by a better-ranked trace; future spans stop
+}
+
+// stratumState holds the top-K smallest hashes selected for one
+// (operation × status class) stratum. K is small (default 5), so a linear scan
+// beats a heap and keeps eviction order obvious.
+type stratumState struct {
+	members map[string]uint64 // traceID -> hash
+}
+
+// serviceWindow is one (service, window) budget cell.
+type serviceWindow struct {
+	traces  map[string]*traceState
+	strata  map[string]*stratumState
+	perName [exemplarClassCount]int
+	bytes   int64
+	logs    [2]int // [0] = ERROR/FATAL raw logs, [1] = WARN raw logs
+}
+
+func newServiceWindow() *serviceWindow {
+	return &serviceWindow{
+		traces: make(map[string]*traceState),
+		strata: make(map[string]*stratumState),
+	}
+}
+
+func (sw *serviceWindow) selectedCount() int {
+	return sw.perName[exemplarClassError] + sw.perName[exemplarClassSlow] + sw.perName[exemplarClassHealthy]
+}
+
+// globalWindow carries the instance-wide budgets for one window.
+type globalWindow struct {
+	traces int
+	bytes  int64
+}
+
+// windowKey identifies a (tenant, service, window) budget cell. Budgets are
+// per-tenant as well as per-service: a noisy tenant must not spend another
+// tenant's exemplar slots.
+type windowKey struct {
+	tenant  string
+	service string
+	window  int64
+}
+
+// ExemplarPolicy is the bounded raw-retention gate for aggregate mode.
+//
+// Concurrency: state is sharded by service so the 100–200-service target does
+// not funnel every span through one mutex. Global (instance-wide) budgets live
+// behind their own small mutex, taken only when a shard actually wants to
+// reserve or release a slot — never on the common "healthy trace fails the hash
+// threshold" path.
+type ExemplarPolicy struct {
+	cfg ExemplarConfig
+
+	healthyThreshold uint64 // hash(traceID) < this => healthy-eligible
+
+	shards [exemplarShardCount]exemplarShard
+
+	globalMu sync.Mutex
+	global   map[int64]*globalWindow
+}
+
+const exemplarShardCount = 16
+
+type exemplarShard struct {
+	mu       sync.Mutex
+	services map[windowKey]*serviceWindow
+}
+
+// NewExemplarPolicy builds a policy from cfg, filling unset fields with the
+// #161 defaults.
+func NewExemplarPolicy(cfg ExemplarConfig) *ExemplarPolicy {
+	cfg.applyDefaults()
+	p := &ExemplarPolicy{
+		cfg:    cfg,
+		global: make(map[int64]*globalWindow),
+	}
+	// Threshold in the full uint64 hash space. rate=0 disables healthy
+	// eligibility entirely; rate=1 makes every healthy trace eligible (the
+	// count/byte budgets still bind).
+	p.healthyThreshold = uint64(cfg.HealthyRate * math.Pow(2, 64))
+	if cfg.HealthyRate >= 1 {
+		p.healthyThreshold = math.MaxUint64
+	}
+	if cfg.HealthyRate <= 0 {
+		p.healthyThreshold = 0
+	}
+	for i := range p.shards {
+		p.shards[i].services = make(map[windowKey]*serviceWindow)
+	}
+	return p
+}
+
+// exemplarHash is the trace-ID hash the whole policy ranks on. FNV-1a over the
+// hex trace ID: stable across processes and restarts (no per-process seed), so
+// two replicas fed the same trace reach the same verdict.
+func exemplarHash(traceID string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(traceID))
+	return h.Sum64()
+}
+
+// windowOf aligns t onto the policy's tumbling window.
+func (p *ExemplarPolicy) windowOf(t time.Time) int64 {
+	w := int64(p.cfg.WindowSize / time.Second)
+	if w <= 0 {
+		w = int64(aggregate.WindowSize / time.Second)
+	}
+	sec := t.Unix()
+	rem := sec % w
+	if rem < 0 {
+		rem += w
+	}
+	return sec - rem
+}
+
+func (p *ExemplarPolicy) shardFor(service string) *exemplarShard {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(service))
+	return &p.shards[h.Sum32()%exemplarShardCount]
+}
+
+// ExemplarSpan is one span offered to the policy. Everything here is already
+// computed on the hot path, so admission adds no parsing.
+type ExemplarSpan struct {
+	Tenant     string
+	Service    string
+	TraceID    string
+	Operation  string
+	Status     string
+	DurationMs float64
+	Timestamp  time.Time
+}
+
+func (in ExemplarSpan) class(latencyThresholdMs float64) int {
+	if in.Status == storage.StatusCodeError {
+		return exemplarClassError
+	}
+	// Overlap is resolved here, once: an error that is ALSO slow consumes one
+	// slot at error priority, never two (#161).
+	if latencyThresholdMs > 0 && in.DurationMs >= latencyThresholdMs {
+		return exemplarClassSlow
+	}
+	return exemplarClassHealthy
+}
+
+// AdmitSpan reports whether this span's raw row may be built and offered to
+// persistence. It is the count-budget half of admission; ChargeSpan meters the
+// bytes actually produced.
+//
+// A trace already selected in this window always admits — that is the
+// complete-retained-trace contract, and it is what makes multi-batch traces and
+// at-least-once retries cohere with zero coordination.
+func (p *ExemplarPolicy) AdmitSpan(in ExemplarSpan) bool {
+	window := p.windowOf(in.Timestamp)
+	class := in.class(p.cfg.LatencyThresholdMs)
+	h := exemplarHash(in.TraceID)
+
+	sh := p.shardFor(in.Service)
+	sh.mu.Lock()
+	sw := sh.window(windowKey{tenant: in.Tenant, service: in.Service, window: window})
+
+	// Already decided? Duplicates and later spans of the same trace re-select
+	// the same slot.
+	if st, ok := sw.traces[in.TraceID]; ok {
+		if st.evicted {
+			sh.mu.Unlock()
+			return false
+		}
+		// Status upgrade: a trace admitted as healthy that turns out to carry
+		// an error keeps its slot but is re-priced at the higher class, so
+		// budget pressure displaces it last rather than first.
+		if class < st.class {
+			sw.perName[st.class]--
+			sw.perName[class]++
+			st.class = class
+		}
+		if st.observed >= p.cfg.MaxSpansPerTrace {
+			// Bounded trace: stop admitting, record truncation once.
+			st.observed++
+			p.markTruncated(st)
+			sh.mu.Unlock()
+			p.cfg.Metrics.RecordExemplarDropped("traces", exemplarReasonBudgetCount)
+			return false
+		}
+		st.observed++
+		sh.mu.Unlock()
+		return true
+	}
+
+	// Not yet selected. Eligibility first, budget second.
+	if class == exemplarClassHealthy {
+		if p.healthyThreshold == 0 || h >= p.healthyThreshold {
+			sh.mu.Unlock()
+			return false
+		}
+	} else if !p.stratumAdmits(sw, in.Operation, class, h) {
+		// Errors and slow spans are ALWAYS eligible — that is the whole point
+		// of #161's wording — but eligibility is not retention.
+		sh.mu.Unlock()
+		p.cfg.Metrics.RecordExemplarEligible("traces", exemplarClassName(class))
+		p.cfg.Metrics.RecordExemplarDropped("traces", exemplarReasonStratum)
+		return false
+	}
+	p.cfg.Metrics.RecordExemplarEligible("traces", exemplarClassName(class))
+
+	// Reserve the instance-wide slot before displacing anything, so global
+	// exhaustion can never cost an already-selected exemplar its slot.
+	if !p.reserveGlobalTrace(window) {
+		sh.mu.Unlock()
+		p.cfg.Metrics.RecordExemplarDropped("traces", exemplarReasonBudgetCount)
+		return false
+	}
+
+	// Stratum displacement first: a full stratum gives up its worst-ranked
+	// member, which also frees the service slot that member was holding.
+	stratum := ""
+	if class != exemplarClassHealthy {
+		stratum = exemplarStratum(in.Operation, class)
+		if ss, ok := sw.strata[stratum]; ok && len(ss.members) >= p.cfg.StratumTopK {
+			if worstID, _ := stratumWorst(ss); worstID != "" {
+				p.evictLocked(sw, window, worstID)
+			}
+		}
+	}
+
+	// Unified per-service budget with priority fill.
+	if sw.selectedCount() >= p.cfg.TracesPerServiceWindow {
+		victim := sw.lowestPriorityVictim(class, h)
+		if victim == "" {
+			p.releaseGlobalTrace(window)
+			sh.mu.Unlock()
+			p.cfg.Metrics.RecordExemplarDropped("traces", exemplarReasonBudgetCount)
+			return false
+		}
+		p.evictLocked(sw, window, victim)
+	}
+
+	st := &traceState{hash: h, class: class, observed: 1, stratum: stratum}
+	if stratum != "" {
+		ss, ok := sw.strata[stratum]
+		if !ok {
+			ss = &stratumState{members: make(map[string]uint64, p.cfg.StratumTopK)}
+			sw.strata[stratum] = ss
+		}
+		ss.members[in.TraceID] = h
+	}
+	sw.traces[in.TraceID] = st
+	sw.perName[class]++
+	sh.mu.Unlock()
+	return true
+}
+
+// ChargeSpan meters the bytes a retained span actually hands to persistence and
+// reports whether it fits. A false return means the row must be dropped: the
+// byte budget bound before the count budget did, and the trace is marked
+// truncated so the gap is visible in the persisted data rather than inferred.
+func (p *ExemplarPolicy) ChargeSpan(tenant, service, traceID string, ts time.Time, size int) bool {
+	window := p.windowOf(ts)
+	sh := p.shardFor(service)
+	sh.mu.Lock()
+	sw := sh.window(windowKey{tenant: tenant, service: service, window: window})
+	st, ok := sw.traces[traceID]
+	if !ok || st.evicted {
+		sh.mu.Unlock()
+		return false
+	}
+	n := int64(size)
+	if st.bytes+n > p.cfg.MaxBytesPerTrace || sw.bytes+n > p.cfg.BytesPerServiceWindow {
+		p.markTruncated(st)
+		sh.mu.Unlock()
+		p.cfg.Metrics.RecordExemplarDropped("traces", exemplarReasonBudgetBytes)
+		return false
+	}
+	if !p.reserveGlobalBytes(window, n) {
+		p.markTruncated(st)
+		sh.mu.Unlock()
+		p.cfg.Metrics.RecordExemplarDropped("traces", exemplarReasonBudgetBytes)
+		return false
+	}
+	st.bytes += n
+	st.retained++
+	sw.bytes += n
+	sh.mu.Unlock()
+	return true
+}
+
+// markTruncated flips a trace to truncated exactly once (counter hygiene).
+// Caller holds the shard lock.
+func (p *ExemplarPolicy) markTruncated(st *traceState) {
+	if st.truncated {
+		return
+	}
+	st.truncated = true
+	p.cfg.Metrics.RecordExemplarTruncation()
+}
+
+// ExemplarTraceStats is the persisted-side view of a retained trace.
+type ExemplarTraceStats struct {
+	Truncated bool
+	Retained  int
+	Observed  int
+}
+
+// TraceStats returns the accounting for a selected trace so the caller can
+// stamp truncated / retained / observed onto the persisted trace row (#163).
+// The second return is false when the trace was never selected.
+func (p *ExemplarPolicy) TraceStats(tenant, service, traceID string, ts time.Time) (ExemplarTraceStats, bool) {
+	window := p.windowOf(ts)
+	sh := p.shardFor(service)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	sw, ok := sh.services[windowKey{tenant: tenant, service: service, window: window}]
+	if !ok {
+		return ExemplarTraceStats{}, false
+	}
+	st, ok := sw.traces[traceID]
+	if !ok {
+		return ExemplarTraceStats{}, false
+	}
+	return ExemplarTraceStats{Truncated: st.truncated, Retained: st.retained, Observed: st.observed}, true
+}
+
+// AdmitLog reports whether a raw log row may be persisted in aggregate mode.
+// INFO/DEBUG are aggregate-only and never raw; ERROR/FATAL get a per-service
+// window budget; WARN is opt-in (#161). Bytes are charged to the same
+// service/global byte budgets as spans — one pool, so a log flood cannot buy
+// itself past the trace budget.
+//
+// size is the variable-length payload (body + serialized attributes); the
+// fixed row overhead is added here so callers do not have to know it.
+func (p *ExemplarPolicy) AdmitLog(tenant, service, severity string, ts time.Time, size int) bool {
+	slot, ok := p.logSlot(severity)
+	if !ok {
+		// Not eligible at all — not an exemplar drop, never was one.
+		return false
+	}
+	budget := p.cfg.LogsErrorPerServiceWindow
+	class := "error"
+	if slot == 1 {
+		budget = p.cfg.LogsWarnPerServiceWindow
+		class = "warn"
+	}
+	p.cfg.Metrics.RecordExemplarEligible("logs", class)
+
+	window := p.windowOf(ts)
+	sh := p.shardFor(service)
+	sh.mu.Lock()
+	sw := sh.window(windowKey{tenant: tenant, service: service, window: window})
+	if sw.logs[slot] >= budget {
+		sh.mu.Unlock()
+		p.cfg.Metrics.RecordExemplarDropped("logs", exemplarReasonBudgetCount)
+		return false
+	}
+	n := int64(size + logRowFixedBytes)
+	if sw.bytes+n > p.cfg.BytesPerServiceWindow {
+		sh.mu.Unlock()
+		p.cfg.Metrics.RecordExemplarDropped("logs", exemplarReasonBudgetBytes)
+		return false
+	}
+	if !p.reserveGlobalBytes(window, n) {
+		sh.mu.Unlock()
+		p.cfg.Metrics.RecordExemplarDropped("logs", exemplarReasonBudgetBytes)
+		return false
+	}
+	sw.logs[slot]++
+	sw.bytes += n
+	sh.mu.Unlock()
+	return true
+}
+
+// AllowSynthesizedLog gates logs synthesized from span events / span status.
+// These ride along with a span the policy already admitted and budgeted, so
+// only the severity floor applies — re-budgeting them would punch holes in the
+// complete-retained-trace contract for no bytes saved.
+func (p *ExemplarPolicy) AllowSynthesizedLog(severity string) bool {
+	_, ok := p.logSlot(severity)
+	return ok
+}
+
+// logSlot maps a severity onto its raw-retention slot: 0 = ERROR/FATAL,
+// 1 = WARN (opt-in). ok=false means aggregate-only. Classification reuses
+// shouldIngestSeverity so the policy and the ingest severity gate can never
+// disagree about what "ERROR" looks like on the wire.
+func (p *ExemplarPolicy) logSlot(severity string) (int, bool) {
+	switch {
+	case shouldIngestSeverity(severity, 40):
+		return 0, true
+	case shouldIngestSeverity(severity, 30):
+		// WARN. INFO/DEBUG and unknown severities are aggregate-only (#161).
+		if !p.cfg.LogsWarnEnabled {
+			return 0, false
+		}
+		return 1, true
+	default:
+		return 0, false
+	}
+}
+
+// window returns (creating if needed) the budget cell for key, pruning windows
+// that can no longer receive data. Caller holds the shard lock.
+func (sh *exemplarShard) window(key windowKey) *serviceWindow {
+	if sw, ok := sh.services[key]; ok {
+		return sw
+	}
+	// Bounded state: drop every cell for this (tenant, service) older than the
+	// incoming window. Windows only ever move forward for a given service, and
+	// the aggregate engine's lateness horizon already rejects points from
+	// windows this far back.
+	for k := range sh.services {
+		if k.tenant == key.tenant && k.service == key.service && k.window < key.window {
+			delete(sh.services, k)
+		}
+	}
+	sw := newServiceWindow()
+	sh.services[key] = sw
+	return sw
+}
+
+// exemplarStratum is the (operation × status class) stratum key. Stratifying
+// stops one repeated failure from consuming every slot while the other ninety
+// operations of the service go unrepresented.
+func exemplarStratum(operation string, class int) string {
+	return exemplarClassName(class) + "\x00" + operation
+}
+
+// stratumAdmits reports whether hash h ranks into the stratum's top-K smallest.
+// A stratum below K always admits. Caller holds the shard lock.
+func (p *ExemplarPolicy) stratumAdmits(sw *serviceWindow, operation string, class int, h uint64) bool {
+	st, ok := sw.strata[exemplarStratum(operation, class)]
+	if !ok || len(st.members) < p.cfg.StratumTopK {
+		return true
+	}
+	// Full: admit only if strictly better than the current worst. The displaced
+	// trace's re-evaluation then yields "reject" for the same reason, which is
+	// what keeps every verdict recomputable without tombstones.
+	_, worst := stratumWorst(st)
+	return h < worst
+}
+
+// stratumWorst returns the member with the LARGEST hash — the one a better
+// candidate displaces. Ties break on trace ID so the choice is deterministic
+// regardless of map iteration order.
+func stratumWorst(st *stratumState) (string, uint64) {
+	var worstID string
+	var worst uint64
+	for id, h := range st.members {
+		if worstID == "" || h > worst || (h == worst && id > worstID) {
+			worstID, worst = id, h
+		}
+	}
+	return worstID, worst
+}
+
+// lowestPriorityVictim picks the trace to displace so a higher-priority class
+// can take a slot in a full service window: the worst-ranked member of the
+// lowest-priority class strictly below the incoming class. Returns "" when
+// nothing may be displaced — the budget then simply refuses, which is exactly
+// the behaviour that keeps an error storm from becoming a write storm.
+func (sw *serviceWindow) lowestPriorityVictim(incoming int, incomingHash uint64) string {
+	for class := exemplarClassHealthy; class > incoming; class-- {
+		if sw.perName[class] == 0 {
+			continue
+		}
+		var victim string
+		var worst uint64
+		for id, st := range sw.traces {
+			if st.evicted || st.class != class {
+				continue
+			}
+			if victim == "" || st.hash > worst || (st.hash == worst && id > victim) {
+				victim, worst = id, st.hash
+			}
+		}
+		if victim != "" {
+			return victim
+		}
+	}
+	// Same class, full window: rank decides. Displace the worst member only
+	// when the newcomer is strictly better, so the retained set for a window
+	// stays a pure function of the hashes offered to it.
+	if sw.perName[incoming] > 0 {
+		var victim string
+		var worst uint64
+		for id, st := range sw.traces {
+			if st.evicted || st.class != incoming {
+				continue
+			}
+			if victim == "" || st.hash > worst || (st.hash == worst && id > victim) {
+				victim, worst = id, st.hash
+			}
+		}
+		if victim != "" && incomingHash < worst {
+			return victim
+		}
+	}
+	return ""
+}
+
+// evictLocked displaces a selected trace. Spans of the evicted trace that were
+// already handed to persistence stay persisted — this is the bounded
+// over-retention documented at the top of the file, and it is counted rather
+// than hidden. Caller holds the shard lock.
+func (p *ExemplarPolicy) evictLocked(sw *serviceWindow, window int64, traceID string) {
+	st, ok := sw.traces[traceID]
+	if !ok || st.evicted {
+		return
+	}
+	st.evicted = true
+	sw.perName[st.class]--
+	if st.stratum != "" {
+		if s, ok := sw.strata[st.stratum]; ok {
+			delete(s.members, traceID)
+			if len(s.members) == 0 {
+				delete(sw.strata, st.stratum)
+			}
+		}
+	}
+	// The evicted trace keeps its traceState (so its own future spans are
+	// refused deterministically) but returns its global slot; its already
+	// charged bytes are NOT refunded, because those bytes really were written.
+	p.releaseGlobalTrace(window)
+	p.cfg.Metrics.RecordExemplarEviction()
+	p.pruneEvictedLocked(sw)
+}
+
+// pruneEvictedLocked bounds the displaced-trace bookkeeping.
+//
+// A displaced trace is kept only so its own later spans are refused without a
+// second look. Dropping the record is safe because the verdict is recomputable:
+// a window's selected set only ever improves (hashes only get smaller, strata
+// only fill), so a trace displaced once can never re-qualify — re-evaluating it
+// from scratch returns the same "reject". Without this the map would grow with
+// admission churn instead of with the budget. Caller holds the shard lock.
+func (p *ExemplarPolicy) pruneEvictedLocked(sw *serviceWindow) {
+	if len(sw.traces) <= 8*p.cfg.TracesPerServiceWindow {
+		return
+	}
+	for id, st := range sw.traces {
+		if st.evicted {
+			delete(sw.traces, id)
+		}
+	}
+}
+
+// reserveGlobalTrace takes one instance-wide trace slot for the window.
+func (p *ExemplarPolicy) reserveGlobalTrace(window int64) bool {
+	p.globalMu.Lock()
+	defer p.globalMu.Unlock()
+	gw := p.globalFor(window)
+	if gw.traces >= p.cfg.TracesGlobalWindow {
+		return false
+	}
+	gw.traces++
+	return true
+}
+
+// releaseGlobalTrace returns one instance-wide slot for the window. Bytes are
+// deliberately not refunded — those bytes really were written.
+func (p *ExemplarPolicy) releaseGlobalTrace(window int64) {
+	p.globalMu.Lock()
+	defer p.globalMu.Unlock()
+	if gw, ok := p.global[window]; ok && gw.traces > 0 {
+		gw.traces--
+	}
+}
+
+// reserveGlobalBytes takes n bytes from the instance-wide window budget.
+func (p *ExemplarPolicy) reserveGlobalBytes(window int64, n int64) bool {
+	p.globalMu.Lock()
+	defer p.globalMu.Unlock()
+	gw := p.globalFor(window)
+	if gw.bytes+n > p.cfg.BytesGlobalWindow {
+		return false
+	}
+	gw.bytes += n
+	return true
+}
+
+// globalFor returns the global cell for a window, pruning older ones. Caller
+// holds globalMu.
+func (p *ExemplarPolicy) globalFor(window int64) *globalWindow {
+	if gw, ok := p.global[window]; ok {
+		return gw
+	}
+	for w := range p.global {
+		if w < window {
+			delete(p.global, w)
+		}
+	}
+	gw := &globalWindow{}
+	p.global[window] = gw
+	return gw
+}
+
+// SelectedTraces returns the trace IDs currently selected in the window
+// containing ts, for a (tenant, service). Test/diagnostic surface: this is the
+// set the determinism property is stated over.
+func (p *ExemplarPolicy) SelectedTraces(tenant, service string, ts time.Time) []string {
+	window := p.windowOf(ts)
+	sh := p.shardFor(service)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	sw, ok := sh.services[windowKey{tenant: tenant, service: service, window: window}]
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(sw.traces))
+	for id, st := range sw.traces {
+		if !st.evicted {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// spanRowBytes estimates the bytes a span row hands to persistence. It counts
+// what is actually written — the variable-length columns plus a fixed overhead
+// for the numeric/timestamp columns — rather than the wire size of the OTLP
+// message, which is what the byte budget is supposed to bound.
+const spanRowFixedBytes = 96
+
+func spanRowBytes(s *storage.Span) int {
+	return spanRowFixedBytes +
+		len(s.TenantID) + len(s.TraceID) + len(s.SpanID) + len(s.ParentSpanID) +
+		len(s.OperationName) + len(s.ServiceName) + len(s.Status) + len(s.AttributesJSON)
+}
+
+// logRowFixedBytes is the log-row equivalent of spanRowFixedBytes: the
+// per-row overhead AdmitLog adds to the caller's body+attributes size.
+const logRowFixedBytes = 64

--- a/internal/ingest/exemplar_test.go
+++ b/internal/ingest/exemplar_test.go
@@ -1,0 +1,710 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// countingExemplarMetrics is a test recorder. The policy's counters are the
+// operator's only view of the completeness-vs-coverage gap, so the tests assert
+// on them rather than trusting the drop paths silently.
+type countingExemplarMetrics struct {
+	mu         sync.Mutex
+	eligible   map[string]int
+	dropped    map[string]int
+	evictions  int
+	truncation int
+}
+
+func newCountingExemplarMetrics() *countingExemplarMetrics {
+	return &countingExemplarMetrics{
+		eligible: make(map[string]int),
+		dropped:  make(map[string]int),
+	}
+}
+
+func (m *countingExemplarMetrics) RecordExemplarEligible(signal, class string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.eligible[signal+"/"+class]++
+}
+
+func (m *countingExemplarMetrics) RecordExemplarDropped(signal, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dropped[signal+"/"+reason]++
+}
+
+func (m *countingExemplarMetrics) RecordExemplarEviction() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.evictions++
+}
+
+func (m *countingExemplarMetrics) RecordExemplarTruncation() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.truncation++
+}
+
+func (m *countingExemplarMetrics) snapshot() (map[string]int, map[string]int, int, int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	e := make(map[string]int, len(m.eligible))
+	for k, v := range m.eligible {
+		e[k] = v
+	}
+	d := make(map[string]int, len(m.dropped))
+	for k, v := range m.dropped {
+		d[k] = v
+	}
+	return e, d, m.evictions, m.truncation
+}
+
+// exemplarOffer is one span offered to the policy in the unit-level tests.
+type exemplarOffer struct {
+	traceID    string
+	operation  string
+	status     string
+	durationMs float64
+}
+
+func offerAll(p *ExemplarPolicy, service string, ts time.Time, offers []exemplarOffer) []string {
+	admitted := make([]string, 0, len(offers))
+	for _, o := range offers {
+		in := ExemplarSpan{
+			Tenant:     storage.DefaultTenantID,
+			Service:    service,
+			TraceID:    o.traceID,
+			Operation:  o.operation,
+			Status:     o.status,
+			DurationMs: o.durationMs,
+			Timestamp:  ts,
+		}
+		if p.AdmitSpan(in) {
+			admitted = append(admitted, o.traceID)
+			// Real callers always follow an admission with a charge; skipping
+			// it here would leave the byte budget untouched and make the count
+			// tests silently depend on charge-free admission.
+			p.ChargeSpan(in.Tenant, service, o.traceID, ts, 512)
+		}
+	}
+	return admitted
+}
+
+func sortedSelected(p *ExemplarPolicy, service string, ts time.Time) []string {
+	got := p.SelectedTraces(storage.DefaultTenantID, service, ts)
+	sort.Strings(got)
+	return got
+}
+
+// TestExemplarSelectionIsOrderIndependentAndDuplicateSafe is the #161 selection
+// contract: the retained set is a property of the traces offered in a window,
+// not of the order they showed up in or how many times they were redelivered.
+// Without this, #160's at-least-once retries and multi-batch traces would each
+// produce a different exemplar set on every replay.
+func TestExemplarSelectionIsOrderIndependentAndDuplicateSafe(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	operations := []string{"GET /a", "GET /b", "POST /c", "GET /d", "PUT /e"}
+
+	base := make([]exemplarOffer, 0, 600)
+	for i := 0; i < 400; i++ {
+		base = append(base, exemplarOffer{
+			traceID:    fmt.Sprintf("%032x", i),
+			operation:  operations[i%len(operations)],
+			status:     storage.StatusCodeError,
+			durationMs: 5,
+		})
+	}
+	// Healthy traces exercise the stateless hash-threshold branch alongside the
+	// stratified top-K branch.
+	for i := 400; i < 600; i++ {
+		base = append(base, exemplarOffer{
+			traceID:    fmt.Sprintf("%032x", i),
+			operation:  operations[i%len(operations)],
+			status:     "STATUS_CODE_OK",
+			durationMs: 5,
+		})
+	}
+
+	newPolicy := func() *ExemplarPolicy {
+		return NewExemplarPolicy(ExemplarConfig{
+			LatencyThresholdMs: 500,
+			HealthyRate:        0.05, // raised so healthy eligibility is not vacuous at n=200
+		})
+	}
+
+	reference := newPolicy()
+	offerAll(reference, "checkout", ts, base)
+	want := sortedSelected(reference, "checkout", ts)
+	if len(want) == 0 {
+		t.Fatal("reference run selected nothing — the test would be vacuous")
+	}
+
+	for run := 0; run < 5; run++ {
+		shuffled := append([]exemplarOffer(nil), base...)
+		rng := rand.New(rand.NewSource(int64(run) + 1)) // #nosec G404 -- deterministic test shuffle, not security
+		rng.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+		// Duplicate a third of the offers: a redelivery must re-select the same
+		// slot, never consume a second one.
+		for i := 0; i < len(base); i += 3 {
+			shuffled = append(shuffled, base[i])
+		}
+		rng.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+
+		p := newPolicy()
+		offerAll(p, "checkout", ts, shuffled)
+		got := sortedSelected(p, "checkout", ts)
+		if len(got) != len(want) {
+			t.Fatalf("run %d selected %d traces, reference selected %d", run, len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("run %d retained set diverged at %d: got %s, want %s", run, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestExemplarPriorityFillDisplacesHealthyBeforeErrors: under budget pressure
+// the cheap signal goes first. An operator triaging an incident must not find
+// their error exemplars evicted by healthy traffic.
+func TestExemplarPriorityFillDisplacesHealthyBeforeErrors(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p := NewExemplarPolicy(ExemplarConfig{
+		TracesPerServiceWindow: 4,
+		HealthyRate:            1.0, // every healthy trace is eligible; the budget is the only bound
+		LatencyThresholdMs:     500,
+		StratumTopK:            10,
+	})
+
+	// Fill the window with healthy traces.
+	healthy := make([]exemplarOffer, 0, 4)
+	for i := 0; i < 4; i++ {
+		healthy = append(healthy, exemplarOffer{
+			traceID: fmt.Sprintf("h%031x", i), operation: "GET /a", status: "STATUS_CODE_OK", durationMs: 5,
+		})
+	}
+	if got := offerAll(p, "checkout", ts, healthy); len(got) != 4 {
+		t.Fatalf("healthy fill admitted %d, want 4", len(got))
+	}
+
+	// Now offer errors. Each must take a slot by displacing a healthy trace.
+	errors := make([]exemplarOffer, 0, 4)
+	for i := 0; i < 4; i++ {
+		errors = append(errors, exemplarOffer{
+			traceID: fmt.Sprintf("e%031x", i), operation: "GET /a", status: storage.StatusCodeError, durationMs: 5,
+		})
+	}
+	if got := offerAll(p, "checkout", ts, errors); len(got) != 4 {
+		t.Fatalf("error fill admitted %d, want 4 — errors must displace healthy", len(got))
+	}
+
+	selected := sortedSelected(p, "checkout", ts)
+	if len(selected) != 4 {
+		t.Fatalf("window holds %d traces, want the 4-trace budget", len(selected))
+	}
+	for _, id := range selected {
+		if !strings.HasPrefix(id, "e") {
+			t.Fatalf("healthy trace %s survived error pressure; selected=%v", id, selected)
+		}
+	}
+
+	// And the reverse must NOT happen: healthy offered against a full error
+	// window is refused, not swapped in.
+	more := []exemplarOffer{{traceID: fmt.Sprintf("h%031x", 99), operation: "GET /a", status: "STATUS_CODE_OK", durationMs: 5}}
+	if got := offerAll(p, "checkout", ts, more); len(got) != 0 {
+		t.Fatalf("healthy trace displaced an error exemplar: %v", got)
+	}
+}
+
+// TestExemplarOverlapConsumesOneSlot: a trace that is both slow and errored is
+// one exemplar, not two (#161).
+func TestExemplarOverlapConsumesOneSlot(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p := NewExemplarPolicy(ExemplarConfig{
+		TracesPerServiceWindow: 2,
+		LatencyThresholdMs:     500,
+		StratumTopK:            10,
+		HealthyRate:            0,
+	})
+
+	// One trace, error AND slow, offered across two spans.
+	overlap := []exemplarOffer{
+		{traceID: fmt.Sprintf("%032x", 1), operation: "GET /a", status: storage.StatusCodeError, durationMs: 900},
+		{traceID: fmt.Sprintf("%032x", 1), operation: "GET /a", status: storage.StatusCodeError, durationMs: 900},
+	}
+	offerAll(p, "checkout", ts, overlap)
+
+	if got := len(sortedSelected(p, "checkout", ts)); got != 1 {
+		t.Fatalf("overlap trace occupies %d slots, want 1", got)
+	}
+
+	// The remaining slot must still be available to a different trace.
+	other := []exemplarOffer{{traceID: fmt.Sprintf("%032x", 2), operation: "GET /b", status: storage.StatusCodeError, durationMs: 10}}
+	if got := offerAll(p, "checkout", ts, other); len(got) != 1 {
+		t.Fatalf("second trace refused — the overlap consumed both slots")
+	}
+}
+
+// TestExemplarByteBudgetBindsIndependentlyOfCount: counts and bytes both bind
+// and the first breach wins. A handful of enormous spans must not slip through
+// just because the trace count is nowhere near its cap.
+func TestExemplarByteBudgetBindsIndependentlyOfCount(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	rec := newCountingExemplarMetrics()
+	p := NewExemplarPolicy(ExemplarConfig{
+		TracesPerServiceWindow: 100, // count budget deliberately far from binding
+		TracesGlobalWindow:     1000,
+		BytesPerServiceWindow:  8192,
+		BytesGlobalWindow:      1 << 20,
+		MaxBytesPerTrace:       1 << 20,
+		LatencyThresholdMs:     500,
+		StratumTopK:            100,
+		HealthyRate:            0,
+		Metrics:                rec,
+	})
+
+	const spanBytes = 1024
+	charged := 0
+	for i := 0; i < 40; i++ {
+		id := fmt.Sprintf("%032x", i)
+		in := ExemplarSpan{
+			Tenant: storage.DefaultTenantID, Service: "checkout", TraceID: id,
+			Operation: fmt.Sprintf("op-%d", i), Status: storage.StatusCodeError, Timestamp: ts,
+		}
+		if !p.AdmitSpan(in) {
+			continue
+		}
+		if p.ChargeSpan(in.Tenant, "checkout", id, ts, spanBytes) {
+			charged++
+		}
+	}
+
+	if want := 8192 / spanBytes; charged != want {
+		t.Fatalf("charged %d spans, want %d — the byte budget did not bind", charged, want)
+	}
+	if selected := len(sortedSelected(p, "checkout", ts)); selected <= charged {
+		t.Fatalf("selected %d traces but only %d were persisted; the count budget should not have bound", selected, charged)
+	}
+	_, dropped, _, truncations := rec.snapshot()
+	if dropped["traces/"+exemplarReasonBudgetBytes] == 0 {
+		t.Error("no budget_bytes drops recorded")
+	}
+	if dropped["traces/"+exemplarReasonBudgetCount] != 0 {
+		t.Errorf("budget_count drops recorded (%d); only the byte budget should have bound", dropped["traces/"+exemplarReasonBudgetCount])
+	}
+	if truncations == 0 {
+		t.Error("byte-budget refusal did not mark any trace truncated")
+	}
+}
+
+// TestExemplarWarnLogsAreOptIn: WARN is off by default and budgeted when on.
+// INFO/DEBUG are never raw in aggregate mode regardless.
+func TestExemplarWarnLogsAreOptIn(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+
+	admitN := func(p *ExemplarPolicy, severity string, n int) int {
+		admitted := 0
+		for i := 0; i < n; i++ {
+			if p.AdmitLog(storage.DefaultTenantID, "checkout", severity, ts, 64) {
+				admitted++
+			}
+		}
+		return admitted
+	}
+
+	off := NewExemplarPolicy(ExemplarConfig{LogsWarnEnabled: false, LogsErrorPerServiceWindow: 50})
+	if got := admitN(off, "WARN", 10); got != 0 {
+		t.Fatalf("WARN admitted %d logs with the opt-in off, want 0", got)
+	}
+
+	on := NewExemplarPolicy(ExemplarConfig{LogsWarnEnabled: true, LogsWarnPerServiceWindow: 3, LogsErrorPerServiceWindow: 50})
+	if got := admitN(on, "WARN", 10); got != 3 {
+		t.Fatalf("WARN admitted %d logs, want the 3-log budget", got)
+	}
+	// The WARN budget is its own slot: it must not have eaten the ERROR budget.
+	if got := admitN(on, "ERROR", 60); got != 50 {
+		t.Fatalf("ERROR admitted %d logs, want the 50-log budget", got)
+	}
+	for _, sev := range []string{"INFO", "DEBUG", "TRACE"} {
+		if got := admitN(on, sev, 5); got != 0 {
+			t.Fatalf("%s admitted %d raw logs, want 0 — INFO/DEBUG are aggregate-only", sev, got)
+		}
+	}
+}
+
+// --- Export-path integration ---
+
+// exemplarTraceRequest builds one export request of single-span traces for a
+// service, all with the same status/duration.
+func exemplarTraceRequest(service string, traces, operations int, status tracepb.Status_StatusCode, durationMs int, ts time.Time, seed int) *coltracepb.ExportTraceServiceRequest {
+	spans := make([]*tracepb.Span, 0, traces)
+	for i := 0; i < traces; i++ {
+		spans = append(spans, &tracepb.Span{
+			TraceId:           []byte(fmt.Sprintf("%08d%08d", seed, i)),
+			SpanId:            []byte(fmt.Sprintf("%08d", i)),
+			Name:              fmt.Sprintf("GET /op-%d", i%operations),
+			Kind:              tracepb.Span_SPAN_KIND_SERVER,
+			StartTimeUnixNano: uint64(ts.UnixNano()), // #nosec G115 -- test timestamps are positive
+			EndTimeUnixNano:   uint64(ts.Add(time.Duration(durationMs) * time.Millisecond).UnixNano()),
+			Status:            &tracepb.Status{Code: status},
+		})
+	}
+	return &coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: []*tracepb.ResourceSpans{{
+			Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
+				{Key: "service.name", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: service}}},
+			}},
+			ScopeSpans: []*tracepb.ScopeSpans{{Spans: spans}},
+		}},
+	}
+}
+
+func exemplarTestPolicy(cfg ExemplarConfig) *ExemplarPolicy {
+	if cfg.LatencyThresholdMs == 0 {
+		cfg.LatencyThresholdMs = 500
+	}
+	return NewExemplarPolicy(cfg)
+}
+
+// TestExemplarErrorStormKeepsAggregateExactAndRawBounded is the acceptance
+// criterion of #176 and the reason #161 exists at all: at 100% error traffic
+// the aggregate error count must be exact while raw persistence stays flat at
+// the caps. If raw persistence tracks the error rate, an outage has turned the
+// platform into its own denial of service.
+func TestExemplarErrorStormKeepsAggregateExactAndRawBounded(t *testing.T) {
+	now := time.Now().UTC() // Export reads arrival from the wall clock
+	repo, db := newAggregateTestRepo(t)
+	srv := NewTraceServer(repo, nil, aggTestConfig())
+	engine := newAggregateEngine(t, now)
+	srv.SetAggregateEngine(engine)
+
+	rec := newCountingExemplarMetrics()
+	const perServiceBudget = 25
+	srv.SetExemplarPolicy(exemplarTestPolicy(ExemplarConfig{
+		TracesPerServiceWindow: perServiceBudget,
+		TracesGlobalWindow:     1500,
+		StratumTopK:            5,
+		HealthyRate:            0.005,
+		Metrics:                rec,
+	}))
+
+	// Ten batches of 500 errored traces: 5,000 error traces, 100% error rate.
+	const batches, perBatch, operations = 10, 500, 10
+	for b := 0; b < batches; b++ {
+		req := exemplarTraceRequest("checkout", perBatch, operations, tracepb.Status_STATUS_CODE_ERROR, 5, now, b)
+		if _, err := srv.Export(context.Background(), req); err != nil {
+			t.Fatalf("Export batch %d: %v", b, err)
+		}
+	}
+
+	const total = batches * perBatch
+
+	// Aggregate accounting is exact — every error counted, no exceptions.
+	count, errCount := engine.Snapshot().Totals(aggregate.SignalTraceOp)
+	if count != total {
+		t.Errorf("aggregate count = %d, want %d — accounting must precede retention", count, total)
+	}
+	if errCount != total {
+		t.Errorf("aggregate error count = %d, want %d", errCount, total)
+	}
+
+	// Raw persistence is bounded. Over-retention from displacement is allowed
+	// and counted; unbounded growth with the error rate is not.
+	persistedSpans := countAggSpans(t, db)
+	_, dropped, evictions, _ := rec.snapshot()
+	maxRaw := int64(perServiceBudget + evictions)
+	if persistedSpans > maxRaw {
+		t.Fatalf("persisted %d spans; budget %d plus %d displacements allows at most %d",
+			persistedSpans, perServiceBudget, evictions, maxRaw)
+	}
+	if persistedSpans >= total/10 {
+		t.Fatalf("persisted %d of %d spans — raw retention is tracking the error rate", persistedSpans, total)
+	}
+	if dropped["traces/"+exemplarReasonStratum]+dropped["traces/"+exemplarReasonBudgetCount] == 0 {
+		t.Error("no exemplar drops recorded during a 5,000-trace storm")
+	}
+	t.Logf("storm: aggregate=%d errors=%d persisted_spans=%d evictions=%d drops=%v",
+		count, errCount, persistedSpans, evictions, dropped)
+}
+
+// TestExemplarRetiresSamplerInAggregateMode: with the exemplar policy wired,
+// SAMPLING_RATE cannot influence what is persisted. Exactly one raw-retention
+// policy governs the active path per mode (#161).
+func TestExemplarRetiresSamplerInAggregateMode(t *testing.T) {
+	now := time.Now().UTC()
+
+	run := func(rate float64) int64 {
+		repo, db := newAggregateTestRepo(t)
+		srv := NewTraceServer(repo, nil, aggTestConfig())
+		srv.SetAggregateEngine(newAggregateEngine(t, now))
+		srv.SetExemplarPolicy(exemplarTestPolicy(ExemplarConfig{
+			TracesPerServiceWindow: 25,
+			StratumTopK:            5,
+			HealthyRate:            0.005,
+		}))
+		// A sampler is deliberately wired alongside. In aggregate mode it must
+		// never be consulted — this is the guard against a future refactor
+		// quietly reinstating it.
+		srv.SetSampler(NewSampler(rate, true, 500))
+		req := exemplarTraceRequest("checkout", 400, 10, tracepb.Status_STATUS_CODE_ERROR, 5, now, 7)
+		if _, err := srv.Export(context.Background(), req); err != nil {
+			t.Fatalf("Export at rate %v: %v", rate, err)
+		}
+		return countAggSpans(t, db)
+	}
+
+	full := run(1.0)
+	sampled := run(0.05)
+	if full != sampled {
+		t.Fatalf("SAMPLING_RATE changed exemplar retention: %d spans at 1.0 vs %d at 0.05", full, sampled)
+	}
+	if full == 0 {
+		t.Fatal("no spans persisted at all — the test would be vacuous")
+	}
+}
+
+// TestExemplarTruncationMetadataPersists checks the #163 contract end to end:
+// a trace cut short by the per-trace span bound lands in the database with
+// truncated=true and honest retained/observed counts.
+func TestExemplarTruncationMetadataPersists(t *testing.T) {
+	now := time.Now().UTC()
+	repo, db := newAggregateTestRepo(t)
+	srv := NewTraceServer(repo, nil, aggTestConfig())
+	srv.SetAggregateEngine(newAggregateEngine(t, now))
+
+	const maxSpans = 5
+	rec := newCountingExemplarMetrics()
+	srv.SetExemplarPolicy(exemplarTestPolicy(ExemplarConfig{
+		TracesPerServiceWindow: 25,
+		StratumTopK:            5,
+		MaxSpansPerTrace:       maxSpans,
+		HealthyRate:            0,
+		Metrics:                rec,
+	}))
+
+	// One trace, 20 errored spans, delivered across two batches so the
+	// truncation only becomes known on the second one.
+	const totalSpans = 20
+	traceID := []byte("0123456789abcdef")
+	mkBatch := func(from, to int) *coltracepb.ExportTraceServiceRequest {
+		spans := make([]*tracepb.Span, 0, to-from)
+		for i := from; i < to; i++ {
+			spans = append(spans, &tracepb.Span{
+				TraceId:           traceID,
+				SpanId:            []byte(fmt.Sprintf("%08d", i)),
+				Name:              "GET /checkout",
+				StartTimeUnixNano: uint64(now.UnixNano()), // #nosec G115 -- test timestamps are positive
+				EndTimeUnixNano:   uint64(now.Add(time.Millisecond).UnixNano()),
+				Status:            &tracepb.Status{Code: tracepb.Status_STATUS_CODE_ERROR},
+			})
+		}
+		return &coltracepb.ExportTraceServiceRequest{
+			ResourceSpans: []*tracepb.ResourceSpans{{
+				Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
+					{Key: "service.name", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "checkout"}}},
+				}},
+				ScopeSpans: []*tracepb.ScopeSpans{{Spans: spans}},
+			}},
+		}
+	}
+	for _, b := range [][2]int{{0, 3}, {3, totalSpans}} {
+		if _, err := srv.Export(context.Background(), mkBatch(b[0], b[1])); err != nil {
+			t.Fatalf("Export: %v", err)
+		}
+	}
+
+	var tr storage.Trace
+	if err := db.Where("trace_id = ?", fmt.Sprintf("%x", traceID)).First(&tr).Error; err != nil {
+		t.Fatalf("load trace: %v", err)
+	}
+	if tr.Truncated == nil || !*tr.Truncated {
+		t.Fatalf("trace not marked truncated: %+v", tr.Truncated)
+	}
+	if tr.RetainedSpanCount == nil || *tr.RetainedSpanCount != maxSpans {
+		t.Fatalf("retained_span_count = %v, want %d", tr.RetainedSpanCount, maxSpans)
+	}
+	if tr.ObservedSpanCount == nil || *tr.ObservedSpanCount != totalSpans {
+		t.Fatalf("observed_span_count = %v, want %d", tr.ObservedSpanCount, totalSpans)
+	}
+	// The claim must match the rows actually on disk.
+	var persisted int64
+	if err := db.Model(&storage.Span{}).Where("trace_id = ?", fmt.Sprintf("%x", traceID)).Count(&persisted).Error; err != nil {
+		t.Fatalf("count spans: %v", err)
+	}
+	if persisted != int64(maxSpans) {
+		t.Fatalf("persisted %d spans, but the trace claims %d retained", persisted, maxSpans)
+	}
+	if _, _, _, truncations := rec.snapshot(); truncations != 1 {
+		t.Errorf("truncation counter = %d, want 1", truncations)
+	}
+}
+
+// TestExemplarUntruncatedTraceLeavesMetadataNull: the truncation columns are a
+// claim, not a default. A trace retained whole must leave them NULL so a reader
+// can tell "not truncated" from "no claim made".
+func TestExemplarUntruncatedTraceLeavesMetadataNull(t *testing.T) {
+	now := time.Now().UTC()
+	repo, db := newAggregateTestRepo(t)
+	srv := NewTraceServer(repo, nil, aggTestConfig())
+	srv.SetAggregateEngine(newAggregateEngine(t, now))
+	srv.SetExemplarPolicy(exemplarTestPolicy(ExemplarConfig{
+		TracesPerServiceWindow: 25, StratumTopK: 5, MaxSpansPerTrace: 500, HealthyRate: 0,
+	}))
+
+	req := exemplarTraceRequest("checkout", 3, 3, tracepb.Status_STATUS_CODE_ERROR, 5, now, 1)
+	if _, err := srv.Export(context.Background(), req); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	var traces []storage.Trace
+	if err := db.Find(&traces).Error; err != nil {
+		t.Fatalf("load traces: %v", err)
+	}
+	if len(traces) == 0 {
+		t.Fatal("no traces persisted")
+	}
+	for _, tr := range traces {
+		if tr.Truncated != nil || tr.RetainedSpanCount != nil || tr.ObservedSpanCount != nil {
+			t.Fatalf("untruncated trace %s carries a truncation claim: %+v", tr.TraceID, tr)
+		}
+	}
+}
+
+// TestExemplarLogBudgetBindsOnExportPath wires the policy into LogsServer and
+// checks the raw-log budget through the real persist path.
+func TestExemplarLogBudgetBindsOnExportPath(t *testing.T) {
+	now := time.Now().UTC()
+	repo, db := newAggregateTestRepo(t)
+	srv := NewLogsServer(repo, nil, aggTestConfig())
+	engine := newAggregateEngine(t, now)
+	srv.SetAggregateEngine(engine)
+
+	const errorBudget = 6
+	srv.SetExemplarPolicy(exemplarTestPolicy(ExemplarConfig{
+		LogsErrorPerServiceWindow: errorBudget,
+		LogsWarnEnabled:           false,
+	}))
+
+	const errorLogs, infoLogs = 50, 20
+	records := make([]*logspb.LogRecord, 0, errorLogs+infoLogs)
+	for i := 0; i < errorLogs; i++ {
+		records = append(records, &logspb.LogRecord{
+			TimeUnixNano: uint64(now.UnixNano()), // #nosec G115 -- test timestamps are positive
+			SeverityText: "ERROR",
+			Body:         &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: fmt.Sprintf("upstream failed %d", i)}},
+		})
+	}
+	for i := 0; i < infoLogs; i++ {
+		records = append(records, &logspb.LogRecord{
+			TimeUnixNano: uint64(now.UnixNano()), // #nosec G115 -- test timestamps are positive
+			SeverityText: "INFO",
+			Body:         &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: fmt.Sprintf("served %d", i)}},
+		})
+	}
+	req := &collogspb.ExportLogsServiceRequest{ResourceLogs: []*logspb.ResourceLogs{{
+		Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{
+			{Key: "service.name", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "checkout"}}},
+		}},
+		ScopeLogs: []*logspb.ScopeLogs{{LogRecords: records}},
+	}}}
+
+	if _, err := srv.Export(context.Background(), req); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	var persisted int64
+	if err := db.Model(&storage.Log{}).Count(&persisted).Error; err != nil {
+		t.Fatalf("count logs: %v", err)
+	}
+	if persisted != errorBudget {
+		t.Fatalf("persisted %d logs, want the %d-log ERROR budget (INFO is aggregate-only)", persisted, errorBudget)
+	}
+	// Aggregate accounting still saw every record.
+	if count, _ := engine.Snapshot().Totals(aggregate.SignalLog); count != errorLogs+infoLogs {
+		t.Errorf("aggregate log count = %d, want %d", count, errorLogs+infoLogs)
+	}
+}
+
+// TestExemplarInertInLegacyAndShadowModes: with no policy wired, nothing about
+// the persisted output changes. This is the mode-ownership guard — legacy and
+// aggregate-shadow keep the Sampler and see none of this code.
+func TestExemplarInertInLegacyAndShadowModes(t *testing.T) {
+	now := time.Now().UTC()
+	req := exemplarTraceRequest("checkout", 40, 5, tracepb.Status_STATUS_CODE_ERROR, 5, now, 3)
+
+	persistedIn := func(withEngine bool) int64 {
+		repo, db := newAggregateTestRepo(t)
+		srv := NewTraceServer(repo, nil, aggTestConfig())
+		if withEngine {
+			srv.SetAggregateEngine(newAggregateEngine(t, now))
+		}
+		if _, err := srv.Export(context.Background(), req); err != nil {
+			t.Fatalf("Export: %v", err)
+		}
+		return countAggSpans(t, db)
+	}
+
+	legacy := persistedIn(false)
+	shadow := persistedIn(true)
+	if legacy != 40 || shadow != 40 {
+		t.Fatalf("legacy persisted %d and shadow persisted %d spans, want 40 each — the exemplar policy leaked into a mode that does not own it", legacy, shadow)
+	}
+}
+
+// TestExemplarConcurrentAdmissionIsRaceFree exercises the sharded state from
+// many goroutines. Run under -race; the assertion is only that the budget still
+// holds afterwards.
+func TestExemplarConcurrentAdmissionIsRaceFree(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p := NewExemplarPolicy(ExemplarConfig{
+		TracesPerServiceWindow: 25,
+		TracesGlobalWindow:     100,
+		StratumTopK:            5,
+		HealthyRate:            0.005,
+		LatencyThresholdMs:     500,
+	})
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 500; i++ {
+				id := fmt.Sprintf("%016x%016x", g, i)
+				in := ExemplarSpan{
+					Tenant: storage.DefaultTenantID, Service: fmt.Sprintf("svc-%d", i%4), TraceID: id,
+					Operation: fmt.Sprintf("op-%d", i%7), Status: storage.StatusCodeError, Timestamp: ts,
+				}
+				if p.AdmitSpan(in) {
+					p.ChargeSpan(in.Tenant, in.Service, id, ts, 256)
+					p.TraceStats(in.Tenant, in.Service, id, ts)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	for i := 0; i < 4; i++ {
+		svc := fmt.Sprintf("svc-%d", i)
+		if got := len(p.SelectedTraces(storage.DefaultTenantID, svc, ts)); got > 25 {
+			t.Fatalf("%s holds %d exemplars, over the 25 budget", svc, got)
+		}
+	}
+}

--- a/internal/ingest/otlp.go
+++ b/internal/ingest/otlp.go
@@ -116,7 +116,11 @@ type TraceServer struct {
 	// aggregate reduction BEFORE the sampler so aggregate counts describe
 	// accepted telemetry rather than the sampling rate (#153 §8). nil leaves
 	// the legacy path untouched.
-	aggregateEngine     *aggregate.Engine
+	aggregateEngine *aggregate.Engine
+	// exemplar, when set (AGGREGATE_MODE=aggregate), is the ONLY raw-retention
+	// gate: the adaptive Sampler is retired in that mode (#161). nil in
+	// legacy/shadow, where the Sampler keeps governing the raw path unchanged.
+	exemplar            *ExemplarPolicy
 	minSeverity         int
 	allowedServices     map[string]bool
 	excludedServices    map[string]bool
@@ -134,7 +138,10 @@ type LogsServer struct {
 	logCallback func(storage.Log)
 	// aggregateEngine — see TraceServer.aggregateEngine. Reduction runs before
 	// the severity gate.
-	aggregateEngine     *aggregate.Engine
+	aggregateEngine *aggregate.Engine
+	// exemplar — see TraceServer.exemplar. In aggregate mode INFO/DEBUG logs
+	// are aggregate-only and ERROR/FATAL/WARN are budgeted per service/window.
+	exemplar            *ExemplarPolicy
 	minSeverity         int
 	allowedServices     map[string]bool
 	excludedServices    map[string]bool
@@ -223,6 +230,19 @@ func (s *LogsServer) SetAggregateEngine(e *aggregate.Engine) {
 // SetAggregateEngine — see TraceServer.SetAggregateEngine.
 func (s *MetricsServer) SetAggregateEngine(e *aggregate.Engine) {
 	s.aggregateEngine = e
+}
+
+// SetExemplarPolicy installs the bounded exemplar retention policy (#176).
+// Wired only for AGGREGATE_MODE=aggregate, where it replaces the adaptive
+// Sampler as the sole raw-retention gate. Passing nil (legacy / shadow) leaves
+// the Sampler in charge and every byte of the export path unchanged.
+func (s *TraceServer) SetExemplarPolicy(p *ExemplarPolicy) {
+	s.exemplar = p
+}
+
+// SetExemplarPolicy — see TraceServer.SetExemplarPolicy.
+func (s *LogsServer) SetExemplarPolicy(p *ExemplarPolicy) {
+	s.exemplar = p
 }
 
 func NewLogsServer(repo *storage.Repository, metrics *telemetry.Metrics, cfg *config.Config) *LogsServer {
@@ -454,9 +474,25 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 						reducer.ReduceSpan(aggregateSpanInput(tenantID, serviceName, span, startTime, endTime))
 					}
 
-					if s.sampler != nil {
-						isError := statusStr == storage.StatusCodeError
-						durationMs := float64(duration) / 1000.0
+					// Raw-retention gate. Exactly one policy governs this per
+					// mode (#161): in aggregate mode the exemplar policy is it
+					// and the Sampler is retired; in legacy/shadow the Sampler
+					// is unchanged and s.exemplar is nil.
+					isError := statusStr == storage.StatusCodeError
+					durationMs := float64(duration) / 1000.0
+					if s.exemplar != nil {
+						if !s.exemplar.AdmitSpan(ExemplarSpan{
+							Tenant:     tenantID,
+							Service:    serviceName,
+							TraceID:    traceIDHex,
+							Operation:  span.Name,
+							Status:     statusStr,
+							DurationMs: durationMs,
+							Timestamp:  startTime,
+						}) {
+							continue
+						}
+					} else if s.sampler != nil {
 						if !s.sampler.ShouldSample(serviceName, isError, durationMs) {
 							continue
 						}
@@ -478,7 +514,19 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 						Status:         statusStr,
 						AttributesJSON: storage.CompressedText(attrs),
 					}
-					localSpans = append(localSpans, sModel)
+					// Byte metering happens here, on the row that is actually
+					// handed to persistence, not on the OTLP wire message —
+					// the byte budget is a budget on what gets written. A
+					// refusal drops this span and marks the trace truncated;
+					// the trace row below still lands so the gap is recorded
+					// in the data rather than left to be inferred.
+					keepSpan := true
+					if s.exemplar != nil {
+						keepSpan = s.exemplar.ChargeSpan(tenantID, serviceName, traceIDHex, startTime, spanRowBytes(&sModel))
+					}
+					if keepSpan {
+						localSpans = append(localSpans, sModel)
+					}
 
 					// Flag the batch for the async pipeline's priority lane.
 					// Errors and slow spans bypass soft-backpressure drops so
@@ -511,6 +559,14 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 						})
 					}
 
+					// Synthesized logs ride along with their span. A span the
+					// byte budget refused takes its synthesized logs with it —
+					// persisting a log whose span was dropped would be exactly
+					// the dangling evidence #163 forbids.
+					if !keepSpan {
+						continue
+					}
+
 					// spanHasErrorLog records whether an ERROR log was already
 					// synthesized for THIS span from its events. It replaces a
 					// rescan of every previously synthesized log per span, which
@@ -525,6 +581,12 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 						}
 
 						if !shouldIngestSeverity(severity, s.minSeverity) {
+							continue
+						}
+						// Aggregate mode: INFO/DEBUG never persist raw (#161).
+						// Only the severity floor applies — these logs belong
+						// to a span the policy already selected and budgeted.
+						if s.exemplar != nil && !s.exemplar.AllowSynthesizedLog(severity) {
 							continue
 						}
 
@@ -574,6 +636,22 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 							localLogs = append(localLogs, l)
 						}
 					}
+				}
+			}
+
+			// Stamp the complete-retained-trace contract onto the trace rows
+			// (#163). Only traces the exemplar policy actually cut short carry
+			// a claim; everything else leaves the columns NULL.
+			if s.exemplar != nil {
+				for i := range localTraces {
+					st, ok := s.exemplar.TraceStats(tenantID, serviceName, localTraces[i].TraceID, localTraces[i].Timestamp)
+					if !ok || !st.Truncated {
+						continue
+					}
+					truncated, retained, observed := true, st.Retained, st.Observed
+					localTraces[i].Truncated = &truncated
+					localTraces[i].RetainedSpanCount = &retained
+					localTraces[i].ObservedSpanCount = &observed
 				}
 			}
 
@@ -763,6 +841,16 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 
 					bodyStr := l.Body.GetStringValue()
 					attrs, _ := json.Marshal(l.Attributes)
+
+					// Aggregate mode: raw log retention is bounded per
+					// service/window and by severity — ERROR/FATAL budgeted,
+					// WARN opt-in, INFO/DEBUG aggregate-only (#161). The
+					// reduction above already accounted every one of them.
+					if s.exemplar != nil {
+						if !s.exemplar.AdmitLog(tenantID, serviceName, severity, timestamp, len(bodyStr)+len(attrs)) {
+							continue
+						}
+					}
 
 					logEntry := storage.Log{
 						TenantID:       tenantID,

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -109,12 +109,25 @@ type Trace struct {
 	// Timestamp is both part of idx_traces_tenant_ts (composite) and retains a
 	// standalone index so range scans on traces across all tenants (e.g.
 	// retention sweeps) still use an index.
-	Timestamp time.Time      `gorm:"index;index:idx_traces_tenant_ts,priority:2" json:"timestamp"`
-	Spans     []Span         `gorm:"foreignKey:TraceID;references:TraceID;constraint:false" json:"spans,omitempty"`
-	Logs      []Log          `gorm:"foreignKey:TraceID;references:TraceID;constraint:false" json:"logs,omitempty"`
-	CreatedAt time.Time      `json:"-"`
-	UpdatedAt time.Time      `json:"-"`
-	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	Timestamp time.Time `gorm:"index;index:idx_traces_tenant_ts,priority:2" json:"timestamp"`
+	// Exemplar truncation metadata (#163's complete-retained-trace contract,
+	// written by the aggregate-mode exemplar policy in internal/ingest).
+	// All three are nullable and stay NULL on every legacy/shadow-mode row and
+	// on any exemplar retained whole — NULL means "no truncation claim was
+	// made", which is deliberately distinct from truncated=false.
+	//
+	// When Truncated is true the trace was cut off by the per-trace span or
+	// byte bound: RetainedSpanCount spans reached the DB out of
+	// ObservedSpanCount seen. Causal-analysis tools must report partial
+	// coverage for such a trace rather than fabricated certainty.
+	Truncated         *bool          `gorm:"column:truncated" json:"truncated,omitempty"`
+	RetainedSpanCount *int           `gorm:"column:retained_span_count" json:"retained_span_count,omitempty"`
+	ObservedSpanCount *int           `gorm:"column:observed_span_count" json:"observed_span_count,omitempty"`
+	Spans             []Span         `gorm:"foreignKey:TraceID;references:TraceID;constraint:false" json:"spans,omitempty"`
+	Logs              []Log          `gorm:"foreignKey:TraceID;references:TraceID;constraint:false" json:"logs,omitempty"`
+	CreatedAt         time.Time      `json:"-"`
+	UpdatedAt         time.Time      `json:"-"`
+	DeletedAt         gorm.DeletedAt `gorm:"index" json:"-"`
 }
 
 // Span represents a single operation within a trace.

--- a/internal/storage/trace_repo.go
+++ b/internal/storage/trace_repo.go
@@ -123,6 +123,40 @@ func createTracesIdempotent(db *gorm.DB, driver string, traces []Trace) error {
 			return err
 		}
 	}
+	return updateTraceTruncation(db, traces)
+}
+
+// updateTraceTruncation stamps the exemplar truncation metadata (#163) onto
+// rows the inserts above may have left untouched.
+//
+// The insert paths are first-writer-wins on everything but status, so a trace
+// whose truncation only becomes known on a later batch would otherwise keep the
+// first batch's NULL forever — and a truncated trace is by definition one with
+// enough spans to arrive across several batches. Truncation counts are
+// cumulative and monotonic, so last-write-wins is the correct direction here.
+//
+// Cost is one UPDATE per truncated trace, which the exemplar budgets bound to a
+// handful per service per window. Rows without a truncation claim (every
+// legacy/shadow-mode row, and every exemplar retained whole) skip this entirely.
+func updateTraceTruncation(db *gorm.DB, traces []Trace) error {
+	for i := range traces {
+		t := &traces[i]
+		if t.Truncated == nil {
+			continue
+		}
+		updates := map[string]any{"truncated": *t.Truncated}
+		if t.RetainedSpanCount != nil {
+			updates["retained_span_count"] = *t.RetainedSpanCount
+		}
+		if t.ObservedSpanCount != nil {
+			updates["observed_span_count"] = *t.ObservedSpanCount
+		}
+		if err := db.Model(&Trace{}).
+			Where("tenant_id = ? AND trace_id = ?", t.TenantID, t.TraceID).
+			Updates(updates).Error; err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/storage/trace_truncation_test.go
+++ b/internal/storage/trace_truncation_test.go
@@ -1,0 +1,95 @@
+package storage
+
+import (
+	"testing"
+	"time"
+)
+
+// Exemplar truncation metadata (#163) round-trips through the real migration
+// and upsert paths. The columns are nullable on purpose: NULL means "no
+// truncation claim was made", which a reader must be able to tell apart from an
+// explicit truncated=false.
+
+func TestTraceTruncationMetadataRoundTrips(t *testing.T) {
+	repo := newTestRepo(t)
+	ts := time.Now().UTC()
+
+	truncated := true
+	retained, observed := 5, 137
+	rows := []Trace{
+		{TenantID: DefaultTenantID, TraceID: "aaaa", ServiceName: "checkout", Status: StatusCodeError, Timestamp: ts,
+			Truncated: &truncated, RetainedSpanCount: &retained, ObservedSpanCount: &observed},
+		{TenantID: DefaultTenantID, TraceID: "bbbb", ServiceName: "checkout", Status: "STATUS_CODE_OK", Timestamp: ts},
+	}
+	if err := repo.BatchCreateTraces(rows); err != nil {
+		t.Fatalf("BatchCreateTraces: %v", err)
+	}
+
+	var got Trace
+	if err := repo.db.Where("trace_id = ?", "aaaa").First(&got).Error; err != nil {
+		t.Fatalf("load truncated trace: %v", err)
+	}
+	if got.Truncated == nil || !*got.Truncated {
+		t.Fatalf("truncated = %v, want true", got.Truncated)
+	}
+	if got.RetainedSpanCount == nil || *got.RetainedSpanCount != retained {
+		t.Fatalf("retained_span_count = %v, want %d", got.RetainedSpanCount, retained)
+	}
+	if got.ObservedSpanCount == nil || *got.ObservedSpanCount != observed {
+		t.Fatalf("observed_span_count = %v, want %d", got.ObservedSpanCount, observed)
+	}
+
+	var plain Trace
+	if err := repo.db.Where("trace_id = ?", "bbbb").First(&plain).Error; err != nil {
+		t.Fatalf("load untruncated trace: %v", err)
+	}
+	if plain.Truncated != nil || plain.RetainedSpanCount != nil || plain.ObservedSpanCount != nil {
+		t.Fatalf("trace with no truncation claim carries one: %+v", plain)
+	}
+}
+
+// TestTraceTruncationLandsOnAlreadyInsertedRow is the case that matters in
+// practice: a trace long enough to be truncated arrives across several batches,
+// so the truncation only becomes known after the row already exists. The insert
+// paths are first-writer-wins, so without the dedicated update pass the row
+// would keep its NULL forever.
+func TestTraceTruncationLandsOnAlreadyInsertedRow(t *testing.T) {
+	repo := newTestRepo(t)
+	ts := time.Now().UTC()
+
+	first := []Trace{{TenantID: DefaultTenantID, TraceID: "cccc", ServiceName: "orders", Status: "STATUS_CODE_UNSET", Timestamp: ts}}
+	if err := repo.BatchCreateTraces(first); err != nil {
+		t.Fatalf("first BatchCreateTraces: %v", err)
+	}
+
+	truncated := true
+	retained, observed := 500, 4212
+	second := []Trace{{TenantID: DefaultTenantID, TraceID: "cccc", ServiceName: "orders", Status: StatusCodeError, Timestamp: ts,
+		Truncated: &truncated, RetainedSpanCount: &retained, ObservedSpanCount: &observed}}
+	if err := repo.BatchCreateTraces(second); err != nil {
+		t.Fatalf("second BatchCreateTraces: %v", err)
+	}
+
+	var got Trace
+	if err := repo.db.Where("trace_id = ?", "cccc").First(&got).Error; err != nil {
+		t.Fatalf("load trace: %v", err)
+	}
+	if got.Truncated == nil || !*got.Truncated {
+		t.Fatalf("truncated = %v, want true after the later batch", got.Truncated)
+	}
+	if got.ObservedSpanCount == nil || *got.ObservedSpanCount != observed {
+		t.Fatalf("observed_span_count = %v, want %d", got.ObservedSpanCount, observed)
+	}
+	// Status upgrade must still work alongside the truncation update.
+	if got.Status != StatusCodeError {
+		t.Fatalf("status = %q, want %q", got.Status, StatusCodeError)
+	}
+
+	var count int64
+	if err := repo.db.Model(&Trace{}).Where("trace_id = ?", "cccc").Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("trace row duplicated: %d rows", count)
+	}
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -182,6 +182,24 @@ type Metrics struct {
 	// service. Cheap invariant only (#165): no per-series comparison.
 	AggregateShadowErrorsTotal *prometheus.CounterVec
 
+	// --- Bounded exemplar retention (AGGREGATE_MODE=aggregate) ---
+	// ExemplarEligibleTotal — telemetry that qualified for raw retention,
+	// per signal and priority class. Eligible is not retained: the gap between
+	// this and the drop counter is what makes aggregate completeness and raw
+	// diagnostic coverage distinguishable during a storm (#161).
+	ExemplarEligibleTotal *prometheus.CounterVec
+	// ExemplarDroppedTotal — eligible telemetry refused raw persistence,
+	// reason=budget_count|budget_bytes|stratum.
+	ExemplarDroppedTotal *prometheus.CounterVec
+	// ExemplarEvictionTotal — selected exemplars displaced by a better-ranked
+	// trace. Each eviction is one trace's worth of bounded OVER-retention:
+	// already-persisted spans are never deleted.
+	ExemplarEvictionTotal prometheus.Counter
+	// ExemplarTruncatedTotal — retained traces forced past their max spans or
+	// max bytes. These persist truncated=true plus retained/observed counts,
+	// and causal-analysis tools report partial coverage for them (#163).
+	ExemplarTruncatedTotal prometheus.Counter
+
 	// Atomic counters for JSON health endpoint (avoids scraping Prometheus)
 	totalIngested  atomic.Int64
 	activeConns    atomic.Int64
@@ -487,8 +505,40 @@ func New() *Metrics {
 		Name: "otelcontext_aggregate_shadow_errors_total",
 		Help: "Errors accounted on the aggregate side, per service. Cheap shadow-mode invariant only.",
 	}, []string{"service"})
+	m.ExemplarEligibleTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_exemplar_eligible_total",
+		Help: "Telemetry eligible for raw exemplar retention, by signal and priority class (error|slow|healthy|warn). Eligible is not retained.",
+	}, []string{"signal", "class"})
+	m.ExemplarDroppedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_exemplar_dropped_total",
+		Help: "Eligible telemetry refused raw persistence by the exemplar budgets. reason=budget_count|budget_bytes|stratum.",
+	}, []string{"signal", "reason"})
+	m.ExemplarEvictionTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "otelcontext_exemplar_eviction_total",
+		Help: "Selected exemplars displaced by a better-ranked trace. Bounded over-retention: already-persisted spans are not deleted.",
+	})
+	m.ExemplarTruncatedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "otelcontext_exemplar_truncated_total",
+		Help: "Retained traces forced past max spans/bytes. Persisted with truncated=true plus retained/observed span counts.",
+	})
 	return m
 }
+
+// RecordExemplarEligible implements ingest.ExemplarMetrics.
+func (m *Metrics) RecordExemplarEligible(signal, class string) {
+	m.ExemplarEligibleTotal.WithLabelValues(signal, class).Inc()
+}
+
+// RecordExemplarDropped implements ingest.ExemplarMetrics.
+func (m *Metrics) RecordExemplarDropped(signal, reason string) {
+	m.ExemplarDroppedTotal.WithLabelValues(signal, reason).Inc()
+}
+
+// RecordExemplarEviction implements ingest.ExemplarMetrics.
+func (m *Metrics) RecordExemplarEviction() { m.ExemplarEvictionTotal.Inc() }
+
+// RecordExemplarTruncation implements ingest.ExemplarMetrics.
+func (m *Metrics) RecordExemplarTruncation() { m.ExemplarTruncatedTotal.Inc() }
 
 // StartRuntimeMetrics samples Go runtime stats every 15 seconds.
 func (m *Metrics) StartRuntimeMetrics() {

--- a/main.go
+++ b/main.go
@@ -495,8 +495,38 @@ func main() {
 		)
 	}
 
-	// Wire adaptive sampler (only when rate < 1.0 to avoid unnecessary overhead)
-	if cfg.SamplingRate > 0 && cfg.SamplingRate < 1.0 {
+	// Bounded exemplar retention (#176). In AGGREGATE_MODE=aggregate this is
+	// the ONLY raw-retention gate — the adaptive sampler below is skipped
+	// entirely, so SAMPLING_RATE has no effect on what gets persisted (#161).
+	// SAMPLING_LATENCY_THRESHOLD_MS survives as the shared "slow" predicate.
+	if cfg.AggregateMode == aggregate.ModeAggregate {
+		exemplarPolicy := ingest.NewExemplarPolicy(ingest.ExemplarConfig{
+			TracesPerServiceWindow:    cfg.ExemplarTracesPerServiceWindow,
+			TracesGlobalWindow:        cfg.ExemplarTracesGlobalWindow,
+			BytesPerServiceWindow:     int64(cfg.ExemplarBytesPerServiceWindow),
+			BytesGlobalWindow:         int64(cfg.ExemplarBytesGlobalWindow),
+			HealthyRate:               cfg.ExemplarHealthyRate,
+			StratumTopK:               cfg.ExemplarStratumTopK,
+			LatencyThresholdMs:        float64(cfg.SamplingLatencyThresholdMs),
+			LogsErrorPerServiceWindow: cfg.ExemplarLogsErrorPerServiceWindow,
+			LogsWarnEnabled:           cfg.ExemplarLogsWarnEnabled,
+			LogsWarnPerServiceWindow:  cfg.ExemplarLogsWarnPerServiceWindow,
+			MaxSpansPerTrace:          cfg.ExemplarMaxSpansPerTrace,
+			MaxBytesPerTrace:          int64(cfg.ExemplarMaxBytesPerTrace),
+			Metrics:                   metrics,
+		})
+		traceServer.SetExemplarPolicy(exemplarPolicy)
+		logsServer.SetExemplarPolicy(exemplarPolicy)
+		slog.Info("🎚️  Bounded exemplar retention enabled (adaptive sampler retired)",
+			"traces_per_service_window", cfg.ExemplarTracesPerServiceWindow,
+			"traces_global_window", cfg.ExemplarTracesGlobalWindow,
+			"bytes_per_service_window", cfg.ExemplarBytesPerServiceWindow,
+			"bytes_global_window", cfg.ExemplarBytesGlobalWindow,
+			"healthy_rate", cfg.ExemplarHealthyRate,
+			"latency_threshold_ms", cfg.SamplingLatencyThresholdMs,
+		)
+	} else if cfg.SamplingRate > 0 && cfg.SamplingRate < 1.0 {
+		// Wire adaptive sampler (only when rate < 1.0 to avoid unnecessary overhead)
 		sampler := ingest.NewSampler(cfg.SamplingRate, cfg.SamplingAlwaysOnErrors, float64(cfg.SamplingLatencyThresholdMs))
 		traceServer.SetSampler(sampler)
 		slog.Info("🎯 Adaptive trace sampling enabled",


### PR DESCRIPTION
Phase 5 of the aggregate-first epic #153. Implements the frozen policy from #161 and the "complete retained traces" quality contract from #163.

## What this does

In `AGGREGATE_MODE=aggregate` the adaptive `Sampler` is retired and `internal/ingest/exemplar.go` becomes the only gate on raw persistence. It sits **after** aggregate reduction (wave 2 already put the reducer ahead of the sampler), so the invariant that matters during an outage holds unconditionally:

```
aggregate counts : 100% of accepted telemetry
raw exemplars    : bounded by count AND bytes, regardless of severity
```

`legacy` and `aggregate-shadow` are byte-for-byte unchanged — no policy is wired, the `Sampler` still governs, and the exemplar code is inert. `SAMPLING_LATENCY_THRESHOLD_MS` survives in every mode as the shared "slow" predicate.

## Selection (#161)

| Class | Rule |
|---|---|
| Healthy | Stateless hash threshold on trace ID (`EXEMPLAR_HEALTHY_RATE`, 0.5%) |
| Error / slow | Per-stratum (operation × status class) top-K by **smallest** `hash(traceID)` |

Deterministic, arrival-order independent, retry-stable, duplicate-safe — no coordination required for multi-batch traces or #160's at-least-once redelivery.

**Boundary behaviour, stated honestly:** selection state is bounded, so a later-arriving smaller-hash trace can displace a selected one. Spans of the displaced trace that were already handed to persistence are **not** deleted — the policy has no delete path. The effect is bounded **over**-retention, never under-retention of a better-ranked trace's future spans, and every displacement is counted as `otelcontext_exemplar_eviction_total`.

## Budgets (#161 defaults)

```
traces:  25 per service/window, unified budget, fill priority ERROR/FATAL > slow > healthy
         1,500 global per window
bytes:   512 KiB per service/window, 8 MiB global (metered on the rows actually
         handed to persistence, not the OTLP wire message); counts and bytes both bind
logs:    ERROR/FATAL 50 per service/window; WARN off by default (20 when enabled);
         INFO/DEBUG aggregate-only
```

An error that is also slow consumes one slot, not two.

## Complete retained traces (#163)

Selection is trace-level, so every span of a selected trace is retained as it arrives — the hash makes this automatic. Bounded by `EXEMPLAR_MAX_SPANS_PER_TRACE` (500) and `EXEMPLAR_MAX_BYTES_PER_TRACE` (256 KiB). Forced truncation persists `truncated=true` plus retained/observed span counts on three new **nullable** `storage.Trace` columns (NULL = "no truncation claim made", deliberately distinct from `truncated=false`).

`createTracesIdempotent` gained a small update pass for these columns: the insert paths are first-writer-wins, and a trace long enough to be truncated arrives across several batches, so without it the row would keep its NULL forever. Cost is one UPDATE per truncated trace, which the budgets bound to a handful per service per window.

## Metrics

- `otelcontext_exemplar_eligible_total{signal,class}`
- `otelcontext_exemplar_dropped_total{signal,reason=budget_count|budget_bytes|stratum}`
- `otelcontext_exemplar_eviction_total`
- `otelcontext_exemplar_truncated_total`

## Config

Eleven `EXEMPLAR_*` vars in `internal/config`, validated at startup in every mode (a typo should fail at boot, not the day someone flips the mode during an incident).

## Tests

- Determinism: 600 offers, 5 shuffles + one-third duplicated → identical retained set
- Storm: 5,000 traces at 100% error rate → aggregate count/errors exact, raw persistence bounded at budget + counted displacements, drops recorded
- Priority fill: errors displace healthy; healthy cannot displace errors
- Byte budget binds with the count budget nowhere near binding (`budget_bytes` drops, zero `budget_count` drops)
- Overlap (error + slow) consumes one slot
- WARN opt-in toggle, and its budget does not eat the ERROR budget
- Truncation metadata end-to-end through Export + SQLite, plus storage-level round-trip and the multi-batch update case
- Sampler retirement: `SAMPLING_RATE` 1.0 vs 0.05 persist identically with a sampler deliberately wired alongside
- Legacy/shadow inertness; concurrent admission under `-race`

## Verification

```
go vet ./...                                    pass
go build ./...                                  pass
go test ./internal/ingest/ ./internal/storage/ ./internal/config/ -count=1 -race   405 passed
go test ./internal/... -count=1                 962 passed, 20 packages
```

## Deviations

- Trace-synthesized logs (span events, span status) apply the exemplar **severity floor** only, not a separate log budget: they belong to a span the policy already selected and metered, and re-budgeting them would punch holes in the complete-retained-trace contract for no bytes saved. The OTLP logs path gets the full per-service/window budget.
- The "2 exemplar refs per aggregate bucket" item from #161 is not implemented here — it belongs with the durable aggregate store (#173), which is being landed concurrently.

Refs #176