### PR TITLE
feat(aggregate): durable store - delta log, group commit, recovery, retention

### DIFF
--- a/internal/aggregate/engine.go
+++ b/internal/aggregate/engine.go
@@ -16,12 +16,14 @@ import (
 // mutable set is the current window plus the windows still inside the lateness
 // horizon; everything older is finalized and never re-enters memory.
 //
-// PHASE 1 LOSS, STATED PLAINLY: there is no durable store yet (#173). A window
-// that rolls out of the mutable set is DISCARDED, not finalized — its counts
-// are gone. That is acceptable only because Phase 1 runs in shadow mode, where
-// the legacy path remains the source of truth and the aggregate numbers exist
-// to be compared, not queried. Nothing in this package may be presented to a
-// user as authoritative until the group-commit writer lands.
+// ROLLOVER IS AN EVICTION, NOT A DELETION — once the durable store is wired
+// (#173). A window leaving the mutable set is dropped from the shards, and the
+// writer's finalize pass has already materialized it from the delta log into
+// aggregate_buckets; finalized history lives on disk and never comes back into
+// RAM. WITHOUT a store (no writer installed, engine constructed directly in a
+// test) rollover really is loss: the counts in the expiring window are gone,
+// which is why nothing may be presented to a user as authoritative unless the
+// group-commit writer is the applier.
 //
 // Shards are four plain mutex-guarded maps (hash & 3). No shard goroutines, no
 // channels. Two shard locks are NEVER held at once: a delta touches exactly one
@@ -89,6 +91,18 @@ type DeltaMap map[SeriesWindowKey]*AggregateDelta
 // the shards a projection of committed state. No caller changes when it does.
 type Applier interface {
 	Apply(DeltaMap) uint64
+}
+
+// FailableApplier is an Applier whose apply path can refuse. The durable
+// group-commit writer (#173) implements it: admission can be saturated
+// (ErrSaturated, mapped to RESOURCE_EXHAUSTED / 429) and a COMMIT can fail, and
+// under the durable-ACK contract neither may be acknowledged as success. The
+// Phase 1 direct applier does not implement it, which is what keeps legacy and
+// shadow behaviour identical when no store is wired.
+type FailableApplier interface {
+	Applier
+	// ApplyErr applies the deltas, returning the revision and any refusal.
+	ApplyErr(DeltaMap) (uint64, error)
 }
 
 // EngineConfig configures an Engine. Zero values take platform defaults.
@@ -294,11 +308,33 @@ func (e *Engine) ApplyReducer(r *Reducer) uint64 {
 
 // ApplyDeltas applies one reducer's output through the configured applier.
 func (e *Engine) ApplyDeltas(m DeltaMap) uint64 {
+	rev, _ := e.ApplyDeltasErr(m)
+	return rev
+}
+
+// ApplyReducerErr is ApplyReducer for callers that must honour the durable-ACK
+// contract: it returns the applier's refusal so an Export can answer
+// RESOURCE_EXHAUSTED instead of acknowledging telemetry that is not durable.
+func (e *Engine) ApplyReducerErr(r *Reducer) (uint64, error) {
+	if r == nil {
+		return e.revision.Load(), nil
+	}
+	e.recordReduction(r)
+	return e.ApplyDeltasErr(r.Deltas())
+}
+
+// ApplyDeltasErr applies one reducer's output and surfaces any refusal. When
+// the configured applier cannot fail (Phase 1's direct applier) the error is
+// always nil.
+func (e *Engine) ApplyDeltasErr(m DeltaMap) (uint64, error) {
 	if len(m) == 0 {
-		return e.revision.Load()
+		return e.revision.Load(), nil
 	}
 	a := *e.applier.Load()
-	return a.Apply(m)
+	if fa, ok := a.(FailableApplier); ok {
+		return fa.ApplyErr(m)
+	}
+	return a.Apply(m), nil
 }
 
 // directApplier is the Phase 1 apply path: no durability, no batching.
@@ -318,6 +354,30 @@ func (d directApplier) Apply(m DeltaMap) uint64 { return d.e.ApplyCommitted(m) }
 func (e *Engine) ApplyCommitted(m DeltaMap) uint64 {
 	if len(m) == 0 {
 		return e.revision.Load()
+	}
+	resolved := e.Admit(m)
+
+	for i := range e.shards {
+		e.applyShard(i, resolved)
+	}
+
+	rev := e.revision.Add(1)
+	e.publishActiveSeries()
+	return rev
+}
+
+// Admit rolls the mutable window set forward and resolves one batch of deltas
+// against the cardinality budget WITHOUT touching the shards.
+//
+// The durable writer (#173) calls it before its COMMIT so the row that becomes
+// durable carries the same identity the shards will later hold: admitting after
+// the write would let the store accumulate series the in-memory caps already
+// rerouted to __other__. Admission is idempotent for a series already present
+// in a window, so the ApplyCommitted that follows the commit re-resolves the
+// same map to itself.
+func (e *Engine) Admit(m DeltaMap) DeltaMap {
+	if len(m) == 0 {
+		return m
 	}
 	e.Rollover(e.now())
 
@@ -344,14 +404,7 @@ func (e *Engine) ApplyCommitted(m DeltaMap) uint64 {
 		}
 		resolved[target] = d
 	}
-
-	for i := range e.shards {
-		e.applyShard(i, resolved)
-	}
-
-	rev := e.revision.Add(1)
-	e.publishActiveSeries()
-	return rev
+	return resolved
 }
 
 // applyShard folds every entry belonging to shard i into it, under that shard's
@@ -385,12 +438,12 @@ func (e *Engine) applyShard(i int, resolved DeltaMap) {
 	}
 }
 
-// Rollover discards every window whose lateness horizon has expired and returns
+// Rollover evicts every window whose lateness horizon has expired and returns
 // how many it dropped.
 //
-// Phase 1 DISCARDS. There is no delta log to finalize from and no bucket table
-// to materialize into, so the counts in an expiring window are lost. See the
-// file header: this is shadow-mode behavior, not the durability contract.
+// With the durable store wired, the window has already been finalized into
+// aggregate_buckets by the writer's finalize pass, so this is an eviction from
+// RAM. Without a store it is loss. See the file header.
 func (e *Engine) Rollover(now time.Time) int {
 	cutoff := now.Unix() - int64(WindowSize/time.Second) - int64(AllowedLateness/time.Second)
 	dropped := 0

--- a/internal/aggregate/metrics.go
+++ b/internal/aggregate/metrics.go
@@ -1,6 +1,10 @@
 package aggregate
 
-import "github.com/RandomCodeSpace/otelcontext/internal/telemetry"
+import (
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/telemetry"
+)
 
 // Metric plumbing. The Prometheus collectors themselves live in
 // internal/telemetry with every other subsystem's metrics — that package owns
@@ -88,4 +92,86 @@ func (r promRecorder) SetActiveSeries(active map[Signal]int) {
 	for sig := SignalTraceOp; sig <= signalMax; sig++ {
 		r.m.AggregateSeriesActive.WithLabelValues(sig.String()).Set(float64(active[sig]))
 	}
+}
+
+// promStoreRecorder bridges the durable store and the group-commit writer onto
+// the platform's Prometheus metrics.
+type promStoreRecorder struct{ m *telemetry.Metrics }
+
+// NewPrometheusStoreMetrics returns a StoreMetrics backed by the platform
+// metrics. A nil *telemetry.Metrics yields a no-op recorder rather than a
+// panic, which is what every store unit test passes.
+func NewPrometheusStoreMetrics(m *telemetry.Metrics) StoreMetrics {
+	if m == nil {
+		return noopStoreMetrics{}
+	}
+	return promStoreRecorder{m: m}
+}
+
+// result renders an error as a metric label value.
+func result(err error) string {
+	if err != nil {
+		return "error"
+	}
+	return "ok"
+}
+
+// RecordCommit implements StoreMetrics.
+func (r promStoreRecorder) RecordCommit(d time.Duration, deltas int, bytes int64, err error) {
+	label := result(err)
+	r.m.AggregateCommitDurationSeconds.WithLabelValues(label).Observe(d.Seconds())
+	r.m.AggregateCommitsTotal.WithLabelValues(label).Inc()
+	r.m.AggregateCommitDeltas.Observe(float64(deltas))
+	if bytes > 0 {
+		r.m.AggregateCommitBytesTotal.Add(float64(bytes))
+	}
+}
+
+// RecordAdmissionRejected implements StoreMetrics.
+func (r promStoreRecorder) RecordAdmissionRejected(bound string) {
+	r.m.AggregateAdmissionRejectedTotal.WithLabelValues(bound).Inc()
+}
+
+// RecordFinalize implements StoreMetrics.
+func (r promStoreRecorder) RecordFinalize(stats FinalizeStats, err error) {
+	r.m.AggregateFinalizeDurationSeconds.Observe(stats.Duration.Seconds())
+	if err != nil {
+		return
+	}
+	if stats.Buckets > 0 {
+		r.m.AggregateFinalizeRowsTotal.WithLabelValues("buckets").Add(float64(stats.Buckets))
+	}
+	if stats.DeltaRows > 0 {
+		r.m.AggregateFinalizeRowsTotal.WithLabelValues("deltas").Add(float64(stats.DeltaRows))
+	}
+}
+
+// RecordPurge implements StoreMetrics.
+func (r promStoreRecorder) RecordPurge(stats PurgeStats, err error) {
+	r.m.AggregatePurgeDurationSeconds.Observe(stats.Duration.Seconds())
+	if err != nil {
+		return
+	}
+	for kind, n := range map[string]int64{
+		"buckets":   stats.Buckets,
+		"deltas":    stats.Deltas,
+		"baselines": stats.Baselines,
+	} {
+		if n > 0 {
+			r.m.AggregatePurgeRowsTotal.WithLabelValues(kind).Add(float64(n))
+		}
+	}
+}
+
+// SetBacklog implements StoreMetrics.
+func (r promStoreRecorder) SetBacklog(rows int64, ageSeconds float64) {
+	r.m.AggregateDeltaLogRows.Set(float64(rows))
+	r.m.AggregateDeltaLogAgeSeconds.Set(ageSeconds)
+}
+
+// RecordRecovery implements StoreMetrics.
+func (r promStoreRecorder) RecordRecovery(d time.Duration, replayed, finalized int) {
+	r.m.AggregateRecoveryDurationSeconds.Set(d.Seconds())
+	r.m.AggregateRecoveryRows.WithLabelValues("replayed").Set(float64(replayed))
+	r.m.AggregateRecoveryRows.WithLabelValues("finalized_windows").Set(float64(finalized))
 }

--- a/internal/aggregate/recovery.go
+++ b/internal/aggregate/recovery.go
@@ -1,0 +1,256 @@
+package aggregate
+
+import (
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+)
+
+// Startup recovery (#160, #173).
+//
+// Three things happen, in this order, before the process reports ready:
+//
+//  1. Windows whose lateness horizon expired while the process was down are
+//     finalized transactionally from the delta log. They are history now; they
+//     must not come back as mutable state.
+//  2. The delta-log rows of still-mutable windows are replayed into the shards,
+//     so acknowledged-but-unfinalized aggregates survive the crash.
+//  3. Durable cumulative baselines are seeded into the tracker, so the first
+//     cumulative point after a restart converts instead of re-seeding.
+//
+// FINALIZED HISTORY NEVER HYDRATES INTO RAM. Only the delta log is read, and
+// only for windows still inside the mutable set — the bucket table is a read
+// path, not a startup path.
+//
+// Readiness is held false until this completes. A process that answers /ready
+// while its shards are half-populated would serve numbers that are wrong in a
+// way no dashboard can detect.
+
+// RecoveryStats is the outcome of one startup recovery.
+type RecoveryStats struct {
+	// FinalizedWindows counts windows finalized because their lateness
+	// horizon expired during downtime.
+	FinalizedWindows int
+	// ReplayedRows and ReplayedSeries count delta-log rows read back and the
+	// distinct (series, window) pairs they folded into.
+	ReplayedRows   int
+	ReplayedSeries int
+	// SeededBaselines counts cumulative baselines restored.
+	SeededBaselines int
+	// SkippedSeries counts delta rows whose series id no longer resolves —
+	// structurally impossible while registration and first delta share a
+	// transaction, so a non-zero value here is a corruption signal.
+	SkippedSeries int
+	// Duration is the wall time of the whole recovery.
+	Duration time.Duration
+}
+
+// RecoveryGate reports whether startup recovery has completed. The readiness
+// probe holds /ready at 503 until Done() is true.
+type RecoveryGate struct {
+	done atomic.Bool
+}
+
+// NewRecoveryGate returns a gate that starts closed.
+func NewRecoveryGate() *RecoveryGate { return &RecoveryGate{} }
+
+// Done reports whether recovery has completed.
+func (g *RecoveryGate) Done() bool {
+	if g == nil {
+		return true
+	}
+	return g.done.Load()
+}
+
+// Complete opens the gate.
+func (g *RecoveryGate) Complete() {
+	if g != nil {
+		g.done.Store(true)
+	}
+}
+
+// Recover replays the durable store into the engine. It must run before the
+// writer starts accepting Exports and before readiness flips.
+func Recover(store Store, engine *Engine, w *Writer, now time.Time) (RecoveryStats, error) {
+	start := time.Now()
+	var stats RecoveryStats
+	if store == nil || engine == nil {
+		return stats, nil
+	}
+
+	// 1. Windows whose lateness expired during downtime finalize now, so the
+	//    replay below cannot resurrect them as mutable state.
+	finalized, err := finalizeExpired(store, now)
+	if err != nil {
+		return stats, err
+	}
+	stats.FinalizedWindows = finalized
+
+	// 2. Replay the mutable delta log into the shards.
+	rows, err := store.ReplayMutable(MutableSince(now))
+	if err != nil {
+		return stats, err
+	}
+	stats.ReplayedRows = len(rows)
+	if len(rows) > 0 {
+		replayed, skipped, err := replayRows(store, engine, w, rows)
+		if err != nil {
+			return stats, err
+		}
+		stats.ReplayedSeries = replayed
+		stats.SkippedSeries = skipped
+	}
+
+	// 3. Seed the cumulative baselines.
+	seeded, err := seedBaselines(store, engine, w)
+	if err != nil {
+		return stats, err
+	}
+	stats.SeededBaselines = seeded
+
+	stats.Duration = time.Since(start)
+	return stats, nil
+}
+
+// finalizeExpired finalizes every window whose lateness horizon expired.
+func finalizeExpired(store Store, now time.Time) (int, error) {
+	done := 0
+	for {
+		windows, err := store.FinalizableWindows(FinalizeCutoff(now), finalizeWindowsPerPass)
+		if err != nil {
+			return done, fmt.Errorf("aggregate recovery: list expired windows: %w", err)
+		}
+		if len(windows) == 0 {
+			return done, nil
+		}
+		for _, window := range windows {
+			if _, err := store.FinalizeWindow(window); err != nil {
+				return done, fmt.Errorf("aggregate recovery: finalize window %d: %w", window, err)
+			}
+			done++
+		}
+		if len(windows) < finalizeWindowsPerPass {
+			return done, nil
+		}
+	}
+}
+
+// replayRows folds delta-log rows back into the shards. Rows are merged per
+// (series, window) first so the engine sees one apply, not one per commit that
+// ever touched the window.
+func replayRows(store Store, engine *Engine, w *Writer, rows []DeltaRow) (replayed, skipped int, err error) {
+	keys, err := seriesKeys(store, w, distinctSeriesIDs(rows))
+	if err != nil {
+		return 0, 0, err
+	}
+	m := make(DeltaMap, len(rows))
+	for _, row := range rows {
+		key, ok := keys[row.SeriesID]
+		if !ok {
+			skipped++
+			continue
+		}
+		swk := SeriesWindowKey{Key: key, WindowStart: row.WindowStart}
+		if cur, ok := m[swk]; ok {
+			cur.Merge(row.Delta)
+			continue
+		}
+		m[swk] = row.Delta
+	}
+	if len(m) > 0 {
+		engine.ApplyCommitted(m)
+	}
+	return len(m), skipped, nil
+}
+
+// seedBaselines restores the durable cumulative baselines.
+func seedBaselines(store Store, engine *Engine, w *Writer) (int, error) {
+	rows, err := store.LoadBaselines(0)
+	if err != nil {
+		return 0, fmt.Errorf("aggregate recovery: load baselines: %w", err)
+	}
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	ids := make([]SeriesID, 0, len(rows))
+	for _, r := range rows {
+		ids = append(ids, r.SeriesID)
+	}
+	keys, err := seriesKeys(store, w, ids)
+	if err != nil {
+		return 0, err
+	}
+	seeded := 0
+	for _, r := range rows {
+		key, ok := keys[r.SeriesID]
+		if !ok {
+			continue
+		}
+		engine.Baselines().Seed(key, r.Producer, r.Baseline)
+		seeded++
+	}
+	return seeded, nil
+}
+
+// distinctSeriesIDs collects the series ids referenced by rows.
+func distinctSeriesIDs(rows []DeltaRow) []SeriesID {
+	seen := make(map[SeriesID]struct{}, len(rows))
+	out := make([]SeriesID, 0, len(rows))
+	for _, r := range rows {
+		if _, ok := seen[r.SeriesID]; ok {
+			continue
+		}
+		seen[r.SeriesID] = struct{}{}
+		out = append(out, r.SeriesID)
+	}
+	return out
+}
+
+// seriesKeys resolves ids to identities, preferring the writer's warmed
+// in-memory map and falling back to the store in chunks that respect the
+// ResolveSeries input cap.
+func seriesKeys(store Store, w *Writer, ids []SeriesID) (map[SeriesID]SeriesKey, error) {
+	out := make(map[SeriesID]SeriesKey, len(ids))
+	var missing []SeriesID
+	for _, id := range ids {
+		if w != nil {
+			if key, ok := w.SeriesKeyByID(id); ok {
+				out[id] = key
+				continue
+			}
+		}
+		missing = append(missing, id)
+	}
+	for start := 0; start < len(missing); start += MaxReadRows {
+		end := start + MaxReadRows
+		if end > len(missing) {
+			end = len(missing)
+		}
+		infos, err := store.ResolveSeries(missing[start:end])
+		if err != nil {
+			return nil, fmt.Errorf("aggregate recovery: resolve series: %w", err)
+		}
+		for _, info := range infos {
+			out[info.ID] = info.Key
+		}
+	}
+	return out, nil
+}
+
+// LogRecovery emits the operator-facing recovery summary.
+func LogRecovery(stats RecoveryStats, path string) {
+	slog.Info("🔁 Aggregate store recovered",
+		"path", path,
+		"finalized_windows", stats.FinalizedWindows,
+		"replayed_rows", stats.ReplayedRows,
+		"replayed_series_windows", stats.ReplayedSeries,
+		"seeded_baselines", stats.SeededBaselines,
+		"unresolved_series", stats.SkippedSeries,
+		"duration", stats.Duration,
+	)
+	if stats.SkippedSeries > 0 {
+		slog.Error("aggregate recovery: delta rows referenced unknown series — the store may be corrupt",
+			"rows", stats.SkippedSeries)
+	}
+}

--- a/internal/aggregate/recovery_test.go
+++ b/internal/aggregate/recovery_test.go
@@ -1,0 +1,281 @@
+package aggregate
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Environment contract for the kill -9 child process.
+const (
+	crashChildEnv = "OTELCONTEXT_AGGREGATE_CRASH_CHILD"
+	crashPathEnv  = "OTELCONTEXT_AGGREGATE_CRASH_DB"
+)
+
+func TestRecoveryReplaysMutableWindowsOnly(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aggregate.db")
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	key := storeKey(1)
+
+	store := newTestStoreAt(t, path, StoreConfig{})
+	mutable := WindowStart(clock.Now())
+	stale := mutable - 4*int64(WindowSize/time.Second)
+	if err := store.CommitGroup(&GroupBatch{
+		Series: []SeriesRow{{ID: 1, Key: key}},
+		Deltas: []DeltaRow{
+			{SeriesID: 1, WindowStart: mutable, Delta: spanDelta(4, 100)},
+			{SeriesID: 1, WindowStart: stale, Delta: spanDelta(9, 100)},
+		},
+	}); err != nil {
+		t.Fatalf("CommitGroup: %v", err)
+	}
+
+	eng := newTestEngine(t, clock, nil)
+	stats, err := Recover(store, eng, nil, clock.Now())
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if stats.FinalizedWindows != 1 {
+		t.Fatalf("finalized %d windows, want 1 (the downtime-expired one)", stats.FinalizedWindows)
+	}
+	if stats.ReplayedRows != 1 {
+		t.Fatalf("replayed %d rows, want 1 (only the mutable window)", stats.ReplayedRows)
+	}
+	snap := eng.Snapshot()
+	count, _ := snap.Totals(SignalTraceOp)
+	if count != 4 {
+		t.Fatalf("engine holds %d points after replay, want 4 — finalized history must not hydrate", count)
+	}
+	if len(snap.Windows) != 1 || snap.Windows[0].Start.Unix() != mutable {
+		t.Fatalf("mutable window set = %+v, want only %d", snap.Windows, mutable)
+	}
+	assertCount(t, store, "aggregate_buckets", 1)
+}
+
+func TestRecoverySeedsBaselines(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aggregate.db")
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	key := SeriesKey{TenantID: 1, ServiceID: 1, NameID: 5, Signal: SignalMetric}
+	store := newTestStoreAt(t, path, StoreConfig{})
+	if err := store.CommitGroup(&GroupBatch{
+		Series: []SeriesRow{{ID: 1, Key: key}},
+		Baselines: []BaselineRow{{
+			SeriesID: 1,
+			Producer: 42,
+			Baseline: Baseline{
+				StartTime:     clock.Now().Add(-time.Hour),
+				LastTimestamp: clock.Now().Add(-time.Minute),
+				Value:         500,
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("CommitGroup: %v", err)
+	}
+
+	eng := newTestEngine(t, clock, nil)
+	stats, err := Recover(store, eng, nil, clock.Now())
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if stats.SeededBaselines != 1 {
+		t.Fatalf("seeded %d baselines, want 1", stats.SeededBaselines)
+	}
+	if eng.Baselines().DirtyCount() != 0 {
+		t.Fatal("recovered baselines must not be marked dirty")
+	}
+	// The next cumulative point converts against the recovered baseline instead
+	// of re-seeding — the restart gap #166 exists to close.
+	out := eng.Baselines().ObserveCumulative(key, 42, clock.Now().Add(-time.Hour), clock.Now(), 505)
+	if out.Seeded {
+		t.Fatal("point re-seeded the baseline; recovery did not restore it")
+	}
+	if out.Delta != 5 {
+		t.Fatalf("delta = %v, want 5", out.Delta)
+	}
+}
+
+func TestRecoveryFinalizesDowntimeExpiredWindows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aggregate.db")
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	store := newTestStoreAt(t, path, StoreConfig{})
+	eng := newTestEngine(t, clock, nil)
+	w := newTestWriter(t, store, eng, clock, WriterConfig{})
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 7)); err != nil {
+		t.Fatalf("ApplyDeltasErr: %v", err)
+	}
+	w.Stop()
+
+	// The process was down long enough for the window's lateness to expire.
+	clock.Advance(2 * (WindowSize + AllowedLateness))
+	eng2 := newTestEngine(t, clock, nil)
+	stats, err := Recover(store, eng2, nil, clock.Now())
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if stats.FinalizedWindows != 1 || stats.ReplayedRows != 0 {
+		t.Fatalf("recovery stats = %+v, want 1 finalized / 0 replayed", stats)
+	}
+	buckets, err := store.ReadBuckets(Selector{
+		TenantID: 1,
+		Start:    WindowStart(clock.Now()) - int64(4*(WindowSize+AllowedLateness)/time.Second),
+		End:      WindowStart(clock.Now()) + 1,
+	})
+	if err != nil {
+		t.Fatalf("ReadBuckets: %v", err)
+	}
+	if len(buckets) != 1 || buckets[0].Delta.Count != 7 {
+		t.Fatalf("finalized buckets = %+v, want one bucket with count 7", buckets)
+	}
+	if count, _ := eng2.Snapshot().Totals(SignalTraceOp); count != 0 {
+		t.Fatalf("engine hydrated %d points of finalized history, want 0", count)
+	}
+}
+
+// TestCrashAfterACKSurvivesKill9 is the release-gate durability test: a child
+// process acknowledges an Export and is then SIGKILLed with no chance to close
+// the database. The acknowledged deltas must be present after reopening, and
+// deltas that were never acknowledged must not be.
+func TestCrashAfterACKSurvivesKill9(t *testing.T) {
+	if os.Getenv(crashChildEnv) == "1" {
+		crashChild(t)
+		return
+	}
+	if runtime.GOOS != "linux" {
+		t.Skip("kill -9 crash test requires linux")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "aggregate.db")
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestCrashAfterACKSurvivesKill9", "-test.v")
+	cmd.Env = append(os.Environ(), crashChildEnv+"=1", crashPathEnv+"="+path)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("child exited cleanly; it was supposed to be killed. output:\n%s", out)
+	}
+	var exitErr *exec.ExitError
+	if !asExitError(err, &exitErr) {
+		t.Fatalf("child failed with %v, want a signal death. output:\n%s", err, out)
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok || !status.Signaled() || status.Signal() != syscall.SIGKILL {
+		t.Fatalf("child exit status = %v (signaled=%v), want SIGKILL. output:\n%s", exitErr, ok, out)
+	}
+	if !strings.Contains(string(out), "ACKED") {
+		t.Fatalf("child was killed before the ACK; the test proves nothing. output:\n%s", out)
+	}
+
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	store := newTestStoreAt(t, path, StoreConfig{})
+	eng := newTestEngine(t, clock, nil)
+	stats, err := Recover(store, eng, nil, clock.Now())
+	if err != nil {
+		t.Fatalf("Recover after kill -9: %v", err)
+	}
+	if stats.ReplayedRows == 0 {
+		t.Fatalf("no acknowledged deltas survived the kill. child output:\n%s", out)
+	}
+	count, _ := eng.Snapshot().Totals(SignalTraceOp)
+	if count != 11 {
+		t.Fatalf("recovered %d acknowledged points, want 11. child output:\n%s", count, out)
+	}
+}
+
+// crashChild is the child half of TestCrashAfterACKSurvivesKill9: acknowledge
+// an Export, then die without closing anything.
+func crashChild(t *testing.T) {
+	path := os.Getenv(crashPathEnv)
+	if path == "" {
+		t.Fatalf("%s is unset", crashPathEnv)
+	}
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	store, err := OpenSQLiteStore(StoreConfig{Path: path})
+	if err != nil {
+		t.Fatalf("child: OpenSQLiteStore: %v", err)
+	}
+	eng, err := NewEngine(EngineConfig{Mode: ModeAggregate, Now: clock.Now})
+	if err != nil {
+		t.Fatalf("child: NewEngine: %v", err)
+	}
+	w, err := NewWriter(WriterConfig{
+		Store: store, Engine: eng, Now: clock.Now, FinalizeInterval: -1,
+	})
+	if err != nil {
+		t.Fatalf("child: NewWriter: %v", err)
+	}
+	eng.SetApplier(w)
+	w.Start()
+
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 11)); err != nil {
+		t.Fatalf("child: ApplyDeltasErr: %v", err)
+	}
+	// Printed only after the durable ACK returned. The parent refuses to draw
+	// any conclusion without it.
+	t.Log("ACKED")
+	os.Stdout.Sync()
+
+	// No Stop(), no Close(), no checkpoint: exactly what a container OOM-kill
+	// or kill -9 does.
+	if err := syscall.Kill(os.Getpid(), syscall.SIGKILL); err != nil {
+		t.Fatalf("child: kill self: %v", err)
+	}
+	select {} // unreachable; keeps the signal from racing the return
+}
+
+// asExitError is errors.As specialised for *exec.ExitError without pulling the
+// generic helper into this file's imports twice.
+func asExitError(err error, target **exec.ExitError) bool {
+	if e, ok := err.(*exec.ExitError); ok {
+		*target = e
+		return true
+	}
+	return false
+}
+
+// TestReopenWithoutCheckpointKeepsAcknowledgedDeltas is the portable sibling of
+// the kill -9 test: it closes the pools without a WAL checkpoint and reopens.
+// It exercises WAL recovery but NOT process death, so it is a weaker claim —
+// the kill -9 test above is the one that proves the ACK contract.
+func TestReopenWithoutCheckpointKeepsAcknowledgedDeltas(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aggregate.db")
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	store, err := OpenSQLiteStore(StoreConfig{Path: path})
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore: %v", err)
+	}
+	eng := newTestEngine(t, clock, nil)
+	w := newTestWriter(t, store, eng, clock, WriterConfig{})
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 6)); err != nil {
+		t.Fatalf("ApplyDeltasErr: %v", err)
+	}
+	w.Stop()
+	_ = store.Close()
+
+	reopened := newTestStoreAt(t, path, StoreConfig{})
+	eng2 := newTestEngine(t, clock, nil)
+	if _, err := Recover(reopened, eng2, nil, clock.Now()); err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if count, _ := eng2.Snapshot().Totals(SignalTraceOp); count != 6 {
+		t.Fatalf("recovered %d points, want 6", count)
+	}
+}
+
+func TestRecoveryGateHoldsReadiness(t *testing.T) {
+	gate := NewRecoveryGate()
+	if gate.Done() {
+		t.Fatal("a fresh gate must report not-ready")
+	}
+	gate.Complete()
+	if !gate.Done() {
+		t.Fatal("gate did not open")
+	}
+	var nilGate *RecoveryGate
+	if !nilGate.Done() {
+		t.Fatal("a nil gate must be transparent for configurations without a store")
+	}
+}

--- a/internal/aggregate/registrar.go
+++ b/internal/aggregate/registrar.go
@@ -1,0 +1,274 @@
+package aggregate
+
+import (
+	"fmt"
+	"math"
+	"slices"
+	"sync"
+)
+
+// Durable identity: dictionary entries and series rows whose IDs are owned by
+// the database (ADR 0001, #162's first atomicity invariant).
+//
+// The hot path needs an ID synchronously — the reducer cannot build a SeriesKey
+// without one — but #162 requires that a registration and the first delta that
+// references it become durable together. Both hold because an ID is MINTED
+// in memory and the row is STAGED: every group commit drains all staged rows,
+// so the registration row is always in the same transaction as the first delta
+// that could reference it, or in an earlier one.
+//
+// A crash between minting and committing loses the ID, not correctness: nothing
+// committed ever referenced it. On restart the counter reseeds from MAX(id) and
+// the number may be minted again for a different value, which is safe for
+// exactly the same reason.
+
+// DurableRegistrar is the Registrar backed by the aggregate store. It replaces
+// MemRegistrar whenever the store is enabled — the seam in dict.go exists for
+// this and needs no other change.
+type DurableRegistrar struct {
+	mu      sync.Mutex
+	next    uint32
+	ids     map[dictScope]map[string]uint32
+	other   map[dictScope]uint32
+	pending map[uint32]DictRow
+	limits  map[Kind]int
+	counts  map[dictScope]int
+}
+
+// NewDurableRegistrar builds a registrar warmed from the store's dictionary so
+// IDs survive restart. limits caps entries per (tenant, kind); a missing or
+// zero entry means unlimited, and __other__ entries are always exempt.
+func NewDurableRegistrar(store Store, limits map[Kind]int) (*DurableRegistrar, error) {
+	r := &DurableRegistrar{
+		next:    1, // 0 is the "none" sentinel and is never minted.
+		ids:     make(map[dictScope]map[string]uint32),
+		other:   make(map[dictScope]uint32),
+		pending: make(map[uint32]DictRow),
+		counts:  make(map[dictScope]int),
+	}
+	if len(limits) > 0 {
+		r.limits = make(map[Kind]int, len(limits))
+		for k, v := range limits {
+			r.limits[k] = v
+		}
+	}
+	if store == nil {
+		return r, nil
+	}
+	rows, err := store.LoadDict(0)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		scope := dictScope{tenant: row.TenantID, kind: row.Kind}
+		inner := r.ids[scope]
+		if inner == nil {
+			inner = make(map[string]uint32)
+			r.ids[scope] = inner
+		}
+		value := string(row.Value)
+		inner[value] = row.ID
+		if value == OtherValue {
+			r.other[scope] = row.ID
+		} else {
+			r.counts[scope]++
+		}
+		if row.ID >= r.next {
+			r.next = row.ID + 1
+		}
+	}
+	return r, nil
+}
+
+// Register implements Registrar.
+func (r *DurableRegistrar) Register(tenantID uint32, kind Kind, value []byte) (uint32, error) {
+	if !kind.Valid() {
+		return 0, fmt.Errorf("aggregate: register: invalid dictionary kind %d", uint8(kind))
+	}
+	if len(value) == 0 {
+		// An empty value cannot be a durable identity: it resolves back to
+		// nothing and every empty value in a namespace would be the same
+		// entry. The Cache turns this into the __other__ ID, which is the
+		// correct home for an identity we cannot name.
+		return 0, ErrDictFull
+	}
+	scope := dictScope{tenant: tenantID, kind: kind}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if id, ok := r.ids[scope][string(value)]; ok {
+		return id, nil
+	}
+	if limit, ok := r.limits[kind]; ok && limit > 0 && r.counts[scope] >= limit {
+		return 0, ErrDictFull
+	}
+	id, err := r.mintLocked(scope, value)
+	if err != nil {
+		return 0, err
+	}
+	r.counts[scope]++
+	return id, nil
+}
+
+// OtherID implements Registrar. The overflow entry bypasses the capacity cap:
+// a quota must never block creation of the entry that absorbs quota violations.
+func (r *DurableRegistrar) OtherID(tenantID uint32, kind Kind) uint32 {
+	scope := dictScope{tenant: tenantID, kind: kind}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if id, ok := r.other[scope]; ok {
+		return id
+	}
+	id, err := r.mintLocked(scope, []byte(OtherValue))
+	if err != nil {
+		return 0
+	}
+	r.other[scope] = id
+	return id
+}
+
+// mintLocked allocates an ID and stages its row. r.mu must be held.
+func (r *DurableRegistrar) mintLocked(scope dictScope, value []byte) (uint32, error) {
+	if r.next == math.MaxUint32 {
+		return 0, ErrDictFull
+	}
+	id := r.next
+	r.next++
+	inner := r.ids[scope]
+	if inner == nil {
+		inner = make(map[string]uint32)
+		r.ids[scope] = inner
+	}
+	inner[string(value)] = id
+	r.pending[id] = DictRow{ID: id, TenantID: scope.tenant, Kind: scope.kind, Value: slices.Clone(value)}
+	return id, nil
+}
+
+// DrainPending returns the staged rows for inclusion in the next group commit.
+// They stay staged until Committed confirms them, so a failed commit re-offers
+// them instead of stranding an ID that no row backs.
+func (r *DurableRegistrar) DrainPending() []DictRow {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.pending) == 0 {
+		return nil
+	}
+	out := make([]DictRow, 0, len(r.pending))
+	for _, row := range r.pending {
+		out = append(out, row)
+	}
+	slices.SortFunc(out, func(a, b DictRow) int { return int(a.ID) - int(b.ID) })
+	return out
+}
+
+// Committed marks drained rows durable.
+func (r *DurableRegistrar) Committed(rows []DictRow) {
+	if len(rows) == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, row := range rows {
+		delete(r.pending, row.ID)
+	}
+}
+
+// PendingCount returns how many registrations are staged but not yet durable.
+func (r *DurableRegistrar) PendingCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.pending)
+}
+
+// seriesRegistry mints and stages series IDs. It follows the registrar's
+// pattern exactly, one level up: the ID is needed to write a delta row, the row
+// that defines it rides the same transaction.
+//
+// Unlike the dictionary, series identity is resolved by the WRITER, not the hot
+// path — the writer already holds the whole (SeriesKey -> delta) map, so no
+// ingest goroutine ever pays for series resolution.
+type seriesRegistry struct {
+	mu      sync.Mutex
+	next    SeriesID
+	ids     map[SeriesKey]SeriesID
+	keys    map[SeriesID]SeriesKey
+	pending map[SeriesID]SeriesRow
+}
+
+// newSeriesRegistry warms a registry from the store.
+func newSeriesRegistry(store Store) (*seriesRegistry, error) {
+	r := &seriesRegistry{
+		next:    1,
+		ids:     make(map[SeriesKey]SeriesID),
+		keys:    make(map[SeriesID]SeriesKey),
+		pending: make(map[SeriesID]SeriesRow),
+	}
+	if store == nil {
+		return r, nil
+	}
+	rows, err := store.LoadSeries(0)
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		r.ids[row.Key] = row.ID
+		r.keys[row.ID] = row.Key
+		if row.ID >= r.next {
+			r.next = row.ID + 1
+		}
+	}
+	return r, nil
+}
+
+// Resolve returns the series ID for key, minting and staging one on first use.
+func (r *seriesRegistry) Resolve(key SeriesKey) SeriesID {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if id, ok := r.ids[key]; ok {
+		return id
+	}
+	id := r.next
+	r.next++
+	r.ids[key] = id
+	r.keys[id] = key
+	r.pending[id] = SeriesRow{ID: id, Key: key}
+	return id
+}
+
+// Key resolves an ID back to its identity from the in-memory map.
+func (r *seriesRegistry) Key(id SeriesID) (SeriesKey, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	k, ok := r.keys[id]
+	return k, ok
+}
+
+// DrainPending returns the staged series rows for the next group commit.
+func (r *seriesRegistry) DrainPending() []SeriesRow {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.pending) == 0 {
+		return nil
+	}
+	out := make([]SeriesRow, 0, len(r.pending))
+	for _, row := range r.pending {
+		out = append(out, row)
+	}
+	slices.SortFunc(out, func(a, b SeriesRow) int { return int(a.ID - b.ID) })
+	return out
+}
+
+// Committed marks drained series rows durable.
+func (r *seriesRegistry) Committed(rows []SeriesRow) {
+	if len(rows) == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, row := range rows {
+		delete(r.pending, row.ID)
+	}
+}
+
+// compile-time assertion that the durable registrar can replace the in-memory
+// one wherever dict.go expects a Registrar.
+var _ Registrar = (*DurableRegistrar)(nil)

--- a/internal/aggregate/store.go
+++ b/internal/aggregate/store.go
@@ -1,0 +1,348 @@
+package aggregate
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// The durable aggregate store (#173, decided in #162 / #160 / #166).
+//
+// This file owns the store's TYPES and CONTRACT; store_sqlite.go owns the only
+// implementation. The split is the escape hatch #162 asked for: if the SQLite
+// benchmark gate fails, a second implementation satisfies this interface
+// without the writer, the engine or the ingest path noticing.
+//
+// Two rules are structural, not conventional:
+//
+//  1. No *sql.Tx, *sql.DB or any transaction-scoped primitive escapes the
+//     implementation. Write ownership is coarse: a caller hands over a whole
+//     GroupBatch and gets back "committed" or "not committed". There is no way
+//     for a caller to hold a transaction open across a lock, which is how the
+//     single SQLite writer stays available.
+//  2. Every read method enforces its own maximum. The worst case is 6,000
+//     series x 2,016 windows; a caller is not trusted to bound that itself.
+
+// StoreSchemaVersion is the aggregate schema version written into
+// aggregate_meta at creation and verified at every open. There are no
+// automatic migrations in v1 (#162): a mismatch fails startup and the operator
+// chooses between an older binary and AGGREGATE_ALLOW_REBUILD=true.
+const StoreSchemaVersion = 1
+
+// Store errors.
+var (
+	// ErrSaturated reports that the group-commit writer refused admission
+	// because one of its three bounds (pending bytes, waiters, deltas) is
+	// full. The ingest path maps it to gRPC RESOURCE_EXHAUSTED / HTTP 429,
+	// exactly like the raw pipeline's ErrQueueFull. Errors returned by the
+	// writer satisfy errors.Is(err, ErrSaturated) and carry which bound
+	// tripped via *SaturationError.
+	ErrSaturated = errors.New("aggregate: store admission saturated")
+
+	// ErrStoreClosed reports use of a closed store or writer.
+	ErrStoreClosed = errors.New("aggregate: store closed")
+
+	// ErrSelectorUnbounded reports a read whose selector is missing a
+	// mandatory bound (window range, tenant scope) or asks for more than the
+	// store-side row cap.
+	ErrSelectorUnbounded = errors.New("aggregate: unbounded selector")
+)
+
+// SchemaError reports a database whose aggregate schema this build cannot use:
+// a partial schema, missing meta, or a version mismatch. It is fatal at
+// startup by design — silently adopting an unknown layout is how a store
+// starts returning numbers nobody can explain.
+type SchemaError struct {
+	// Reason is a short machine-ish description ("missing_meta",
+	// "partial_schema", "version_mismatch").
+	Reason string
+	// Key names the meta key when Reason is "version_mismatch".
+	Key string
+	// Got and Want are the mismatched values.
+	Got, Want string
+	// Detail carries anything else worth printing.
+	Detail string
+}
+
+func (e *SchemaError) Error() string {
+	switch e.Reason {
+	case "version_mismatch":
+		return fmt.Sprintf("aggregate store: %s is %s, this build writes %s "+
+			"(no automatic migrations in v1; run an older binary or set AGGREGATE_ALLOW_REBUILD=true to DESTROY and recreate aggregate data)",
+			e.Key, e.Got, e.Want)
+	default:
+		return fmt.Sprintf("aggregate store: %s: %s "+
+			"(set AGGREGATE_ALLOW_REBUILD=true to DESTROY and recreate aggregate data)", e.Reason, e.Detail)
+	}
+}
+
+// SaturationError reports which admission bound refused a CommitGroup.
+type SaturationError struct {
+	// Bound is "bytes", "waiters" or "deltas".
+	Bound string
+	// Current is the value at the moment of refusal; Limit is the cap.
+	Current, Limit int64
+}
+
+func (e *SaturationError) Error() string {
+	return fmt.Sprintf("aggregate: commit admission refused: %s %d >= %d", e.Bound, e.Current, e.Limit)
+}
+
+// Is makes errors.Is(err, ErrSaturated) true for every saturation refusal.
+func (e *SaturationError) Is(target error) bool { return target == ErrSaturated }
+
+// SeriesID is the durable identity of a series. IDs are minted by the database
+// (ADR 0001) so a recovered bucket always resolves to an identity that exists.
+type SeriesID int64
+
+// DictRow is one dictionary registration awaiting commit. ID is assigned by the
+// registrar before the row is written, because the hot path needs the ID
+// synchronously; the row itself lands in the same transaction as the first
+// delta that references it (#162's first atomicity invariant).
+type DictRow struct {
+	ID       uint32
+	TenantID uint32
+	Kind     Kind
+	Value    []byte
+}
+
+// SeriesRow is one series registration awaiting commit. Identity columns are
+// explicit — there is no generic "variant" column (#162).
+type SeriesRow struct {
+	ID  SeriesID
+	Key SeriesKey
+}
+
+// DeltaRow is one append-only delta-log row: the pre-merged contribution of one
+// group commit to one (series, window).
+type DeltaRow struct {
+	// Seq is the monotonic local sequence number. It is assigned by the
+	// database on insert and is only meaningful on rows read back.
+	Seq int64
+	// SeriesID and WindowStart identify the bucket the row contributes to.
+	SeriesID    SeriesID
+	WindowStart int64
+	// Delta is the aggregate contribution. Its sketch is encoded with the
+	// versioned codec from #157 on write and decoded on read.
+	Delta *AggregateDelta
+}
+
+// BaselineRow is one durable cumulative baseline (#166). It is upserted inside
+// the same group commit as the deltas it justifies, so a restart never has to
+// re-seed a counter it already acknowledged points for.
+type BaselineRow struct {
+	SeriesID SeriesID
+	Producer ProducerID
+	Baseline Baseline
+}
+
+// GroupBatch is one group commit: everything that must become durable together.
+//
+// The three atomicity invariants of #162 are structural here — they are not a
+// convention the implementation is asked to honour, they are the shape of the
+// only write entry point:
+//
+//	Dicts + Series + Deltas in one struct  -> registration and the first
+//	                                          referencing delta cannot split.
+//	Baselines in the same struct           -> a baseline cannot become durable
+//	                                          without the delta it justifies
+//	                                          (and vice versa).
+//	FinalizeWindow's materialize+delete    -> the third invariant, one method.
+type GroupBatch struct {
+	Dicts     []DictRow
+	Series    []SeriesRow
+	Deltas    []DeltaRow
+	Baselines []BaselineRow
+}
+
+// Empty reports whether the batch would commit nothing.
+func (b *GroupBatch) Empty() bool {
+	return len(b.Dicts) == 0 && len(b.Series) == 0 && len(b.Deltas) == 0 && len(b.Baselines) == 0
+}
+
+// SeriesInfo is a series' durable identity, resolved back from its ID.
+type SeriesInfo struct {
+	ID  SeriesID
+	Key SeriesKey
+}
+
+// Bucket is one finalized (window, series) row.
+type Bucket struct {
+	WindowStart int64
+	SeriesID    SeriesID
+	Delta       *AggregateDelta
+}
+
+// Selector bounds a bucket read. Both window bounds and a tenant are
+// mandatory: an unbounded scan of seven days of history is not a query, it is
+// an outage (#162).
+type Selector struct {
+	// TenantID scopes the read. Required.
+	TenantID uint32
+	// Start and End bound the window range, inclusive of Start and exclusive
+	// of End, in UTC-aligned Unix seconds. Required, Start < End.
+	Start, End int64
+	// Signal, when non-zero, restricts the read to one signal.
+	Signal Signal
+	// SeriesIDs, when non-empty, restricts the read to these series.
+	SeriesIDs []SeriesID
+	// Limit caps returned rows. Zero takes MaxReadRows; anything above it is
+	// clamped down, never up.
+	Limit int
+}
+
+// MaxReadRows is the store-side cap on rows returned by one ReadBuckets call
+// and on IDs accepted by one ResolveSeries call.
+const MaxReadRows = 20000
+
+// MaxReadWindowSpan bounds the window range one ReadBuckets call may cover: the
+// 168 h retention horizon plus one window of slack, expressed in seconds.
+const MaxReadWindowSpan = int64(168*time.Hour/time.Second) + int64(WindowSize/time.Second)
+
+// Validate applies the mandatory bounds and returns the effective row limit.
+func (s Selector) Validate() (int, error) {
+	if s.TenantID == 0 && s.Start == 0 && s.End == 0 {
+		return 0, fmt.Errorf("%w: selector is empty", ErrSelectorUnbounded)
+	}
+	if s.Start <= 0 || s.End <= 0 || s.End <= s.Start {
+		return 0, fmt.Errorf("%w: window range [%d,%d) is not a bounded forward range", ErrSelectorUnbounded, s.Start, s.End)
+	}
+	if s.End-s.Start > MaxReadWindowSpan {
+		return 0, fmt.Errorf("%w: window range spans %ds, cap is %ds", ErrSelectorUnbounded, s.End-s.Start, MaxReadWindowSpan)
+	}
+	if len(s.SeriesIDs) > MaxReadRows {
+		return 0, fmt.Errorf("%w: %d series ids, cap is %d", ErrSelectorUnbounded, len(s.SeriesIDs), MaxReadRows)
+	}
+	limit := s.Limit
+	if limit <= 0 || limit > MaxReadRows {
+		limit = MaxReadRows
+	}
+	return limit, nil
+}
+
+// FinalizeStats is the outcome of finalizing one window.
+type FinalizeStats struct {
+	// WindowStart is the finalized window.
+	WindowStart int64
+	// Buckets is the number of bucket rows written or merged.
+	Buckets int
+	// DeltaRows is the number of delta-log rows incorporated and deleted.
+	DeltaRows int
+	// Duration is the wall time of the transaction.
+	Duration time.Duration
+}
+
+// PurgeStats is the outcome of one retention purge.
+type PurgeStats struct {
+	// Buckets and Deltas count deleted rows.
+	Buckets int64
+	Deltas  int64
+	// Baselines counts baselines dropped because their series has no
+	// remaining data.
+	Baselines int64
+	// Duration is the wall time of the whole purge.
+	Duration time.Duration
+}
+
+// BacklogStats describes the delta-log backlog — the health bound #160 requires
+// an operator to be able to alarm on.
+type BacklogStats struct {
+	// Rows is the number of delta-log rows currently awaiting finalization.
+	Rows int64
+	// OldestWindow is the oldest un-finalized window start, 0 when empty.
+	OldestWindow int64
+	// Bytes is the approximate delta-log payload size.
+	Bytes int64
+}
+
+// Store is the durable aggregate store. Implementations must be safe for
+// concurrent use; CommitGroup and FinalizeWindow serialize internally on the
+// single writer.
+type Store interface {
+	// CommitGroup writes one group batch inside exactly one transaction.
+	// Either everything in the batch is durable when it returns nil, or
+	// nothing in it is.
+	CommitGroup(b *GroupBatch) error
+
+	// FinalizeWindow materializes the window's buckets from the delta log and
+	// deletes exactly the delta rows it incorporated, in one transaction.
+	FinalizeWindow(windowStart int64) (FinalizeStats, error)
+
+	// FinalizableWindows returns the un-finalized window starts at or below
+	// cutoff, oldest first, capped at limit.
+	FinalizableWindows(cutoff int64, limit int) ([]int64, error)
+
+	// PurgeBefore deletes finalized history older than cutoff.
+	PurgeBefore(cutoff int64) (PurgeStats, error)
+
+	// ReadBuckets returns finalized buckets matching sel. The selector's
+	// bounds are mandatory and the row cap is enforced store-side.
+	ReadBuckets(sel Selector) ([]Bucket, error)
+
+	// ReplayMutable returns the delta-log rows for windows at or after since —
+	// the mutable set only. Finalized history never hydrates into RAM (#160).
+	ReplayMutable(since int64) ([]DeltaRow, error)
+
+	// LoadBaselines returns every durable cumulative baseline, capped at max.
+	LoadBaselines(max int) ([]BaselineRow, error)
+
+	// ResolveSeries resolves series IDs back to their identity. The input
+	// count is capped at MaxReadRows.
+	ResolveSeries(ids []SeriesID) ([]SeriesInfo, error)
+
+	// LoadDict returns every dictionary row, capped at max. It is how the
+	// durable registrar warms its cache at startup so IDs stay stable.
+	LoadDict(max int) ([]DictRow, error)
+
+	// LoadSeries returns every series row, capped at max.
+	LoadSeries(max int) ([]SeriesRow, error)
+
+	// Backlog reports the delta-log backlog health bounds.
+	Backlog() (BacklogStats, error)
+
+	// Close releases the store's connections.
+	Close() error
+}
+
+// StoreMetrics is the durable path's metric surface. It mirrors the
+// MetricsRecorder pattern: an interface so tests need no live registry, and a
+// nil-safe no-op default.
+type StoreMetrics interface {
+	// RecordCommit publishes one group commit: its wall time, how many
+	// deltas it carried and how many bytes it wrote.
+	RecordCommit(d time.Duration, deltas int, bytes int64, err error)
+	// RecordAdmissionRejected counts one ErrSaturated refusal by bound.
+	RecordAdmissionRejected(bound string)
+	// RecordFinalize publishes one window finalization.
+	RecordFinalize(stats FinalizeStats, err error)
+	// RecordPurge publishes one retention purge.
+	RecordPurge(stats PurgeStats, err error)
+	// SetBacklog publishes the delta-log backlog health bounds.
+	SetBacklog(rows int64, ageSeconds float64)
+	// RecordRecovery publishes the startup recovery duration and how many
+	// delta rows were replayed.
+	RecordRecovery(d time.Duration, replayed int, finalized int)
+}
+
+// noopStoreMetrics is the default when no metrics are wired.
+type noopStoreMetrics struct{}
+
+func (noopStoreMetrics) RecordCommit(time.Duration, int, int64, error) {}
+func (noopStoreMetrics) RecordAdmissionRejected(string)                {}
+func (noopStoreMetrics) RecordFinalize(FinalizeStats, error)           {}
+func (noopStoreMetrics) RecordPurge(PurgeStats, error)                 {}
+func (noopStoreMetrics) SetBacklog(int64, float64)                     {}
+func (noopStoreMetrics) RecordRecovery(time.Duration, int, int)        {}
+
+// MutableSince returns the oldest window start still inside the mutable set at
+// now: the current window minus the lateness horizon. Everything strictly older
+// is finalized history and never re-enters memory.
+func MutableSince(now time.Time) int64 {
+	return WindowStart(now) - int64(AllowedLateness/time.Second)
+}
+
+// FinalizeCutoff returns the newest window start whose lateness horizon has
+// expired at now — windows at or below it are ready to finalize.
+func FinalizeCutoff(now time.Time) int64 {
+	return now.Unix() - int64(WindowSize/time.Second) - int64(AllowedLateness/time.Second)
+}

--- a/internal/aggregate/store_bench_test.go
+++ b/internal/aggregate/store_bench_test.go
@@ -1,0 +1,122 @@
+package aggregate
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// benchSeries is the dirty-series count #162's benchmark gate names.
+const benchSeries = 5000
+
+// benchStore opens a store outside the testing.T helpers.
+func benchStore(b *testing.B) *SQLiteStore {
+	b.Helper()
+	store, err := OpenSQLiteStore(StoreConfig{Path: filepath.Join(b.TempDir(), "aggregate.db")})
+	if err != nil {
+		b.Fatalf("OpenSQLiteStore: %v", err)
+	}
+	b.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// benchBatch builds one group commit touching n series in one window.
+func benchBatch(n int, window int64, withSeries bool) *GroupBatch {
+	batch := &GroupBatch{Deltas: make([]DeltaRow, 0, n)}
+	for i := 1; i <= n; i++ {
+		if withSeries {
+			batch.Series = append(batch.Series, SeriesRow{ID: SeriesID(i), Key: storeKey(uint32(i))})
+		}
+		batch.Deltas = append(batch.Deltas, DeltaRow{
+			SeriesID:    SeriesID(i),
+			WindowStart: window,
+			Delta:       spanDelta(4, float64(100+i%700)),
+		})
+	}
+	return batch
+}
+
+// BenchmarkCommitGroup5kSeries measures the group-commit shape the release gate
+// cares about: one transaction, 5,000 pre-merged delta rows with sketches.
+func BenchmarkCommitGroup5kSeries(b *testing.B) {
+	store := benchStore(b)
+	if err := store.CommitGroup(&GroupBatch{Series: benchBatch(benchSeries, 0, true).Series}); err != nil {
+		b.Fatalf("seed series: %v", err)
+	}
+	window := WindowStart(time.Unix(3_000_000, 0).UTC())
+	batch := benchBatch(benchSeries, window, false)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := store.CommitGroup(batch); err != nil {
+			b.Fatalf("CommitGroup: %v", err)
+		}
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(benchSeries), "deltas/commit")
+}
+
+// BenchmarkFinalizeWindow measures materializing a full window: 5,000 series x
+// 4 commits of delta rows collapsed into buckets and deleted.
+func BenchmarkFinalizeWindow(b *testing.B) {
+	window := WindowStart(time.Unix(3_000_000, 0).UTC())
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		store := benchStore(b)
+		if err := store.CommitGroup(&GroupBatch{Series: benchBatch(benchSeries, 0, true).Series}); err != nil {
+			b.Fatalf("seed series: %v", err)
+		}
+		batch := benchBatch(benchSeries, window, false)
+		for c := 0; c < 4; c++ {
+			if err := store.CommitGroup(batch); err != nil {
+				b.Fatalf("CommitGroup: %v", err)
+			}
+		}
+		b.StartTimer()
+		stats, err := store.FinalizeWindow(window)
+		if err != nil {
+			b.Fatalf("FinalizeWindow: %v", err)
+		}
+		b.StopTimer()
+		if stats.Buckets != benchSeries {
+			b.Fatalf("finalized %d buckets, want %d", stats.Buckets, benchSeries)
+		}
+		_ = store.Close()
+		b.StartTimer()
+	}
+}
+
+// BenchmarkWriterApply measures the end-to-end durable ACK path: reduce ->
+// admit -> group commit -> shard apply -> release.
+func BenchmarkWriterApply(b *testing.B) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	store := benchStore(b)
+	eng, err := NewEngine(EngineConfig{Mode: ModeAggregate, Now: clock.Now})
+	if err != nil {
+		b.Fatalf("NewEngine: %v", err)
+	}
+	w, err := NewWriter(WriterConfig{Store: store, Engine: eng, Now: clock.Now, FinalizeInterval: -1})
+	if err != nil {
+		b.Fatalf("NewWriter: %v", err)
+	}
+	eng.SetApplier(w)
+	w.Start()
+	defer w.Stop()
+
+	window := WindowStart(clock.Now())
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		n := uint32(0)
+		for pb.Next() {
+			n++
+			m := DeltaMap{
+				SeriesWindowKey{Key: storeKey(n % 64), WindowStart: window}: spanDelta(4, 250),
+			}
+			if _, err := eng.ApplyDeltasErr(m); err != nil {
+				b.Fatalf("ApplyDeltasErr: %v", err)
+			}
+		}
+	})
+}

--- a/internal/aggregate/store_sqlite.go
+++ b/internal/aggregate/store_sqlite.go
@@ -1,0 +1,1441 @@
+package aggregate
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	// Registers the "sqlite" database/sql driver. Same pure-Go engine the
+	// main relational path uses through its GORM dialector — the aggregate
+	// store deliberately does NOT go through GORM: it owns raw statements,
+	// its own connections, and its own PRAGMA stanza (ADR 0003).
+	_ "github.com/glebarez/go-sqlite"
+)
+
+// The SQLite aggregate store: data/aggregate.db, its own WAL, its own pool,
+// its own PRAGMA stanza (ADR 0003).
+//
+// Why a separate file at all: SQLite allows exactly one writer per database
+// file. Sharing OtelContext.db would serialize the durable-ACK group commit
+// behind raw-exemplar, GraphRAG and legacy writes, which is the same as saying
+// OTLP acknowledgment latency is a function of unrelated write bursts. No
+// cross-file transaction is needed because every aggregate table is
+// aggregate-owned.
+//
+// Connections: ONE writer connection (MaxOpenConns=1, plus an explicit mutex so
+// the ordering is visible rather than emergent) and a small read pool. The
+// writer mutex is also what makes FinalizeWindow's "materialize then delete
+// exactly the incorporated rows" safe: no commit can interleave with it.
+
+// Default store tuning.
+const (
+	// DefaultAggregateDBPath is the default AGGREGATE_DB_PATH.
+	DefaultAggregateDBPath = "./data/aggregate.db"
+	// defaultReadPoolSize is the read-connection count. Reads are dashboard
+	// range scans and recovery replays, not a hot path.
+	defaultReadPoolSize = 4
+	// defaultBusyTimeoutMs bounds how long a statement waits on the writer
+	// lock before erroring, matching the main DB's stanza.
+	defaultBusyTimeoutMs = 5000
+	// maxDictRows and maxSeriesRows bound the startup warm-up loads. Both are
+	// far above the #158 caps; they exist so a corrupted or hostile file
+	// cannot make startup allocate without bound.
+	maxDictRows   = 2_000_000
+	maxSeriesRows = 500_000
+	// purgeWindowsPerPass bounds how many windows one PurgeBefore call
+	// deletes, so retention never opens an unbounded transaction.
+	purgeWindowsPerPass = 4096
+)
+
+// aggregateTables is every table this store owns. AGGREGATE_ALLOW_REBUILD drops
+// exactly these and nothing else — the aggregate DB is its own file, but an
+// operator who points AGGREGATE_DB_PATH at the wrong file deserves a store that
+// only ever destroys its own tables.
+var aggregateTables = []string{
+	"aggregate_baseline",
+	"aggregate_buckets",
+	"aggregate_delta_log",
+	"aggregate_series",
+	"aggregate_dict",
+	"aggregate_meta",
+}
+
+// StoreConfig configures the SQLite aggregate store.
+type StoreConfig struct {
+	// Path is the database file (AGGREGATE_DB_PATH). Empty takes
+	// DefaultAggregateDBPath. ":memory:" and file: URIs are honoured for
+	// tests.
+	Path string
+	// AllowRebuild permits DESTROYING and recreating the aggregate tables
+	// when the on-disk schema is partial or version-mismatched
+	// (AGGREGATE_ALLOW_REBUILD). Off by default: silent data loss is worse
+	// than a refused startup.
+	AllowRebuild bool
+	// Synchronous is the SQLite synchronous mode ("NORMAL" or "FULL").
+	// Empty takes NORMAL. See the stanza comment in open() for the durability
+	// argument.
+	Synchronous string
+	// ReadPoolSize is the read-connection count. Zero takes the default.
+	ReadPoolSize int
+	// CacheSizeKB is the per-connection page cache in KB, applied as a
+	// negative cache_size. Zero takes 32 MB — the aggregate working set is
+	// the mutable delta log, not seven days of buckets.
+	CacheSizeKB int
+	// Metrics is the durable path's metric surface. nil disables recording.
+	Metrics StoreMetrics
+}
+
+// SQLiteStore is the Store implementation on a dedicated SQLite file.
+type SQLiteStore struct {
+	path    string
+	writer  *sql.DB
+	reader  *sql.DB
+	metrics StoreMetrics
+
+	// writeMu serializes every write path. MaxOpenConns(1) already
+	// serializes at the pool, but the mutex is what lets FinalizeWindow hold
+	// "no commit interleaves" across its read-then-write phases.
+	writeMu chan struct{}
+
+	uuid string
+}
+
+// OpenSQLiteStore opens (creating if absent) the aggregate database.
+//
+// Schema handling per #162: absent schema is created at the current version; a
+// partial schema, missing meta, or any version mismatch fails startup with an
+// explicit error. There are no automatic migrations in v1.
+func OpenSQLiteStore(cfg StoreConfig) (*SQLiteStore, error) {
+	if cfg.Path == "" {
+		cfg.Path = DefaultAggregateDBPath
+	}
+	if cfg.ReadPoolSize <= 0 {
+		cfg.ReadPoolSize = defaultReadPoolSize
+	}
+	if cfg.CacheSizeKB <= 0 {
+		cfg.CacheSizeKB = 32768
+	}
+	sync := strings.ToUpper(strings.TrimSpace(cfg.Synchronous))
+	switch sync {
+	case "":
+		sync = "NORMAL"
+	case "NORMAL", "FULL":
+	default:
+		return nil, fmt.Errorf("aggregate store: invalid synchronous mode %q (want NORMAL or FULL)", cfg.Synchronous)
+	}
+
+	if dir := filepath.Dir(cfg.Path); dir != "" && dir != "." && !strings.HasPrefix(cfg.Path, ":") {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			return nil, fmt.Errorf("aggregate store: create %s: %w", dir, err)
+		}
+	}
+
+	writer, err := openAggregateDB(cfg.Path, sync, cfg.CacheSizeKB, true)
+	if err != nil {
+		return nil, err
+	}
+	reader, err := openAggregateDB(cfg.Path, sync, cfg.CacheSizeKB, false)
+	if err != nil {
+		_ = writer.Close()
+		return nil, err
+	}
+	writer.SetMaxOpenConns(1)
+	writer.SetMaxIdleConns(1)
+	writer.SetConnMaxLifetime(0)
+	reader.SetMaxOpenConns(cfg.ReadPoolSize)
+	reader.SetMaxIdleConns(cfg.ReadPoolSize)
+	reader.SetConnMaxLifetime(0)
+
+	s := &SQLiteStore{
+		path:    cfg.Path,
+		writer:  writer,
+		reader:  reader,
+		metrics: cfg.Metrics,
+		writeMu: make(chan struct{}, 1),
+	}
+	if s.metrics == nil {
+		s.metrics = noopStoreMetrics{}
+	}
+
+	if err := verifyPragmas(writer, sync); err != nil {
+		_ = s.Close()
+		return nil, err
+	}
+	if err := s.ensureSchema(cfg.AllowRebuild); err != nil {
+		_ = s.Close()
+		return nil, err
+	}
+	return s, nil
+}
+
+// openAggregateDB opens one pool against the aggregate file with the store's
+// PRAGMA stanza attached to the DSN, so EVERY connection the pool opens —
+// including one replacing a broken connection — carries it. The driver applies
+// _pragma values at connection setup and fails the connection if one is
+// rejected, which is the fail-closed behaviour the main DB gets from its
+// explicit Exec stanza (internal/storage/factory.go).
+func openAggregateDB(path, synchronous string, cacheKB int, writer bool) (*sql.DB, error) {
+	pragmas := []string{
+		"journal_mode(WAL)",
+		"synchronous(" + synchronous + ")",
+		fmt.Sprintf("cache_size(-%d)", cacheKB),
+		"temp_store(MEMORY)",
+		fmt.Sprintf("busy_timeout(%d)", defaultBusyTimeoutMs),
+		// The WAL is the durability boundary; cap it so a burst of group
+		// commits cannot grow the file without bound between checkpoints.
+		"wal_autocheckpoint(4000)",
+		"journal_size_limit(67108864)",
+		"foreign_keys(0)",
+	}
+	dsn := path + "?"
+	q := url.Values{}
+	for _, p := range pragmas {
+		q.Add("_pragma", p)
+	}
+	if writer {
+		// Every writer transaction takes the write lock immediately rather
+		// than starting deferred and upgrading — upgrades are what produce
+		// SQLITE_BUSY under concurrent readers.
+		q.Set("_txlock", "immediate")
+	}
+	dsn += q.Encode()
+
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate store: open %s: %w", path, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("aggregate store: connect %s: %w", path, err)
+	}
+	return db, nil
+}
+
+// verifyPragmas reads back the two PRAGMAs the durability contract depends on.
+// A SQLite build that silently ignored journal_mode=WAL would turn durable ACK
+// into a rollback-journal lie, so this is fail-closed exactly like the main
+// DB's stanza.
+//
+// synchronous=NORMAL is the default and is the honest match for the ACK
+// contract as #160 states it: the contract is "no acknowledged aggregate loss
+// on process or container crash" (emptyDir survives a container restart; heap
+// does not). Under WAL, NORMAL fsyncs at checkpoint rather than at each COMMIT,
+// which survives a process kill -9 — the release-gate test — but not a host
+// power loss. FULL buys power-loss durability for one fsync per group commit;
+// at a <=5 ms coalescing window that is up to 200 fsyncs/s on the 2-vCPU
+// target, which is exactly the ACK p99 budget the gate measures. Operators who
+// need power-loss durability set AGGREGATE_SYNCHRONOUS=FULL and pay for it.
+func verifyPragmas(db *sql.DB, wantSync string) error {
+	var journal string
+	if err := db.QueryRow("PRAGMA journal_mode").Scan(&journal); err != nil {
+		return fmt.Errorf("aggregate store: read journal_mode: %w", err)
+	}
+	if !strings.EqualFold(journal, "wal") {
+		return fmt.Errorf("aggregate store: journal_mode is %q, want wal — durable ACK requires WAL", journal)
+	}
+	var sync int
+	if err := db.QueryRow("PRAGMA synchronous").Scan(&sync); err != nil {
+		return fmt.Errorf("aggregate store: read synchronous: %w", err)
+	}
+	want := 1 // NORMAL
+	if strings.EqualFold(wantSync, "FULL") {
+		want = 2
+	}
+	if sync != want {
+		return fmt.Errorf("aggregate store: synchronous is %d, want %d (%s)", sync, want, wantSync)
+	}
+	return nil
+}
+
+// Path returns the database file path.
+func (s *SQLiteStore) Path() string { return s.path }
+
+// UUID returns the store's identity, minted at creation. It is what tells an
+// operator "this is a different store", not "this is the same store rebuilt".
+func (s *SQLiteStore) UUID() string { return s.uuid }
+
+// lockWriter acquires the exclusive write slot.
+func (s *SQLiteStore) lockWriter() { s.writeMu <- struct{}{} }
+
+// unlockWriter releases the exclusive write slot.
+func (s *SQLiteStore) unlockWriter() { <-s.writeMu }
+
+// Close releases both pools.
+func (s *SQLiteStore) Close() error {
+	var errs []error
+	if s.reader != nil {
+		if err := s.reader.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if s.writer != nil {
+		if err := s.writer.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// --- schema -----------------------------------------------------------------
+
+// deltaColumnList is the shared column list of the delta log and the bucket
+// table. Both carry the same aggregate payload; only their keys differ.
+const deltaColumnList = `point_count, error_count, duration_count, duration_sum, duration_min, duration_max,
+	gauge_count, gauge_sum, gauge_min, gauge_max, gauge_last, gauge_last_ts,
+	counter_delta, reset_count, log_count, first_ts, last_ts, sketch`
+
+// deltaColumnDDL is deltaColumnList with types, shared by both tables.
+const deltaColumnDDL = `point_count INTEGER NOT NULL,
+	error_count INTEGER NOT NULL,
+	duration_count INTEGER NOT NULL,
+	duration_sum REAL NOT NULL,
+	duration_min REAL NOT NULL,
+	duration_max REAL NOT NULL,
+	gauge_count INTEGER NOT NULL,
+	gauge_sum REAL NOT NULL,
+	gauge_min REAL NOT NULL,
+	gauge_max REAL NOT NULL,
+	gauge_last REAL NOT NULL,
+	gauge_last_ts INTEGER NOT NULL,
+	counter_delta REAL NOT NULL,
+	reset_count INTEGER NOT NULL,
+	log_count INTEGER NOT NULL,
+	first_ts INTEGER NOT NULL,
+	last_ts INTEGER NOT NULL,
+	sketch BLOB`
+
+// deltaValuePlaceholders matches deltaColumnList's arity.
+const deltaValuePlaceholders = `?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?`
+
+// schemaDDL is the complete aggregate schema (#162).
+func schemaDDL() []string {
+	return []string{
+		`CREATE TABLE IF NOT EXISTS aggregate_meta (
+			key TEXT PRIMARY KEY,
+			value TEXT NOT NULL
+		) WITHOUT ROWID`,
+
+		// The length CHECK is not decoration: a zero-length dictionary value is
+		// an identity that can never be resolved back to anything, and it would
+		// collide with every other empty value in its namespace. The durable
+		// registrar refuses to mint one, so this constraint is unreachable from
+		// the ingest path and exists to catch a corrupt or hand-edited file.
+		`CREATE TABLE IF NOT EXISTS aggregate_dict (
+			id INTEGER PRIMARY KEY,
+			tenant_id INTEGER NOT NULL,
+			kind INTEGER NOT NULL,
+			value BLOB NOT NULL CHECK (length(value) > 0)
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_aggregate_dict_scope
+			ON aggregate_dict (tenant_id, kind, value)`,
+
+		// Explicit identity columns, no generic variant (#162). status_class
+		// carries span status for traces/edges; severity carries the log
+		// severity tier. Exactly one of the two is ever non-zero, which is
+		// what lets the pair round-trip onto the single SeriesKey.StatusClass
+		// field the engine uses.
+		`CREATE TABLE IF NOT EXISTS aggregate_series (
+			id INTEGER PRIMARY KEY,
+			tenant_id INTEGER NOT NULL,
+			service_id INTEGER NOT NULL,
+			name_id INTEGER NOT NULL,
+			dims_id INTEGER NOT NULL,
+			signal INTEGER NOT NULL,
+			status_class INTEGER NOT NULL,
+			http_class INTEGER NOT NULL,
+			method INTEGER NOT NULL,
+			span_kind INTEGER NOT NULL,
+			severity INTEGER NOT NULL
+		)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS idx_aggregate_series_identity
+			ON aggregate_series (tenant_id, service_id, name_id, dims_id, signal,
+				status_class, http_class, method, span_kind, severity)`,
+		`CREATE INDEX IF NOT EXISTS idx_aggregate_series_scope
+			ON aggregate_series (tenant_id, signal)`,
+
+		`CREATE TABLE IF NOT EXISTS aggregate_delta_log (
+			seq INTEGER PRIMARY KEY,
+			series_id INTEGER NOT NULL,
+			window_start INTEGER NOT NULL,
+			` + deltaColumnDDL + `
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_aggregate_delta_log_window
+			ON aggregate_delta_log (window_start, series_id, seq)`,
+
+		// WITHOUT ROWID so the composite PK IS the table B-tree: purge,
+		// finalize and window reads are all leading-range operations on
+		// window_start, and a duplicated rowid + unique index would cost real
+		// bytes against the 5 GiB aggregate allowance at ~10M retained rows.
+		`CREATE TABLE IF NOT EXISTS aggregate_buckets (
+			window_start INTEGER NOT NULL,
+			series_id INTEGER NOT NULL,
+			` + deltaColumnDDL + `,
+			PRIMARY KEY (window_start, series_id)
+		) WITHOUT ROWID`,
+
+		`CREATE TABLE IF NOT EXISTS aggregate_baseline (
+			series_id INTEGER NOT NULL,
+			producer_id BLOB NOT NULL,
+			start_ts INTEGER NOT NULL,
+			last_ts INTEGER NOT NULL,
+			value REAL NOT NULL,
+			PRIMARY KEY (series_id, producer_id)
+		) WITHOUT ROWID`,
+	}
+}
+
+// ensureSchema creates, verifies or (when permitted) rebuilds the schema.
+func (s *SQLiteStore) ensureSchema(allowRebuild bool) error {
+	present, err := s.presentTables()
+	if err != nil {
+		return err
+	}
+	switch {
+	case len(present) == 0:
+		return s.createSchema()
+	case len(present) == len(aggregateTables):
+		err := s.verifyMeta()
+		if err == nil {
+			return nil
+		}
+		var schemaErr *SchemaError
+		if !errors.As(err, &schemaErr) || !allowRebuild {
+			return err
+		}
+		s.warnRebuild(err.Error())
+		return s.rebuild()
+	default:
+		missing := missingTables(present)
+		err := &SchemaError{
+			Reason: "partial_schema",
+			Detail: fmt.Sprintf("%s is missing %s", s.path, strings.Join(missing, ", ")),
+		}
+		if !allowRebuild {
+			return err
+		}
+		s.warnRebuild(err.Error())
+		return s.rebuild()
+	}
+}
+
+// warnRebuild logs the destructive-rebuild warning. It is deliberately loud:
+// this is the one code path in the aggregate store that destroys data.
+func (s *SQLiteStore) warnRebuild(reason string) {
+	slog.Warn("💥 AGGREGATE_ALLOW_REBUILD=true — DESTROYING and recreating the aggregate store",
+		"path", s.path,
+		"reason", reason,
+		"data_loss", "all aggregate history in this file is deleted; raw telemetry in the main database is untouched",
+	)
+}
+
+// presentTables returns which aggregate-owned tables exist.
+func (s *SQLiteStore) presentTables() ([]string, error) {
+	rows, err := s.reader.Query(
+		`SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'aggregate_%'`)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate store: inspect schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var present []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("aggregate store: inspect schema: %w", err)
+		}
+		for _, want := range aggregateTables {
+			if want == name {
+				present = append(present, name)
+				break
+			}
+		}
+	}
+	return present, rows.Err()
+}
+
+// missingTables returns the aggregate tables absent from present.
+func missingTables(present []string) []string {
+	have := make(map[string]struct{}, len(present))
+	for _, p := range present {
+		have[p] = struct{}{}
+	}
+	var missing []string
+	for _, want := range aggregateTables {
+		if _, ok := have[want]; !ok {
+			missing = append(missing, want)
+		}
+	}
+	return missing
+}
+
+// createSchema builds the schema at the current version and stamps meta.
+func (s *SQLiteStore) createSchema() error {
+	s.lockWriter()
+	defer s.unlockWriter()
+	tx, err := s.writer.Begin()
+	if err != nil {
+		return fmt.Errorf("aggregate store: begin create: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, ddl := range schemaDDL() {
+		if _, err := tx.Exec(ddl); err != nil {
+			return fmt.Errorf("aggregate store: create schema: %w", err)
+		}
+	}
+	uuid, err := newStoreUUID()
+	if err != nil {
+		return err
+	}
+	meta := [][2]string{
+		{"schema_version", fmt.Sprint(StoreSchemaVersion)},
+		{"series_key_version", fmt.Sprint(SeriesKeyVersion)},
+		{"sketch_codec_version", fmt.Sprint(SketchEncodingVersion)},
+		{"store_uuid", uuid},
+		{"created_at", time.Now().UTC().Format(time.RFC3339)},
+	}
+	for _, kv := range meta {
+		if _, err := tx.Exec(`INSERT OR REPLACE INTO aggregate_meta (key, value) VALUES (?, ?)`, kv[0], kv[1]); err != nil {
+			return fmt.Errorf("aggregate store: stamp meta %s: %w", kv[0], err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("aggregate store: commit create: %w", err)
+	}
+	s.uuid = uuid
+	slog.Info("🗄️  Aggregate store created",
+		"path", s.path,
+		"schema_version", StoreSchemaVersion,
+		"series_key_version", SeriesKeyVersion,
+		"sketch_codec_version", SketchEncodingVersion,
+		"store_uuid", uuid,
+	)
+	return nil
+}
+
+// rebuild drops only the aggregate-owned tables and recreates them.
+func (s *SQLiteStore) rebuild() error {
+	s.lockWriter()
+	tx, err := s.writer.Begin()
+	if err != nil {
+		s.unlockWriter()
+		return fmt.Errorf("aggregate store: begin rebuild: %w", err)
+	}
+	for _, table := range aggregateTables {
+		if _, err := tx.Exec("DROP TABLE IF EXISTS " + table); err != nil {
+			_ = tx.Rollback()
+			s.unlockWriter()
+			return fmt.Errorf("aggregate store: drop %s: %w", table, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		s.unlockWriter()
+		return fmt.Errorf("aggregate store: commit rebuild: %w", err)
+	}
+	s.unlockWriter()
+	return s.createSchema()
+}
+
+// verifyMeta checks the three versions this build depends on.
+func (s *SQLiteStore) verifyMeta() error {
+	meta := map[string]string{}
+	rows, err := s.reader.Query(`SELECT key, value FROM aggregate_meta`)
+	if err != nil {
+		return fmt.Errorf("aggregate store: read meta: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var k, v string
+		if err := rows.Scan(&k, &v); err != nil {
+			return fmt.Errorf("aggregate store: read meta: %w", err)
+		}
+		meta[k] = v
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("aggregate store: read meta: %w", err)
+	}
+	checks := [][3]string{
+		{"schema_version", meta["schema_version"], fmt.Sprint(StoreSchemaVersion)},
+		{"series_key_version", meta["series_key_version"], fmt.Sprint(SeriesKeyVersion)},
+		{"sketch_codec_version", meta["sketch_codec_version"], fmt.Sprint(SketchEncodingVersion)},
+	}
+	for _, c := range checks {
+		if c[1] == "" {
+			return &SchemaError{Reason: "missing_meta", Detail: c[0] + " is absent from aggregate_meta"}
+		}
+		if c[1] != c[2] {
+			return &SchemaError{Reason: "version_mismatch", Key: c[0], Got: c[1], Want: c[2]}
+		}
+	}
+	s.uuid = meta["store_uuid"]
+	if s.uuid == "" {
+		return &SchemaError{Reason: "missing_meta", Detail: "store_uuid is absent from aggregate_meta"}
+	}
+	return nil
+}
+
+// newStoreUUID mints the store's identity.
+func newStoreUUID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("aggregate store: mint uuid: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// --- writes -----------------------------------------------------------------
+
+// CommitGroup implements Store. One transaction carries the registrations, the
+// pre-merged delta rows and the baseline upserts, so none of #162's three
+// atomicity invariants can be violated by a partial write.
+func (s *SQLiteStore) CommitGroup(b *GroupBatch) error {
+	if b == nil || b.Empty() {
+		return nil
+	}
+	start := time.Now()
+	bytes, err := s.commitGroup(b)
+	s.metrics.RecordCommit(time.Since(start), len(b.Deltas), bytes, err)
+	return err
+}
+
+func (s *SQLiteStore) commitGroup(b *GroupBatch) (int64, error) {
+	s.lockWriter()
+	defer s.unlockWriter()
+
+	tx, err := s.writer.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("aggregate store: begin commit: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := insertDicts(tx, b.Dicts); err != nil {
+		return 0, err
+	}
+	if err := insertSeries(tx, b.Series); err != nil {
+		return 0, err
+	}
+	bytes, err := insertDeltas(tx, b.Deltas)
+	if err != nil {
+		return 0, err
+	}
+	if err := upsertBaselines(tx, b.Baselines); err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("aggregate store: commit: %w", err)
+	}
+	committed = true
+	return bytes, nil
+}
+
+// insertDicts writes the dictionary registrations.
+//
+// Plain INSERT, deliberately NOT "OR IGNORE": OR IGNORE skips rows that violate
+// ANY constraint, which would let a rejected registration disappear while the
+// delta referencing it commits — precisely the atomicity invariant this batch
+// exists to enforce. A registrar re-offers a row only after a failed commit,
+// and a failed commit rolled the row back, so there is nothing to conflict
+// with. A conflict here is corruption and must be loud.
+func insertDicts(tx *sql.Tx, rows []DictRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	stmt, err := tx.Prepare(`INSERT INTO aggregate_dict (id, tenant_id, kind, value) VALUES (?,?,?,?)`)
+	if err != nil {
+		return fmt.Errorf("aggregate store: prepare dict insert: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+	for _, r := range rows {
+		if _, err := stmt.Exec(int64(r.ID), int64(r.TenantID), int64(r.Kind), r.Value); err != nil {
+			return fmt.Errorf("aggregate store: insert dict %d: %w", r.ID, err)
+		}
+	}
+	return nil
+}
+
+// insertSeries writes the series registrations. Plain INSERT for the same
+// reason as insertDicts.
+func insertSeries(tx *sql.Tx, rows []SeriesRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	stmt, err := tx.Prepare(`INSERT INTO aggregate_series
+		(id, tenant_id, service_id, name_id, dims_id, signal, status_class, http_class, method, span_kind, severity)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?)`)
+	if err != nil {
+		return fmt.Errorf("aggregate store: prepare series insert: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+	for _, r := range rows {
+		statusClass, severity := splitStatus(r.Key)
+		if _, err := stmt.Exec(
+			int64(r.ID),
+			int64(r.Key.TenantID), int64(r.Key.ServiceID), int64(r.Key.NameID), int64(r.Key.DimsID),
+			int64(r.Key.Signal), int64(statusClass), int64(r.Key.HTTPClass), int64(r.Key.Method),
+			int64(r.Key.Variant), int64(severity),
+		); err != nil {
+			return fmt.Errorf("aggregate store: insert series %d: %w", r.ID, err)
+		}
+	}
+	return nil
+}
+
+// splitStatus maps SeriesKey.StatusClass onto the schema's two explicit
+// columns. Logs carry a severity tier; traces and edges carry a span status;
+// metrics carry neither. Exactly one column is ever non-zero.
+func splitStatus(k SeriesKey) (statusClass, severity StatusClass) {
+	if k.Signal == SignalLog {
+		return 0, k.StatusClass
+	}
+	return k.StatusClass, 0
+}
+
+// joinStatus is splitStatus in reverse.
+func joinStatus(signal Signal, statusClass, severity StatusClass) StatusClass {
+	if signal == SignalLog {
+		return severity
+	}
+	return statusClass
+}
+
+// insertDeltas appends the pre-merged delta rows and returns their approximate
+// payload size.
+//
+// One prepared statement, one Exec per row, and one scratch buffer reused
+// across rows. Batching rows into multi-row VALUES was measured and is SLOWER
+// with this driver (~105 ms vs ~87 ms for a 5,000-row commit): the cost is in
+// per-parameter binding, which a wider statement does not avoid, and a
+// 800-parameter statement pays extra to compile.
+func insertDeltas(tx *sql.Tx, rows []DeltaRow) (int64, error) {
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	stmt, err := tx.Prepare(`INSERT INTO aggregate_delta_log
+		(series_id, window_start, ` + deltaColumnList + `)
+		VALUES (?,?,` + deltaValuePlaceholders + `)`)
+	if err != nil {
+		return 0, fmt.Errorf("aggregate store: prepare delta insert: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	var (
+		bytes   int64
+		scratch []byte
+		args    = make([]any, 0, 20)
+	)
+	for _, r := range rows {
+		var sketch []byte
+		if r.Delta != nil && r.Delta.Sketch != nil {
+			// Safe to reuse scratch: Exec has consumed the bind before the
+			// next iteration overwrites it.
+			scratch = r.Delta.Sketch.AppendTo(scratch[:0])
+			sketch = scratch
+		}
+		args = append(args[:0], int64(r.SeriesID), r.WindowStart)
+		args = append(args, deltaArgs(r.Delta, sketch)...)
+		if _, err := stmt.Exec(args...); err != nil {
+			return 0, fmt.Errorf("aggregate store: insert delta (series %d, window %d): %w", r.SeriesID, r.WindowStart, err)
+		}
+		bytes += deltaRowBytes + int64(len(sketch))
+	}
+	return bytes, nil
+}
+
+// deltaRowBytes is the fixed on-disk cost of a delta row before its sketch:
+// eighteen scalar columns plus the seq/series/window key.
+const deltaRowBytes = 96
+
+// upsertBaselines writes the durable cumulative baselines (#166). They ride the
+// same transaction as the deltas they justify.
+func upsertBaselines(tx *sql.Tx, rows []BaselineRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	stmt, err := tx.Prepare(`INSERT INTO aggregate_baseline (series_id, producer_id, start_ts, last_ts, value)
+		VALUES (?,?,?,?,?)
+		ON CONFLICT(series_id, producer_id) DO UPDATE SET
+			start_ts = excluded.start_ts, last_ts = excluded.last_ts, value = excluded.value`)
+	if err != nil {
+		return fmt.Errorf("aggregate store: prepare baseline upsert: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+	for _, r := range rows {
+		if _, err := stmt.Exec(
+			int64(r.SeriesID), producerBytes(r.Producer),
+			nanosOf(r.Baseline.StartTime), nanosOf(r.Baseline.LastTimestamp), r.Baseline.Value,
+		); err != nil {
+			return fmt.Errorf("aggregate store: upsert baseline (series %d): %w", r.SeriesID, err)
+		}
+	}
+	return nil
+}
+
+// --- finalize ---------------------------------------------------------------
+
+// FinalizableWindows implements Store.
+func (s *SQLiteStore) FinalizableWindows(cutoff int64, limit int) ([]int64, error) {
+	if limit <= 0 || limit > purgeWindowsPerPass {
+		limit = purgeWindowsPerPass
+	}
+	rows, err := s.reader.Query(
+		`SELECT DISTINCT window_start FROM aggregate_delta_log WHERE window_start <= ? ORDER BY window_start LIMIT ?`,
+		cutoff, limit)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate store: list finalizable windows: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []int64
+	for rows.Next() {
+		var w int64
+		if err := rows.Scan(&w); err != nil {
+			return nil, fmt.Errorf("aggregate store: list finalizable windows: %w", err)
+		}
+		out = append(out, w)
+	}
+	return out, rows.Err()
+}
+
+// FinalizeWindow implements Store: it materializes the window's buckets and
+// deletes exactly the delta rows it incorporated, in one transaction.
+//
+// "Exactly the incorporated rows" is enforced with a sequence bound rather than
+// a bare window predicate: the maximum seq is read first and only rows at or
+// below it are merged and deleted. The writer lock is held throughout, so no
+// commit can interleave — but the bound is what makes that a structural
+// guarantee instead of a scheduling accident.
+//
+// The delta rows are streamed from the READ pool while the writes go to the
+// writer transaction. A window can hold hundreds of thousands of delta rows;
+// loading them all to satisfy one transaction would trade a durability win for
+// an OOM.
+func (s *SQLiteStore) FinalizeWindow(windowStart int64) (FinalizeStats, error) {
+	start := time.Now()
+	stats, err := s.finalizeWindow(windowStart)
+	stats.WindowStart = windowStart
+	stats.Duration = time.Since(start)
+	s.metrics.RecordFinalize(stats, err)
+	return stats, err
+}
+
+func (s *SQLiteStore) finalizeWindow(windowStart int64) (FinalizeStats, error) {
+	var stats FinalizeStats
+	s.lockWriter()
+	defer s.unlockWriter()
+
+	var maxSeq sql.NullInt64
+	if err := s.reader.QueryRow(
+		`SELECT MAX(seq) FROM aggregate_delta_log WHERE window_start = ?`, windowStart).Scan(&maxSeq); err != nil {
+		return stats, fmt.Errorf("aggregate store: finalize %d: bound seq: %w", windowStart, err)
+	}
+	if !maxSeq.Valid {
+		return stats, nil // nothing to finalize
+	}
+
+	tx, err := s.writer.Begin()
+	if err != nil {
+		return stats, fmt.Errorf("aggregate store: finalize %d: begin: %w", windowStart, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := s.materializeWindow(tx, windowStart, maxSeq.Int64, &stats); err != nil {
+		return stats, fmt.Errorf("aggregate store: finalize %d: %w", windowStart, err)
+	}
+
+	if _, err := tx.Exec(
+		`DELETE FROM aggregate_delta_log WHERE window_start = ? AND seq <= ?`, windowStart, maxSeq.Int64); err != nil {
+		return stats, fmt.Errorf("aggregate store: finalize %d: delete deltas: %w", windowStart, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return stats, fmt.Errorf("aggregate store: finalize %d: commit: %w", windowStart, err)
+	}
+	committed = true
+	return stats, nil
+}
+
+// materializeWindow streams the window's delta rows from the READ pool, merging
+// each series in Go (SQL cannot merge sketches) and writing its bucket into the
+// writer transaction as soon as the series id changes. Only one series' worth of
+// state is held at a time: a busy window carries hundreds of thousands of delta
+// rows, and loading them all to satisfy one transaction would trade a durability
+// win for an OOM.
+func (s *SQLiteStore) materializeWindow(tx *sql.Tx, windowStart, maxSeq int64, stats *FinalizeStats) error {
+	rows, err := s.reader.Query(
+		`SELECT series_id, `+deltaColumnList+`
+		 FROM aggregate_delta_log
+		 WHERE window_start = ? AND seq <= ?
+		 ORDER BY series_id, seq`, windowStart, maxSeq)
+	if err != nil {
+		return fmt.Errorf("read deltas: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var (
+		curID    SeriesID
+		curDelta *AggregateDelta
+	)
+	flush := func() error {
+		if curDelta == nil {
+			return nil
+		}
+		if err := s.mergeBucket(tx, windowStart, curID, curDelta); err != nil {
+			return err
+		}
+		stats.Buckets++
+		curDelta = nil
+		return nil
+	}
+	for rows.Next() {
+		var id int64
+		d, err := scanDelta(rows.Scan, &id)
+		if err != nil {
+			return err
+		}
+		stats.DeltaRows++
+		if curDelta != nil && SeriesID(id) != curID {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+		if curDelta == nil {
+			curID = SeriesID(id)
+			curDelta = d
+			continue
+		}
+		curDelta.Merge(d)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("read deltas: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("read deltas: %w", err)
+	}
+	return flush()
+}
+
+// mergeBucket folds one merged delta into the bucket row, reading any existing
+// row first. A window is normally finalized once, but a window finalized during
+// downtime recovery and then again by the scheduler must add, not replace.
+func (s *SQLiteStore) mergeBucket(tx *sql.Tx, windowStart int64, id SeriesID, d *AggregateDelta) error {
+	row := tx.QueryRow(
+		`SELECT `+deltaColumnList+` FROM aggregate_buckets WHERE window_start = ? AND series_id = ?`,
+		windowStart, int64(id))
+	existing, err := scanDelta(row.Scan, nil)
+	switch {
+	case err == nil:
+		existing.Merge(d)
+		d = existing
+	case errors.Is(err, sql.ErrNoRows):
+	default:
+		return fmt.Errorf("read bucket (series %d): %w", id, err)
+	}
+
+	var sketch []byte
+	if d.Sketch != nil {
+		sketch = d.Sketch.Encode()
+	}
+	args := make([]any, 0, 20)
+	args = append(args, windowStart, int64(id))
+	args = append(args, deltaArgs(d, sketch)...)
+	if _, err := tx.Exec(
+		`INSERT OR REPLACE INTO aggregate_buckets (window_start, series_id, `+deltaColumnList+`)
+		 VALUES (?,?,`+deltaValuePlaceholders+`)`, args...); err != nil {
+		return fmt.Errorf("write bucket (series %d): %w", id, err)
+	}
+	return nil
+}
+
+// --- retention --------------------------------------------------------------
+
+// PurgeBefore implements Store. Deletion is per-window so retention never opens
+// an unbounded transaction, and there is NO VACUUM: rolling retention on this
+// file relies on range deletes, WAL checkpointing and free-page reuse (#162).
+func (s *SQLiteStore) PurgeBefore(cutoff int64) (PurgeStats, error) {
+	start := time.Now()
+	stats, err := s.purgeBefore(cutoff)
+	stats.Duration = time.Since(start)
+	s.metrics.RecordPurge(stats, err)
+	return stats, err
+}
+
+func (s *SQLiteStore) purgeBefore(cutoff int64) (PurgeStats, error) {
+	var stats PurgeStats
+	windows, err := s.purgeableWindows(cutoff)
+	if err != nil {
+		return stats, err
+	}
+	for _, w := range windows {
+		s.lockWriter()
+		buckets, deltas, err := purgeWindow(s.writer, w)
+		s.unlockWriter()
+		if err != nil {
+			return stats, err
+		}
+		stats.Buckets += buckets
+		stats.Deltas += deltas
+	}
+
+	// Baselines whose last observation predates the retention horizon can
+	// never produce a correct delta again — #166 re-seeds anything older than
+	// the lateness window anyway.
+	s.lockWriter()
+	res, err := s.writer.Exec(`DELETE FROM aggregate_baseline WHERE last_ts < ?`, cutoff*int64(time.Second))
+	s.unlockWriter()
+	if err != nil {
+		return stats, fmt.Errorf("aggregate store: purge baselines: %w", err)
+	}
+	if n, err := res.RowsAffected(); err == nil {
+		stats.Baselines = n
+	}
+	return stats, nil
+}
+
+// purgeableWindows lists the windows below cutoff that still hold rows.
+func (s *SQLiteStore) purgeableWindows(cutoff int64) ([]int64, error) {
+	rows, err := s.reader.Query(
+		`SELECT window_start FROM (
+			SELECT DISTINCT window_start FROM aggregate_buckets WHERE window_start < ?
+			UNION
+			SELECT DISTINCT window_start FROM aggregate_delta_log WHERE window_start < ?
+		) ORDER BY window_start LIMIT ?`, cutoff, cutoff, purgeWindowsPerPass)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate store: list purgeable windows: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []int64
+	for rows.Next() {
+		var w int64
+		if err := rows.Scan(&w); err != nil {
+			return nil, fmt.Errorf("aggregate store: list purgeable windows: %w", err)
+		}
+		out = append(out, w)
+	}
+	return out, rows.Err()
+}
+
+// purgeWindow deletes one window's buckets and any stale delta rows.
+func purgeWindow(db *sql.DB, window int64) (buckets, deltas int64, err error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return 0, 0, fmt.Errorf("aggregate store: purge %d: begin: %w", window, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	res, err := tx.Exec(`DELETE FROM aggregate_buckets WHERE window_start = ?`, window)
+	if err != nil {
+		return 0, 0, fmt.Errorf("aggregate store: purge %d: buckets: %w", window, err)
+	}
+	buckets, _ = res.RowsAffected()
+	res, err = tx.Exec(`DELETE FROM aggregate_delta_log WHERE window_start = ?`, window)
+	if err != nil {
+		return 0, 0, fmt.Errorf("aggregate store: purge %d: deltas: %w", window, err)
+	}
+	deltas, _ = res.RowsAffected()
+	if err := tx.Commit(); err != nil {
+		return 0, 0, fmt.Errorf("aggregate store: purge %d: commit: %w", window, err)
+	}
+	committed = true
+	return buckets, deltas, nil
+}
+
+// Analyze refreshes the planner statistics. It is the only maintenance the
+// aggregate file gets: #162 excludes routine VACUUM outright, and ANALYZE is
+// cheap enough to ride the existing daily maintenance tick.
+func (s *SQLiteStore) Analyze() error {
+	s.lockWriter()
+	defer s.unlockWriter()
+	if _, err := s.writer.Exec("ANALYZE"); err != nil {
+		return fmt.Errorf("aggregate store: analyze: %w", err)
+	}
+	return nil
+}
+
+// --- reads ------------------------------------------------------------------
+
+// ReadBuckets implements Store. The selector's bounds are mandatory and the row
+// cap is enforced here, not by the caller: the worst case is 6,000 series x
+// 2,016 windows and a dashboard is not trusted with it.
+func (s *SQLiteStore) ReadBuckets(sel Selector) ([]Bucket, error) {
+	limit, err := sel.Validate()
+	if err != nil {
+		return nil, err
+	}
+	var (
+		sb   strings.Builder
+		args []any
+	)
+	sb.WriteString(`SELECT b.window_start, b.series_id, `)
+	for i, col := range strings.Split(deltaColumnList, ",") {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString("b." + strings.TrimSpace(col))
+	}
+	sb.WriteString(` FROM aggregate_buckets b JOIN aggregate_series s ON s.id = b.series_id
+		WHERE b.window_start >= ? AND b.window_start < ? AND s.tenant_id = ?`)
+	args = append(args, sel.Start, sel.End, int64(sel.TenantID))
+	if sel.Signal != SignalUnspecified {
+		sb.WriteString(` AND s.signal = ?`)
+		args = append(args, int64(sel.Signal))
+	}
+	if len(sel.SeriesIDs) > 0 {
+		sb.WriteString(` AND b.series_id IN (` + placeholders(len(sel.SeriesIDs)) + `)`)
+		for _, id := range sel.SeriesIDs {
+			args = append(args, int64(id))
+		}
+	}
+	sb.WriteString(` ORDER BY b.window_start, b.series_id LIMIT ?`)
+	args = append(args, limit)
+
+	rows, err := s.reader.Query(sb.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate store: read buckets: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := make([]Bucket, 0, 64)
+	for rows.Next() {
+		var window, id int64
+		d, err := scanDelta(func(dst ...any) error {
+			return rows.Scan(append([]any{&window, &id}, dst...)...)
+		}, nil)
+		if err != nil {
+			return nil, fmt.Errorf("aggregate store: read buckets: %w", err)
+		}
+		out = append(out, Bucket{WindowStart: window, SeriesID: SeriesID(id), Delta: d})
+	}
+	return out, rows.Err()
+}
+
+// ReplayMutable implements Store. Only mutable windows are returned: finalized
+// history never hydrates into RAM (#160).
+func (s *SQLiteStore) ReplayMutable(since int64) ([]DeltaRow, error) {
+	rows, err := s.reader.Query(
+		`SELECT seq, series_id, window_start, `+deltaColumnList+`
+		 FROM aggregate_delta_log WHERE window_start >= ? ORDER BY window_start, series_id, seq`, since)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate store: replay: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []DeltaRow
+	for rows.Next() {
+		var seq, id, window int64
+		d, err := scanDelta(func(dst ...any) error {
+			return rows.Scan(append([]any{&seq, &id, &window}, dst...)...)
+		}, nil)
+		if err != nil {
+			return nil, fmt.Errorf("aggregate store: replay: %w", err)
+		}
+		out = append(out, DeltaRow{Seq: seq, SeriesID: SeriesID(id), WindowStart: window, Delta: d})
+	}
+	return out, rows.Err()
+}
+
+// LoadBaselines implements Store.
+func (s *SQLiteStore) LoadBaselines(max int) ([]BaselineRow, error) {
+	if max <= 0 {
+		max = MaxReadRows
+	}
+	rows, err := s.reader.Query(
+		`SELECT series_id, producer_id, start_ts, last_ts, value FROM aggregate_baseline LIMIT ?`, max)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate store: load baselines: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []BaselineRow
+	for rows.Next() {
+		var (
+			id             int64
+			producer       []byte
+			startTS, lastT int64
+			value          float64
+		)
+		if err := rows.Scan(&id, &producer, &startTS, &lastT, &value); err != nil {
+			return nil, fmt.Errorf("aggregate store: load baselines: %w", err)
+		}
+		out = append(out, BaselineRow{
+			SeriesID: SeriesID(id),
+			Producer: producerFromBytes(producer),
+			Baseline: Baseline{
+				StartTime:     timeFromNanos(startTS),
+				LastTimestamp: timeFromNanos(lastT),
+				Value:         value,
+			},
+		})
+	}
+	return out, rows.Err()
+}
+
+// ResolveSeries implements Store. The input count is capped at MaxReadRows.
+func (s *SQLiteStore) ResolveSeries(ids []SeriesID) ([]SeriesInfo, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	if len(ids) > MaxReadRows {
+		return nil, fmt.Errorf("%w: %d series ids, cap is %d", ErrSelectorUnbounded, len(ids), MaxReadRows)
+	}
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = int64(id)
+	}
+	// #nosec G202 -- the only interpolation is a placeholder run generated
+	// from len(ids); every value is bound.
+	query := `SELECT id, tenant_id, service_id, name_id, dims_id, signal, status_class, http_class, method, span_kind, severity
+		 FROM aggregate_series WHERE id IN (` + placeholders(len(ids)) + `)`
+	rows, err := s.reader.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate store: resolve series: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := make([]SeriesInfo, 0, len(ids))
+	for rows.Next() {
+		info, err := scanSeries(rows.Scan)
+		if err != nil {
+			return nil, fmt.Errorf("aggregate store: resolve series: %w", err)
+		}
+		out = append(out, info)
+	}
+	return out, rows.Err()
+}
+
+// LoadDict implements Store.
+func (s *SQLiteStore) LoadDict(max int) ([]DictRow, error) {
+	if max <= 0 || max > maxDictRows {
+		max = maxDictRows
+	}
+	rows, err := s.reader.Query(`SELECT id, tenant_id, kind, value FROM aggregate_dict LIMIT ?`, max)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate store: load dict: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []DictRow
+	for rows.Next() {
+		var (
+			id, tenant, kind int64
+			value            []byte
+		)
+		if err := rows.Scan(&id, &tenant, &kind, &value); err != nil {
+			return nil, fmt.Errorf("aggregate store: load dict: %w", err)
+		}
+		// #nosec G115 -- dictionary IDs, tenant IDs and kinds are written from
+		// uint32/uint8 values by this package and nothing else writes the table.
+		out = append(out, DictRow{
+			ID:       uint32(id),
+			TenantID: uint32(tenant),
+			Kind:     Kind(kind),
+			Value:    value,
+		})
+	}
+	return out, rows.Err()
+}
+
+// LoadSeries implements Store.
+func (s *SQLiteStore) LoadSeries(max int) ([]SeriesRow, error) {
+	if max <= 0 || max > maxSeriesRows {
+		max = maxSeriesRows
+	}
+	rows, err := s.reader.Query(
+		`SELECT id, tenant_id, service_id, name_id, dims_id, signal, status_class, http_class, method, span_kind, severity
+		 FROM aggregate_series LIMIT ?`, max)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate store: load series: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []SeriesRow
+	for rows.Next() {
+		info, err := scanSeries(rows.Scan)
+		if err != nil {
+			return nil, fmt.Errorf("aggregate store: load series: %w", err)
+		}
+		out = append(out, SeriesRow(info))
+	}
+	return out, rows.Err()
+}
+
+// Backlog implements Store.
+func (s *SQLiteStore) Backlog() (BacklogStats, error) {
+	var (
+		stats  BacklogStats
+		oldest sql.NullInt64
+	)
+	if err := s.reader.QueryRow(
+		`SELECT COUNT(*), MIN(window_start) FROM aggregate_delta_log`).Scan(&stats.Rows, &oldest); err != nil {
+		return stats, fmt.Errorf("aggregate store: backlog: %w", err)
+	}
+	if oldest.Valid {
+		stats.OldestWindow = oldest.Int64
+	}
+	stats.Bytes = stats.Rows * deltaRowBytes
+	return stats, nil
+}
+
+// --- row helpers ------------------------------------------------------------
+
+// scanFunc is the shape of sql.Rows.Scan / sql.Row.Scan.
+type scanFunc func(dst ...any) error
+
+// scanDelta reads the shared delta column list through scan. When id is
+// non-nil, it is prepended to the destination list (the delta-log read path
+// that also wants the series id).
+func scanDelta(scan scanFunc, id *int64) (*AggregateDelta, error) {
+	var (
+		d                   AggregateDelta
+		gaugeLastTS         int64
+		firstTS, lastTS     int64
+		sketch              []byte
+		dst                 []any
+		pointCount, errCnt  int64
+		durCount, gaugeCnt  int64
+		resetCount, logCnt  int64
+		durSum, durMin      float64
+		durMax, gaugeSum    float64
+		gaugeMin, gaugeMax  float64
+		gaugeLast, counterD float64
+	)
+	if id != nil {
+		dst = append(dst, id)
+	}
+	dst = append(dst,
+		&pointCount, &errCnt, &durCount, &durSum, &durMin, &durMax,
+		&gaugeCnt, &gaugeSum, &gaugeMin, &gaugeMax, &gaugeLast, &gaugeLastTS,
+		&counterD, &resetCount, &logCnt, &firstTS, &lastTS, &sketch,
+	)
+	if err := scan(dst...); err != nil {
+		return nil, err
+	}
+	d.Count = uint64(pointCount)       // #nosec G115 -- counters are written from uint64
+	d.ErrorCount = uint64(errCnt)      // #nosec G115 -- counters are written from uint64
+	d.DurationCount = uint64(durCount) // #nosec G115 -- counters are written from uint64
+	d.GaugeCount = uint64(gaugeCnt)    // #nosec G115 -- counters are written from uint64
+	d.ResetCount = uint64(resetCount)  // #nosec G115 -- counters are written from uint64
+	d.LogCount = uint64(logCnt)        // #nosec G115 -- counters are written from uint64
+	d.DurationSum, d.DurationMin, d.DurationMax = durSum, durMin, durMax
+	d.GaugeSum, d.GaugeMin, d.GaugeMax, d.GaugeLast = gaugeSum, gaugeMin, gaugeMax, gaugeLast
+	d.CounterDelta = counterD
+	d.GaugeLastTime = timeFromNanos(gaugeLastTS)
+	d.FirstTimestamp = timeFromNanos(firstTS)
+	d.LastTimestamp = timeFromNanos(lastTS)
+	if len(sketch) > 0 {
+		sk, err := DecodeSketch(sketch)
+		if err != nil {
+			return nil, fmt.Errorf("decode sketch: %w", err)
+		}
+		d.Sketch = sk
+	}
+	return &d, nil
+}
+
+// deltaArgs renders a delta as the shared column list's bind arguments.
+func deltaArgs(d *AggregateDelta, sketch []byte) []any {
+	if d == nil {
+		d = &AggregateDelta{}
+	}
+	var blob any
+	if len(sketch) > 0 {
+		blob = sketch
+	}
+	return []any{
+		int64(d.Count), int64(d.ErrorCount), int64(d.DurationCount), // #nosec G115 -- counters are bounded by ingest volume
+		d.DurationSum, d.DurationMin, d.DurationMax,
+		int64(d.GaugeCount), d.GaugeSum, d.GaugeMin, d.GaugeMax, d.GaugeLast, nanosOf(d.GaugeLastTime), // #nosec G115
+		d.CounterDelta, int64(d.ResetCount), int64(d.LogCount), // #nosec G115
+		nanosOf(d.FirstTimestamp), nanosOf(d.LastTimestamp), blob,
+	}
+}
+
+// scanSeries reads one aggregate_series row.
+func scanSeries(scan scanFunc) (SeriesInfo, error) {
+	var (
+		id                                     int64
+		tenant, service, name, dims            int64
+		signal, statusClass, httpClass, method int64
+		spanKind, severity                     int64
+	)
+	if err := scan(&id, &tenant, &service, &name, &dims, &signal, &statusClass, &httpClass, &method, &spanKind, &severity); err != nil {
+		return SeriesInfo{}, err
+	}
+	sig := Signal(signal) // #nosec G115 -- signal is written from the bounded Signal enum
+	return SeriesInfo{
+		ID: SeriesID(id),
+		Key: SeriesKey{
+			TenantID:    uint32(tenant),  // #nosec G115 -- dictionary IDs are uint32
+			ServiceID:   uint32(service), // #nosec G115 -- dictionary IDs are uint32
+			NameID:      uint32(name),    // #nosec G115 -- dictionary IDs are uint32
+			DimsID:      uint32(dims),    // #nosec G115 -- dictionary IDs are uint32
+			Signal:      sig,
+			StatusClass: joinStatus(sig, StatusClass(statusClass), StatusClass(severity)), // #nosec G115
+			HTTPClass:   HTTPClass(httpClass),                                             // #nosec G115 -- bounded enum
+			Method:      Method(method),                                                   // #nosec G115 -- bounded enum
+			Variant:     Variant(spanKind),                                                // #nosec G115 -- bounded enum
+		},
+	}, nil
+}
+
+// placeholders returns "?,?,..." with n placeholders.
+func placeholders(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return strings.TrimSuffix(strings.Repeat("?,", n), ",")
+}
+
+// nanosOf renders a time as Unix nanoseconds, mapping the zero time to 0 so a
+// round trip preserves "unset".
+func nanosOf(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UnixNano()
+}
+
+// timeFromNanos is nanosOf in reverse.
+func timeFromNanos(n int64) time.Time {
+	if n == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, n).UTC()
+}
+
+// producerBytes renders a ProducerID as the schema's 8-byte BLOB.
+func producerBytes(p ProducerID) []byte {
+	b := make([]byte, 8)
+	v := uint64(p)
+	for i := 7; i >= 0; i-- {
+		b[i] = byte(v)
+		v >>= 8
+	}
+	return b
+}
+
+// producerFromBytes is producerBytes in reverse.
+func producerFromBytes(b []byte) ProducerID {
+	var v uint64
+	for _, c := range b {
+		v = v<<8 | uint64(c)
+	}
+	return ProducerID(v)
+}
+
+// compile-time assertion that the SQLite store satisfies the interface.
+var _ Store = (*SQLiteStore)(nil)

--- a/internal/aggregate/store_test.go
+++ b/internal/aggregate/store_test.go
@@ -1,0 +1,566 @@
+package aggregate
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newTestStore opens a store in a temp directory and closes it on cleanup.
+func newTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	return newTestStoreAt(t, filepath.Join(t.TempDir(), "aggregate.db"), StoreConfig{})
+}
+
+func newTestStoreAt(t *testing.T, path string, cfg StoreConfig) *SQLiteStore {
+	t.Helper()
+	cfg.Path = path
+	store, err := OpenSQLiteStore(cfg)
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore(%s): %v", path, err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// storeKey builds a distinct trace-operation series key.
+func storeKey(n uint32) SeriesKey {
+	return SeriesKey{
+		TenantID:    1,
+		ServiceID:   2,
+		NameID:      n,
+		Signal:      SignalTraceOp,
+		StatusClass: StatusOK,
+		HTTPClass:   HTTPClass2xx,
+		Method:      MethodGet,
+		Variant:     SpanKindServer,
+	}
+}
+
+// spanDelta builds a delta carrying counters and a sketch.
+func spanDelta(count int, micros float64) *AggregateDelta {
+	d := &AggregateDelta{}
+	for i := 0; i < count; i++ {
+		d.ObserveSpan(micros, i%3 == 0)
+	}
+	return d
+}
+
+func TestStoreCreateVerifyReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aggregate.db")
+	store := newTestStoreAt(t, path, StoreConfig{})
+	if store.UUID() == "" {
+		t.Fatal("store uuid is empty")
+	}
+	first := store.UUID()
+	if err := store.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopened := newTestStoreAt(t, path, StoreConfig{})
+	if reopened.UUID() != first {
+		t.Fatalf("uuid changed across reopen: %q -> %q", first, reopened.UUID())
+	}
+}
+
+func TestStoreVersionMismatchFailsStartup(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aggregate.db")
+	store := newTestStoreAt(t, path, StoreConfig{})
+	if _, err := store.writer.Exec(
+		`UPDATE aggregate_meta SET value = ? WHERE key = 'schema_version'`, StoreSchemaVersion+1); err != nil {
+		t.Fatalf("tamper meta: %v", err)
+	}
+	_ = store.Close()
+
+	_, err := OpenSQLiteStore(StoreConfig{Path: path})
+	var schemaErr *SchemaError
+	if !errors.As(err, &schemaErr) {
+		t.Fatalf("open with mismatched schema_version: got %v, want *SchemaError", err)
+	}
+	if schemaErr.Key != "schema_version" {
+		t.Fatalf("mismatch key = %q, want schema_version", schemaErr.Key)
+	}
+
+	rebuilt, err := OpenSQLiteStore(StoreConfig{Path: path, AllowRebuild: true})
+	if err != nil {
+		t.Fatalf("open with AGGREGATE_ALLOW_REBUILD=true: %v", err)
+	}
+	defer func() { _ = rebuilt.Close() }()
+	if rebuilt.UUID() == store.UUID() {
+		t.Fatal("rebuild kept the old store uuid; it must mint a new identity")
+	}
+}
+
+func TestStorePartialSchemaFailsStartup(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aggregate.db")
+	store := newTestStoreAt(t, path, StoreConfig{})
+	if _, err := store.writer.Exec(`DROP TABLE aggregate_buckets`); err != nil {
+		t.Fatalf("drop table: %v", err)
+	}
+	_ = store.Close()
+
+	_, err := OpenSQLiteStore(StoreConfig{Path: path})
+	var schemaErr *SchemaError
+	if !errors.As(err, &schemaErr) || schemaErr.Reason != "partial_schema" {
+		t.Fatalf("open with partial schema: got %v, want partial_schema *SchemaError", err)
+	}
+
+	rebuilt, err := OpenSQLiteStore(StoreConfig{Path: path, AllowRebuild: true})
+	if err != nil {
+		t.Fatalf("rebuild partial schema: %v", err)
+	}
+	_ = rebuilt.Close()
+}
+
+func TestStoreRejectsBadSynchronous(t *testing.T) {
+	_, err := OpenSQLiteStore(StoreConfig{
+		Path:        filepath.Join(t.TempDir(), "aggregate.db"),
+		Synchronous: "OFF",
+	})
+	if err == nil {
+		t.Fatal("synchronous=OFF was accepted; the ACK contract forbids it")
+	}
+}
+
+func TestCommitGroupRoundTrip(t *testing.T) {
+	store := newTestStore(t)
+	key := storeKey(10)
+	batch := &GroupBatch{
+		Dicts:  []DictRow{{ID: 10, TenantID: 1, Kind: KindOperation, Value: []byte("GET /orders")}},
+		Series: []SeriesRow{{ID: 1, Key: key}},
+		Deltas: []DeltaRow{{SeriesID: 1, WindowStart: 300, Delta: spanDelta(6, 1500)}},
+		Baselines: []BaselineRow{{
+			SeriesID: 1,
+			Producer: ProducerID(0x1122334455667788),
+			Baseline: Baseline{
+				StartTime:     time.Unix(100, 0).UTC(),
+				LastTimestamp: time.Unix(200, 0).UTC(),
+				Value:         42,
+			},
+		}},
+	}
+	if err := store.CommitGroup(batch); err != nil {
+		t.Fatalf("CommitGroup: %v", err)
+	}
+
+	rows, err := store.ReplayMutable(0)
+	if err != nil {
+		t.Fatalf("ReplayMutable: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("replayed %d rows, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.SeriesID != 1 || got.WindowStart != 300 {
+		t.Fatalf("row identity = (%d,%d), want (1,300)", got.SeriesID, got.WindowStart)
+	}
+	want := batch.Deltas[0].Delta
+	if got.Delta.Count != want.Count || got.Delta.ErrorCount != want.ErrorCount {
+		t.Fatalf("counters = (%d,%d), want (%d,%d)",
+			got.Delta.Count, got.Delta.ErrorCount, want.Count, want.ErrorCount)
+	}
+	if got.Delta.Sketch == nil {
+		t.Fatal("sketch did not survive the round trip")
+	}
+	if got.Delta.Sketch.Count() != want.Sketch.Count() {
+		t.Fatalf("sketch count = %d, want %d", got.Delta.Sketch.Count(), want.Sketch.Count())
+	}
+
+	infos, err := store.ResolveSeries([]SeriesID{1})
+	if err != nil {
+		t.Fatalf("ResolveSeries: %v", err)
+	}
+	if len(infos) != 1 || infos[0].Key != key {
+		t.Fatalf("ResolveSeries = %+v, want key %+v", infos, key)
+	}
+
+	baselines, err := store.LoadBaselines(0)
+	if err != nil {
+		t.Fatalf("LoadBaselines: %v", err)
+	}
+	if len(baselines) != 1 || baselines[0].Producer != ProducerID(0x1122334455667788) {
+		t.Fatalf("LoadBaselines = %+v", baselines)
+	}
+	if baselines[0].Baseline.Value != 42 {
+		t.Fatalf("baseline value = %v, want 42", baselines[0].Baseline.Value)
+	}
+
+	dicts, err := store.LoadDict(0)
+	if err != nil {
+		t.Fatalf("LoadDict: %v", err)
+	}
+	if len(dicts) != 1 || string(dicts[0].Value) != "GET /orders" {
+		t.Fatalf("LoadDict = %+v", dicts)
+	}
+}
+
+func TestResolveSeriesRoundTripsEverySignal(t *testing.T) {
+	store := newTestStore(t)
+	keys := []SeriesKey{
+		{TenantID: 1, ServiceID: 2, NameID: 3, Signal: SignalTraceOp, StatusClass: StatusError, HTTPClass: HTTPClass5xx, Method: MethodPost, Variant: SpanKindClient},
+		{TenantID: 1, ServiceID: 2, NameID: 4, Signal: SignalServiceEdge, StatusClass: StatusOK, Variant: SpanKindServer},
+		{TenantID: 1, ServiceID: 2, NameID: 5, Signal: SignalLog, StatusClass: SeverityTierError},
+		{TenantID: 1, ServiceID: 2, NameID: 6, Signal: SignalMetric},
+	}
+	batch := &GroupBatch{}
+	ids := make([]SeriesID, 0, len(keys))
+	for i, k := range keys {
+		id := SeriesID(i + 1)
+		batch.Series = append(batch.Series, SeriesRow{ID: id, Key: k})
+		ids = append(ids, id)
+	}
+	if err := store.CommitGroup(batch); err != nil {
+		t.Fatalf("CommitGroup: %v", err)
+	}
+	infos, err := store.ResolveSeries(ids)
+	if err != nil {
+		t.Fatalf("ResolveSeries: %v", err)
+	}
+	byID := map[SeriesID]SeriesKey{}
+	for _, info := range infos {
+		byID[info.ID] = info.Key
+	}
+	for i, k := range keys {
+		got, ok := byID[SeriesID(i+1)]
+		if !ok {
+			t.Fatalf("series %d missing from resolve", i+1)
+		}
+		if got != k {
+			t.Fatalf("series %d round trip = %+v, want %+v", i+1, got, k)
+		}
+	}
+}
+
+// TestCommitGroupAllOrNothing proves the batch is one transaction: a failure in
+// the FIRST phase (dictionary) must leave the series, delta and baseline rows
+// of the SAME batch absent.
+func TestCommitGroupAllOrNothing(t *testing.T) {
+	store := newTestStore(t)
+	bad := &GroupBatch{
+		// The schema's length CHECK rejects an empty dictionary value; the
+		// durable registrar never mints one, so this is the failure injection
+		// a corrupt row would produce.
+		Dicts:     []DictRow{{ID: 1, TenantID: 1, Kind: KindOperation, Value: []byte{}}},
+		Series:    []SeriesRow{{ID: 1, Key: storeKey(1)}},
+		Deltas:    []DeltaRow{{SeriesID: 1, WindowStart: 300, Delta: spanDelta(3, 500)}},
+		Baselines: []BaselineRow{{SeriesID: 1, Producer: 7, Baseline: Baseline{Value: 1}}},
+	}
+	if err := store.CommitGroup(bad); err == nil {
+		t.Fatal("CommitGroup accepted a NULL dictionary value")
+	}
+	assertEmpty(t, store, "aggregate_dict")
+	assertEmpty(t, store, "aggregate_series")
+	assertEmpty(t, store, "aggregate_delta_log")
+	assertEmpty(t, store, "aggregate_baseline")
+
+	// The store is still usable afterwards.
+	good := &GroupBatch{
+		Dicts:  []DictRow{{ID: 1, TenantID: 1, Kind: KindOperation, Value: []byte("ok")}},
+		Series: []SeriesRow{{ID: 1, Key: storeKey(1)}},
+		Deltas: []DeltaRow{{SeriesID: 1, WindowStart: 300, Delta: spanDelta(3, 500)}},
+	}
+	if err := store.CommitGroup(good); err != nil {
+		t.Fatalf("CommitGroup after rollback: %v", err)
+	}
+	assertCount(t, store, "aggregate_delta_log", 1)
+}
+
+func TestFinalizeWindowMaterializesAndDeletes(t *testing.T) {
+	store := newTestStore(t)
+	seed := &GroupBatch{Series: []SeriesRow{{ID: 1, Key: storeKey(1)}, {ID: 2, Key: storeKey(2)}}}
+	if err := store.CommitGroup(seed); err != nil {
+		t.Fatalf("seed series: %v", err)
+	}
+	// Three commits touching two series in one window: the pre-merge shape the
+	// finalizer has to collapse.
+	for i := 0; i < 3; i++ {
+		batch := &GroupBatch{Deltas: []DeltaRow{
+			{SeriesID: 1, WindowStart: 600, Delta: spanDelta(2, 100)},
+			{SeriesID: 2, WindowStart: 600, Delta: spanDelta(1, 900)},
+		}}
+		if err := store.CommitGroup(batch); err != nil {
+			t.Fatalf("commit %d: %v", i, err)
+		}
+	}
+	assertCount(t, store, "aggregate_delta_log", 6)
+
+	stats, err := store.FinalizeWindow(600)
+	if err != nil {
+		t.Fatalf("FinalizeWindow: %v", err)
+	}
+	if stats.Buckets != 2 || stats.DeltaRows != 6 {
+		t.Fatalf("finalize stats = %+v, want 2 buckets / 6 delta rows", stats)
+	}
+	assertCount(t, store, "aggregate_delta_log", 0)
+	assertCount(t, store, "aggregate_buckets", 2)
+
+	buckets, err := store.ReadBuckets(Selector{TenantID: 1, Start: 300, End: 900})
+	if err != nil {
+		t.Fatalf("ReadBuckets: %v", err)
+	}
+	if len(buckets) != 2 {
+		t.Fatalf("read %d buckets, want 2", len(buckets))
+	}
+	for _, b := range buckets {
+		switch b.SeriesID {
+		case 1:
+			if b.Delta.Count != 6 {
+				t.Fatalf("series 1 count = %d, want 6", b.Delta.Count)
+			}
+		case 2:
+			if b.Delta.Count != 3 {
+				t.Fatalf("series 2 count = %d, want 3", b.Delta.Count)
+			}
+		}
+		if b.Delta.Sketch == nil {
+			t.Fatalf("series %d lost its sketch through finalize", b.SeriesID)
+		}
+	}
+}
+
+// TestFinalizeWindowMergesIntoExistingBucket covers the second finalize of the
+// same window — which is what a late delta arriving after a downtime-expiry
+// finalization produces.
+func TestFinalizeWindowMergesIntoExistingBucket(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.CommitGroup(&GroupBatch{
+		Series: []SeriesRow{{ID: 1, Key: storeKey(1)}},
+		Deltas: []DeltaRow{{SeriesID: 1, WindowStart: 600, Delta: spanDelta(4, 100)}},
+	}); err != nil {
+		t.Fatalf("first commit: %v", err)
+	}
+	if _, err := store.FinalizeWindow(600); err != nil {
+		t.Fatalf("first finalize: %v", err)
+	}
+	if err := store.CommitGroup(&GroupBatch{
+		Deltas: []DeltaRow{{SeriesID: 1, WindowStart: 600, Delta: spanDelta(3, 200)}},
+	}); err != nil {
+		t.Fatalf("late commit: %v", err)
+	}
+	if _, err := store.FinalizeWindow(600); err != nil {
+		t.Fatalf("second finalize: %v", err)
+	}
+	buckets, err := store.ReadBuckets(Selector{TenantID: 1, Start: 600, End: 900})
+	if err != nil {
+		t.Fatalf("ReadBuckets: %v", err)
+	}
+	if len(buckets) != 1 || buckets[0].Delta.Count != 7 {
+		t.Fatalf("merged bucket = %+v, want count 7", buckets)
+	}
+}
+
+// TestFinalizeWindowAtomicity kills the write half of the transaction (by
+// closing the writer pool) and proves the delta rows survive un-deleted and no
+// bucket was written: materialize+delete is one transaction or neither.
+func TestFinalizeWindowAtomicity(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aggregate.db")
+	store := newTestStoreAt(t, path, StoreConfig{})
+	if err := store.CommitGroup(&GroupBatch{
+		Series: []SeriesRow{{ID: 1, Key: storeKey(1)}},
+		Deltas: []DeltaRow{{SeriesID: 1, WindowStart: 600, Delta: spanDelta(4, 100)}},
+	}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if err := store.writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	if _, err := store.FinalizeWindow(600); err == nil {
+		t.Fatal("FinalizeWindow succeeded with a closed writer")
+	}
+	_ = store.Close()
+
+	reopened := newTestStoreAt(t, path, StoreConfig{})
+	assertCount(t, reopened, "aggregate_delta_log", 1)
+	assertCount(t, reopened, "aggregate_buckets", 0)
+}
+
+func TestReadBucketsEnforcesBounds(t *testing.T) {
+	store := newTestStore(t)
+	cases := []struct {
+		name string
+		sel  Selector
+	}{
+		{"empty", Selector{}},
+		{"no range", Selector{TenantID: 1}},
+		{"backwards range", Selector{TenantID: 1, Start: 900, End: 600}},
+		{"span too wide", Selector{TenantID: 1, Start: 0 + 1, End: MaxReadWindowSpan + 100}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := store.ReadBuckets(tc.sel); !errors.Is(err, ErrSelectorUnbounded) {
+				t.Fatalf("ReadBuckets(%+v) = %v, want ErrSelectorUnbounded", tc.sel, err)
+			}
+		})
+	}
+}
+
+func TestReadBucketsClampsLimitAndScopesTenant(t *testing.T) {
+	store := newTestStore(t)
+	batch := &GroupBatch{}
+	for i := 1; i <= 5; i++ {
+		key := storeKey(uint32(i))
+		if i > 3 {
+			key.TenantID = 2
+		}
+		batch.Series = append(batch.Series, SeriesRow{ID: SeriesID(i), Key: key})
+		batch.Deltas = append(batch.Deltas, DeltaRow{SeriesID: SeriesID(i), WindowStart: 600, Delta: spanDelta(1, 10)})
+	}
+	if err := store.CommitGroup(batch); err != nil {
+		t.Fatalf("CommitGroup: %v", err)
+	}
+	if _, err := store.FinalizeWindow(600); err != nil {
+		t.Fatalf("FinalizeWindow: %v", err)
+	}
+
+	got, err := store.ReadBuckets(Selector{TenantID: 1, Start: 600, End: 900})
+	if err != nil {
+		t.Fatalf("ReadBuckets: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("tenant 1 read %d buckets, want 3 (tenant 2 rows must not leak)", len(got))
+	}
+
+	limited, err := store.ReadBuckets(Selector{TenantID: 1, Start: 600, End: 900, Limit: 2})
+	if err != nil {
+		t.Fatalf("ReadBuckets(limit): %v", err)
+	}
+	if len(limited) != 2 {
+		t.Fatalf("limit 2 returned %d rows", len(limited))
+	}
+
+	signalScoped, err := store.ReadBuckets(Selector{TenantID: 1, Start: 600, End: 900, Signal: SignalLog})
+	if err != nil {
+		t.Fatalf("ReadBuckets(signal): %v", err)
+	}
+	if len(signalScoped) != 0 {
+		t.Fatalf("log-scoped read returned %d trace buckets", len(signalScoped))
+	}
+}
+
+func TestResolveSeriesRejectsOversizedInput(t *testing.T) {
+	store := newTestStore(t)
+	ids := make([]SeriesID, MaxReadRows+1)
+	if _, err := store.ResolveSeries(ids); !errors.Is(err, ErrSelectorUnbounded) {
+		t.Fatalf("ResolveSeries(oversized) = %v, want ErrSelectorUnbounded", err)
+	}
+}
+
+func TestReplayMutableSkipsFinalizedWindows(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.CommitGroup(&GroupBatch{
+		Series: []SeriesRow{{ID: 1, Key: storeKey(1)}},
+		Deltas: []DeltaRow{
+			{SeriesID: 1, WindowStart: 300, Delta: spanDelta(1, 10)},
+			{SeriesID: 1, WindowStart: 1200, Delta: spanDelta(2, 10)},
+		},
+	}); err != nil {
+		t.Fatalf("CommitGroup: %v", err)
+	}
+	rows, err := store.ReplayMutable(1200)
+	if err != nil {
+		t.Fatalf("ReplayMutable: %v", err)
+	}
+	if len(rows) != 1 || rows[0].WindowStart != 1200 {
+		t.Fatalf("ReplayMutable(1200) = %+v, want only window 1200", rows)
+	}
+}
+
+func TestPurgeBeforeDropsHistory(t *testing.T) {
+	store := newTestStore(t)
+	batch := &GroupBatch{Series: []SeriesRow{{ID: 1, Key: storeKey(1)}}}
+	for _, w := range []int64{300, 600, 900} {
+		batch.Deltas = append(batch.Deltas, DeltaRow{SeriesID: 1, WindowStart: w, Delta: spanDelta(1, 10)})
+	}
+	batch.Baselines = []BaselineRow{{
+		SeriesID: 1,
+		Producer: 5,
+		Baseline: Baseline{LastTimestamp: time.Unix(300, 0).UTC(), Value: 1},
+	}}
+	if err := store.CommitGroup(batch); err != nil {
+		t.Fatalf("CommitGroup: %v", err)
+	}
+	for _, w := range []int64{300, 600, 900} {
+		if _, err := store.FinalizeWindow(w); err != nil {
+			t.Fatalf("FinalizeWindow(%d): %v", w, err)
+		}
+	}
+
+	stats, err := store.PurgeBefore(900)
+	if err != nil {
+		t.Fatalf("PurgeBefore: %v", err)
+	}
+	if stats.Buckets != 2 {
+		t.Fatalf("purged %d buckets, want 2", stats.Buckets)
+	}
+	if stats.Baselines != 1 {
+		t.Fatalf("purged %d baselines, want 1", stats.Baselines)
+	}
+	assertCount(t, store, "aggregate_buckets", 1)
+}
+
+func TestBacklogReportsOldestWindow(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.CommitGroup(&GroupBatch{
+		Series: []SeriesRow{{ID: 1, Key: storeKey(1)}},
+		Deltas: []DeltaRow{
+			{SeriesID: 1, WindowStart: 900, Delta: spanDelta(1, 10)},
+			{SeriesID: 1, WindowStart: 600, Delta: spanDelta(1, 10)},
+		},
+	}); err != nil {
+		t.Fatalf("CommitGroup: %v", err)
+	}
+	backlog, err := store.Backlog()
+	if err != nil {
+		t.Fatalf("Backlog: %v", err)
+	}
+	if backlog.Rows != 2 || backlog.OldestWindow != 600 {
+		t.Fatalf("backlog = %+v, want 2 rows / oldest 600", backlog)
+	}
+}
+
+func TestFinalizableWindowsRespectsCutoff(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.CommitGroup(&GroupBatch{
+		Series: []SeriesRow{{ID: 1, Key: storeKey(1)}},
+		Deltas: []DeltaRow{
+			{SeriesID: 1, WindowStart: 600, Delta: spanDelta(1, 10)},
+			{SeriesID: 1, WindowStart: 1200, Delta: spanDelta(1, 10)},
+		},
+	}); err != nil {
+		t.Fatalf("CommitGroup: %v", err)
+	}
+	windows, err := store.FinalizableWindows(600, 0)
+	if err != nil {
+		t.Fatalf("FinalizableWindows: %v", err)
+	}
+	if len(windows) != 1 || windows[0] != 600 {
+		t.Fatalf("FinalizableWindows(600) = %v, want [600]", windows)
+	}
+}
+
+func TestProducerIDRoundTrip(t *testing.T) {
+	for _, p := range []ProducerID{0, 1, 0xdeadbeefcafef00d, ^ProducerID(0)} {
+		if got := producerFromBytes(producerBytes(p)); got != p {
+			t.Fatalf("producer round trip %d -> %d", p, got)
+		}
+	}
+}
+
+// assertCount fails unless the table holds exactly n rows.
+func assertCount(t *testing.T, s *SQLiteStore, table string, n int) {
+	t.Helper()
+	var got int
+	if err := s.reader.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&got); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	if got != n {
+		t.Fatalf("%s holds %d rows, want %d", table, got, n)
+	}
+}
+
+func assertEmpty(t *testing.T, s *SQLiteStore, table string) {
+	t.Helper()
+	assertCount(t, s, table, 0)
+}

--- a/internal/aggregate/temporality.go
+++ b/internal/aggregate/temporality.go
@@ -21,10 +21,12 @@ import (
 // Non-monotonic sums never enter this path at all: they are gauge-like, and
 // applying value-decrease reset detection to an UpDownCounter mangles it.
 //
-// Baselines are in-memory in Phase 1. Durability — upserting the baseline row
-// inside the same group commit as the deltas it justifies — is #173. Until then
-// a restart re-seeds every baseline, which is the accepted-gap fallback #166
-// documents, not the target contract.
+// Baselines are durable when the store is enabled (#173): every mutation marks
+// the record dirty, the group-commit writer drains the dirty set into the same
+// transaction as the deltas it justifies, and startup recovery seeds the
+// tracker from the store. Without a store the tracker is in-memory only and a
+// restart re-seeds every baseline — the accepted-gap fallback #166 documents,
+// not the target contract.
 
 // Temporality is the OTLP aggregation temporality of a metric point.
 type Temporality uint8
@@ -195,6 +197,21 @@ type BaselineTrackerConfig struct {
 	GapThreshold time.Duration
 }
 
+// DirtyBaseline is one baseline awaiting durable upsert. The group-commit
+// writer drains them into the same transaction as the deltas they justify
+// (#166), which is what closes the restart gap durable ACK exists to close.
+type DirtyBaseline struct {
+	Key      SeriesKey
+	Producer ProducerID
+	Baseline Baseline
+}
+
+// baselineRef identifies one baseline record.
+type baselineRef struct {
+	key      SeriesKey
+	producer ProducerID
+}
+
 // BaselineTracker converts cumulative monotonic points into deltas and detects
 // resets. It is safe for concurrent use.
 type BaselineTracker struct {
@@ -202,6 +219,7 @@ type BaselineTracker struct {
 
 	mu      sync.Mutex
 	series  map[SeriesKey]map[ProducerID]*Baseline
+	dirty   map[baselineRef]struct{}
 	entries int
 
 	stale            uint64
@@ -228,7 +246,75 @@ func NewBaselineTracker(cfg BaselineTrackerConfig) *BaselineTracker {
 	return &BaselineTracker{
 		cfg:    cfg,
 		series: make(map[SeriesKey]map[ProducerID]*Baseline),
+		dirty:  make(map[baselineRef]struct{}),
 	}
+}
+
+// Seed installs a baseline read back from the durable store at startup. It
+// does NOT mark the record dirty: it is already durable, and re-writing every
+// recovered baseline on the first commit would make restart the most expensive
+// transaction the store ever runs.
+func (t *BaselineTracker) Seed(key SeriesKey, producer ProducerID, b Baseline) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	byProducer, ok := t.series[key]
+	if !ok {
+		byProducer = make(map[ProducerID]*Baseline, 1)
+		t.series[key] = byProducer
+	}
+	if _, exists := byProducer[producer]; !exists {
+		t.entries++
+	}
+	cp := b
+	byProducer[producer] = &cp
+}
+
+// DrainDirty returns the baselines mutated since the last drain and clears the
+// dirty set. The writer calls it while building a group batch, so every drained
+// record is at least as new as the deltas in that batch: on a crash a baseline
+// can be ahead of the durable deltas (the next point under-counts by one
+// interval) but never behind them (which would double-count).
+func (t *BaselineTracker) DrainDirty() []DirtyBaseline {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.dirty) == 0 {
+		return nil
+	}
+	out := make([]DirtyBaseline, 0, len(t.dirty))
+	for ref := range t.dirty {
+		b, ok := t.series[ref.key][ref.producer]
+		if !ok {
+			continue
+		}
+		out = append(out, DirtyBaseline{Key: ref.key, Producer: ref.producer, Baseline: *b})
+	}
+	clear(t.dirty)
+	return out
+}
+
+// Redirty puts drained baselines back after a failed commit.
+func (t *BaselineTracker) Redirty(rows []DirtyBaseline) {
+	if len(rows) == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, r := range rows {
+		t.dirty[baselineRef{key: r.Key, producer: r.Producer}] = struct{}{}
+	}
+}
+
+// DirtyCount reports how many baselines are awaiting a durable upsert.
+func (t *BaselineTracker) DirtyCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.dirty)
+}
+
+// markDirtyLocked records that (key, producer) needs a durable upsert. t.mu
+// must be held.
+func (t *BaselineTracker) markDirtyLocked(key SeriesKey, producer ProducerID) {
+	t.dirty[baselineRef{key: key, producer: producer}] = struct{}{}
 }
 
 // ObserveCumulative applies the normative #166 evaluation order to one
@@ -271,6 +357,7 @@ func (t *BaselineTracker) ObserveCumulative(key SeriesKey, producer ProducerID, 
 		byProducer[producer] = &Baseline{StartTime: startTime, LastTimestamp: ts, Value: value}
 		t.entries++
 		t.seeded++
+		t.markDirtyLocked(key, producer)
 		out.Seeded = true
 		return out
 	}
@@ -289,6 +376,7 @@ func (t *BaselineTracker) ObserveCumulative(key SeriesKey, producer ProducerID, 
 		b.LastTimestamp = ts
 		b.Value = value
 		t.gaps++
+		t.markDirtyLocked(key, producer)
 		out.Gap = true
 		return out
 	}
@@ -314,6 +402,7 @@ func (t *BaselineTracker) ObserveCumulative(key SeriesKey, producer ProducerID, 
 	b.StartTime = startTime
 	b.LastTimestamp = ts
 	b.Value = value
+	t.markDirtyLocked(key, producer)
 	return out
 }
 

--- a/internal/aggregate/writer.go
+++ b/internal/aggregate/writer.go
@@ -1,0 +1,534 @@
+package aggregate
+
+import (
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// The group-commit writer (#160, ADR 0002).
+//
+// Contract: an Export is acknowledged only after its reduced deltas are inside
+// a committed SQLite transaction AND those committed deltas have been applied
+// to the shards. Commit first, apply second, release waiters third — in that
+// order, so the shards are a projection of committed state and memory can lag
+// durability but never lead it.
+//
+// Cadence: the first waiter opens a coalescing window of at most
+// CoalesceWindow; the commit fires early once the batch reaches its size or
+// count target. While a COMMIT is in flight the next batch accumulates in the
+// submission channel, which is bounded by the same waiter cap that bounds
+// admission — there is exactly one place where memory can grow and it is
+// capped three ways.
+//
+// Admission is bounded by pending bytes, waiter count and a defensive delta
+// count. A breach returns *SaturationError (errors.Is(err, ErrSaturated)),
+// which internal/ingest maps to gRPC RESOURCE_EXHAUSTED / HTTP 429 exactly
+// like the raw pipeline's ErrQueueFull. It never degrades to bounded-loss ACK
+// on its own: that is explicit configuration only, never runtime degradation.
+
+// Writer defaults. They are the provisional numbers of #160/#162; the
+// benchmark gate ratifies or replaces them.
+const (
+	// DefaultCommitCoalesceMs is the first-waiter coalescing window.
+	DefaultCommitCoalesceMs = 5
+	// DefaultCommitMaxDeltas is the early-commit count target — the "5k dirty
+	// series" shape the gate benchmarks.
+	DefaultCommitMaxDeltas = 5000
+	// DefaultCommitMaxBytes is the early-commit size target.
+	DefaultCommitMaxBytes = 8 << 20
+	// DefaultCommitMaxPendingBytes bounds un-committed delta payload.
+	DefaultCommitMaxPendingBytes = 64 << 20
+	// DefaultCommitMaxWaiters bounds Export goroutines parked on a commit.
+	DefaultCommitMaxWaiters = 512
+	// DefaultCommitMaxPendingDeltas is the defensive delta-count bound.
+	DefaultCommitMaxPendingDeltas = 200000
+	// DefaultFinalizeIntervalSec is how often the writer looks for windows
+	// whose lateness horizon has expired.
+	DefaultFinalizeIntervalSec = 30
+	// finalizeWindowsPerPass bounds one finalization pass.
+	finalizeWindowsPerPass = 32
+)
+
+// WriterConfig configures the group-commit writer.
+type WriterConfig struct {
+	// Store is the durable store. Required.
+	Store Store
+	// Engine is the engine whose shards receive committed deltas. Required.
+	Engine *Engine
+	// Registrar is the durable dictionary registrar whose staged rows ride
+	// each commit. Required when the engine was built with one.
+	Registrar *DurableRegistrar
+
+	// CoalesceWindow, MaxBatchDeltas and MaxBatchBytes set the commit cadence.
+	CoalesceWindow time.Duration
+	MaxBatchDeltas int
+	MaxBatchBytes  int64
+
+	// MaxPendingBytes, MaxWaiters and MaxPendingDeltas are the triple
+	// admission bound.
+	MaxPendingBytes  int64
+	MaxWaiters       int
+	MaxPendingDeltas int
+
+	// FinalizeInterval is the window-finalization tick. Zero takes the
+	// default; negative disables the loop (tests drive it by hand).
+	FinalizeInterval time.Duration
+
+	// Metrics is the durable path's metric surface.
+	Metrics StoreMetrics
+
+	// Now is the clock, injectable for tests.
+	Now func() time.Time
+}
+
+// withDefaults fills unset knobs.
+func (c WriterConfig) withDefaults() WriterConfig {
+	if c.CoalesceWindow <= 0 {
+		c.CoalesceWindow = DefaultCommitCoalesceMs * time.Millisecond
+	}
+	if c.MaxBatchDeltas <= 0 {
+		c.MaxBatchDeltas = DefaultCommitMaxDeltas
+	}
+	if c.MaxBatchBytes <= 0 {
+		c.MaxBatchBytes = DefaultCommitMaxBytes
+	}
+	if c.MaxPendingBytes <= 0 {
+		c.MaxPendingBytes = DefaultCommitMaxPendingBytes
+	}
+	if c.MaxWaiters <= 0 {
+		c.MaxWaiters = DefaultCommitMaxWaiters
+	}
+	if c.MaxPendingDeltas <= 0 {
+		c.MaxPendingDeltas = DefaultCommitMaxPendingDeltas
+	}
+	if c.FinalizeInterval == 0 {
+		c.FinalizeInterval = DefaultFinalizeIntervalSec * time.Second
+	}
+	if c.Metrics == nil {
+		c.Metrics = noopStoreMetrics{}
+	}
+	if c.Now == nil {
+		c.Now = time.Now
+	}
+	return c
+}
+
+// commitResult is what a waiter receives once its batch is durable and applied.
+type commitResult struct {
+	revision uint64
+	err      error
+}
+
+// submission is one Export's deltas awaiting a commit.
+type submission struct {
+	deltas DeltaMap
+	bytes  int64
+	count  int
+	done   chan commitResult
+}
+
+// WriterStats is a snapshot of writer counters.
+type WriterStats struct {
+	// Commits and CommitErrors count group commits attempted and failed.
+	Commits, CommitErrors uint64
+	// Deltas counts delta rows written.
+	Deltas uint64
+	// Rejections counts ErrSaturated refusals.
+	Rejections uint64
+	// PendingBytes, PendingDeltas and Waiters are the live admission
+	// occupancy.
+	PendingBytes  int64
+	PendingDeltas int
+	Waiters       int
+	// Finalized counts windows finalized by the writer's state machine.
+	Finalized uint64
+}
+
+// Writer is the group-commit writer. It is the engine's Applier once the
+// durable store is enabled.
+type Writer struct {
+	cfg    WriterConfig
+	store  Store
+	engine *Engine
+	reg    *DurableRegistrar
+	series *seriesRegistry
+
+	submissions chan *submission
+	stop        chan struct{}
+	stopOnce    sync.Once
+	wg          sync.WaitGroup
+	closed      atomic.Bool
+
+	// admission counters, guarded by mu.
+	mu            sync.Mutex
+	pendingBytes  int64
+	pendingDeltas int
+	waiters       int
+
+	commits      atomic.Uint64
+	commitErrors atomic.Uint64
+	deltas       atomic.Uint64
+	rejections   atomic.Uint64
+	finalized    atomic.Uint64
+}
+
+// NewWriter builds a writer over store and engine. It does not start it.
+func NewWriter(cfg WriterConfig) (*Writer, error) {
+	cfg = cfg.withDefaults()
+	if cfg.Store == nil {
+		return nil, errNilStore
+	}
+	if cfg.Engine == nil {
+		return nil, errNilEngine
+	}
+	series, err := newSeriesRegistry(cfg.Store)
+	if err != nil {
+		return nil, err
+	}
+	return &Writer{
+		cfg:         cfg,
+		store:       cfg.Store,
+		engine:      cfg.Engine,
+		reg:         cfg.Registrar,
+		series:      series,
+		submissions: make(chan *submission, cfg.MaxWaiters),
+		stop:        make(chan struct{}),
+	}, nil
+}
+
+// Start launches the commit loop and, unless disabled, the finalize loop.
+func (w *Writer) Start() {
+	w.wg.Add(1)
+	go w.commitLoop()
+	if w.cfg.FinalizeInterval > 0 {
+		w.wg.Add(1)
+		go w.finalizeLoop()
+	}
+}
+
+// Stop drains the in-flight submissions, commits them, and returns once the
+// loops have exited. It is idempotent.
+func (w *Writer) Stop() {
+	w.stopOnce.Do(func() {
+		w.closed.Store(true)
+		close(w.stop)
+	})
+	w.wg.Wait()
+}
+
+// Stats returns a snapshot of the writer counters.
+func (w *Writer) Stats() WriterStats {
+	w.mu.Lock()
+	pendingBytes, pendingDeltas, waiters := w.pendingBytes, w.pendingDeltas, w.waiters
+	w.mu.Unlock()
+	return WriterStats{
+		Commits:       w.commits.Load(),
+		CommitErrors:  w.commitErrors.Load(),
+		Deltas:        w.deltas.Load(),
+		Rejections:    w.rejections.Load(),
+		PendingBytes:  pendingBytes,
+		PendingDeltas: pendingDeltas,
+		Waiters:       waiters,
+		Finalized:     w.finalized.Load(),
+	}
+}
+
+// Apply implements Applier. It exists so a caller that cannot act on an error
+// still gets the durable path; every ingest caller uses ApplyErr instead.
+func (w *Writer) Apply(m DeltaMap) uint64 {
+	rev, err := w.ApplyErr(m)
+	if err != nil {
+		slog.Warn("aggregate: group commit failed", "error", err)
+	}
+	return rev
+}
+
+// ApplyErr implements FailableApplier: it blocks until the deltas are durable
+// and applied, or until admission refuses them.
+func (w *Writer) ApplyErr(m DeltaMap) (uint64, error) {
+	if len(m) == 0 {
+		return w.engine.Revision(), nil
+	}
+	if w.closed.Load() {
+		return w.engine.Revision(), ErrStoreClosed
+	}
+	s := &submission{
+		deltas: m,
+		bytes:  estimateDeltaBytes(m),
+		count:  len(m),
+		done:   make(chan commitResult, 1),
+	}
+	if err := w.admit(s); err != nil {
+		return w.engine.Revision(), err
+	}
+	select {
+	case w.submissions <- s:
+	case <-w.stop:
+		// The writer is shutting down and may already have stopped reading.
+		// Release the admission budget and refuse rather than park forever.
+		w.release(s)
+		return w.engine.Revision(), ErrStoreClosed
+	}
+	res := <-s.done
+	return res.revision, res.err
+}
+
+// admit applies the triple bound.
+func (w *Writer) admit(s *submission) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	var err *SaturationError
+	switch {
+	case w.waiters >= w.cfg.MaxWaiters:
+		err = &SaturationError{Bound: "waiters", Current: int64(w.waiters), Limit: int64(w.cfg.MaxWaiters)}
+	case w.pendingBytes+s.bytes > w.cfg.MaxPendingBytes:
+		err = &SaturationError{Bound: "bytes", Current: w.pendingBytes + s.bytes, Limit: w.cfg.MaxPendingBytes}
+	case w.pendingDeltas+s.count > w.cfg.MaxPendingDeltas:
+		err = &SaturationError{Bound: "deltas", Current: int64(w.pendingDeltas + s.count), Limit: int64(w.cfg.MaxPendingDeltas)}
+	}
+	if err != nil {
+		w.rejections.Add(1)
+		w.cfg.Metrics.RecordAdmissionRejected(err.Bound)
+		return err
+	}
+	w.waiters++
+	w.pendingBytes += s.bytes
+	w.pendingDeltas += s.count
+	return nil
+}
+
+// release returns one submission's admission budget.
+func (w *Writer) release(s *submission) {
+	w.mu.Lock()
+	w.waiters--
+	w.pendingBytes -= s.bytes
+	w.pendingDeltas -= s.count
+	w.mu.Unlock()
+}
+
+// commitLoop is the writer's state machine.
+func (w *Writer) commitLoop() {
+	defer w.wg.Done()
+	for {
+		select {
+		case <-w.stop:
+			w.drain()
+			return
+		case s := <-w.submissions:
+			w.collectAndCommit(s)
+		}
+	}
+}
+
+// drain commits whatever is still queued at shutdown. gRPC GracefulStop has
+// already stopped new Exports by the time this runs, so the queue is finite.
+func (w *Writer) drain() {
+	for {
+		select {
+		case s := <-w.submissions:
+			w.collectAndCommit(s)
+		default:
+			return
+		}
+	}
+}
+
+// collectAndCommit opens the coalescing window on the first waiter and commits
+// once the window closes or a size/count target is reached.
+func (w *Writer) collectAndCommit(first *submission) {
+	batch := []*submission{first}
+	bytes, count := first.bytes, first.count
+
+	timer := time.NewTimer(w.cfg.CoalesceWindow)
+	defer timer.Stop()
+collect:
+	for count < w.cfg.MaxBatchDeltas && bytes < w.cfg.MaxBatchBytes {
+		select {
+		case s := <-w.submissions:
+			batch = append(batch, s)
+			bytes += s.bytes
+			count += s.count
+		case <-timer.C:
+			break collect
+		}
+	}
+	w.commit(batch)
+}
+
+// commit is the durability boundary: one transaction, then the shard apply,
+// then the waiters.
+func (w *Writer) commit(batch []*submission) {
+	// Pre-merge: the same (series, window) touched by several Exports becomes
+	// one delta row. This is the pre-merge ratio #162's gate measures.
+	merged := make(DeltaMap, len(batch[0].deltas))
+	for _, s := range batch {
+		for swk, d := range s.deltas {
+			if cur, ok := merged[swk]; ok {
+				cur.Merge(d)
+				continue
+			}
+			merged[swk] = d
+		}
+	}
+
+	// Admission against the cardinality budget happens BEFORE the write so the
+	// row that becomes durable carries the same identity the shards will hold.
+	// Doing it after the commit would let the store accumulate series the
+	// in-memory caps already rejected.
+	resolved := w.engine.Admit(merged)
+
+	gb := &GroupBatch{Deltas: make([]DeltaRow, 0, len(resolved))}
+	for swk, d := range resolved {
+		gb.Deltas = append(gb.Deltas, DeltaRow{
+			SeriesID:    w.series.Resolve(swk.Key),
+			WindowStart: swk.WindowStart,
+			Delta:       d,
+		})
+	}
+	// Baselines are keyed by the FULL canonical identity, before cardinality
+	// overflow routing (#166): two series that collapse onto one __other__
+	// series still have independent counters. That means a baseline can mint a
+	// series row for a key the shards never materialize — bounded, because the
+	// baseline table itself is bounded by AGGREGATE_MAX_BASELINES.
+	dirty := w.engine.Baselines().DrainDirty()
+	for _, b := range dirty {
+		gb.Baselines = append(gb.Baselines, BaselineRow{
+			SeriesID: w.series.Resolve(b.Key),
+			Producer: b.Producer,
+			Baseline: b.Baseline,
+		})
+	}
+	// Series first, dictionary second: resolving a series may have minted a
+	// dictionary-free identity, but never the reverse, and both drains must
+	// happen after every Resolve above.
+	gb.Series = w.series.DrainPending()
+	if w.reg != nil {
+		gb.Dicts = w.reg.DrainPending()
+	}
+
+	err := w.store.CommitGroup(gb)
+	w.commits.Add(1)
+	if err != nil {
+		w.commitErrors.Add(1)
+		// Nothing became durable: put the baselines back so the next commit
+		// carries them, and leave the staged registrations staged.
+		w.engine.Baselines().Redirty(dirty)
+		w.finish(batch, commitResult{revision: w.engine.Revision(), err: err})
+		return
+	}
+	w.deltas.Add(uint64(len(gb.Deltas)))
+	w.series.Committed(gb.Series)
+	if w.reg != nil {
+		w.reg.Committed(gb.Dicts)
+	}
+
+	// Commit-then-apply: the shards only ever see committed state.
+	rev := w.engine.ApplyCommitted(resolved)
+	w.finish(batch, commitResult{revision: rev})
+}
+
+// finish releases the batch's waiters and their admission budget.
+func (w *Writer) finish(batch []*submission, res commitResult) {
+	for _, s := range batch {
+		w.release(s)
+		s.done <- res
+	}
+}
+
+// finalizeLoop drives window finalization. It lives on the writer because
+// finalization has to serialize with incoming late deltas (#162): the store's
+// writer lock is what provides that, and the loop is what decides when.
+func (w *Writer) finalizeLoop() {
+	defer w.wg.Done()
+	tick := time.NewTicker(w.cfg.FinalizeInterval)
+	defer tick.Stop()
+	for {
+		select {
+		case <-w.stop:
+			return
+		case <-tick.C:
+			w.FinalizeDue(w.cfg.Now())
+			w.publishBacklog(w.cfg.Now())
+		}
+	}
+}
+
+// FinalizeDue finalizes every window whose lateness horizon expired at now and
+// returns how many it finalized. Exported so recovery and tests can drive the
+// same state machine the loop drives.
+func (w *Writer) FinalizeDue(now time.Time) int {
+	windows, err := w.store.FinalizableWindows(FinalizeCutoff(now), finalizeWindowsPerPass)
+	if err != nil {
+		slog.Error("aggregate: list finalizable windows failed", "error", err)
+		return 0
+	}
+	done := 0
+	for _, window := range windows {
+		if _, err := w.store.FinalizeWindow(window); err != nil {
+			slog.Error("aggregate: finalize window failed", "window_start", window, "error", err)
+			continue
+		}
+		w.finalized.Add(1)
+		done++
+	}
+	return done
+}
+
+// publishBacklog pushes the delta-log health bounds into the metric surface.
+func (w *Writer) publishBacklog(now time.Time) {
+	stats, err := w.store.Backlog()
+	if err != nil {
+		slog.Warn("aggregate: backlog probe failed", "error", err)
+		return
+	}
+	age := 0.0
+	if stats.OldestWindow > 0 {
+		age = now.Sub(time.Unix(stats.OldestWindow, 0)).Seconds()
+	}
+	w.cfg.Metrics.SetBacklog(stats.Rows, age)
+}
+
+// SeriesID exposes the writer's series resolution for tests and for the read
+// path that has to turn a SeriesKey into a durable ID.
+func (w *Writer) SeriesID(key SeriesKey) SeriesID { return w.series.Resolve(key) }
+
+// SeriesKeyByID resolves a durable ID back to its identity from memory.
+func (w *Writer) SeriesKeyByID(id SeriesID) (SeriesKey, bool) { return w.series.Key(id) }
+
+// estimateDeltaBytes approximates the on-disk cost of one reducer's output. It
+// is an admission input, not an accounting figure: it must be cheap and it must
+// never under-count a sketch badly enough to matter.
+func estimateDeltaBytes(m DeltaMap) int64 {
+	var n int64
+	for _, d := range m {
+		n += deltaRowBytes
+		if d != nil && d.Sketch != nil {
+			bins := int64(d.Sketch.PopulatedBins())
+			if bins > SketchMaxSerializedBins {
+				bins = SketchMaxSerializedBins
+			}
+			n += 16 + bins*3
+		}
+	}
+	return n
+}
+
+// compile-time assertions.
+var (
+	_ Applier         = (*Writer)(nil)
+	_ FailableApplier = (*Writer)(nil)
+)
+
+// Writer construction errors.
+var (
+	errNilStore  = errStr("aggregate: writer requires a store")
+	errNilEngine = errStr("aggregate: writer requires an engine")
+)
+
+// errStr is a tiny constant error type: these two are programming errors at
+// construction time, not conditions a caller branches on.
+type errStr string
+
+func (e errStr) Error() string { return string(e) }

--- a/internal/aggregate/writer_test.go
+++ b/internal/aggregate/writer_test.go
@@ -1,0 +1,400 @@
+package aggregate
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fixedClock is a settable clock for the engine and the writer.
+type fixedClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newClock(t time.Time) *fixedClock { return &fixedClock{now: t} }
+
+func (c *fixedClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fixedClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// hookStore wraps a Store so a test can block, fail, or observe a commit.
+type hookStore struct {
+	Store
+	beforeCommit func(*GroupBatch)
+	commitErr    error
+	commits      atomic.Int64
+}
+
+func (h *hookStore) CommitGroup(b *GroupBatch) error {
+	h.commits.Add(1)
+	if h.beforeCommit != nil {
+		h.beforeCommit(b)
+	}
+	if h.commitErr != nil {
+		return h.commitErr
+	}
+	return h.Store.CommitGroup(b)
+}
+
+// newTestEngine builds an engine on a fixed clock.
+func newTestEngine(t *testing.T, clock *fixedClock, reg Registrar) *Engine {
+	t.Helper()
+	eng, err := NewEngine(EngineConfig{
+		Mode:      ModeAggregate,
+		Registrar: reg,
+		Now:       clock.Now,
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	return eng
+}
+
+// newTestWriter wires a writer over store and engine and starts it.
+func newTestWriter(t *testing.T, store Store, eng *Engine, clock *fixedClock, cfg WriterConfig) *Writer {
+	t.Helper()
+	cfg.Store = store
+	cfg.Engine = eng
+	cfg.Now = clock.Now
+	if cfg.FinalizeInterval == 0 {
+		cfg.FinalizeInterval = -1 // driven by hand in tests
+	}
+	w, err := NewWriter(cfg)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	eng.SetApplier(w)
+	w.Start()
+	t.Cleanup(w.Stop)
+	return w
+}
+
+// deltaFor builds a one-series delta map in the current window.
+func deltaFor(now time.Time, name uint32, count int) DeltaMap {
+	return DeltaMap{
+		SeriesWindowKey{Key: storeKey(name), WindowStart: WindowStart(now)}: spanDelta(count, 250),
+	}
+}
+
+func TestWriterCommitsAndApplies(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	store := newTestStore(t)
+	eng := newTestEngine(t, clock, nil)
+	w := newTestWriter(t, store, eng, clock, WriterConfig{})
+
+	rev, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 4))
+	if err != nil {
+		t.Fatalf("ApplyDeltasErr: %v", err)
+	}
+	if rev == 0 {
+		t.Fatal("revision did not advance after a durable apply")
+	}
+	snap := eng.Snapshot()
+	count, _ := snap.Totals(SignalTraceOp)
+	if count != 4 {
+		t.Fatalf("engine count = %d, want 4", count)
+	}
+	rows, err := store.ReplayMutable(0)
+	if err != nil {
+		t.Fatalf("ReplayMutable: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Delta.Count != 4 {
+		t.Fatalf("durable rows = %+v, want one row with count 4", rows)
+	}
+	if got := w.Stats().Deltas; got != 1 {
+		t.Fatalf("writer wrote %d delta rows, want 1", got)
+	}
+}
+
+// TestWriterCommitPrecedesApply proves the ordering the ACK contract depends
+// on: at the moment the transaction is being written, the shards must not yet
+// hold the deltas.
+func TestWriterCommitPrecedesApply(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	eng := newTestEngine(t, clock, nil)
+
+	var appliedAtCommit uint64
+	hooked := &hookStore{Store: base}
+	hooked.beforeCommit = func(*GroupBatch) {
+		snap := eng.Snapshot()
+		appliedAtCommit, _ = snap.Totals(SignalTraceOp)
+	}
+	newTestWriter(t, hooked, eng, clock, WriterConfig{})
+
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 3)); err != nil {
+		t.Fatalf("ApplyDeltasErr: %v", err)
+	}
+	if appliedAtCommit != 0 {
+		t.Fatalf("shards held %d points during COMMIT; apply must follow the commit", appliedAtCommit)
+	}
+	snap := eng.Snapshot()
+	if count, _ := snap.Totals(SignalTraceOp); count != 3 {
+		t.Fatalf("shards hold %d points after the commit, want 3", count)
+	}
+}
+
+func TestWriterCommitFailureIsNotAcknowledged(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	eng := newTestEngine(t, clock, nil)
+	boom := errors.New("commit exploded")
+	hooked := &hookStore{Store: base, commitErr: boom}
+	newTestWriter(t, hooked, eng, clock, WriterConfig{})
+
+	_, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 3))
+	if !errors.Is(err, boom) {
+		t.Fatalf("ApplyDeltasErr = %v, want the commit error", err)
+	}
+	snap := eng.Snapshot()
+	if count, _ := snap.Totals(SignalTraceOp); count != 0 {
+		t.Fatalf("shards hold %d points after a failed commit, want 0", count)
+	}
+}
+
+// TestWriterCoalescesConcurrentApplies asserts the natural group commit: many
+// concurrent Exports must produce materially fewer transactions than callers,
+// and every caller must be released only after its commit.
+func TestWriterCoalescesConcurrentApplies(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	eng := newTestEngine(t, clock, nil)
+
+	release := make(chan struct{})
+	var firstCommit sync.Once
+	hooked := &hookStore{Store: base}
+	hooked.beforeCommit = func(*GroupBatch) {
+		// Hold the first commit open long enough for the rest of the callers
+		// to queue behind it — the "next batch accumulates while a COMMIT is
+		// in flight" shape from #160.
+		firstCommit.Do(func() { <-release })
+	}
+	newTestWriter(t, hooked, eng, clock, WriterConfig{CoalesceWindow: 20 * time.Millisecond})
+
+	const callers = 32
+	var wg sync.WaitGroup
+	errs := make([]error, callers)
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = eng.ApplyDeltasErr(deltaFor(clock.Now(), uint32(i%4)+1, 1))
+		}(i)
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("caller %d: %v", i, err)
+		}
+	}
+	commits := hooked.commits.Load()
+	if commits >= callers {
+		t.Fatalf("%d callers produced %d commits; coalescing did nothing", callers, commits)
+	}
+	snap := eng.Snapshot()
+	if count, _ := snap.Totals(SignalTraceOp); count != callers {
+		t.Fatalf("engine counted %d points, want %d", count, callers)
+	}
+	rows, err := base.ReplayMutable(0)
+	if err != nil {
+		t.Fatalf("ReplayMutable: %v", err)
+	}
+	var durable uint64
+	for _, r := range rows {
+		durable += r.Delta.Count
+	}
+	if durable != callers {
+		t.Fatalf("durable points = %d, want %d", durable, callers)
+	}
+	if w := eng; w == nil {
+		t.Fatal("unreachable")
+	}
+}
+
+func TestWriterAdmissionBounds(t *testing.T) {
+	cases := []struct {
+		name  string
+		cfg   WriterConfig
+		bound string
+	}{
+		{"waiters", WriterConfig{MaxWaiters: 1}, "waiters"},
+		{"bytes", WriterConfig{MaxPendingBytes: deltaRowBytes + 64}, "bytes"},
+		{"deltas", WriterConfig{MaxPendingDeltas: 1}, "deltas"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := newClock(time.Unix(3_000_000, 0).UTC())
+			base := newTestStore(t)
+			eng := newTestEngine(t, clock, nil)
+			release := make(chan struct{})
+			var once sync.Once
+			hooked := &hookStore{Store: base}
+			hooked.beforeCommit = func(*GroupBatch) { once.Do(func() { <-release }) }
+			newTestWriter(t, hooked, eng, clock, tc.cfg)
+
+			// One caller parks inside the commit, holding its admission budget.
+			parked := make(chan error, 1)
+			go func() {
+				_, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 1))
+				parked <- err
+			}()
+			waitFor(t, func() bool { return hooked.commits.Load() == 1 })
+
+			// Two more series so the delta-count bound is genuinely exceeded.
+			m := deltaFor(clock.Now(), 2, 1)
+			for k, v := range deltaFor(clock.Now(), 3, 1) {
+				m[k] = v
+			}
+			_, err := eng.ApplyDeltasErr(m)
+			if !errors.Is(err, ErrSaturated) {
+				t.Fatalf("second apply = %v, want ErrSaturated", err)
+			}
+			var sat *SaturationError
+			if !errors.As(err, &sat) || sat.Bound != tc.bound {
+				t.Fatalf("saturation bound = %+v, want %s", sat, tc.bound)
+			}
+
+			close(release)
+			if err := <-parked; err != nil {
+				t.Fatalf("parked caller: %v", err)
+			}
+		})
+	}
+}
+
+// TestWriterDurableRegistrationRidesTheCommit proves #162's first atomicity
+// invariant end to end: the dictionary and series rows an Export minted are in
+// the same transaction as its first delta.
+func TestWriterDurableRegistrationRidesTheCommit(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	reg, err := NewDurableRegistrar(base, nil)
+	if err != nil {
+		t.Fatalf("NewDurableRegistrar: %v", err)
+	}
+	eng := newTestEngine(t, clock, reg)
+	w := newTestWriter(t, base, eng, clock, WriterConfig{Registrar: reg})
+
+	tenant := eng.Cache().InternTenant("acme")
+	nameID := eng.Cache().Intern(tenant, KindOperation, "GET /orders")
+	if reg.PendingCount() == 0 {
+		t.Fatal("registrations were not staged before the commit")
+	}
+	assertEmpty(t, base, "aggregate_dict")
+
+	key := SeriesKey{TenantID: tenant, ServiceID: 1, NameID: nameID, Signal: SignalTraceOp}
+	m := DeltaMap{SeriesWindowKey{Key: key, WindowStart: WindowStart(clock.Now())}: spanDelta(2, 100)}
+	if _, err := eng.ApplyDeltasErr(m); err != nil {
+		t.Fatalf("ApplyDeltasErr: %v", err)
+	}
+	if reg.PendingCount() != 0 {
+		t.Fatalf("%d registrations still staged after a successful commit", reg.PendingCount())
+	}
+	dicts, err := base.LoadDict(0)
+	if err != nil {
+		t.Fatalf("LoadDict: %v", err)
+	}
+	if len(dicts) < 2 {
+		t.Fatalf("dictionary holds %d rows, want the tenant and operation entries", len(dicts))
+	}
+	series, err := base.LoadSeries(0)
+	if err != nil {
+		t.Fatalf("LoadSeries: %v", err)
+	}
+	if len(series) != 1 || series[0].Key != key {
+		t.Fatalf("series rows = %+v, want exactly the referenced key", series)
+	}
+	if _, ok := w.SeriesKeyByID(series[0].ID); !ok {
+		t.Fatal("writer cannot resolve the series id it just minted")
+	}
+}
+
+// TestWriterBaselineRidesTheCommit covers #166: the baseline upsert and the
+// delta it justifies are one transaction.
+func TestWriterBaselineRidesTheCommit(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	eng := newTestEngine(t, clock, nil)
+	newTestWriter(t, base, eng, clock, WriterConfig{})
+
+	key := SeriesKey{TenantID: 1, ServiceID: 1, NameID: 9, Signal: SignalMetric}
+	out := eng.Baselines().ObserveCumulative(key, 77, clock.Now().Add(-time.Hour), clock.Now(), 100)
+	if !out.Seeded {
+		t.Fatalf("first cumulative point = %+v, want a seed", out)
+	}
+	if eng.Baselines().DirtyCount() != 1 {
+		t.Fatal("baseline mutation did not mark the record dirty")
+	}
+	m := DeltaMap{SeriesWindowKey{Key: key, WindowStart: WindowStart(clock.Now())}: spanDelta(1, 10)}
+	if _, err := eng.ApplyDeltasErr(m); err != nil {
+		t.Fatalf("ApplyDeltasErr: %v", err)
+	}
+	if eng.Baselines().DirtyCount() != 0 {
+		t.Fatal("baseline is still dirty after a successful commit")
+	}
+	rows, err := base.LoadBaselines(0)
+	if err != nil {
+		t.Fatalf("LoadBaselines: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Producer != 77 || rows[0].Baseline.Value != 100 {
+		t.Fatalf("durable baselines = %+v", rows)
+	}
+}
+
+func TestWriterFinalizeDue(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	eng := newTestEngine(t, clock, nil)
+	w := newTestWriter(t, base, eng, clock, WriterConfig{})
+
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 5)); err != nil {
+		t.Fatalf("ApplyDeltasErr: %v", err)
+	}
+	if n := w.FinalizeDue(clock.Now()); n != 0 {
+		t.Fatalf("finalized %d windows while still mutable", n)
+	}
+	clock.Advance(WindowSize + AllowedLateness + time.Minute)
+	if n := w.FinalizeDue(clock.Now()); n != 1 {
+		t.Fatalf("finalized %d windows after the lateness horizon, want 1", n)
+	}
+	assertCount(t, base, "aggregate_delta_log", 0)
+	assertCount(t, base, "aggregate_buckets", 1)
+}
+
+func TestWriterRefusesAfterStop(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	eng := newTestEngine(t, clock, nil)
+	w := newTestWriter(t, base, eng, clock, WriterConfig{})
+	w.Stop()
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 1)); !errors.Is(err, ErrStoreClosed) {
+		t.Fatalf("apply after Stop = %v, want ErrStoreClosed", err)
+	}
+}
+
+// waitFor spins until cond is true or the test times out.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("condition not met within 2s")
+}

--- a/internal/api/health_aggregate_test.go
+++ b/internal/api/health_aggregate_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// readyChecks runs /ready and returns its status code and per-check breakdown.
+func readyChecks(t *testing.T, s *Server) (int, map[string]string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rr := httptest.NewRecorder()
+	s.handleReady(rr, req)
+	var body struct {
+		Ready  bool              `json:"ready"`
+		Checks map[string]string `json:"checks"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode /ready body: %v", err)
+	}
+	return rr.Code, body.Checks
+}
+
+// TestReadyHeldDuringAggregateRecovery covers the #173 requirement that a
+// process whose aggregate shards are only half-replayed must not be routed to.
+func TestReadyHeldDuringAggregateRecovery(t *testing.T) {
+	s := newTestServer(t)
+	recovered := false
+	s.SetAggregateRecoveryProbe(func() bool { return recovered })
+
+	code, checks := readyChecks(t, s)
+	if code != http.StatusServiceUnavailable {
+		t.Fatalf("/ready = %d during recovery, want 503", code)
+	}
+	if checks["aggregate_store"] != "recovering" {
+		t.Fatalf("aggregate_store check = %q, want recovering", checks["aggregate_store"])
+	}
+
+	recovered = true
+	code, checks = readyChecks(t, s)
+	if code != http.StatusOK {
+		t.Fatalf("/ready = %d after recovery, want 200", code)
+	}
+	if checks["aggregate_store"] != "ok" {
+		t.Fatalf("aggregate_store check = %q, want ok", checks["aggregate_store"])
+	}
+}
+
+// TestReadySkipsAggregateCheckWhenUnconfigured keeps AGGREGATE_MODE=legacy
+// deployments unaffected.
+func TestReadySkipsAggregateCheckWhenUnconfigured(t *testing.T) {
+	s := newTestServer(t)
+	code, checks := readyChecks(t, s)
+	if code != http.StatusOK {
+		t.Fatalf("/ready = %d without an aggregate store, want 200", code)
+	}
+	if checks["aggregate_store"] != "skipped" {
+		t.Fatalf("aggregate_store check = %q, want skipped", checks["aggregate_store"])
+	}
+}

--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -87,6 +87,19 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 		checks["pipeline"] = "skipped"
 	}
 
+	// Aggregate store recovery. Until the delta log has been replayed the
+	// shards hold only part of the acknowledged aggregates, and numbers served
+	// from them would be wrong in a way no dashboard can detect (#173).
+	switch {
+	case s.aggregateRecovered == nil:
+		checks["aggregate_store"] = "skipped"
+	case !s.aggregateRecovered():
+		checks["aggregate_store"] = "recovering"
+		ready = false
+	default:
+		checks["aggregate_store"] = "ok"
+	}
+
 	status := http.StatusOK
 	if !ready {
 		status = http.StatusServiceUnavailable

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -29,6 +29,12 @@ type Server struct {
 	// imports and lets tests inject deterministic values.
 	dlqSaturation      func() float64
 	pipelineSaturation func() float64
+
+	// aggregateRecovered reports whether the durable aggregate store has
+	// finished startup recovery. /ready stays 503 until it returns true, so
+	// no orchestrator routes traffic to a process whose shards are only
+	// half-replayed (#173). nil means "no store configured" and is skipped.
+	aggregateRecovered func() bool
 }
 
 // NewServer creates a new API server.
@@ -65,6 +71,13 @@ func (s *Server) SetDLQSaturationProbe(fn func() float64) {
 // to clients). Pass nil to disable the check.
 func (s *Server) SetPipelineSaturationProbe(fn func() float64) {
 	s.pipelineSaturation = fn
+}
+
+// SetAggregateRecoveryProbe registers a callback reporting whether the durable
+// aggregate store has finished replaying its delta log. /ready returns 503
+// until it does. Pass nil (the default) when no aggregate store is configured.
+func (s *Server) SetAggregateRecoveryProbe(fn func() bool) {
+	s.aggregateRecovered = fn
 }
 
 // RegisterRoutes registers API endpoints on the provided mux.

--- a/internal/config/aggregate_store_config_test.go
+++ b/internal/config/aggregate_store_config_test.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Durable aggregate store configuration (#173).
+
+func TestValidate_AggregateStore_LegacyModeSkipsStoreChecks(t *testing.T) {
+	c := baseValid()
+	c.AggregateMode = "legacy"
+	c.AggregateDBPath = ""
+	c.AggregateSynchronous = "nonsense"
+	c.AggregateCommitMaxWaiters = 0
+	if err := c.Validate(); err != nil {
+		t.Fatalf("legacy mode must not read the store config, got %v", err)
+	}
+}
+
+func TestValidate_AggregateStore_Bounds(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Config)
+		want   string
+	}{
+		{"empty path", func(c *Config) { c.AggregateDBPath = "" }, "AGGREGATE_DB_PATH"},
+		{"bad synchronous", func(c *Config) { c.AggregateSynchronous = "OFF" }, "AGGREGATE_SYNCHRONOUS"},
+		{"zero coalesce", func(c *Config) { c.AggregateCommitCoalesceMs = 0 }, "AGGREGATE_COMMIT_COALESCE_MS"},
+		{"zero waiters", func(c *Config) { c.AggregateCommitMaxWaiters = 0 }, "AGGREGATE_COMMIT_MAX_WAITERS"},
+		{"zero finalize", func(c *Config) { c.AggregateFinalizeIntervalSec = 0 }, "AGGREGATE_FINALIZE_INTERVAL_SEC"},
+		{
+			"pending deltas below batch target",
+			func(c *Config) { c.AggregateCommitMaxPendingDeltas = 10 },
+			"AGGREGATE_COMMIT_MAX_PENDING_DELTAS",
+		},
+		{
+			"pending bytes below batch target",
+			func(c *Config) { c.AggregateCommitMaxPendingBytes = 1024 },
+			"AGGREGATE_COMMIT_MAX_PENDING_BYTES",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := baseValid()
+			c.AggregateMode = "aggregate-shadow"
+			tc.mutate(c)
+			err := c.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %s error, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestLoad_AggregateStoreEnv(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aggregate.db")
+	t.Setenv("AGGREGATE_MODE", "aggregate-shadow")
+	t.Setenv("AGGREGATE_DB_PATH", path)
+	t.Setenv("AGGREGATE_ALLOW_REBUILD", "true")
+	t.Setenv("AGGREGATE_SYNCHRONOUS", "full")
+	t.Setenv("AGGREGATE_COMMIT_COALESCE_MS", "9")
+	t.Setenv("AGGREGATE_COMMIT_MAX_WAITERS", "64")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.AggregateDBPath != path {
+		t.Errorf("AggregateDBPath = %q, want %q", cfg.AggregateDBPath, path)
+	}
+	if !cfg.AggregateAllowRebuild {
+		t.Error("AggregateAllowRebuild = false, want true")
+	}
+	if cfg.AggregateSynchronous != "FULL" {
+		t.Errorf("AggregateSynchronous = %q, want FULL (upper-cased)", cfg.AggregateSynchronous)
+	}
+	if cfg.AggregateCommitCoalesceMs != 9 || cfg.AggregateCommitMaxWaiters != 64 {
+		t.Errorf("commit knobs = %d/%d, want 9/64", cfg.AggregateCommitCoalesceMs, cfg.AggregateCommitMaxWaiters)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -291,6 +291,44 @@ type Config struct {
 	// AggregateMaxProducerBaselinesPerSeries. Nonzero overrides.
 	// Use ResolvedAggregateMaxBaselines() to get the final value.
 	AggregateMaxBaselines int
+
+	// Durable aggregate store (Phase 2, #173). Active whenever
+	// AggregateMode != "legacy" — shadow mode persists too, because shadow
+	// IS the durability rehearsal.
+
+	// AggregateDBPath is the aggregate database file (ADR 0003: its own
+	// file, its own WAL, its own PRAGMA stanza — never the main DB).
+	AggregateDBPath string
+
+	// AggregateAllowRebuild permits DESTROYING and recreating the
+	// aggregate-owned tables when the on-disk schema is partial or
+	// version-mismatched. Off by default: v1 has no automatic migrations and
+	// a refused startup is better than silent data loss.
+	AggregateAllowRebuild bool
+
+	// AggregateSynchronous is the aggregate DB's SQLite synchronous mode,
+	// "NORMAL" or "FULL". NORMAL survives process/container death (the ACK
+	// contract of #160); FULL additionally survives host power loss at the
+	// cost of one fsync per group commit.
+	AggregateSynchronous string
+
+	// Group-commit cadence (#160): the first waiter opens a coalescing
+	// window of AggregateCommitCoalesceMs, and the commit fires early once
+	// the batch reaches the delta-count or byte target.
+	AggregateCommitCoalesceMs int
+	AggregateCommitMaxDeltas  int
+	AggregateCommitMaxBytes   int
+
+	// Triple admission bound (#160). A breach returns gRPC
+	// RESOURCE_EXHAUSTED / HTTP 429, never a silent drop and never an
+	// automatic downgrade to bounded-loss ACK.
+	AggregateCommitMaxPendingBytes  int
+	AggregateCommitMaxWaiters       int
+	AggregateCommitMaxPendingDeltas int
+
+	// AggregateFinalizeIntervalSec is how often the writer looks for windows
+	// whose lateness horizon has expired.
+	AggregateFinalizeIntervalSec int
 }
 
 func Load(customPath string) (*Config, error) {
@@ -433,6 +471,18 @@ func Load(customPath string) (*Config, error) {
 		AggregateSeriesPerTenantFraction:       getEnvFloat("AGGREGATE_SERIES_PER_TENANT_FRACTION", 0),
 		AggregateMaxProducerBaselinesPerSeries: getEnvInt("AGGREGATE_MAX_PRODUCER_BASELINES_PER_SERIES", 8),
 		AggregateMaxBaselines:                  getEnvInt("AGGREGATE_MAX_BASELINES", 0),
+
+		// Durable aggregate store (#173)
+		AggregateDBPath:                 strings.TrimSpace(getEnv("AGGREGATE_DB_PATH", "./data/aggregate.db")),
+		AggregateAllowRebuild:           parseTruthy(getEnv("AGGREGATE_ALLOW_REBUILD", "")),
+		AggregateSynchronous:            strings.ToUpper(strings.TrimSpace(getEnv("AGGREGATE_SYNCHRONOUS", "NORMAL"))),
+		AggregateCommitCoalesceMs:       getEnvInt("AGGREGATE_COMMIT_COALESCE_MS", 5),
+		AggregateCommitMaxDeltas:        getEnvInt("AGGREGATE_COMMIT_MAX_DELTAS", 5000),
+		AggregateCommitMaxBytes:         getEnvInt("AGGREGATE_COMMIT_MAX_BYTES", 8*1024*1024),
+		AggregateCommitMaxPendingBytes:  getEnvInt("AGGREGATE_COMMIT_MAX_PENDING_BYTES", 64*1024*1024),
+		AggregateCommitMaxWaiters:       getEnvInt("AGGREGATE_COMMIT_MAX_WAITERS", 512),
+		AggregateCommitMaxPendingDeltas: getEnvInt("AGGREGATE_COMMIT_MAX_PENDING_DELTAS", 200000),
+		AggregateFinalizeIntervalSec:    getEnvInt("AGGREGATE_FINALIZE_INTERVAL_SEC", 30),
 	}
 	applyDriverDefaults(cfg)
 
@@ -741,6 +791,44 @@ func (c *Config) Validate() error {
 	}
 	if c.AggregateMaxBaselines > 0 && c.AggregateMaxBaselines < c.AggregateMaxProducerBaselinesPerSeries {
 		return fmt.Errorf("AGGREGATE_MAX_BASELINES when nonzero must be >= AGGREGATE_MAX_PRODUCER_BASELINES_PER_SERIES (%d), got %d", c.AggregateMaxProducerBaselinesPerSeries, c.AggregateMaxBaselines)
+	}
+
+	// Durable aggregate store validation. Only enforced when the engine runs:
+	// AGGREGATE_MODE=legacy constructs no store and reads none of these.
+	if c.AggregateMode != "legacy" {
+		if c.AggregateDBPath == "" {
+			return fmt.Errorf("AGGREGATE_DB_PATH must not be empty when AGGREGATE_MODE=%s", c.AggregateMode)
+		}
+		if c.AggregateSynchronous != "NORMAL" && c.AggregateSynchronous != "FULL" {
+			return fmt.Errorf("invalid AGGREGATE_SYNCHRONOUS %q: must be NORMAL or FULL", c.AggregateSynchronous)
+		}
+		commitBounds := []struct {
+			name  string
+			value int
+		}{
+			{"AGGREGATE_COMMIT_COALESCE_MS", c.AggregateCommitCoalesceMs},
+			{"AGGREGATE_COMMIT_MAX_DELTAS", c.AggregateCommitMaxDeltas},
+			{"AGGREGATE_COMMIT_MAX_BYTES", c.AggregateCommitMaxBytes},
+			{"AGGREGATE_COMMIT_MAX_PENDING_BYTES", c.AggregateCommitMaxPendingBytes},
+			{"AGGREGATE_COMMIT_MAX_WAITERS", c.AggregateCommitMaxWaiters},
+			{"AGGREGATE_COMMIT_MAX_PENDING_DELTAS", c.AggregateCommitMaxPendingDeltas},
+			{"AGGREGATE_FINALIZE_INTERVAL_SEC", c.AggregateFinalizeIntervalSec},
+		}
+		for _, b := range commitBounds {
+			if b.value < 1 {
+				return fmt.Errorf("%s must be >= 1, got %d", b.name, b.value)
+			}
+		}
+		// A pending bound below the per-commit target would refuse the very
+		// batch the writer is trying to build.
+		if c.AggregateCommitMaxPendingDeltas < c.AggregateCommitMaxDeltas {
+			return fmt.Errorf("AGGREGATE_COMMIT_MAX_PENDING_DELTAS (%d) must be >= AGGREGATE_COMMIT_MAX_DELTAS (%d)",
+				c.AggregateCommitMaxPendingDeltas, c.AggregateCommitMaxDeltas)
+		}
+		if c.AggregateCommitMaxPendingBytes < c.AggregateCommitMaxBytes {
+			return fmt.Errorf("AGGREGATE_COMMIT_MAX_PENDING_BYTES (%d) must be >= AGGREGATE_COMMIT_MAX_BYTES (%d)",
+				c.AggregateCommitMaxPendingBytes, c.AggregateCommitMaxBytes)
+		}
 	}
 
 	// Sum-of-caps validation: sub-caps must fit under global cap

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,6 +41,16 @@ func baseValid() *Config {
 		AggregateSeriesPerTenantFraction:       0,
 		AggregateMaxProducerBaselinesPerSeries: 8,
 		AggregateMaxBaselines:                  0,
+		// Durable aggregate store defaults (#173)
+		AggregateDBPath:                 "./data/aggregate.db",
+		AggregateSynchronous:            "NORMAL",
+		AggregateCommitCoalesceMs:       5,
+		AggregateCommitMaxDeltas:        5000,
+		AggregateCommitMaxBytes:         8 * 1024 * 1024,
+		AggregateCommitMaxPendingBytes:  64 * 1024 * 1024,
+		AggregateCommitMaxWaiters:       512,
+		AggregateCommitMaxPendingDeltas: 200000,
+		AggregateFinalizeIntervalSec:    30,
 	}
 }
 

--- a/internal/ingest/aggregate_bridge.go
+++ b/internal/ingest/aggregate_bridge.go
@@ -1,13 +1,48 @@
 package ingest
 
 import (
+	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
+
+// applyAggregate applies one Export's reduced deltas and maps a refusal onto
+// the error the OTLP client should see.
+//
+// Under the durable-ACK contract (#160) an Export may only succeed once its
+// deltas are inside a committed transaction, so a saturated group-commit
+// writer answers RESOURCE_EXHAUSTED — the same signal, and the same HTTP 429
+// mapping, the raw pipeline's ErrQueueFull already produces.
+//
+// A commit FAILURE is treated by mode. In aggregate mode the store is the
+// authoritative dataset and a failed commit must not be acknowledged. In shadow
+// mode the legacy path is still the source of truth and the aggregate numbers
+// exist to be compared: failing the Export there would turn a shadow-side
+// problem into raw telemetry loss, so it is logged and metered instead.
+func applyAggregate(eng *aggregate.Engine, r *aggregate.Reducer) error {
+	if eng == nil || r == nil {
+		return nil
+	}
+	_, err := eng.ApplyReducerErr(r)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, aggregate.ErrSaturated) {
+		return grpcstatus.Errorf(codes.ResourceExhausted, "aggregate store at capacity")
+	}
+	if eng.Mode() == aggregate.ModeAggregate {
+		return grpcstatus.Errorf(codes.Unavailable, "aggregate store commit failed")
+	}
+	slog.Error("aggregate shadow commit failed (legacy path remains the source of truth)", "error", err)
+	return nil
+}
 
 // OTLP -> aggregate translation.
 //

--- a/internal/ingest/aggregate_saturation_test.go
+++ b/internal/ingest/aggregate_saturation_test.go
@@ -1,0 +1,94 @@
+package ingest
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+// stubApplier stands in for the durable group-commit writer.
+type stubApplier struct{ err error }
+
+func (s stubApplier) Apply(m aggregate.DeltaMap) uint64 { return 0 }
+
+func (s stubApplier) ApplyErr(m aggregate.DeltaMap) (uint64, error) { return 0, s.err }
+
+// engineWithApplier builds an engine in the given mode with a stubbed apply path.
+func engineWithApplier(t *testing.T, mode string, err error) *aggregate.Engine {
+	t.Helper()
+	eng, buildErr := aggregate.NewEngine(aggregate.EngineConfig{Mode: mode})
+	if buildErr != nil {
+		t.Fatalf("NewEngine: %v", buildErr)
+	}
+	eng.SetApplier(stubApplier{err: err})
+	return eng
+}
+
+// reducerWithOneSpan produces a reducer holding a single accepted span.
+func reducerWithOneSpan(eng *aggregate.Engine) *aggregate.Reducer {
+	now := time.Now()
+	r := eng.NewReducer(now)
+	r.ReduceSpan(aggregate.SpanInput{
+		Tenant:         "default",
+		Service:        "checkout",
+		SpanName:       "GET /orders",
+		Method:         "GET",
+		HTTPStatusCode: 200,
+		Timestamp:      now,
+		DurationMicros: 1200,
+	})
+	return r
+}
+
+// TestApplyAggregateMapsSaturationToResourceExhausted covers the backpressure
+// contract: a saturated group-commit writer answers like the raw pipeline's
+// ErrQueueFull, which the HTTP OTLP handler already turns into 429.
+func TestApplyAggregateMapsSaturationToResourceExhausted(t *testing.T) {
+	saturated := &aggregate.SaturationError{Bound: "waiters", Current: 512, Limit: 512}
+	for _, mode := range []string{aggregate.ModeShadow, aggregate.ModeAggregate} {
+		t.Run(mode, func(t *testing.T) {
+			eng := engineWithApplier(t, mode, saturated)
+			err := applyAggregate(eng, reducerWithOneSpan(eng))
+			if err == nil {
+				t.Fatal("saturated writer was acknowledged as success")
+			}
+			st, ok := grpcstatus.FromError(err)
+			if !ok || st.Code() != codes.ResourceExhausted {
+				t.Fatalf("error = %v, want RESOURCE_EXHAUSTED", err)
+			}
+			if !isQueueFull(err) {
+				t.Fatal("HTTP handler would not map this error to 429")
+			}
+		})
+	}
+}
+
+// TestApplyAggregateCommitFailureByMode: in aggregate mode the store is the
+// authoritative dataset and a failed commit must not be acknowledged; in shadow
+// mode the legacy path is still the truth and raw telemetry must not be lost
+// over an aggregate-side problem.
+func TestApplyAggregateCommitFailureByMode(t *testing.T) {
+	boom := errors.New("disk on fire")
+
+	eng := engineWithApplier(t, aggregate.ModeAggregate, boom)
+	err := applyAggregate(eng, reducerWithOneSpan(eng))
+	st, ok := grpcstatus.FromError(err)
+	if err == nil || !ok || st.Code() != codes.Unavailable {
+		t.Fatalf("aggregate mode commit failure = %v, want UNAVAILABLE", err)
+	}
+
+	shadow := engineWithApplier(t, aggregate.ModeShadow, boom)
+	if err := applyAggregate(shadow, reducerWithOneSpan(shadow)); err != nil {
+		t.Fatalf("shadow mode commit failure = %v, want nil (legacy path is the source of truth)", err)
+	}
+}
+
+func TestApplyAggregateNilEngineIsNoop(t *testing.T) {
+	if err := applyAggregate(nil, nil); err != nil {
+		t.Fatalf("legacy mode (nil engine) = %v, want nil", err)
+	}
+}

--- a/internal/ingest/otlp.go
+++ b/internal/ingest/otlp.go
@@ -270,7 +270,6 @@ func (s *MetricsServer) Export(ctx context.Context, req *colmetricspb.ExportMetr
 	var reducer *aggregate.Reducer
 	if s.aggregateEngine != nil {
 		reducer = s.aggregateEngine.NewReducer(start)
-		defer func() { s.aggregateEngine.ApplyReducer(reducer) }()
 	}
 
 	for _, resourceMetrics := range req.ResourceMetrics {
@@ -352,6 +351,12 @@ func (s *MetricsServer) Export(ctx context.Context, req *colmetricspb.ExportMetr
 				}
 			}
 		}
+	}
+
+	// Apply the request's aggregate deltas. Under durable ACK this blocks
+	// until the group commit lands, and a refusal is the client's answer.
+	if err := applyAggregate(s.aggregateEngine, reducer); err != nil {
+		return nil, err
 	}
 
 	if s.metrics != nil {
@@ -621,9 +626,10 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 
 	// Apply the request's aggregate deltas before the persist decision: the
 	// aggregate path has already accepted this telemetry, and a downstream
-	// queue rejection must not retroactively unaccount it.
-	if merged != nil {
-		s.aggregateEngine.ApplyReducer(merged)
+	// queue rejection must not retroactively unaccount it. Under durable ACK
+	// this blocks until the group commit lands.
+	if err := applyAggregate(s.aggregateEngine, merged); err != nil {
+		return nil, err
 	}
 
 	// Intake metrics fire before the persist decision so operators see
@@ -806,8 +812,8 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 		}
 		mergedReducer.MergeFrom(r)
 	}
-	if mergedReducer != nil {
-		s.aggregateEngine.ApplyReducer(mergedReducer)
+	if err := applyAggregate(s.aggregateEngine, mergedReducer); err != nil {
+		return nil, err
 	}
 
 	if len(logsToInsert) == 0 {

--- a/internal/storage/retention.go
+++ b/internal/storage/retention.go
@@ -46,6 +46,17 @@ type RetentionScheduler struct {
 	// skippedRuns increments every time a tick is dropped because running==true.
 	// Test hook; exported via SkippedRuns().
 	skippedRuns atomic.Int64
+
+	// aggregatePurge and aggregateAnalyze are the durable aggregate store's
+	// share of retention (#173). They are plain callbacks rather than a typed
+	// dependency so this package keeps no import of internal/aggregate.
+	//
+	// The aggregate DB never gets a VACUUM: rolling retention there is range
+	// deletes plus WAL free-page reuse by design (#162). ANALYZE rides the
+	// existing daily maintenance tick because it is cheap and the planner
+	// statistics of a table that is written and deleted every hour go stale.
+	aggregatePurge   func(cutoff time.Time) (int64, error)
+	aggregateAnalyze func() error
 }
 
 // NewRetentionScheduler constructs a scheduler but does not start it.
@@ -75,6 +86,34 @@ func (r *RetentionScheduler) SkippedRuns() int64 { return r.skippedRuns.Load() }
 // SetFullVacuum opts the daily SQLite maintenance back into a full VACUUM
 // (wired from RETENTION_FULL_VACUUM). Call before Start; not synchronized.
 func (r *RetentionScheduler) SetFullVacuum(enabled bool) { r.fullVacuum = enabled }
+
+// SetAggregateRetention wires the durable aggregate store into the hourly purge
+// and the daily maintenance pass. purge receives the same age cutoff the
+// relational purge uses and returns how many rows it removed; analyze refreshes
+// the aggregate planner statistics. Either may be nil. Call before Start; not
+// synchronized.
+func (r *RetentionScheduler) SetAggregateRetention(purge func(time.Time) (int64, error), analyze func() error) {
+	r.aggregatePurge = purge
+	r.aggregateAnalyze = analyze
+}
+
+// purgeAggregate runs the aggregate store's share of one retention tick.
+func (r *RetentionScheduler) purgeAggregate(cutoff time.Time) {
+	if r.aggregatePurge == nil {
+		return
+	}
+	start := time.Now()
+	rows, err := r.aggregatePurge(cutoff)
+	if err != nil {
+		slog.Error("retention: aggregate purge failed", "error", err)
+		return
+	}
+	slog.Info("retention: aggregate purge complete",
+		"cutoff", cutoff.Format(time.RFC3339),
+		"rows_deleted", rows,
+		"duration", time.Since(start),
+	)
+}
 
 // sqliteVacuumStatement returns the page-reclaim statement for the daily
 // SQLite maintenance pass. Default is incremental_vacuum: it releases up to
@@ -172,6 +211,10 @@ func (r *RetentionScheduler) runPurge(ctx context.Context) {
 		driver = "sqlite"
 	}
 	cutoff := time.Now().UTC().Add(-time.Duration(r.retentionDays) * 24 * time.Hour)
+
+	// The aggregate store is a separate database file with its own writer, so
+	// its purge never contends with the relational one (ADR 0003).
+	r.purgeAggregate(cutoff)
 
 	// SQLite: single-writer, parallel purges would just contend on the DB lock.
 	if driver == "sqlite" {
@@ -501,6 +544,16 @@ func (r *RetentionScheduler) runMaintenance(ctx context.Context) {
 		}
 		// SQLite maintenance is whole-DB; record a single observation under "all".
 		observe("all", time.Since(start))
+	}
+
+	// Aggregate store: ANALYZE only. No VACUUM, ever (#162) — its retention is
+	// range deletes and free-page reuse, and an exclusive whole-file lock on
+	// the durable-ACK path would stall ingest into a 429 storm.
+	if r.aggregateAnalyze != nil {
+		if err := r.aggregateAnalyze(); err != nil {
+			slog.Error("retention: aggregate analyze failed", "error", err)
+			maintFailed = true
+		}
 	}
 	slog.Info("retention maintenance complete", "driver", driver)
 }

--- a/internal/storage/retention_aggregate_test.go
+++ b/internal/storage/retention_aggregate_test.go
@@ -1,0 +1,75 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// Retention's share of the durable aggregate store (#173): an hourly purge on
+// the same age cutoff as the relational purge, a conservative ANALYZE on the
+// daily maintenance tick, and NEVER a VACUUM.
+
+func TestRetentionScheduler_PurgesAggregateStore(t *testing.T) {
+	repo := newTestRepo(t)
+	r := NewRetentionScheduler(repo, 7, 10_000, 0)
+
+	var (
+		calls  int
+		cutoff time.Time
+	)
+	r.SetAggregateRetention(func(c time.Time) (int64, error) {
+		calls++
+		cutoff = c
+		return 12, nil
+	}, nil)
+
+	before := time.Now().UTC().Add(-7 * 24 * time.Hour)
+	r.runPurge(context.Background())
+	after := time.Now().UTC().Add(-7 * 24 * time.Hour)
+
+	if calls != 1 {
+		t.Fatalf("aggregate purge called %d times, want 1", calls)
+	}
+	if cutoff.Before(before.Add(-time.Minute)) || cutoff.After(after.Add(time.Minute)) {
+		t.Fatalf("aggregate purge cutoff %s is not the retention horizon", cutoff)
+	}
+}
+
+func TestRetentionScheduler_AggregatePurgeFailureDoesNotStopRelationalPurge(t *testing.T) {
+	repo := newTestRepo(t)
+	r := NewRetentionScheduler(repo, 7, 10_000, 0)
+	r.SetAggregateRetention(func(time.Time) (int64, error) {
+		return 0, errors.New("aggregate store unavailable")
+	}, nil)
+
+	// runPurge must complete; a failing aggregate store is logged, not fatal.
+	r.runPurge(context.Background())
+	if r.SkippedRuns() != 0 {
+		t.Fatalf("skipped runs = %d, want 0", r.SkippedRuns())
+	}
+}
+
+func TestRetentionScheduler_MaintenanceAnalyzesAggregateStore(t *testing.T) {
+	repo := newTestRepo(t)
+	r := NewRetentionScheduler(repo, 7, 10_000, 0)
+	analyzed := 0
+	r.SetAggregateRetention(nil, func() error {
+		analyzed++
+		return nil
+	})
+
+	r.runMaintenance(context.Background())
+
+	if analyzed != 1 {
+		t.Fatalf("aggregate ANALYZE ran %d times, want 1", analyzed)
+	}
+}
+
+func TestRetentionScheduler_NoAggregateHooksIsANoop(t *testing.T) {
+	repo := newTestRepo(t)
+	r := NewRetentionScheduler(repo, 7, 10_000, 0)
+	r.runPurge(context.Background())
+	r.runMaintenance(context.Background())
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -182,6 +182,40 @@ type Metrics struct {
 	// service. Cheap invariant only (#165): no per-series comparison.
 	AggregateShadowErrorsTotal *prometheus.CounterVec
 
+	// --- Durable aggregate store (#173) ---
+	// AggregateCommitDurationSeconds — group-commit wall time. This IS the
+	// ACK latency floor: an Export cannot return before its commit does.
+	AggregateCommitDurationSeconds *prometheus.HistogramVec
+	// AggregateCommitDeltas — delta rows per group commit. The pre-merge
+	// ratio and the coalescing behaviour both show up here.
+	AggregateCommitDeltas prometheus.Histogram
+	// AggregateCommitsTotal — commits by result (ok|error).
+	AggregateCommitsTotal *prometheus.CounterVec
+	// AggregateCommitBytesTotal — delta payload written to the store.
+	AggregateCommitBytesTotal prometheus.Counter
+	// AggregateAdmissionRejectedTotal — ErrSaturated refusals by the bound
+	// that tripped (bytes|waiters|deltas). Non-zero at sustained load is a
+	// release-gate failure, not a tuning hint.
+	AggregateAdmissionRejectedTotal *prometheus.CounterVec
+	// AggregateFinalizeDurationSeconds — window finalization wall time.
+	AggregateFinalizeDurationSeconds prometheus.Histogram
+	// AggregateFinalizeRowsTotal — rows materialized/deleted by finalization,
+	// by kind (buckets|deltas).
+	AggregateFinalizeRowsTotal *prometheus.CounterVec
+	// AggregatePurgeDurationSeconds — retention purge wall time on the
+	// aggregate DB.
+	AggregatePurgeDurationSeconds prometheus.Histogram
+	// AggregatePurgeRowsTotal — rows purged by kind (buckets|deltas|baselines).
+	AggregatePurgeRowsTotal *prometheus.CounterVec
+	// AggregateDeltaLogRows and AggregateDeltaLogAgeSeconds are the delta-log
+	// backlog health bounds from #160: alert when either climbs.
+	AggregateDeltaLogRows       prometheus.Gauge
+	AggregateDeltaLogAgeSeconds prometheus.Gauge
+	// AggregateRecoveryDurationSeconds and AggregateRecoveryRows describe the
+	// last startup recovery. The gate allows 30s.
+	AggregateRecoveryDurationSeconds prometheus.Gauge
+	AggregateRecoveryRows            *prometheus.GaugeVec
+
 	// Atomic counters for JSON health endpoint (avoids scraping Prometheus)
 	totalIngested  atomic.Int64
 	activeConns    atomic.Int64
@@ -487,6 +521,62 @@ func New() *Metrics {
 		Name: "otelcontext_aggregate_shadow_errors_total",
 		Help: "Errors accounted on the aggregate side, per service. Cheap shadow-mode invariant only.",
 	}, []string{"service"})
+	m.AggregateCommitDurationSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "otelcontext_aggregate_commit_duration_seconds",
+		Help:    "Group-commit wall time on the aggregate store. This is the floor of OTLP ACK latency under durable ACK.",
+		Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5},
+	}, []string{"result"})
+	m.AggregateCommitDeltas = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "otelcontext_aggregate_commit_deltas",
+		Help:    "Delta rows per group commit. Shows the pre-merge ratio and how much coalescing is happening.",
+		Buckets: []float64{1, 10, 50, 100, 500, 1000, 2500, 5000, 10000},
+	})
+	m.AggregateCommitsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_commits_total",
+		Help: "Aggregate group commits by result (ok|error).",
+	}, []string{"result"})
+	m.AggregateCommitBytesTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_commit_bytes_total",
+		Help: "Approximate delta payload written to the aggregate delta log.",
+	})
+	m.AggregateAdmissionRejectedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_admission_rejected_total",
+		Help: "Group-commit admissions refused (RESOURCE_EXHAUSTED / 429), by the bound that tripped: bytes|waiters|deltas.",
+	}, []string{"bound"})
+	m.AggregateFinalizeDurationSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "otelcontext_aggregate_finalize_duration_seconds",
+		Help:    "Wall time of one window finalization (materialize buckets + delete incorporated deltas).",
+		Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+	})
+	m.AggregateFinalizeRowsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_finalize_rows_total",
+		Help: "Rows written or removed by window finalization, by kind (buckets|deltas).",
+	}, []string{"kind"})
+	m.AggregatePurgeDurationSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "otelcontext_aggregate_purge_duration_seconds",
+		Help:    "Wall time of one retention purge on the aggregate store.",
+		Buckets: []float64{0.01, 0.1, 0.5, 1, 5, 15, 60, 300},
+	})
+	m.AggregatePurgeRowsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_purge_rows_total",
+		Help: "Rows purged from the aggregate store by kind (buckets|deltas|baselines).",
+	}, []string{"kind"})
+	m.AggregateDeltaLogRows = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "otelcontext_aggregate_delta_log_rows",
+		Help: "Delta-log rows awaiting window finalization. Sustained growth means the finalizer is falling behind.",
+	})
+	m.AggregateDeltaLogAgeSeconds = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "otelcontext_aggregate_delta_log_age_seconds",
+		Help: "Age of the oldest un-finalized window. Should stay near the window size plus allowed lateness.",
+	})
+	m.AggregateRecoveryDurationSeconds = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "otelcontext_aggregate_recovery_duration_seconds",
+		Help: "Wall time of the last aggregate startup recovery. Readiness is held false for its duration.",
+	})
+	m.AggregateRecoveryRows = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "otelcontext_aggregate_recovery_rows",
+		Help: "Rows handled by the last aggregate startup recovery, by kind (replayed|finalized_windows).",
+	}, []string{"kind"})
 	return m
 }
 

--- a/main.go
+++ b/main.go
@@ -223,8 +223,8 @@ func main() {
 		time.Duration(cfg.RetentionBatchSleepMs)*time.Millisecond,
 	)
 	retention.SetFullVacuum(cfg.RetentionFullVacuum)
-	retention.Start(ctxRetention)
-	slog.Info("🧹 Retention scheduler started", "retention_days", cfg.HotRetentionDays)
+	// Start() is deferred until after the aggregate store is wired in below —
+	// SetAggregateRetention must be called before the loop reads the fields.
 
 	// 2b. Partition scheduler: only when DB_POSTGRES_PARTITIONING=daily.
 	// Maintains lookahead daily partitions and drops expired ones — DROP
@@ -456,14 +456,52 @@ func main() {
 	logsServer := ingest.NewLogsServer(repo, metrics, cfg)
 	metricsServer := ingest.NewMetricsServer(repo, metrics, tsdbAgg, cfg)
 
-	// Aggregate engine (AGGREGATE_MODE != legacy). Phase 1 is accounting only:
-	// the reducer runs inside Export() ahead of the sampler, the read path
-	// stays legacy, and mutable windows are discarded rather than persisted
-	// until the durable store lands (#173). AGGREGATE_MODE=legacy constructs
-	// nothing and leaves every ingest path byte-for-byte unchanged.
+	// Aggregate engine + durable store (AGGREGATE_MODE != legacy). The reducer
+	// runs inside Export() ahead of the sampler; the group-commit writer makes
+	// the reduced deltas durable before the Export is acknowledged (#160), and
+	// startup recovery replays the mutable delta log before readiness flips.
+	// Shadow mode persists too — shadow IS the durability rehearsal.
+	// AGGREGATE_MODE=legacy constructs nothing and leaves every ingest path
+	// byte-for-byte unchanged.
+	var (
+		aggStore     *aggregate.SQLiteStore
+		aggWriter    *aggregate.Writer
+		aggRecovery  *aggregate.RecoveryGate
+		aggStoreMetr = aggregate.NewPrometheusStoreMetrics(metrics)
+	)
 	if cfg.AggregateMode != aggregate.ModeLegacy {
+		store, err := aggregate.OpenSQLiteStore(aggregate.StoreConfig{
+			Path:         cfg.AggregateDBPath,
+			AllowRebuild: cfg.AggregateAllowRebuild,
+			Synchronous:  cfg.AggregateSynchronous,
+			Metrics:      aggStoreMetr,
+		})
+		if err != nil {
+			fatal("❌ Aggregate store rejected", err, "path", cfg.AggregateDBPath)
+		}
+		aggStore = store
+
+		// Dictionary IDs become DB-owned: the in-memory registrar's IDs are
+		// provisional and would strand every persisted SeriesKey on restart.
+		//
+		// The per-kind caps bound dictionary DISK growth. A name that can never
+		// appear in an admitted series is pure disk cost, so each name namespace
+		// is capped at the series budget that could reference it; past the cap
+		// the value resolves to __other__, the designed degradation. Service,
+		// tenant and dimension namespaces stay uncapped — they are bounded by
+		// the deployment and by AGGREGATE_METRIC_DIMS respectively.
+		registrar, err := aggregate.NewDurableRegistrar(aggStore, map[aggregate.Kind]int{
+			aggregate.KindOperation:   cfg.AggregateMaxSeriesTraces + cfg.AggregateMaxSeriesEdges,
+			aggregate.KindMetricName:  cfg.AggregateMaxSeriesMetrics,
+			aggregate.KindLogTemplate: cfg.AggregateMaxSeriesLogs,
+		})
+		if err != nil {
+			fatal("❌ Aggregate dictionary could not be loaded", err, "path", cfg.AggregateDBPath)
+		}
+
 		aggEngine, err := aggregate.NewEngine(aggregate.EngineConfig{
-			Mode: cfg.AggregateMode,
+			Mode:      cfg.AggregateMode,
+			Registrar: registrar,
 			Limiter: aggregate.LimiterConfig{
 				MaxSeries:                 cfg.AggregateMaxSeries,
 				MaxSeriesMetrics:          cfg.AggregateMaxSeriesMetrics,
@@ -484,6 +522,40 @@ func main() {
 		if err != nil {
 			fatal("❌ Aggregate engine configuration rejected", err, "mode", cfg.AggregateMode)
 		}
+
+		aggWriter, err = aggregate.NewWriter(aggregate.WriterConfig{
+			Store:            aggStore,
+			Engine:           aggEngine,
+			Registrar:        registrar,
+			CoalesceWindow:   time.Duration(cfg.AggregateCommitCoalesceMs) * time.Millisecond,
+			MaxBatchDeltas:   cfg.AggregateCommitMaxDeltas,
+			MaxBatchBytes:    int64(cfg.AggregateCommitMaxBytes),
+			MaxPendingBytes:  int64(cfg.AggregateCommitMaxPendingBytes),
+			MaxWaiters:       cfg.AggregateCommitMaxWaiters,
+			MaxPendingDeltas: cfg.AggregateCommitMaxPendingDeltas,
+			FinalizeInterval: time.Duration(cfg.AggregateFinalizeIntervalSec) * time.Second,
+			Metrics:          aggStoreMetr,
+		})
+		if err != nil {
+			fatal("❌ Aggregate group-commit writer rejected", err)
+		}
+
+		// Recovery runs BEFORE the writer starts accepting Exports and before
+		// readiness flips: acknowledged-but-unfinalized deltas go back into the
+		// shards, windows whose lateness expired during downtime finalize, and
+		// durable baselines are seeded.
+		aggRecovery = aggregate.NewRecoveryGate()
+		recoveryStats, err := aggregate.Recover(aggStore, aggEngine, aggWriter, time.Now())
+		if err != nil {
+			fatal("❌ Aggregate store recovery failed", err, "path", cfg.AggregateDBPath)
+		}
+		aggregate.LogRecovery(recoveryStats, cfg.AggregateDBPath)
+		aggStoreMetr.RecordRecovery(recoveryStats.Duration, recoveryStats.ReplayedRows, recoveryStats.FinalizedWindows)
+
+		aggEngine.SetApplier(aggWriter)
+		aggWriter.Start()
+		aggRecovery.Complete()
+
 		traceServer.SetAggregateEngine(aggEngine)
 		logsServer.SetAggregateEngine(aggEngine)
 		metricsServer.SetAggregateEngine(aggEngine)
@@ -491,9 +563,29 @@ func main() {
 			"mode", cfg.AggregateMode,
 			"max_series", cfg.AggregateMaxSeries,
 			"max_baselines", cfg.ResolvedAggregateMaxBaselines(),
-			"note", "Phase 1: accounting only, windows are not persisted",
+			"store_path", cfg.AggregateDBPath,
+			"store_uuid", aggStore.UUID(),
+			"synchronous", cfg.AggregateSynchronous,
+			"commit_coalesce_ms", cfg.AggregateCommitCoalesceMs,
+			"note", "durable ACK: Export returns only after the group commit",
+		)
+
+		// Retention owns the hourly aggregate purge and the conservative daily
+		// ANALYZE. No VACUUM on this file, by decision (#162).
+		retention.SetAggregateRetention(
+			func(cutoff time.Time) (int64, error) {
+				stats, err := aggStore.PurgeBefore(aggregate.WindowStart(cutoff))
+				return stats.Buckets + stats.Deltas + stats.Baselines, err
+			},
+			aggStore.Analyze,
 		)
 	}
+
+	retention.Start(ctxRetention)
+	slog.Info("🧹 Retention scheduler started",
+		"retention_days", cfg.HotRetentionDays,
+		"aggregate_store", cfg.AggregateMode != aggregate.ModeLegacy,
+	)
 
 	// Wire adaptive sampler (only when rate < 1.0 to avoid unnecessary overhead)
 	if cfg.SamplingRate > 0 && cfg.SamplingRate < 1.0 {
@@ -574,6 +666,10 @@ func main() {
 			}
 			return float64(st.QueueDepth) / float64(st.Capacity)
 		})
+	}
+	if aggRecovery != nil {
+		// /ready stays 503 until the aggregate delta log has been replayed.
+		apiServer.SetAggregateRecoveryProbe(aggRecovery.Done)
 	}
 
 	// Wire up live log streaming + AI + DLQ metrics
@@ -992,6 +1088,13 @@ func main() {
 		ingestPipeline.Stop()
 	}
 
+	// 3b. Drain the aggregate group-commit writer. gRPC GracefulStop above
+	// guarantees no new Exports, so this commits whatever was still queued
+	// rather than dropping deltas an Export is still waiting on.
+	if aggWriter != nil {
+		aggWriter.Stop()
+	}
+
 	// 4. Stop DLQ (may still be replaying)
 	dlq.Stop()
 
@@ -1028,7 +1131,14 @@ func main() {
 		slog.Warn("hydrator did not finish before shutdown; cancelling")
 	}
 
-	// 5. Close database last (everything above may still write)
+	// 5. Close the databases last (everything above may still write). The
+	// aggregate store closes before the main DB: its writer has already
+	// drained, and retention — which touches both — has already stopped.
+	if aggStore != nil {
+		if err := aggStore.Close(); err != nil {
+			slog.Error("Failed to close aggregate store", "error", err)
+		}
+	}
 	if err := repo.Close(); err != nil {
 		slog.Error("Failed to close database", "error", err)
 	}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,11 @@
 # the legacy internal/graph package is excluded from duplication checks
 # repo-wide.
 sonar.cpd.exclusions=**/*_test.go,internal/graph/**,test/**
+
+# store_sqlite.go is the aggregate store's SQL layer: statements are assembled
+# from compile-time column-list constants and counted placeholder runs, and
+# every value is bound as a parameter. S2077 flags the concatenation itself;
+# no runtime data ever reaches the SQL text in this file.
+sonar.issue.ignore.multicriteria=sql1
+sonar.issue.ignore.multicriteria.sql1.ruleKey=go:S2077
+sonar.issue.ignore.multicriteria.sql1.resourceKey=internal/aggregate/store_sqlite.go

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,11 +4,3 @@
 # the legacy internal/graph package is excluded from duplication checks
 # repo-wide.
 sonar.cpd.exclusions=**/*_test.go,internal/graph/**,test/**
-
-# store_sqlite.go is the aggregate store's SQL layer: statements are assembled
-# from compile-time column-list constants and counted placeholder runs, and
-# every value is bound as a parameter. S2077 flags the concatenation itself;
-# no runtime data ever reaches the SQL text in this file.
-sonar.issue.ignore.multicriteria=sql1
-sonar.issue.ignore.multicriteria.sql1.ruleKey=go:S2077
-sonar.issue.ignore.multicriteria.sql1.resourceKey=internal/aggregate/store_sqlite.go


### PR DESCRIPTION
Phase 2 of the aggregate-first epic (#153): the durable aggregate store. Decisions implemented: #162 (schema, interface, versioning), #160 (durable ACK, group commit, windows, recovery), #166 (durable cumulative baselines), #157 (sketch codec). ADR 0002, ADR 0003.

## Components

**`internal/aggregate/store.go`** — Store interface + types. `CommitGroup` / `FinalizeWindow` / `FinalizableWindows` / `PurgeBefore` / `ReadBuckets` / `ReplayMutable` / `LoadBaselines` / `ResolveSeries` / `LoadDict` / `LoadSeries` / `Backlog` / `Close`. No `*sql.Tx` or transaction-scoped primitive escapes an implementation. Every read enforces its own maximum (`MaxReadRows`, `MaxReadWindowSpan`); `Selector` requires a bounded window range and a tenant scope or returns `ErrSelectorUnbounded`.

**`internal/aggregate/store_sqlite.go`** — `data/aggregate.db` per ADR 0003: own connections via the same `glebarez` engine the main DB uses (raw `database/sql`, deliberately not GORM), own fail-closed PRAGMA stanza attached to the DSN so every connection in the pool carries it, single writer connection (`MaxOpenConns=1` + an explicit write mutex) and a 4-connection read pool. Six tables exactly per #162, including `aggregate_buckets PRIMARY KEY(window_start, series_id) WITHOUT ROWID` with a nullable sketch BLOB, `aggregate_delta_log(seq INTEGER PRIMARY KEY)` with `INDEX(window_start, series_id, seq)`, and `aggregate_baseline PK(series_id, producer_id BLOB)`. Absent schema → created; partial or version-mismatched → startup fails with an explicit `*SchemaError`; `AGGREGATE_ALLOW_REBUILD=true` drops only aggregate-owned tables behind a prominent data-loss warning. No automatic migrations.

**`internal/aggregate/writer.go`** — group-commit writer per #160. First waiter opens a ≤5 ms coalescing window, early commit on size/count target, next batch accumulates in a bounded channel while a COMMIT is in flight. Triple admission bound (pending bytes, waiters, delta count) returns `*SaturationError`, matched by `errors.Is(err, ErrSaturated)`. Order is commit → `engine.ApplyCommitted` → release waiters. Owns the finalize state machine (finalization must serialize with incoming late deltas; the store's writer lock provides that).

**`internal/aggregate/registrar.go`** — `DurableRegistrar` replaces the provisional in-memory registrar behind the existing `Registrar` seam. IDs are minted in memory and their rows staged; every commit drains all staged rows, so a registration is always in the same transaction as the first delta that could reference it. A crash between minting and committing loses the ID, never correctness — nothing committed referenced it, and the counter reseeds from `MAX(id)`.

**`internal/aggregate/recovery.go`** — downtime-expired windows finalize transactionally, mutable delta-log rows replay into the shards, durable baselines seed the tracker. Finalized history never hydrates into RAM. `RecoveryGate` holds `/ready` at 503 until it completes.

**Wiring** — `main.go` opens the store whenever `AGGREGATE_MODE != legacy` (shadow persists too: shadow is the durability rehearsal), recovers before the writer accepts anything, and shuts down LIFO: writer drains → aggregate store closes → main DB closes. `internal/ingest` maps `ErrSaturated` to `RESOURCE_EXHAUSTED` (the existing HTTP handler already turns that into 429 + `Retry-After`). `RetentionScheduler` gains an hourly `PurgeBefore` on the same age cutoff plus a conservative ANALYZE on the daily tick — and no VACUUM on that file, ever.

**Config** — `AGGREGATE_DB_PATH` (`./data/aggregate.db`), `AGGREGATE_ALLOW_REBUILD` (false), `AGGREGATE_SYNCHRONOUS` (NORMAL), `AGGREGATE_COMMIT_COALESCE_MS` (5), `AGGREGATE_COMMIT_MAX_DELTAS` (5000), `AGGREGATE_COMMIT_MAX_BYTES` (8 MiB), `AGGREGATE_COMMIT_MAX_PENDING_BYTES` (64 MiB), `AGGREGATE_COMMIT_MAX_WAITERS` (512), `AGGREGATE_COMMIT_MAX_PENDING_DELTAS` (200000), `AGGREGATE_FINALIZE_INTERVAL_SEC` (30). Validated only when the engine runs.

**Metrics** — commit latency (`otelcontext_aggregate_commit_duration_seconds`) and batch size, admission rejections by bound, finalize/purge durations and row counts, delta-log backlog rows + age (the #160 health bounds), recovery duration.

## Test results

```
go vet ./...                → no issues
go build ./...              → success
go test ./internal/aggregate/ ./internal/ingest/ ./internal/storage/ -count=1 -race
                            → 603 passed, 0 failed
go test ./internal/... -count=1
                            → 1005 passed, 0 failed (20 packages)
golangci-lint (touched packages) → 0 issues
```

Notable tests: all-or-nothing group commit (a constraint violation in the first phase leaves the batch's series, delta and baseline rows absent); finalize materialize+delete atomicity (a broken writer leaves the delta rows un-deleted and no bucket written); coalescing (32 concurrent callers → strictly fewer transactions, every waiter released post-COMMIT); each of the three admission bounds → `ErrSaturated` with the right `Bound`; commit-before-apply ordering asserted from inside the commit; replay of mutable windows only; downtime-expired finalization; version mismatch → startup error; rebuild flag; `ReadBuckets` bounds and tenant scoping; `ResolveSeries` round trip across all four signals; retention purge and ANALYZE hooks; `-race` on the writer.

**kill -9 after ACK**: a real process-kill test. The parent forks the test binary, the child acknowledges an Export and `SIGKILL`s itself with no close and no checkpoint; the parent asserts the child died by `SIGKILL` *after* printing its post-ACK marker, then reopens the store and recovers all 11 acknowledged points. A portable close-without-checkpoint variant is kept alongside it and documented as the weaker claim.

## Benchmarks (AMD EPYC 9354P, not the 2-vCPU gate profile)

```
BenchmarkCommitGroup5kSeries   82.6 ms/op    6.6 MB/op   64760 allocs/op   (5000 deltas/commit)
BenchmarkFinalizeWindow       365.5 ms/op    (20k delta rows → 5k buckets)
BenchmarkWriterApply            1.1 ms/op    4.8 KB/op      21 allocs/op   (end-to-end durable ACK)
```

⚠️ A full 5,000-delta commit costs ~83 ms here and will be materially worse on 2 vCPU. That is the burst shape, not the steady state (`BenchmarkWriterApply` is the steady-state path at ~1.1 ms), but it is the number the #162 gate has to survive: the gate run belongs to the benchmark issue, and `AGGREGATE_COMMIT_MAX_DELTAS` is the knob if it fails. Batching delta rows into multi-row `INSERT ... VALUES` was measured and is **slower** with this driver (~105 ms vs ~83 ms), so the per-row prepared statement stays.

## Deviations and decisions worth reviewing

- **`synchronous=NORMAL` by default**, not FULL. #160's contract is "no acknowledged aggregate loss" on process/container crash, which WAL + NORMAL satisfies (and the kill -9 test proves). FULL buys power-loss durability for one fsync per group commit — up to 200/s at a 5 ms coalescing window on 2 vCPU, which is exactly the ACK p99 budget. Exposed as `AGGREGATE_SYNCHRONOUS=FULL`. Reasoning is in the `verifyPragmas` doc comment.
- **Store-side aggregation for broad queries is not implemented.** `ReadBuckets` is bounded and cap-enforced, but #162's "prefer store-side aggregation over materializing bounded-but-huge row sets" belongs to the read path (#164), which knows the query shapes. Flagged, not built.
- **Admission runs before the write, not after.** `Engine.Admit` was extracted from `ApplyCommitted` so the writer resolves cardinality routing *before* the commit. Admitting afterwards would let the store accumulate series the in-memory caps already rerouted to `__other__`.
- **Baselines can be one commit ahead of their deltas.** The dirty set is drained while the batch is built, so a drained baseline is at least as new as the deltas in that batch. On a crash a baseline may be ahead of the durable deltas (the next point under-counts by one interval) but never behind them (which would double-count). Documented on `DrainDirty`.
- **Commit failure is handled by mode.** Aggregate mode fails the Export (the store is authoritative); shadow mode logs and continues (the legacy path is still the source of truth, and failing there would turn an aggregate-side problem into raw telemetry loss). Saturation returns `RESOURCE_EXHAUSTED` in both.
- **Dictionary insert is `INSERT`, not `INSERT OR IGNORE`.** `OR IGNORE` skips rows violating *any* constraint, which would let a rejected registration vanish while the delta referencing it commits — the exact invariant the batch exists to enforce. A conflict here is corruption and is now loud. (Caught by the atomicity test, which initially passed for the wrong reason.)
- **`aggregate_dict.value` gained `CHECK (length(value) > 0)`** and `DurableRegistrar.Register` refuses empty values (routing them to `__other__`). A zero-length dictionary value is an identity that resolves to nothing and collides with every other empty value in its namespace.
- **Per-kind dictionary caps are wired in `main.go`** (operation ≤ trace+edge series caps, metric name ≤ metric series cap, log template ≤ log series cap). Phase 1 ran the registrar uncapped, which cost only RAM; a durable dictionary costs disk. Service/tenant/dimension namespaces stay uncapped.
- **`RetentionScheduler.Start()` moved** a few lines later in `main.go` so `SetAggregateRetention` lands before the loop reads the fields.
- **Pre-existing lint findings left alone** (none in touched files): `internal/storage/metrics_repo.go:118` errcheck, gofmt on `internal/api/log_handlers_trace_filter_test.go` and `internal/storage/tenant_sanitize_test.go`, two gosec G706 log-injection findings in `internal/storage/`.

## Where #162's spec did not survive contact

- **`aggregate_series` lists both `status_class` and `severity`** as explicit identity columns, but the wave-2 `SeriesKey` carries one `StatusClass` field whose meaning is signal-dependent (span status for traces/edges, severity tier for logs). Both columns exist as specified; exactly one is ever non-zero, and `splitStatus`/`joinStatus` round-trip the pair onto the single field. Anyone reading the table directly needs to know that.
- **`FinalizableWindows` is not in #162's interface list** but finalization cannot be driven without it — the writer has to ask which windows are ready. Same for `LoadDict`/`LoadSeries`, which the durable registrar needs to keep IDs stable across restart, and `Backlog`, which #160's health bounds require.
- **The interface takes `CommitGroup(*GroupBatch)`**, a pointer, not the value in #162's sketch: a batch carries thousands of delta rows.
- **Sketches cannot be merged in SQL**, so `FinalizeWindow` streams delta rows from the read pool ordered by `series_id` and writes each bucket into the writer transaction as the id changes. One series' state at a time — a busy window carries hundreds of thousands of delta rows and loading them all to satisfy one transaction would trade a durability win for an OOM.

Refs #173
