### PR TITLE
feat(api): dashboard and WebSocket aggregate reads with coverage honesty

### DIFF
--- a/internal/aggregate/dict.go
+++ b/internal/aggregate/dict.go
@@ -89,6 +89,18 @@ type Registrar interface {
 	OtherID(tenantID uint32, kind Kind) uint32
 }
 
+// Resolver reverses a dictionary ID back to its entry. It is a READ-PATH
+// capability: the ingest hot path never reverses an ID, but the query facade
+// has to turn a SeriesKey back into service, operation and metric names.
+//
+// It is deliberately separate from Registrar so an implementation that cannot
+// reverse (a write-only registrar) stays usable; the Cache degrades to
+// "unresolved" rather than failing the query.
+type Resolver interface {
+	// Lookup returns the entry for id. ok is false when the ID is unknown.
+	Lookup(id uint32) (DictEntry, bool)
+}
+
 // dictScope is the (tenant, kind) namespace of a dictionary entry. Splitting
 // the scope out of the map key lets the value map stay string-keyed, which is
 // what makes the byte-slice lookup path allocation-free.
@@ -209,6 +221,17 @@ func (c *Cache) register(scope dictScope, value []byte) uint32 {
 // series carries the __other__ entry as its NameID.
 func (c *Cache) OtherID(tenantID uint32, kind Kind) uint32 {
 	return c.reg.OtherID(tenantID, kind)
+}
+
+// Lookup reverses a dictionary ID through the underlying registrar. It returns
+// ok=false when the registrar cannot reverse IDs at all, so a caller that only
+// needs presentation names degrades to "unresolved" instead of failing.
+func (c *Cache) Lookup(id uint32) (DictEntry, bool) {
+	res, ok := c.reg.(Resolver)
+	if !ok {
+		return DictEntry{}, false
+	}
+	return res.Lookup(id)
 }
 
 // Len returns the number of cached entries across every scope. Diagnostic only.

--- a/internal/aggregate/engine.go
+++ b/internal/aggregate/engine.go
@@ -3,6 +3,7 @@ package aggregate
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -152,6 +153,16 @@ type Engine struct {
 
 	shards [NumShards]shard
 
+	// own is the ownership record: which windows memory owns, which windows
+	// the store owns, and the process generation the revision counter belongs
+	// to. It is the OUTER lock of the engine — a shard lock is only ever taken
+	// while it is held, never the reverse. See ownership.
+	own ownership
+
+	// store is the durable store used by the read path for finalized windows.
+	// nil (the Phase 1 / test case) means finalized windows are simply gone.
+	store atomic.Pointer[Store]
+
 	applier  atomic.Pointer[Applier]
 	revision atomic.Uint64
 
@@ -163,6 +174,57 @@ type Engine struct {
 type shard struct {
 	mu      sync.Mutex
 	windows map[int64]map[SeriesKey]*AggregateDelta
+}
+
+// ownership answers "who owns this window" for the read path (#164).
+//
+// A window is owned by memory or by the store, never by both and never by
+// neither. Reads of an engine-owned window come exclusively from the shards
+// even when crash-recovery delta rows exist for it; reads of a store-owned
+// window come exclusively from the store. Ownership, not row presence, is the
+// dedup rule.
+//
+// Every transition — a new window appearing, rollover evicting one,
+// finalization handing one to the store — happens under mu together with the
+// shard mutation that implements it, so a concurrent Ownership() can neither
+// omit nor double-count a window. That is why mu is the engine's OUTER lock:
+// a shard mutex may be taken while mu is held, never the other way round.
+type ownership struct {
+	mu sync.RWMutex
+	// mutable is the set of window starts the shards own.
+	mutable map[int64]struct{}
+	// watermark is the newest window start handed to the store. Every window
+	// at or below it is store-owned.
+	watermark int64
+	// epoch identifies this process generation. The revision counter restarts
+	// at zero on every boot, so a consumer that only compared revisions could
+	// mistake a restarted counter for a rollback; the epoch is what makes the
+	// pair {epoch, revision} a total order (#164).
+	epoch string
+}
+
+// Ownership is an atomic snapshot of {mutable set, finalized watermark,
+// revision, epoch}. A query captures one and reads every window through it.
+type Ownership struct {
+	// Epoch is the process generation.
+	Epoch string
+	// Revision is the engine revision at capture time.
+	Revision uint64
+	// Mutable is the memory-owned window starts, oldest first.
+	Mutable []int64
+	// FinalizedWatermark is the newest store-owned window start. Zero means
+	// nothing has been handed over yet.
+	FinalizedWatermark int64
+}
+
+// OwnsInMemory reports whether windowStart is memory-owned in this snapshot.
+func (o Ownership) OwnsInMemory(windowStart int64) bool {
+	for _, w := range o.Mutable {
+		if w == windowStart {
+			return true
+		}
+	}
+	return false
 }
 
 // NewEngine builds an Engine. It fails on a budget that cannot hold — a
@@ -213,6 +275,8 @@ func NewEngine(cfg EngineConfig) (*Engine, error) {
 	for i := range e.shards {
 		e.shards[i].windows = make(map[int64]map[SeriesKey]*AggregateDelta)
 	}
+	e.own.mutable = make(map[int64]struct{})
+	e.own.epoch = newEpoch(cfg.Now())
 	var a Applier = directApplier{e}
 	e.applier.Store(&a)
 	return e, nil
@@ -240,6 +304,104 @@ func (e *Engine) MetricDims() DimsConfig { return e.dims }
 // batch and never decreases, so a consumer can tell "nothing changed" from
 // "changed back to the same numbers" (#163's replacement-by-revision topology).
 func (e *Engine) Revision() uint64 { return e.revision.Load() }
+
+// Epoch returns the process generation identifier. It is stable for the life
+// of the engine and pairs with Revision to give consumers a total order across
+// restarts (#164).
+func (e *Engine) Epoch() string { return e.own.epoch }
+
+// SetStore wires the durable store into the READ path. The write path already
+// reaches the store through the group-commit writer; this is what lets the
+// query facade serve finalized windows. Call it once at startup, before the
+// engine takes traffic.
+func (e *Engine) SetStore(st Store) {
+	if st == nil {
+		return
+	}
+	e.store.Store(&st)
+}
+
+// Store returns the wired durable store, or nil when none is configured.
+func (e *Engine) Store() Store {
+	p := e.store.Load()
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+// TenantID resolves a tenant name to its dictionary ID for the read path.
+func (e *Engine) TenantID(name string) uint32 { return e.cache.InternTenant(name) }
+
+// Ownership captures {mutable set, finalized watermark, revision, epoch} in
+// one critical section. Every read path starts here.
+func (e *Engine) Ownership() Ownership {
+	e.own.mu.RLock()
+	defer e.own.mu.RUnlock()
+	return e.ownershipLocked()
+}
+
+// ownershipLocked builds the snapshot. e.own.mu must be held (read or write).
+func (e *Engine) ownershipLocked() Ownership {
+	mutable := make([]int64, 0, len(e.own.mutable))
+	for start := range e.own.mutable {
+		mutable = append(mutable, start)
+	}
+	sort.Slice(mutable, func(i, j int) bool { return mutable[i] < mutable[j] })
+	return Ownership{
+		Epoch:              e.own.epoch,
+		Revision:           e.revision.Load(),
+		Mutable:            mutable,
+		FinalizedWatermark: e.own.watermark,
+	}
+}
+
+// MarkFinalized transitions one window from memory ownership to store
+// ownership. The writer calls it after store.FinalizeWindow has committed, so
+// the handover is exactly as atomic as the transaction that materialized the
+// buckets: a query either sees the window in memory or in the store, never in
+// both and never in neither.
+func (e *Engine) MarkFinalized(windowStart int64) {
+	e.own.mu.Lock()
+	released := e.evictWindowLocked(windowStart)
+	delete(e.own.mutable, windowStart)
+	if windowStart > e.own.watermark {
+		e.own.watermark = windowStart
+	}
+	e.own.mu.Unlock()
+	for _, swk := range released {
+		e.limiter.Release(swk.Key, swk.WindowStart)
+	}
+	if len(released) > 0 {
+		e.seriesDiscarded.Add(uint64(len(released)))
+		e.publishActiveSeries()
+	}
+}
+
+// evictWindowLocked drops one window from every shard and returns the series
+// it released. e.own.mu must be held for writing.
+func (e *Engine) evictWindowLocked(start int64) []SeriesWindowKey {
+	var released []SeriesWindowKey
+	for i := range e.shards {
+		sh := &e.shards[i]
+		sh.mu.Lock()
+		if w, ok := sh.windows[start]; ok {
+			for key := range w {
+				released = append(released, SeriesWindowKey{Key: key, WindowStart: start})
+			}
+			delete(sh.windows, start)
+		}
+		sh.mu.Unlock()
+	}
+	return released
+}
+
+// newEpoch derives a process generation identifier. It only has to differ from
+// the previous generation of the same process lineage, which a boot timestamp
+// in base 36 does without pulling in a UUID dependency.
+func newEpoch(now time.Time) string {
+	return strconv.FormatInt(now.UnixNano(), 36)
+}
 
 // SetApplier replaces the apply path. Phase 2 uses it to insert the
 // group-commit writer between the reducer and the shards.
@@ -366,11 +528,19 @@ func (e *Engine) ApplyCommitted(m DeltaMap) uint64 {
 	}
 	resolved := e.Admit(m)
 
+	// The shard writes and the ownership registration happen inside one
+	// ownership critical section so a concurrent Ownership() never reports a
+	// window as memory-owned before memory holds it, nor the reverse.
+	e.own.mu.Lock()
 	for i := range e.shards {
 		e.applyShard(i, resolved)
 	}
-
+	for swk := range resolved {
+		e.own.mutable[swk.WindowStart] = struct{}{}
+	}
 	rev := e.revision.Add(1)
+	e.own.mu.Unlock()
+
 	e.publishActiveSeries()
 	return rev
 }
@@ -457,6 +627,7 @@ func (e *Engine) Rollover(now time.Time) int {
 	cutoff := now.Unix() - int64(WindowSize/time.Second) - int64(AllowedLateness/time.Second)
 	dropped := 0
 	var released []SeriesWindowKey
+	e.own.mu.Lock()
 	for i := range e.shards {
 		sh := &e.shards[i]
 		sh.mu.Lock()
@@ -472,6 +643,21 @@ func (e *Engine) Rollover(now time.Time) int {
 		}
 		sh.mu.Unlock()
 	}
+	// A window whose lateness horizon expired is no longer memory-owned even
+	// if the writer has not finalized it yet: the shards no longer hold it, so
+	// claiming memory ownership would report zero for a window that has data.
+	// Handing it to the store is the honest transition — the delta rows are
+	// already durable and the next finalize pass materializes them.
+	for start := range e.own.mutable {
+		if start > cutoff {
+			continue
+		}
+		delete(e.own.mutable, start)
+		if start > e.own.watermark {
+			e.own.watermark = start
+		}
+	}
+	e.own.mu.Unlock()
 	for _, swk := range released {
 		e.limiter.Release(swk.Key, swk.WindowStart)
 	}

--- a/internal/aggregate/query.go
+++ b/internal/aggregate/query.go
@@ -1,0 +1,554 @@
+package aggregate
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"time"
+)
+
+// The engine's query facade (#164, #175).
+//
+// The engine is the SOLE query facade for aggregate data: HTTP handlers, MCP
+// tools and the WebSocket publisher call QueryBuckets / QueryDashboard /
+// QueryTopology, and nothing outside this package touches aggregate.db. The
+// three entry points are purpose-built for broad requests — none of them hands
+// a caller millions of Bucket structs through one generic call.
+//
+// Every query starts by capturing an ownership snapshot. Memory-owned windows
+// are read exclusively from the shards, store-owned windows exclusively from
+// the store, and the handover between the two is atomic (see ownership in
+// engine.go). Row presence never decides the source; ownership does.
+
+// Coverage is the honesty vocabulary of a response (#164). It says what the
+// numbers are derived from, so a surface can never imply completeness it does
+// not have.
+type Coverage string
+
+// Coverage values.
+const (
+	// CoverageFull means the numbers describe every accepted event.
+	CoverageFull Coverage = "full"
+	// CoverageSampled means part of the response is derived from a subset of
+	// events — exact where the aggregate engine counted, partial elsewhere.
+	CoverageSampled Coverage = "sampled"
+	// CoverageExemplar means the response is built only from retained raw
+	// exemplars. An absent exemplar NEVER implies zero matching events.
+	CoverageExemplar Coverage = "exemplar"
+)
+
+// CoverageHeader is the response header that carries Coverage on bare-array
+// endpoints, where an envelope would silently break the response shape.
+const CoverageHeader = "OtelContext-Data-Coverage"
+
+// Coverage notes. They exist because "exemplar" is only honest if the surface
+// also says what an absent exemplar does and does not mean.
+const (
+	// SampledCoverageNote explains a partially aggregate-derived response.
+	SampledCoverageNote = "counts and rates are exact for accepted telemetry; " +
+		"parts of this response are derived from retained exemplars and are not complete"
+	// ExemplarCoverageNote explains an exemplar-only response.
+	ExemplarCoverageNote = "results come from retained raw exemplars only; " +
+		"a missing exemplar does not mean zero matching events occurred"
+)
+
+// Note returns the caveat that belongs with a coverage value, or "" for full
+// coverage, which needs none.
+func (c Coverage) Note() string {
+	switch c {
+	case CoverageSampled:
+		return SampledCoverageNote
+	case CoverageExemplar:
+		return ExemplarCoverageNote
+	default:
+		return ""
+	}
+}
+
+// AccuracyMetadata describes how accurate a percentile in the response is. It
+// is computed from the FINAL MERGED sketch on every response and is never a
+// hard-coded figure: merging mismatched scales downscales to the coarser one,
+// so a merged sketch can be less accurate than the platform default scale.
+type AccuracyMetadata struct {
+	// Approximate is true whenever a percentile came from a sketch.
+	Approximate bool `json:"approximate"`
+	// SketchScale is the mapping scale of the merged sketch.
+	SketchScale uint8 `json:"sketch_scale"`
+	// RelativeErrorBound is the worst-case relative error of a quantile
+	// estimate at SketchScale, as a fraction (0.0217 = 2.17%).
+	RelativeErrorBound float64 `json:"relative_error_bound"`
+	// Degraded reports that the merged sketch collapsed or saturated, which
+	// puts estimates in the affected range OUTSIDE RelativeErrorBound.
+	Degraded bool `json:"degraded,omitempty"`
+}
+
+// AccuracyFromSketch derives the accuracy metadata of a merged sketch. A nil
+// sketch still reports approximate: the path is approximate whether or not any
+// duration happened to arrive in the window.
+func AccuracyFromSketch(s *Sketch) AccuracyMetadata {
+	if s == nil {
+		gamma := sketchBase(SketchDefaultScale)
+		return AccuracyMetadata{
+			Approximate:        true,
+			SketchScale:        SketchDefaultScale,
+			RelativeErrorBound: (gamma - 1) / (gamma + 1),
+		}
+	}
+	return AccuracyMetadata{
+		Approximate:        true,
+		SketchScale:        s.Scale(),
+		RelativeErrorBound: s.RelativeError(),
+		Degraded:           s.Collapsed() || s.Saturations() > 0,
+	}
+}
+
+// Query bounds one read. Tenant, Start and End are mandatory; the rest narrow
+// the scan.
+type Query struct {
+	// Tenant is the tenant name. Required.
+	Tenant string
+	// Start and End bound the read. Required, Start before End.
+	Start, End time.Time
+	// Services, when non-empty, restricts the read to these service names.
+	Services []string
+	// Signal, when non-zero, restricts the read to one signal.
+	Signal Signal
+}
+
+// TrafficPoint is one window of the traffic series.
+type TrafficPoint struct {
+	// WindowStart is the UTC start of the five-minute window.
+	WindowStart time.Time
+	// Count is accepted events; ErrorCount is the error subset.
+	Count, ErrorCount int64
+}
+
+// BucketsResult is the answer to QueryBuckets.
+type BucketsResult struct {
+	Points   []TrafficPoint
+	Coverage Coverage
+	Epoch    string
+	Revision uint64
+}
+
+// ServiceStat is one service's aggregate accounting over the queried range.
+type ServiceStat struct {
+	Service      string
+	Count        int64
+	ErrorCount   int64
+	ErrorRate    float64
+	AvgLatencyMs float64
+}
+
+// DashboardResult is the answer to QueryDashboard. Field names mirror the
+// legacy dashboard payload so the response contract survives the migration.
+type DashboardResult struct {
+	TotalTraces      int64
+	TotalLogs        int64
+	TotalErrors      int64
+	AvgLatencyMs     float64
+	ErrorRate        float64
+	ActiveServices   int64
+	P99LatencyMicros float64
+	TopFailing       []ServiceStat
+	Accuracy         AccuracyMetadata
+	Coverage         Coverage
+	Epoch            string
+	Revision         uint64
+}
+
+// TopologyEdge is one caller/callee edge of the topology.
+type TopologyEdge struct {
+	Source, Target string
+	CallCount      int64
+	AvgLatencyMs   float64
+	ErrorRate      float64
+}
+
+// TopologyResult is the answer to QueryTopology.
+type TopologyResult struct {
+	Nodes    []ServiceStat
+	Edges    []TopologyEdge
+	Coverage Coverage
+	Epoch    string
+	Revision uint64
+}
+
+// asInt64 narrows an aggregate counter to the signed type the wire format uses,
+// saturating rather than wrapping. A count past 2^63 is not reachable in this
+// system, but a wrapped negative total on a dashboard would be worse than a
+// pinned one.
+func asInt64(v uint64) int64 {
+	if v > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(v)
+}
+
+// visitFunc receives one (window, series, delta) triple. The delta pointer is
+// only valid for the duration of the call: memory-owned deltas are visited
+// under the shard lock and are NOT cloned, because every caller folds them
+// into accumulators rather than retaining them.
+type visitFunc func(windowStart int64, key SeriesKey, d *AggregateDelta)
+
+// scan walks every series in the query's range, memory-owned windows from the
+// shards and store-owned windows from the store, and returns the ownership
+// snapshot the walk was consistent with.
+func (e *Engine) scan(q Query, visit visitFunc) (Ownership, error) {
+	var own Ownership
+	if q.Tenant == "" {
+		return own, fmt.Errorf("%w: tenant is required", ErrSelectorUnbounded)
+	}
+	if !q.End.After(q.Start) {
+		return own, fmt.Errorf("%w: [%s,%s) is not a bounded forward range",
+			ErrSelectorUnbounded, q.Start.Format(time.RFC3339), q.End.Format(time.RFC3339))
+	}
+	tenantID := e.cache.InternTenant(q.Tenant)
+	start := WindowStart(q.Start)
+	end := WindowStart(q.End.Add(WindowSize - time.Second))
+	if end <= start {
+		end = start + int64(WindowSize/time.Second)
+	}
+
+	// Memory first, under the ownership read lock, so the shard contents and
+	// the snapshot describe the same instant.
+	own = e.readMutable(tenantID, start, end, q.Signal, visit)
+
+	// Everything below the oldest memory-owned window in range belongs to the
+	// store. The mutable set is a contiguous suffix by construction, so this
+	// is one bounded query rather than one per window.
+	storeEnd := end
+	for _, w := range own.Mutable {
+		if w >= start && w < storeEnd {
+			storeEnd = w
+		}
+	}
+	if storeEnd <= start {
+		return own, nil
+	}
+	st := e.Store()
+	if st == nil {
+		return own, nil
+	}
+	if err := e.readFinalized(st, tenantID, start, storeEnd, q.Signal, visit); err != nil {
+		return own, err
+	}
+	return own, nil
+}
+
+// readMutable visits the memory-owned windows in [start, end) and returns the
+// ownership snapshot it read under.
+func (e *Engine) readMutable(tenantID uint32, start, end int64, signal Signal, visit visitFunc) Ownership {
+	e.own.mu.RLock()
+	defer e.own.mu.RUnlock()
+	own := e.ownershipLocked()
+	for _, w := range own.Mutable {
+		if w < start || w >= end {
+			continue
+		}
+		for i := range e.shards {
+			sh := &e.shards[i]
+			sh.mu.Lock()
+			for key, d := range sh.windows[w] {
+				if key.TenantID != tenantID {
+					continue
+				}
+				if signal != SignalUnspecified && key.Signal != signal {
+					continue
+				}
+				visit(w, key, d)
+			}
+			sh.mu.Unlock()
+		}
+	}
+	return own
+}
+
+// readFinalized visits the store-owned windows in [start, end).
+func (e *Engine) readFinalized(st Store, tenantID uint32, start, end int64, signal Signal, visit visitFunc) error {
+	buckets, err := st.ReadBuckets(Selector{
+		TenantID: tenantID,
+		Start:    start,
+		End:      end,
+		Signal:   signal,
+	})
+	if err != nil {
+		return err
+	}
+	if len(buckets) == 0 {
+		return nil
+	}
+	ids := make([]SeriesID, 0, len(buckets))
+	seen := make(map[SeriesID]struct{}, len(buckets))
+	for _, b := range buckets {
+		if _, ok := seen[b.SeriesID]; ok {
+			continue
+		}
+		seen[b.SeriesID] = struct{}{}
+		ids = append(ids, b.SeriesID)
+	}
+	infos, err := st.ResolveSeries(ids)
+	if err != nil {
+		return err
+	}
+	keys := make(map[SeriesID]SeriesKey, len(infos))
+	for _, info := range infos {
+		keys[info.ID] = info.Key
+	}
+	for _, b := range buckets {
+		key, ok := keys[b.SeriesID]
+		if !ok {
+			// A bucket whose identity no longer resolves cannot be attributed
+			// to a service. Counting it under an invented name would be worse
+			// than leaving it out of a per-service breakdown.
+			continue
+		}
+		visit(b.WindowStart, key, b.Delta)
+	}
+	return nil
+}
+
+// serviceName resolves a series' service through the dictionary. An
+// unresolvable ID yields "" and the caller drops the series from per-service
+// breakdowns; totals still count it.
+func (e *Engine) serviceName(key SeriesKey) string {
+	entry, ok := e.cache.Lookup(key.ServiceID)
+	if !ok {
+		return ""
+	}
+	return string(entry.Value)
+}
+
+// serviceFilter turns the query's service list into a membership test. A nil
+// result means "no filter".
+func serviceFilter(services []string) map[string]struct{} {
+	if len(services) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(services))
+	for _, s := range services {
+		set[s] = struct{}{}
+	}
+	return set
+}
+
+// QueryBuckets returns per-window traffic counts. It is the traffic-chart
+// query: one point per five-minute window, never one row per series.
+func (e *Engine) QueryBuckets(q Query) (*BucketsResult, error) {
+	if q.Signal == SignalUnspecified {
+		q.Signal = SignalTraceOp
+	}
+	filter := serviceFilter(q.Services)
+	type counters struct{ count, errors int64 }
+	byWindow := make(map[int64]*counters)
+
+	own, err := e.scan(q, func(windowStart int64, key SeriesKey, d *AggregateDelta) {
+		if filter != nil {
+			if _, ok := filter[e.serviceName(key)]; !ok {
+				return
+			}
+		}
+		c := byWindow[windowStart]
+		if c == nil {
+			c = &counters{}
+			byWindow[windowStart] = c
+		}
+		c.count += asInt64(d.Count)
+		c.errors += asInt64(d.ErrorCount)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	points := make([]TrafficPoint, 0, len(byWindow))
+	for start, c := range byWindow {
+		points = append(points, TrafficPoint{
+			WindowStart: time.Unix(start, 0).UTC(),
+			Count:       c.count,
+			ErrorCount:  c.errors,
+		})
+	}
+	sort.Slice(points, func(i, j int) bool { return points[i].WindowStart.Before(points[j].WindowStart) })
+	return &BucketsResult{
+		Points:   points,
+		Coverage: CoverageFull,
+		Epoch:    own.Epoch,
+		Revision: own.Revision,
+	}, nil
+}
+
+// dashAccum accumulates one service's contribution to the dashboard.
+type dashAccum struct {
+	count    uint64
+	errors   uint64
+	durCount uint64
+	durSum   float64
+}
+
+// QueryDashboard returns the dashboard summary: totals, averages, active
+// services, the p99 from the merged sketch, and the accuracy metadata that
+// sketch justifies.
+func (e *Engine) QueryDashboard(q Query) (*DashboardResult, error) {
+	q.Signal = SignalUnspecified // the scan covers traces and logs in one pass
+	filter := serviceFilter(q.Services)
+
+	var (
+		total    dashAccum
+		logs     uint64
+		merged   *Sketch
+		perSvc   = make(map[string]*dashAccum)
+		services = make(map[uint32]struct{})
+	)
+	own, err := e.scan(q, func(_ int64, key SeriesKey, d *AggregateDelta) {
+		name := e.serviceName(key)
+		if filter != nil {
+			if _, ok := filter[name]; !ok {
+				return
+			}
+		}
+		switch key.Signal {
+		case SignalLog:
+			logs += d.LogCount
+			return
+		case SignalTraceOp:
+		default:
+			return
+		}
+		services[key.ServiceID] = struct{}{}
+		total.count += d.Count
+		total.errors += d.ErrorCount
+		total.durCount += d.DurationCount
+		total.durSum += d.DurationSum
+		if d.Sketch != nil {
+			if merged == nil {
+				merged = NewSketchAtScaleUnchecked(d.Sketch.Scale())
+			}
+			merged.Merge(d.Sketch)
+		}
+		if name == "" {
+			return
+		}
+		acc := perSvc[name]
+		if acc == nil {
+			acc = &dashAccum{}
+			perSvc[name] = acc
+		}
+		acc.count += d.Count
+		acc.errors += d.ErrorCount
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	res := &DashboardResult{
+		TotalTraces:    asInt64(total.count),
+		TotalLogs:      asInt64(logs),
+		TotalErrors:    asInt64(total.errors),
+		ActiveServices: int64(len(services)),
+		Accuracy:       AccuracyFromSketch(merged),
+		Coverage:       CoverageFull,
+		Epoch:          own.Epoch,
+		Revision:       own.Revision,
+	}
+	if total.durCount > 0 {
+		res.AvgLatencyMs = total.durSum / float64(total.durCount) / 1000.0
+	}
+	if total.count > 0 {
+		res.ErrorRate = float64(total.errors) / float64(total.count) * 100
+	}
+	if merged != nil {
+		res.P99LatencyMicros = merged.Quantile(0.99)
+	}
+	res.TopFailing = topFailing(perSvc, 5)
+	return res, nil
+}
+
+// topFailing ranks services by error count, highest first, capped at limit.
+func topFailing(perSvc map[string]*dashAccum, limit int) []ServiceStat {
+	out := make([]ServiceStat, 0, len(perSvc))
+	for name, acc := range perSvc {
+		if acc.errors == 0 {
+			continue
+		}
+		rate := 0.0
+		if acc.count > 0 {
+			rate = float64(acc.errors) / float64(acc.count)
+		}
+		out = append(out, ServiceStat{
+			Service:    name,
+			Count:      asInt64(acc.count),
+			ErrorCount: asInt64(acc.errors),
+			ErrorRate:  rate,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ErrorCount != out[j].ErrorCount {
+			return out[i].ErrorCount > out[j].ErrorCount
+		}
+		return out[i].Service < out[j].Service
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// QueryTopology returns the service topology: one node per service with its
+// aggregate accounting, plus whatever caller/callee edge series exist.
+func (e *Engine) QueryTopology(q Query) (*TopologyResult, error) {
+	q.Signal = SignalUnspecified
+	filter := serviceFilter(q.Services)
+	nodes := make(map[string]*dashAccum)
+
+	own, err := e.scan(q, func(_ int64, key SeriesKey, d *AggregateDelta) {
+		if key.Signal != SignalTraceOp {
+			return
+		}
+		name := e.serviceName(key)
+		if name == "" {
+			return
+		}
+		if filter != nil {
+			if _, ok := filter[name]; !ok {
+				return
+			}
+		}
+		acc := nodes[name]
+		if acc == nil {
+			acc = &dashAccum{}
+			nodes[name] = acc
+		}
+		acc.count += d.Count
+		acc.errors += d.ErrorCount
+		acc.durCount += d.DurationCount
+		acc.durSum += d.DurationSum
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]ServiceStat, 0, len(nodes))
+	for name, acc := range nodes {
+		stat := ServiceStat{
+			Service:    name,
+			Count:      asInt64(acc.count),
+			ErrorCount: asInt64(acc.errors),
+		}
+		if acc.count > 0 {
+			stat.ErrorRate = float64(acc.errors) / float64(acc.count)
+		}
+		if acc.durCount > 0 {
+			stat.AvgLatencyMs = acc.durSum / float64(acc.durCount) / 1000.0
+		}
+		out = append(out, stat)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Service < out[j].Service })
+
+	return &TopologyResult{
+		Nodes:    out,
+		Edges:    []TopologyEdge{},
+		Coverage: CoverageFull,
+		Epoch:    own.Epoch,
+		Revision: own.Revision,
+	}, nil
+}

--- a/internal/aggregate/query_test.go
+++ b/internal/aggregate/query_test.go
@@ -1,0 +1,389 @@
+package aggregate
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// stubStore is a Store that serves a fixed set of finalized buckets. It exists
+// so the query facade's ownership rules can be tested without a live SQLite
+// file: what matters here is WHICH source a window is read from, not how the
+// bytes got there.
+type stubStore struct {
+	buckets []Bucket
+	infos   map[SeriesID]SeriesKey
+	reads   int
+	// readRanges records every [Start,End) the facade asked for, so a test can
+	// assert that a memory-owned window was never requested from the store.
+	readRanges [][2]int64
+}
+
+func newStubStore() *stubStore {
+	return &stubStore{infos: make(map[SeriesID]SeriesKey)}
+}
+
+// put records one finalized bucket under a stable series ID.
+func (s *stubStore) put(id SeriesID, key SeriesKey, windowStart int64, d *AggregateDelta) {
+	s.infos[id] = key
+	s.buckets = append(s.buckets, Bucket{WindowStart: windowStart, SeriesID: id, Delta: d})
+}
+
+func (s *stubStore) CommitGroup(*GroupBatch) error { return nil }
+func (s *stubStore) FinalizeWindow(int64) (FinalizeStats, error) {
+	return FinalizeStats{}, nil
+}
+func (s *stubStore) FinalizableWindows(int64, int) ([]int64, error) { return nil, nil }
+func (s *stubStore) PurgeBefore(int64) (PurgeStats, error)          { return PurgeStats{}, nil }
+func (s *stubStore) ReadBuckets(sel Selector) ([]Bucket, error) {
+	s.reads++
+	s.readRanges = append(s.readRanges, [2]int64{sel.Start, sel.End})
+	out := make([]Bucket, 0, len(s.buckets))
+	for _, b := range s.buckets {
+		if b.WindowStart < sel.Start || b.WindowStart >= sel.End {
+			continue
+		}
+		key := s.infos[b.SeriesID]
+		if key.TenantID != sel.TenantID {
+			continue
+		}
+		if sel.Signal != SignalUnspecified && key.Signal != sel.Signal {
+			continue
+		}
+		out = append(out, b)
+	}
+	return out, nil
+}
+func (s *stubStore) ReplayMutable(int64) ([]DeltaRow, error)  { return nil, nil }
+func (s *stubStore) LoadBaselines(int) ([]BaselineRow, error) { return nil, nil }
+func (s *stubStore) ResolveSeries(ids []SeriesID) ([]SeriesInfo, error) {
+	out := make([]SeriesInfo, 0, len(ids))
+	for _, id := range ids {
+		if key, ok := s.infos[id]; ok {
+			out = append(out, SeriesInfo{ID: id, Key: key})
+		}
+	}
+	return out, nil
+}
+func (s *stubStore) LoadDict(int) ([]DictRow, error)     { return nil, nil }
+func (s *stubStore) LoadSeries(int) ([]SeriesRow, error) { return nil, nil }
+func (s *stubStore) Backlog() (BacklogStats, error)      { return BacklogStats{}, nil }
+func (s *stubStore) Close() error                        { return nil }
+
+var _ Store = (*stubStore)(nil)
+
+// queryFixture builds an engine with a fixed clock and named services.
+type queryFixture struct {
+	engine   *Engine
+	now      time.Time
+	tenantID uint32
+}
+
+func newQueryFixture(t *testing.T) *queryFixture {
+	t.Helper()
+	now := mustTime(t, "2026-08-21T12:02:00Z")
+	e := testEngine(t, now)
+	return &queryFixture{engine: e, now: now, tenantID: e.TenantID("default")}
+}
+
+// traceKey builds a trace-operation series key for a named service.
+func (f *queryFixture) traceKey(service, op string) SeriesKey {
+	return SeriesKey{
+		TenantID:    f.tenantID,
+		ServiceID:   f.engine.Cache().Intern(f.tenantID, KindService, service),
+		NameID:      f.engine.Cache().Intern(f.tenantID, KindOperation, op),
+		Signal:      SignalTraceOp,
+		StatusClass: StatusOK,
+		Variant:     SpanKindServer,
+	}
+}
+
+// logKey builds a log series key for a named service.
+func (f *queryFixture) logKey(service, template string) SeriesKey {
+	return SeriesKey{
+		TenantID:  f.tenantID,
+		ServiceID: f.engine.Cache().Intern(f.tenantID, KindService, service),
+		NameID:    f.engine.Cache().Intern(f.tenantID, KindLogTemplate, template),
+		Signal:    SignalLog,
+	}
+}
+
+// apply folds one delta into the engine's mutable window set.
+func (f *queryFixture) apply(key SeriesKey, windowStart int64, d *AggregateDelta) {
+	f.engine.ApplyCommitted(DeltaMap{{Key: key, WindowStart: windowStart}: d})
+}
+
+// window is the fixture's current window start.
+func (f *queryFixture) window() int64 { return WindowStart(f.now) }
+
+// rangeQuery is a query covering the fixture's whole mutable horizon.
+func (f *queryFixture) rangeQuery() Query {
+	return Query{
+		Tenant: "default",
+		Start:  f.now.Add(-30 * time.Minute),
+		End:    f.now.Add(time.Minute),
+	}
+}
+
+func TestQueryDashboardFromMutableMemory(t *testing.T) {
+	f := newQueryFixture(t)
+	f.apply(f.traceKey("checkout", "POST /pay"), f.window(), spanDelta(9, 1000))
+	f.apply(f.traceKey("cart", "GET /cart"), f.window(), spanDelta(3, 4000))
+	logs := &AggregateDelta{}
+	logs.ObserveLog(f.now, true)
+	logs.ObserveLog(f.now, false)
+	f.apply(f.logKey("checkout", "payment failed <*>"), f.window(), logs)
+
+	res, err := f.engine.QueryDashboard(f.rangeQuery())
+	if err != nil {
+		t.Fatalf("QueryDashboard: %v", err)
+	}
+	if res.TotalTraces != 12 {
+		t.Errorf("TotalTraces = %d, want 12", res.TotalTraces)
+	}
+	if res.TotalLogs != 2 {
+		t.Errorf("TotalLogs = %d, want 2", res.TotalLogs)
+	}
+	// spanDelta marks every third observation an error: 3 of 9 plus 1 of 3.
+	if res.TotalErrors != 4 {
+		t.Errorf("TotalErrors = %d, want 4", res.TotalErrors)
+	}
+	if res.ActiveServices != 2 {
+		t.Errorf("ActiveServices = %d, want 2", res.ActiveServices)
+	}
+	wantAvg := (9*1000.0 + 3*4000.0) / 12 / 1000.0
+	if math.Abs(res.AvgLatencyMs-wantAvg) > 1e-9 {
+		t.Errorf("AvgLatencyMs = %v, want %v", res.AvgLatencyMs, wantAvg)
+	}
+	if res.Coverage != CoverageFull {
+		t.Errorf("Coverage = %q, want %q", res.Coverage, CoverageFull)
+	}
+	if res.Epoch != f.engine.Epoch() {
+		t.Errorf("Epoch = %q, want %q", res.Epoch, f.engine.Epoch())
+	}
+	if len(res.TopFailing) != 2 {
+		t.Fatalf("TopFailing = %d entries, want 2", len(res.TopFailing))
+	}
+	if res.TopFailing[0].Service != "checkout" {
+		t.Errorf("top failing service = %q, want checkout", res.TopFailing[0].Service)
+	}
+}
+
+// TestQueryDashboardPercentileWithinReportedBound is the accuracy contract:
+// the p99 must land inside the relative-error bound the response advertises,
+// and that bound must come from the merged sketch rather than a constant.
+func TestQueryDashboardPercentileWithinReportedBound(t *testing.T) {
+	f := newQueryFixture(t)
+	d := &AggregateDelta{}
+	for i := 1; i <= 1000; i++ {
+		d.ObserveSpan(float64(i)*100, false)
+	}
+	f.apply(f.traceKey("checkout", "POST /pay"), f.window(), d)
+
+	res, err := f.engine.QueryDashboard(f.rangeQuery())
+	if err != nil {
+		t.Fatalf("QueryDashboard: %v", err)
+	}
+	if !res.Accuracy.Approximate {
+		t.Error("Accuracy.Approximate = false, want true for a sketch-derived percentile")
+	}
+	if res.Accuracy.SketchScale != SketchDefaultScale {
+		t.Errorf("SketchScale = %d, want %d", res.Accuracy.SketchScale, SketchDefaultScale)
+	}
+	if res.Accuracy.RelativeErrorBound <= 0 {
+		t.Fatalf("RelativeErrorBound = %v, want > 0", res.Accuracy.RelativeErrorBound)
+	}
+	want := 99000.0 // the 990th of 1000 values, in microseconds
+	rel := math.Abs(res.P99LatencyMicros-want) / want
+	if rel > res.Accuracy.RelativeErrorBound {
+		t.Errorf("p99 = %v (rel err %v) exceeds advertised bound %v",
+			res.P99LatencyMicros, rel, res.Accuracy.RelativeErrorBound)
+	}
+}
+
+// TestAccuracyMetadataTracksDownscaledMerge pins the reason the bound is
+// computed and not hard-coded: merging a coarser sketch downscales the result,
+// so the advertised error must GROW past the scale-4 2.17%.
+func TestAccuracyMetadataTracksDownscaledMerge(t *testing.T) {
+	f := newQueryFixture(t)
+
+	fine := &AggregateDelta{}
+	fine.ObserveSpan(1000, false)
+
+	coarse := &AggregateDelta{}
+	coarse.ObserveSpan(1000, false)
+	sk, err := NewSketchAtScale(1)
+	if err != nil {
+		t.Fatalf("NewSketchAtScale: %v", err)
+	}
+	sk.Observe(1000)
+	coarse.Sketch = sk
+
+	f.apply(f.traceKey("a", "op"), f.window(), fine)
+	f.apply(f.traceKey("b", "op"), f.window(), coarse)
+
+	res, err := f.engine.QueryDashboard(f.rangeQuery())
+	if err != nil {
+		t.Fatalf("QueryDashboard: %v", err)
+	}
+	if res.Accuracy.SketchScale != 1 {
+		t.Fatalf("SketchScale = %d, want 1 (the coarser of the merged pair)", res.Accuracy.SketchScale)
+	}
+	defaultBound := AccuracyFromSketch(NewSketch()).RelativeErrorBound
+	if res.Accuracy.RelativeErrorBound <= defaultBound {
+		t.Errorf("RelativeErrorBound = %v, want greater than the scale-%d bound %v",
+			res.Accuracy.RelativeErrorBound, SketchDefaultScale, defaultBound)
+	}
+}
+
+// TestAccuracyMetadataReportsCollapse covers the other way a sketch leaves its
+// nominal bound: a collapsed sketch's low tail is outside it.
+func TestAccuracyMetadataReportsCollapse(t *testing.T) {
+	s := NewSketch()
+	// A dynamic range wide enough to force a collapse into the lowest bin.
+	s.Observe(1)
+	s.Observe(1e12)
+	if !s.Collapsed() {
+		t.Skip("sketch did not collapse at this scale; nothing to assert")
+	}
+	acc := AccuracyFromSketch(s)
+	if !acc.Degraded {
+		t.Error("Degraded = false for a collapsed sketch, want true")
+	}
+}
+
+// TestQueryBucketsOnePointPerWindow pins the traffic shape: one point per
+// five-minute window, ordered, with error counts carried through.
+func TestQueryBucketsOnePointPerWindow(t *testing.T) {
+	f := newQueryFixture(t)
+	cur := f.window()
+	prev := cur - int64(WindowSize/time.Second)
+	f.apply(f.traceKey("checkout", "op"), prev, spanDelta(3, 1000))
+	f.apply(f.traceKey("checkout", "op"), cur, spanDelta(6, 1000))
+
+	res, err := f.engine.QueryBuckets(f.rangeQuery())
+	if err != nil {
+		t.Fatalf("QueryBuckets: %v", err)
+	}
+	if len(res.Points) != 2 {
+		t.Fatalf("points = %d, want 2", len(res.Points))
+	}
+	if !res.Points[0].WindowStart.Before(res.Points[1].WindowStart) {
+		t.Error("points are not ordered oldest first")
+	}
+	if res.Points[0].Count != 3 || res.Points[1].Count != 6 {
+		t.Errorf("counts = %d,%d want 3,6", res.Points[0].Count, res.Points[1].Count)
+	}
+	if res.Points[1].ErrorCount != 2 {
+		t.Errorf("error count = %d, want 2", res.Points[1].ErrorCount)
+	}
+}
+
+func TestQueryTopologyNodesFromAggregates(t *testing.T) {
+	f := newQueryFixture(t)
+	f.apply(f.traceKey("cart", "op"), f.window(), spanDelta(3, 2000))
+	f.apply(f.traceKey("checkout", "op"), f.window(), spanDelta(6, 1000))
+
+	res, err := f.engine.QueryTopology(f.rangeQuery())
+	if err != nil {
+		t.Fatalf("QueryTopology: %v", err)
+	}
+	if len(res.Nodes) != 2 {
+		t.Fatalf("nodes = %d, want 2", len(res.Nodes))
+	}
+	if res.Nodes[0].Service != "cart" || res.Nodes[1].Service != "checkout" {
+		t.Errorf("nodes not sorted by service: %v", res.Nodes)
+	}
+	if res.Nodes[1].Count != 6 {
+		t.Errorf("checkout count = %d, want 6", res.Nodes[1].Count)
+	}
+	if math.Abs(res.Nodes[1].AvgLatencyMs-1.0) > 1e-9 {
+		t.Errorf("checkout avg latency = %v ms, want 1", res.Nodes[1].AvgLatencyMs)
+	}
+}
+
+// TestOwnershipIsExclusivePerWindow is the read-consistency contract of #164:
+// a window owned by the engine is read ONLY from memory even when the store
+// holds rows for it, and after finalization it is read ONLY from the store.
+// Neither transition may omit or double-count.
+func TestOwnershipIsExclusivePerWindow(t *testing.T) {
+	f := newQueryFixture(t)
+	st := newStubStore()
+	f.engine.SetStore(st)
+
+	key := f.traceKey("checkout", "op")
+	w := f.window()
+	f.apply(key, w, spanDelta(10, 1000))
+	// A crash-recovery checkpoint row exists for the SAME window. Row presence
+	// must not add a second count.
+	st.put(1, key, w, spanDelta(10, 1000))
+
+	res, err := f.engine.QueryDashboard(f.rangeQuery())
+	if err != nil {
+		t.Fatalf("QueryDashboard: %v", err)
+	}
+	if res.TotalTraces != 10 {
+		t.Fatalf("TotalTraces = %d with a checkpointed mutable window, want 10", res.TotalTraces)
+	}
+	for _, r := range st.readRanges {
+		if w >= r[0] && w < r[1] {
+			t.Fatalf("store was asked for memory-owned window %d (range %v)", w, r)
+		}
+	}
+
+	own := f.engine.Ownership()
+	if !own.OwnsInMemory(w) {
+		t.Fatalf("window %d is not memory-owned before finalization", w)
+	}
+
+	// Finalization hands the window over. The count must stay 10 — now served
+	// entirely from the store.
+	f.engine.MarkFinalized(w)
+	own = f.engine.Ownership()
+	if own.OwnsInMemory(w) {
+		t.Fatal("window is still memory-owned after MarkFinalized")
+	}
+	if own.FinalizedWatermark != w {
+		t.Errorf("FinalizedWatermark = %d, want %d", own.FinalizedWatermark, w)
+	}
+
+	res, err = f.engine.QueryDashboard(f.rangeQuery())
+	if err != nil {
+		t.Fatalf("QueryDashboard after finalize: %v", err)
+	}
+	if res.TotalTraces != 10 {
+		t.Fatalf("TotalTraces = %d after finalization, want 10", res.TotalTraces)
+	}
+}
+
+// TestQueryRejectsUnboundedRange keeps the store-side bound rule visible at the
+// facade: a query without a forward range is refused, not clamped silently.
+func TestQueryRejectsUnboundedRange(t *testing.T) {
+	f := newQueryFixture(t)
+	if _, err := f.engine.QueryDashboard(Query{Tenant: "default"}); err == nil {
+		t.Fatal("QueryDashboard accepted an empty range")
+	}
+	if _, err := f.engine.QueryDashboard(Query{Start: f.now.Add(-time.Hour), End: f.now}); err == nil {
+		t.Fatal("QueryDashboard accepted a query with no tenant")
+	}
+}
+
+// TestRolloverHandsOwnershipToTheStore pins that an evicted window stops
+// claiming memory ownership: claiming it would report zero for a window whose
+// deltas are already durable.
+func TestRolloverHandsOwnershipToTheStore(t *testing.T) {
+	f := newQueryFixture(t)
+	old := f.window() - int64((WindowSize+AllowedLateness+WindowSize)/time.Second)
+	f.engine.own.mu.Lock()
+	f.engine.own.mutable[old] = struct{}{}
+	f.engine.own.mu.Unlock()
+
+	f.engine.Rollover(f.now)
+	own := f.engine.Ownership()
+	if own.OwnsInMemory(old) {
+		t.Fatal("expired window is still memory-owned after rollover")
+	}
+	if own.FinalizedWatermark < old {
+		t.Errorf("FinalizedWatermark = %d, want at least %d", own.FinalizedWatermark, old)
+	}
+}

--- a/internal/aggregate/registrar.go
+++ b/internal/aggregate/registrar.go
@@ -33,6 +33,10 @@ type DurableRegistrar struct {
 	pending map[uint32]DictRow
 	limits  map[Kind]int
 	counts  map[dictScope]int
+	// byID is the reverse index used by the read path (Resolver). IDs are
+	// minted from one process-wide counter, so a single flat map is enough:
+	// an ID is unique across every (tenant, kind) scope.
+	byID map[uint32]DictEntry
 }
 
 // NewDurableRegistrar builds a registrar warmed from the store's dictionary so
@@ -45,6 +49,7 @@ func NewDurableRegistrar(store Store, limits map[Kind]int) (*DurableRegistrar, e
 		other:   make(map[dictScope]uint32),
 		pending: make(map[uint32]DictRow),
 		counts:  make(map[dictScope]int),
+		byID:    make(map[uint32]DictEntry),
 	}
 	if len(limits) > 0 {
 		r.limits = make(map[Kind]int, len(limits))
@@ -68,6 +73,7 @@ func NewDurableRegistrar(store Store, limits map[Kind]int) (*DurableRegistrar, e
 		}
 		value := string(row.Value)
 		inner[value] = row.ID
+		r.byID[row.ID] = DictEntry{ID: row.ID, TenantID: row.TenantID, Kind: row.Kind, Value: slices.Clone(row.Value)}
 		if value == OtherValue {
 			r.other[scope] = row.ID
 		} else {
@@ -139,8 +145,20 @@ func (r *DurableRegistrar) mintLocked(scope dictScope, value []byte) (uint32, er
 		r.ids[scope] = inner
 	}
 	inner[string(value)] = id
-	r.pending[id] = DictRow{ID: id, TenantID: scope.tenant, Kind: scope.kind, Value: slices.Clone(value)}
+	row := DictRow{ID: id, TenantID: scope.tenant, Kind: scope.kind, Value: slices.Clone(value)}
+	r.pending[id] = row
+	r.byID[id] = DictEntry(row)
 	return id, nil
+}
+
+// Lookup implements Resolver. The entry is visible as soon as the ID is minted,
+// before the row is durable: a query that resolves a name the next commit will
+// persist is correct, and one that cannot resolve it at all is not.
+func (r *DurableRegistrar) Lookup(id uint32) (DictEntry, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e, ok := r.byID[id]
+	return e, ok
 }
 
 // DrainPending returns the staged rows for inclusion in the next group commit.
@@ -271,4 +289,8 @@ func (r *seriesRegistry) Committed(rows []SeriesRow) {
 
 // compile-time assertion that the durable registrar can replace the in-memory
 // one wherever dict.go expects a Registrar.
-var _ Registrar = (*DurableRegistrar)(nil)
+var (
+	_ Registrar = (*DurableRegistrar)(nil)
+	_ Resolver  = (*DurableRegistrar)(nil)
+	_ Resolver  = (*MemRegistrar)(nil)
+)

--- a/internal/aggregate/sketch.go
+++ b/internal/aggregate/sketch.go
@@ -84,6 +84,17 @@ func NewSketchAtScale(scale uint8) (*Sketch, error) {
 	return &Sketch{scale: scale}, nil
 }
 
+// NewSketchAtScaleUnchecked returns an empty sketch at scale, clamping an
+// out-of-range scale to the platform default. It exists for the read path,
+// which builds a merge target from an already-validated sketch and has no
+// error to return.
+func NewSketchAtScaleUnchecked(scale uint8) *Sketch {
+	if scale > SketchMaxScale {
+		scale = SketchDefaultScale
+	}
+	return &Sketch{scale: scale}
+}
+
 // Scale returns the mapping scale of the sketch.
 func (s *Sketch) Scale() uint8 { return s.scale }
 

--- a/internal/aggregate/writer.go
+++ b/internal/aggregate/writer.go
@@ -187,6 +187,9 @@ func NewWriter(cfg WriterConfig) (*Writer, error) {
 	if err != nil {
 		return nil, err
 	}
+	// The engine's read path serves finalized windows from the store; the
+	// writer is the one place that already holds both.
+	cfg.Engine.SetStore(cfg.Store)
 	return &Writer{
 		cfg:         cfg,
 		store:       cfg.Store,
@@ -470,6 +473,9 @@ func (w *Writer) FinalizeDue(now time.Time) int {
 			slog.Error("aggregate: finalize window failed", "window_start", window, "error", err)
 			continue
 		}
+		// The buckets are committed, so ownership of the window moves to the
+		// store in the same step that evicts it from the shards (#164).
+		w.engine.MarkFinalized(window)
 		w.finalized.Add(1)
 		done++
 	}

--- a/internal/api/aggregate_reads_test.go
+++ b/internal/api/aggregate_reads_test.go
@@ -1,0 +1,340 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/cache"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"gorm.io/gorm"
+)
+
+// rawTableCounter counts GORM reads that touch the raw telemetry tables. It is
+// how "no raw trace/log table scans behind the dashboard in aggregate mode"
+// stops being a claim and becomes an assertion.
+type rawTableCounter struct{ hits []string }
+
+var rawTables = map[string]bool{"traces": true, "logs": true, "spans": true}
+
+func (c *rawTableCounter) install(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	record := func(tx *gorm.DB) {
+		table := tx.Statement.Table
+		if table == "" {
+			table = strings.ToLower(tx.Statement.SQL.String())
+		}
+		for raw := range rawTables {
+			if strings.Contains(strings.ToLower(table), raw) {
+				c.hits = append(c.hits, table)
+				return
+			}
+		}
+	}
+	if err := db.Callback().Query().Before("gorm:query").Register("test:count_raw_reads", record); err != nil {
+		t.Fatalf("register query callback: %v", err)
+	}
+	if err := db.Callback().Raw().Before("gorm:raw").Register("test:count_raw_reads", record); err != nil {
+		t.Fatalf("register raw callback: %v", err)
+	}
+}
+
+// aggregateTestServer builds an API server with a real repository and, when
+// withEngine is set, an aggregate engine in aggregate mode.
+func aggregateTestServer(t *testing.T, withEngine bool) (*Server, *rawTableCounter, *aggregate.Engine) {
+	t.Helper()
+	db, err := storage.NewDatabase("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	if err := storage.AutoMigrateModels(db, "sqlite"); err != nil {
+		t.Fatalf("AutoMigrateModels: %v", err)
+	}
+	repo := storage.NewRepositoryFromDB(db, "sqlite")
+	c := cache.New()
+	t.Cleanup(func() {
+		c.Stop()
+		_ = repo.Close()
+	})
+	s := &Server{repo: repo, cache: c}
+
+	var engine *aggregate.Engine
+	if withEngine {
+		engine, err = aggregate.NewEngine(aggregate.EngineConfig{Mode: aggregate.ModeAggregate})
+		if err != nil {
+			t.Fatalf("NewEngine: %v", err)
+		}
+		s.SetAggregateEngine(engine)
+		if !s.aggregateReads() {
+			t.Fatal("aggregate engine was not adopted by the server")
+		}
+	}
+	counter := &rawTableCounter{}
+	counter.install(t, db)
+	return s, counter, engine
+}
+
+// seedAggregate folds one service's worth of spans and logs into the engine's
+// current window.
+func seedAggregate(t *testing.T, e *aggregate.Engine, tenant, service string, spans int, micros float64) {
+	t.Helper()
+	tenantID := e.TenantID(tenant)
+	key := aggregate.SeriesKey{
+		TenantID:    tenantID,
+		ServiceID:   e.Cache().Intern(tenantID, aggregate.KindService, service),
+		NameID:      e.Cache().Intern(tenantID, aggregate.KindOperation, "GET /"+service),
+		Signal:      aggregate.SignalTraceOp,
+		StatusClass: aggregate.StatusOK,
+		Variant:     aggregate.SpanKindServer,
+	}
+	d := &aggregate.AggregateDelta{}
+	for i := 0; i < spans; i++ {
+		d.ObserveSpan(micros, i%3 == 0)
+	}
+	logKey := aggregate.SeriesKey{
+		TenantID:  tenantID,
+		ServiceID: key.ServiceID,
+		NameID:    e.Cache().Intern(tenantID, aggregate.KindLogTemplate, service+"|<*> failed"),
+		Signal:    aggregate.SignalLog,
+	}
+	ld := &aggregate.AggregateDelta{}
+	ld.ObserveLog(time.Now(), true)
+
+	w := aggregate.WindowStart(time.Now())
+	e.ApplyCommitted(aggregate.DeltaMap{
+		{Key: key, WindowStart: w}:    d,
+		{Key: logKey, WindowStart: w}: ld,
+	})
+}
+
+// seedLegacy inserts equivalent raw rows so the legacy path has something to
+// aggregate.
+func seedLegacy(t *testing.T, s *Server, tenant, service string, spans int, micros int64) {
+	t.Helper()
+	now := time.Now().UTC()
+	traces := make([]storage.Trace, 0, spans)
+	for i := 0; i < spans; i++ {
+		status := "STATUS_CODE_OK"
+		if i%3 == 0 {
+			status = storage.StatusCodeError
+		}
+		traces = append(traces, storage.Trace{
+			TenantID: tenant, TraceID: service + "-" + string(rune('a'+i)),
+			ServiceName: service, Timestamp: now, Duration: micros, Status: status,
+		})
+	}
+	if err := s.repo.BatchCreateTraces(traces); err != nil {
+		t.Fatalf("seed traces: %v", err)
+	}
+	if err := s.repo.BatchCreateLogs([]storage.Log{{
+		TenantID: tenant, ServiceName: service, Severity: "ERROR",
+		Body: "failed", Timestamp: now,
+	}}); err != nil {
+		t.Fatalf("seed logs: %v", err)
+	}
+}
+
+func getJSON(t *testing.T, h http.HandlerFunc, target, tenant string) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	ctx := storage.WithTenantContext(context.Background(), tenant)
+	req := httptest.NewRequest(http.MethodGet, target, nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET %s = %d: %s", target, rr.Code, rr.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode %s: %v (%s)", target, err, rr.Body.String())
+	}
+	return rr, body
+}
+
+// TestDashboardContractLegacyVsAggregate is the migration's contract: every
+// field the legacy dashboard emits must exist in the aggregate response with
+// the same JSON type. New fields are allowed; missing or retyped ones are not.
+func TestDashboardContractLegacyVsAggregate(t *testing.T) {
+	const tenant = "default"
+
+	legacy, _, _ := aggregateTestServer(t, false)
+	seedLegacy(t, legacy, tenant, "checkout", 9, 1000)
+	_, legacyBody := getJSON(t, legacy.handleGetDashboardStats, "/api/metrics/dashboard", tenant)
+
+	agg, _, engine := aggregateTestServer(t, true)
+	seedAggregate(t, engine, tenant, "checkout", 9, 1000)
+	_, aggBody := getJSON(t, agg.handleGetDashboardStats, "/api/metrics/dashboard", tenant)
+
+	assertFieldCompatible(t, "dashboard", legacyBody, aggBody)
+
+	if aggBody["coverage"] != string(aggregate.CoverageFull) {
+		t.Errorf("aggregate coverage = %v, want %q", aggBody["coverage"], aggregate.CoverageFull)
+	}
+	accuracy, ok := aggBody["accuracy"].(map[string]any)
+	if !ok {
+		t.Fatalf("aggregate response carries no accuracy metadata: %v", aggBody)
+	}
+	if accuracy["approximate"] != true {
+		t.Errorf("accuracy.approximate = %v, want true", accuracy["approximate"])
+	}
+	bound, _ := accuracy["relative_error_bound"].(float64)
+	if bound <= 0 {
+		t.Errorf("accuracy.relative_error_bound = %v, want > 0", accuracy["relative_error_bound"])
+	}
+	if _, ok := accuracy["sketch_scale"]; !ok {
+		t.Error("accuracy carries no sketch_scale")
+	}
+	// Legacy must stay exactly what it was: no additive fields leak into it.
+	for _, field := range []string{"coverage", "accuracy", "epoch", "revision", "coverage_note"} {
+		if _, present := legacyBody[field]; present {
+			t.Errorf("legacy dashboard response gained %q", field)
+		}
+	}
+}
+
+func TestServiceMapContractLegacyVsAggregate(t *testing.T) {
+	const tenant = "default"
+
+	legacy, _, _ := aggregateTestServer(t, false)
+	seedServiceMapSpans(t, legacy, tenant, "x")
+	_, legacyBody := getJSON(t, legacy.handleGetServiceMapMetrics, "/api/metrics/service-map", tenant)
+
+	agg, _, engine := aggregateTestServer(t, true)
+	seedAggregate(t, engine, tenant, "checkout", 6, 2000)
+	_, aggBody := getJSON(t, agg.handleGetServiceMapMetrics, "/api/metrics/service-map", tenant)
+
+	assertFieldCompatible(t, "service-map", legacyBody, aggBody)
+	if aggBody["coverage"] != string(aggregate.CoverageSampled) {
+		t.Errorf("service-map coverage = %v, want %q", aggBody["coverage"], aggregate.CoverageSampled)
+	}
+	if note, _ := aggBody["coverage_note"].(string); note == "" {
+		t.Error("sampled service-map carries no coverage note")
+	}
+}
+
+// TestTrafficUsesCoverageHeaderNotAnEnvelope pins the bare-array rule: the body
+// shape is unchanged and coverage rides in the header.
+func TestTrafficUsesCoverageHeaderNotAnEnvelope(t *testing.T) {
+	const tenant = "default"
+	agg, _, engine := aggregateTestServer(t, true)
+	seedAggregate(t, engine, tenant, "checkout", 6, 1000)
+
+	ctx := storage.WithTenantContext(context.Background(), tenant)
+	req := httptest.NewRequest(http.MethodGet, "/api/metrics/traffic", nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+	agg.handleGetTrafficMetrics(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("traffic = %d: %s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get(aggregate.CoverageHeader); got != string(aggregate.CoverageFull) {
+		t.Errorf("%s = %q, want %q", aggregate.CoverageHeader, got, aggregate.CoverageFull)
+	}
+	var points []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &points); err != nil {
+		t.Fatalf("traffic body is not a bare array: %v (%s)", err, rr.Body.String())
+	}
+	if len(points) == 0 {
+		t.Fatal("traffic returned no points")
+	}
+	for _, field := range []string{"timestamp", "count", "error_count"} {
+		if _, ok := points[0][field]; !ok {
+			t.Errorf("traffic point is missing %q: %v", field, points[0])
+		}
+	}
+}
+
+// TestLatencyHeatmapDeclaresExemplarCoverage: an empty heatmap in aggregate
+// mode must not read as "nothing happened".
+func TestLatencyHeatmapDeclaresExemplarCoverage(t *testing.T) {
+	agg, _, _ := aggregateTestServer(t, true)
+	ctx := storage.WithTenantContext(context.Background(), "default")
+	req := httptest.NewRequest(http.MethodGet, "/api/metrics/latency_heatmap", nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+	agg.handleGetLatencyHeatmap(rr, req)
+	if got := rr.Header().Get(aggregate.CoverageHeader); got != string(aggregate.CoverageExemplar) {
+		t.Errorf("%s = %q, want %q", aggregate.CoverageHeader, got, aggregate.CoverageExemplar)
+	}
+}
+
+// TestNoRawTableScansBehindDashboardInAggregateMode is the acceptance
+// criterion: with the aggregate engine wired, the dashboard, traffic and
+// topology endpoints must not read the traces, logs or spans tables at all.
+func TestNoRawTableScansBehindDashboardInAggregateMode(t *testing.T) {
+	const tenant = "default"
+	agg, counter, engine := aggregateTestServer(t, true)
+	seedAggregate(t, engine, tenant, "checkout", 12, 1500)
+
+	ctx := storage.WithTenantContext(context.Background(), tenant)
+	endpoints := []struct {
+		target  string
+		handler http.HandlerFunc
+	}{
+		{"/api/metrics/dashboard", agg.handleGetDashboardStats},
+		{"/api/metrics/traffic", agg.handleGetTrafficMetrics},
+		{"/api/metrics/service-map", agg.handleGetServiceMapMetrics},
+	}
+	for _, ep := range endpoints {
+		req := httptest.NewRequest(http.MethodGet, ep.target, nil).WithContext(ctx)
+		rr := httptest.NewRecorder()
+		ep.handler(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("GET %s = %d: %s", ep.target, rr.Code, rr.Body.String())
+		}
+	}
+	if len(counter.hits) != 0 {
+		t.Fatalf("aggregate-mode dashboard endpoints hit raw tables: %v", counter.hits)
+	}
+
+	// Control: the same endpoints in legacy mode DO scan the raw tables, so a
+	// silently broken counter cannot make the assertion above vacuous.
+	legacy, legacyCounter, _ := aggregateTestServer(t, false)
+	seedLegacy(t, legacy, tenant, "checkout", 3, 1000)
+	legacyCounter.hits = nil
+	req := httptest.NewRequest(http.MethodGet, "/api/metrics/dashboard", nil).WithContext(ctx)
+	legacy.handleGetDashboardStats(httptest.NewRecorder(), req)
+	if len(legacyCounter.hits) == 0 {
+		t.Fatal("legacy dashboard hit no raw tables; the query counter is not wired")
+	}
+}
+
+// assertFieldCompatible checks that every field of the legacy payload survives
+// into the aggregate payload with the same JSON type.
+func assertFieldCompatible(t *testing.T, name string, legacy, agg map[string]any) {
+	t.Helper()
+	for field, legacyVal := range legacy {
+		aggVal, ok := agg[field]
+		if !ok {
+			t.Errorf("%s: aggregate response dropped field %q", name, field)
+			continue
+		}
+		if legacyVal == nil || aggVal == nil {
+			continue
+		}
+		if jsonKind(legacyVal) != jsonKind(aggVal) {
+			t.Errorf("%s: field %q changed type: legacy %s, aggregate %s",
+				name, field, jsonKind(legacyVal), jsonKind(aggVal))
+		}
+	}
+}
+
+// jsonKind names the decoded JSON kind of v.
+func jsonKind(v any) string {
+	switch v.(type) {
+	case float64:
+		return "number"
+	case string:
+		return "string"
+	case bool:
+		return "bool"
+	case []any:
+		return "array"
+	case map[string]any:
+		return "object"
+	default:
+		return "null"
+	}
+}

--- a/internal/api/coverage.go
+++ b/internal/api/coverage.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+)
+
+// setCoverage stamps the data-coverage header on a response.
+//
+// Endpoints that return a bare JSON array cannot carry an additive "coverage"
+// field without changing their shape, and silently wrapping them in an
+// envelope would break every existing client. The header is how those
+// endpoints stay honest without breaking (#164).
+func setCoverage(w http.ResponseWriter, c aggregate.Coverage) {
+	if c == "" {
+		return
+	}
+	w.Header().Set(aggregate.CoverageHeader, string(c))
+}

--- a/internal/api/metrics_handlers.go
+++ b/internal/api/metrics_handlers.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/api/views"
 	"github.com/RandomCodeSpace/otelcontext/internal/httpconst"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
@@ -30,6 +32,27 @@ func (s *Server) handleGetTrafficMetrics(w http.ResponseWriter, r *http.Request)
 
 	serviceNames := r.URL.Query()["service_name"]
 
+	// /api/metrics/traffic returns a BARE ARRAY. Wrapping it in an envelope to
+	// carry coverage would silently break every existing client, so coverage
+	// travels in the response header instead (#164).
+	if s.aggregateReads() {
+		res, err := s.aggregateEngine.QueryBuckets(aggregate.Query{
+			Tenant:   storage.TenantFromContext(r.Context()),
+			Start:    start,
+			End:      end,
+			Services: serviceNames,
+		})
+		if err != nil {
+			slog.Error("Failed to get aggregate traffic metrics", "error", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		setCoverage(w, res.Coverage)
+		w.Header().Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
+		_ = json.NewEncoder(w).Encode(trafficPointsFromAggregate(res))
+		return
+	}
+
 	points, err := s.repo.GetTrafficMetrics(r.Context(), start, end, serviceNames)
 	if err != nil {
 		slog.Error("Failed to get traffic metrics", "error", err)
@@ -39,6 +62,21 @@ func (s *Server) handleGetTrafficMetrics(w http.ResponseWriter, r *http.Request)
 
 	w.Header().Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
 	_ = json.NewEncoder(w).Encode(points)
+}
+
+// trafficPointsFromAggregate converts engine traffic buckets into the same
+// wire shape the legacy repository produces. Only the bucket WIDTH changes:
+// five-minute aggregate windows instead of one-minute row scans.
+func trafficPointsFromAggregate(res *aggregate.BucketsResult) []storage.TrafficPoint {
+	points := make([]storage.TrafficPoint, 0, len(res.Points))
+	for _, p := range res.Points {
+		points = append(points, storage.TrafficPoint{
+			Timestamp:  p.WindowStart,
+			Count:      p.Count,
+			ErrorCount: p.ErrorCount,
+		})
+	}
+	return points
 }
 
 // handleGetLatencyHeatmap handles GET /api/metrics/latency_heatmap
@@ -66,6 +104,13 @@ func (s *Server) handleGetLatencyHeatmap(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// The heatmap plots individual span durations, which in aggregate mode
+	// exist only as retained exemplars. The endpoint keeps its bare-array
+	// shape and declares that honestly in the header: an empty heatmap is not
+	// evidence that no spans ran.
+	if s.aggregateReads() {
+		setCoverage(w, aggregate.CoverageExemplar)
+	}
 	w.Header().Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
 	_ = json.NewEncoder(w).Encode(points)
 }
@@ -104,14 +149,14 @@ func (s *Server) handleGetDashboardStats(w http.ResponseWriter, r *http.Request)
 
 	serviceNames := r.URL.Query()["service_name"]
 
-	stats, err := s.repo.GetDashboardStats(r.Context(), start, end, serviceNames)
+	view, err := s.dashboardView(r, start, end, serviceNames)
 	if err != nil {
 		slog.Error("Failed to get dashboard stats", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	cj, err := newCachedJSON(views.DashboardStatsFromModel(stats))
+	cj, err := newCachedJSON(view)
 	if err != nil {
 		http.Error(w, "failed to encode dashboard stats", http.StatusInternalServerError)
 		return
@@ -120,6 +165,31 @@ func (s *Server) handleGetDashboardStats(w http.ResponseWriter, r *http.Request)
 		s.cache.Set(cacheKey, cj, hotPollCacheTTL)
 	}
 	cj.write(w, r, "MISS")
+}
+
+// dashboardView produces the dashboard payload from whichever source owns the
+// numbers in this mode. In aggregate mode every figure comes from engine
+// queries — no COUNT/AVG/DISTINCT scan of the trace or log tables, and no
+// sqliteP99RowCap sort: the p99 comes from the merged sketch with the accuracy
+// bound that sketch justifies.
+func (s *Server) dashboardView(r *http.Request, start, end time.Time, serviceNames []string) (views.DashboardStats, error) {
+	if s.aggregateReads() {
+		res, err := s.aggregateEngine.QueryDashboard(aggregate.Query{
+			Tenant:   storage.TenantFromContext(r.Context()),
+			Start:    start,
+			End:      end,
+			Services: serviceNames,
+		})
+		if err != nil {
+			return views.DashboardStats{}, err
+		}
+		return views.DashboardStatsFromAggregate(res), nil
+	}
+	stats, err := s.repo.GetDashboardStats(r.Context(), start, end, serviceNames)
+	if err != nil {
+		return views.DashboardStats{}, err
+	}
+	return views.DashboardStatsFromModel(stats), nil
 }
 
 // handleGetServiceMapMetrics handles GET /api/metrics/service-map.
@@ -154,18 +224,67 @@ func (s *Server) handleGetServiceMapMetrics(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	metrics, err := s.repo.GetServiceMapMetrics(r.Context(), start, end)
+	resp, err := s.serviceMapView(r, start, end)
 	if err != nil {
 		slog.Error("Failed to get service map metrics", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-
-	resp := views.ServiceMapMetricsFromModel(metrics)
 	s.cache.Set(cacheKey, resp, cacheTTL)
 	w.Header().Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
 	w.Header().Set("X-Cache", "MISS")
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// serviceMapView produces the topology payload.
+//
+// In aggregate mode the NODES come from engine queries and are exact for
+// accepted telemetry. The EDGES do not: caller/callee identity is not part of
+// a SeriesKey, so no reducer emits a service-edge series today and the edge
+// metrics come from the GraphRAG topology store, which is fed by retained
+// exemplars. That is why the response is marked "sampled" rather than "full" —
+// the node counts are complete, the edges are not.
+func (s *Server) serviceMapView(r *http.Request, start, end time.Time) (views.ServiceMapMetrics, error) {
+	if !s.aggregateReads() {
+		metrics, err := s.repo.GetServiceMapMetrics(r.Context(), start, end)
+		if err != nil {
+			return views.ServiceMapMetrics{}, err
+		}
+		return views.ServiceMapMetricsFromModel(metrics), nil
+	}
+	res, err := s.aggregateEngine.QueryTopology(aggregate.Query{
+		Tenant: storage.TenantFromContext(r.Context()),
+		Start:  start,
+		End:    end,
+	})
+	if err != nil {
+		return views.ServiceMapMetrics{}, err
+	}
+	return views.ServiceMapMetricsFromAggregate(res, s.topologyEdges(r.Context()), aggregate.CoverageSampled), nil
+}
+
+// topologyEdges reads caller/callee edges out of the GraphRAG service store.
+// The edges themselves are observed for every span before any retention gate,
+// but their call counts and latencies come from retained spans only.
+func (s *Server) topologyEdges(ctx context.Context) []views.ServiceMapEdge {
+	if s.graphRAG == nil {
+		return nil
+	}
+	all := s.graphRAG.AllServiceEdges(ctx)
+	edges := make([]views.ServiceMapEdge, 0, len(all))
+	for _, e := range all {
+		if e.Type != "CALLS" {
+			continue
+		}
+		edges = append(edges, views.ServiceMapEdge{
+			Source:       e.FromID,
+			Target:       e.ToID,
+			CallCount:    e.CallCount,
+			AvgLatencyMs: e.AvgMs,
+			ErrorRate:    e.ErrorRate,
+		})
+	}
+	return edges
 }
 
 // handleGetMetricBuckets handles GET /api/metrics

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/cache"
 	"github.com/RandomCodeSpace/otelcontext/internal/graph"
 	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
@@ -29,6 +30,13 @@ type Server struct {
 	// imports and lets tests inject deterministic values.
 	dlqSaturation      func() float64
 	pipelineSaturation func() float64
+
+	// aggregateEngine is the aggregate query facade. It is non-nil only in
+	// AGGREGATE_MODE=aggregate: shadow mode writes aggregates but must not
+	// serve them, and legacy mode has no engine at all. Every read migrated
+	// to the engine branches on aggregateReads(), so legacy responses stay
+	// byte-for-byte what they were.
+	aggregateEngine *aggregate.Engine
 
 	// aggregateRecovered reports whether the durable aggregate store has
 	// finished startup recovery. /ready stays 503 until it returns true, so
@@ -72,6 +80,20 @@ func (s *Server) SetDLQSaturationProbe(fn func() float64) {
 func (s *Server) SetPipelineSaturationProbe(fn func() float64) {
 	s.pipelineSaturation = fn
 }
+
+// SetAggregateEngine wires the aggregate query facade into the read path. Pass
+// the engine only in AGGREGATE_MODE=aggregate; a nil engine, or an engine in
+// any other mode, leaves every handler on the legacy path.
+func (s *Server) SetAggregateEngine(e *aggregate.Engine) {
+	if e == nil || e.Mode() != aggregate.ModeAggregate {
+		return
+	}
+	s.aggregateEngine = e
+}
+
+// aggregateReads reports whether this request should be served from the
+// aggregate engine.
+func (s *Server) aggregateReads() bool { return s.aggregateEngine != nil }
 
 // SetAggregateRecoveryProbe registers a callback reporting whether the durable
 // aggregate store has finished replaying its delta log. /ready returns 503

--- a/internal/api/views/views.go
+++ b/internal/api/views/views.go
@@ -14,6 +14,7 @@ package views
 import (
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 )
@@ -95,6 +96,10 @@ type ServiceError struct {
 }
 
 // DashboardStats is the aggregated dashboard metric view.
+//
+// The coverage/accuracy/epoch/revision fields are ADDITIVE and only populated
+// in aggregate mode: `omitempty` keeps the legacy payload byte-for-byte what it
+// has always been.
 type DashboardStats struct {
 	TotalTraces        int64          `json:"total_traces"`
 	TotalLogs          int64          `json:"total_logs"`
@@ -104,6 +109,12 @@ type DashboardStats struct {
 	ActiveServices     int64          `json:"active_services"`
 	P99LatencyMs       float64        `json:"p99_latency_ms"`
 	TopFailingServices []ServiceError `json:"top_failing_services"`
+
+	Coverage     string                      `json:"coverage,omitempty"`
+	CoverageNote string                      `json:"coverage_note,omitempty"`
+	Accuracy     *aggregate.AccuracyMetadata `json:"accuracy,omitempty"`
+	Epoch        string                      `json:"epoch,omitempty"`
+	Revision     uint64                      `json:"revision,omitempty"`
 }
 
 // ServiceMapNode is a node on the service topology view.
@@ -123,10 +134,16 @@ type ServiceMapEdge struct {
 	ErrorRate    float64 `json:"error_rate"`
 }
 
-// ServiceMapMetrics is the full topology view.
+// ServiceMapMetrics is the full topology view. Coverage is additive and only
+// populated in aggregate mode.
 type ServiceMapMetrics struct {
 	Nodes []ServiceMapNode `json:"nodes"`
 	Edges []ServiceMapEdge `json:"edges"`
+
+	Coverage     string `json:"coverage,omitempty"`
+	CoverageNote string `json:"coverage_note,omitempty"`
+	Epoch        string `json:"epoch,omitempty"`
+	Revision     uint64 `json:"revision,omitempty"`
 }
 
 // --- GraphRAG views ---
@@ -348,6 +365,74 @@ func DashboardStatsFromModel(s *storage.DashboardStats) DashboardStats {
 		}
 	}
 	return out
+}
+
+// DashboardStatsFromAggregate converts an engine dashboard query into the same
+// view the legacy path produces, plus the additive coverage and accuracy
+// metadata. Field names, units and structure are deliberately identical: a
+// client cannot tell which mode served it except by reading the new fields.
+func DashboardStatsFromAggregate(r *aggregate.DashboardResult) DashboardStats {
+	if r == nil {
+		return DashboardStats{}
+	}
+	acc := r.Accuracy
+	out := DashboardStats{
+		TotalTraces:    r.TotalTraces,
+		TotalLogs:      r.TotalLogs,
+		TotalErrors:    r.TotalErrors,
+		AvgLatencyMs:   r.AvgLatencyMs,
+		ErrorRate:      r.ErrorRate,
+		ActiveServices: r.ActiveServices,
+		// The engine reports microseconds, matching storage.P99Latency; the
+		// view is milliseconds in both modes.
+		P99LatencyMs: r.P99LatencyMicros / 1000.0,
+		Coverage:     string(r.Coverage),
+		CoverageNote: r.Coverage.Note(),
+		Accuracy:     &acc,
+		Epoch:        r.Epoch,
+		Revision:     r.Revision,
+	}
+	if len(r.TopFailing) > 0 {
+		out.TopFailingServices = make([]ServiceError, len(r.TopFailing))
+		for i, s := range r.TopFailing {
+			out.TopFailingServices[i] = ServiceError{
+				ServiceName: s.Service,
+				ErrorCount:  s.ErrorCount,
+				TotalCount:  s.Count,
+				ErrorRate:   s.ErrorRate,
+			}
+		}
+	}
+	return out
+}
+
+// ServiceMapMetricsFromAggregate converts an engine topology query into the
+// topology view. Edges are passed in by the caller because caller/callee
+// identity is not aggregate data — see the handler.
+func ServiceMapMetricsFromAggregate(r *aggregate.TopologyResult, edges []ServiceMapEdge, coverage aggregate.Coverage) ServiceMapMetrics {
+	if r == nil {
+		return ServiceMapMetrics{Nodes: []ServiceMapNode{}, Edges: []ServiceMapEdge{}}
+	}
+	nodes := make([]ServiceMapNode, len(r.Nodes))
+	for i, n := range r.Nodes {
+		nodes[i] = ServiceMapNode{
+			Name:         n.Service,
+			TotalTraces:  n.Count,
+			ErrorCount:   n.ErrorCount,
+			AvgLatencyMs: n.AvgLatencyMs,
+		}
+	}
+	if edges == nil {
+		edges = []ServiceMapEdge{}
+	}
+	return ServiceMapMetrics{
+		Nodes:        nodes,
+		Edges:        edges,
+		Coverage:     string(coverage),
+		CoverageNote: coverage.Note(),
+		Epoch:        r.Epoch,
+		Revision:     r.Revision,
+	}
 }
 
 // ServiceMapMetricsFromModel converts repo topology into the view form.

--- a/internal/mcp/coverage_test.go
+++ b/internal/mcp/coverage_test.go
@@ -1,0 +1,68 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+)
+
+// TestWithCoverageIsAdditive: coverage metadata rides as an EXTRA content item
+// so the primary body — often a bare JSON array — keeps its shape.
+func TestWithCoverageIsAdditive(t *testing.T) {
+	s := New("default", nil, nil, nil)
+	s.SetAggregateMode(true)
+
+	body := `[{"id":1}]`
+	res := s.withCoverage(textResult(body), aggregate.CoverageExemplar)
+	if len(res.Content) != 2 {
+		t.Fatalf("content items = %d, want 2 (body + coverage)", len(res.Content))
+	}
+	if res.Content[0].Text != body {
+		t.Fatalf("primary body was rewritten: %q", res.Content[0].Text)
+	}
+	var meta coverageMeta
+	if err := json.Unmarshal([]byte(res.Content[1].Text), &meta); err != nil {
+		t.Fatalf("decode coverage metadata: %v (%s)", err, res.Content[1].Text)
+	}
+	if meta.Coverage != string(aggregate.CoverageExemplar) {
+		t.Errorf("coverage = %q, want %q", meta.Coverage, aggregate.CoverageExemplar)
+	}
+	if meta.Note == "" {
+		t.Error("exemplar coverage carries no note; a missing exemplar must not read as zero events")
+	}
+}
+
+// TestWithCoverageSilentInLegacyMode: legacy and shadow responses stay
+// byte-for-byte what they were.
+func TestWithCoverageSilentInLegacyMode(t *testing.T) {
+	s := New("default", nil, nil, nil)
+	res := s.withCoverage(textResult(`[]`), aggregate.CoverageExemplar)
+	if len(res.Content) != 1 {
+		t.Fatalf("legacy result gained content items: %d", len(res.Content))
+	}
+}
+
+// TestWithCoverageSkipsErrors: an error result must not be decorated as if it
+// had returned data.
+func TestWithCoverageSkipsErrors(t *testing.T) {
+	s := New("default", nil, nil, nil)
+	s.SetAggregateMode(true)
+	res := s.withCoverage(errorResult("boom"), aggregate.CoverageExemplar)
+	if len(res.Content) != 1 {
+		t.Fatalf("error result gained content items: %d", len(res.Content))
+	}
+}
+
+// TestEveryToolDeclaresCoverage keeps the map and the dispatch surface in step:
+// a tool added without a coverage entry would silently claim nothing.
+func TestEveryToolDeclaresCoverage(t *testing.T) {
+	for _, def := range toolDefs {
+		if _, ok := toolCoverage[def.Name]; !ok {
+			t.Errorf("tool %q has no coverage declaration", def.Name)
+		}
+	}
+	if len(toolCoverage) != len(toolDefs) {
+		t.Errorf("coverage map has %d entries, tool surface has %d", len(toolCoverage), len(toolDefs))
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -72,6 +72,11 @@ type Server struct {
 	graphRAG      *graphrag.GraphRAG
 	defaultTenant string
 
+	// aggregateMode makes every successful tool result carry coverage body
+	// metadata. Set only in AGGREGATE_MODE=aggregate; legacy and shadow
+	// responses stay byte-for-byte what they were.
+	aggregateMode bool
+
 	// callSlots is a counting-semaphore implemented as a buffered channel:
 	// buffer size is the max concurrent tools/call invocations. A non-
 	// blocking send acquires a slot, a receive on defer releases it.
@@ -187,6 +192,12 @@ func (s *Server) SetDefaultTenant(t string) {
 // SetGraphRAG wires the GraphRAG instance for advanced query tools.
 func (s *Server) SetGraphRAG(g *graphrag.GraphRAG) {
 	s.graphRAG = g
+}
+
+// SetAggregateMode makes tool results carry coverage body metadata. Call it
+// with true only in AGGREGATE_MODE=aggregate.
+func (s *Server) SetAggregateMode(on bool) {
+	s.aggregateMode = on
 }
 
 // Handler returns an http.Handler for the MCP server with CORS applied.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
 	"github.com/RandomCodeSpace/otelcontext/internal/httpconst"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
@@ -134,9 +135,51 @@ func (s *Server) toolHandler(ctx context.Context, name string, args map[string]a
 		"search_logs":          s.toolSearchLogs,
 	}
 	if fn, ok := dispatch[name]; ok {
-		return fn(ctx, args)
+		return s.withCoverage(fn(ctx, args), toolCoverage[name])
 	}
 	return errorResult(fmt.Sprintf("unknown tool: %s", name))
+}
+
+// toolCoverage records what each tool's numbers are derived from once the
+// aggregate read path is live (#164). Raw-backed tools read tables that hold
+// only retained exemplars; the GraphRAG-backed tools are built from those same
+// exemplars plus complete log-template mining, which is "sampled", not "full".
+//
+// In legacy and shadow modes this map is not consulted at all.
+var toolCoverage = map[string]aggregate.Coverage{
+	"get_anomaly_timeline": aggregate.CoverageSampled,
+	"get_service_map":      aggregate.CoverageSampled,
+	"get_service_health":   aggregate.CoverageSampled,
+	"root_cause_analysis":  aggregate.CoverageSampled,
+	"impact_analysis":      aggregate.CoverageSampled,
+	"trace_graph":          aggregate.CoverageExemplar,
+	"search_logs":          aggregate.CoverageExemplar,
+}
+
+// coverageMeta is the body metadata appended to every successful tool result
+// in aggregate mode.
+type coverageMeta struct {
+	Coverage string `json:"coverage"`
+	Note     string `json:"coverage_note,omitempty"`
+}
+
+// withCoverage appends coverage metadata as an ADDITIONAL content item.
+//
+// Most tool bodies are bare JSON arrays; wrapping one in an envelope to carry a
+// "coverage" field would silently break every client parsing it. An extra
+// content item is additive — a client that ignores it sees exactly the body it
+// saw before, and a client that reads it learns that a missing exemplar is not
+// evidence of absence.
+func (s *Server) withCoverage(res ToolCallResult, c aggregate.Coverage) ToolCallResult {
+	if s == nil || !s.aggregateMode || res.IsError || c == "" {
+		return res
+	}
+	data, err := json.Marshal(coverageMeta{Coverage: string(c), Note: c.Note()})
+	if err != nil {
+		return res
+	}
+	res.Content = append(res.Content, ContentItem{Type: "text", Text: string(data)})
+	return res
 }
 
 // --- Tool implementations ---

--- a/internal/realtime/aggregate_publisher.go
+++ b/internal/realtime/aggregate_publisher.go
@@ -1,0 +1,158 @@
+package realtime
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+// EnginePublisher is the AggregatePublisher backed by the aggregate engine.
+//
+// The payload it builds is deliberately the COALESCED one #164 froze: summary,
+// recent traffic, service health and topology over a short trailing window. The
+// seven-day history is never in a WebSocket message — a client that wants it
+// asks for it over HTTP once, not on every revision bump.
+type EnginePublisher struct {
+	engine *aggregate.Engine
+	// window is how far back the coalesced payload reaches.
+	window time.Duration
+	// edges supplies caller/callee topology, which is not aggregate data.
+	// nil is allowed and yields a node-only topology.
+	edges func(ctx context.Context) []storage.ServiceMapEdge
+	// tenant scopes the queries. The WebSocket protocol carries no tenant, so
+	// this is the default tenant, exactly as the legacy snapshot path assumed.
+	tenant string
+}
+
+// EnginePublisherConfig configures an EnginePublisher.
+type EnginePublisherConfig struct {
+	// Engine is the aggregate query facade. Required.
+	Engine *aggregate.Engine
+	// Window is the trailing range of the coalesced payload. Zero takes 15
+	// minutes, matching the legacy snapshot window.
+	Window time.Duration
+	// Tenant scopes every query. Empty takes storage.DefaultTenantID.
+	Tenant string
+	// Edges supplies topology edges. Optional.
+	Edges func(ctx context.Context) []storage.ServiceMapEdge
+}
+
+// NewEnginePublisher builds a publisher over the engine. It returns nil when no
+// engine is configured, which is what keeps the caller's wiring a one-liner.
+func NewEnginePublisher(cfg EnginePublisherConfig) *EnginePublisher {
+	if cfg.Engine == nil {
+		return nil
+	}
+	if cfg.Window <= 0 {
+		cfg.Window = 15 * time.Minute
+	}
+	if cfg.Tenant == "" {
+		cfg.Tenant = storage.DefaultTenantID
+	}
+	return &EnginePublisher{
+		engine: cfg.Engine,
+		window: cfg.Window,
+		edges:  cfg.Edges,
+		tenant: cfg.Tenant,
+	}
+}
+
+// Epoch implements AggregatePublisher.
+func (p *EnginePublisher) Epoch() string { return p.engine.Epoch() }
+
+// Revision implements AggregatePublisher.
+func (p *EnginePublisher) Revision() uint64 { return p.engine.Revision() }
+
+// Snapshot implements AggregatePublisher.
+func (p *EnginePublisher) Snapshot(ctx context.Context, service string) *LiveSnapshot {
+	now := time.Now()
+	start := now.Add(-p.window)
+
+	var services []string
+	if service != "" {
+		services = []string{service}
+	}
+	q := aggregate.Query{Tenant: p.tenant, Start: start, End: now, Services: services}
+
+	snap := &LiveSnapshot{
+		Type:     "live_snapshot",
+		Epoch:    p.engine.Epoch(),
+		Revision: p.engine.Revision(),
+	}
+
+	// Topology edges are exemplar-fed, so the coalesced payload as a whole is
+	// "sampled": the counts are exact, the edges are not.
+	coverage := aggregate.CoverageSampled
+	snap.Coverage = string(coverage)
+	snap.CoverageNote = coverage.Note()
+
+	if dash, err := p.engine.QueryDashboard(q); err == nil {
+		snap.Dashboard = &storage.DashboardStats{
+			TotalTraces:    dash.TotalTraces,
+			TotalLogs:      dash.TotalLogs,
+			TotalErrors:    dash.TotalErrors,
+			AvgLatencyMs:   dash.AvgLatencyMs,
+			ErrorRate:      dash.ErrorRate,
+			ActiveServices: dash.ActiveServices,
+			P99Latency:     int64(dash.P99LatencyMicros),
+		}
+		for _, s := range dash.TopFailing {
+			snap.Dashboard.TopFailingServices = append(snap.Dashboard.TopFailingServices, storage.ServiceError{
+				ServiceName: s.Service,
+				ErrorCount:  s.ErrorCount,
+				TotalCount:  s.Count,
+				ErrorRate:   s.ErrorRate,
+			})
+		}
+	} else {
+		slog.Debug("aggregate snapshot: dashboard query failed", "error", err)
+	}
+
+	if traffic, err := p.engine.QueryBuckets(q); err == nil {
+		points := make([]storage.TrafficPoint, 0, len(traffic.Points))
+		for _, pt := range traffic.Points {
+			points = append(points, storage.TrafficPoint{
+				Timestamp:  pt.WindowStart,
+				Count:      pt.Count,
+				ErrorCount: pt.ErrorCount,
+			})
+		}
+		snap.Traffic = points
+	} else {
+		slog.Debug("aggregate snapshot: traffic query failed", "error", err)
+	}
+
+	if topo, err := p.engine.QueryTopology(q); err == nil {
+		sm := &storage.ServiceMapMetrics{
+			Nodes: make([]storage.ServiceMapNode, 0, len(topo.Nodes)),
+			Edges: []storage.ServiceMapEdge{},
+		}
+		for _, n := range topo.Nodes {
+			sm.Nodes = append(sm.Nodes, storage.ServiceMapNode{
+				Name:         n.Service,
+				TotalTraces:  n.Count,
+				ErrorCount:   n.ErrorCount,
+				AvgLatencyMs: n.AvgLatencyMs,
+			})
+		}
+		if p.edges != nil {
+			if e := p.edges(ctx); len(e) > 0 {
+				sm.Edges = e
+			}
+		}
+		snap.ServiceMap = sm
+	} else {
+		slog.Debug("aggregate snapshot: topology query failed", "error", err)
+	}
+
+	// Traces stay absent: individual traces are exemplars in aggregate mode,
+	// and shipping a handful of them inside a snapshot would read as "these
+	// are the traces that happened". They are fetched explicitly instead.
+	return snap
+}
+
+// compile-time assertion.
+var _ AggregatePublisher = (*EnginePublisher)(nil)

--- a/internal/realtime/aggregate_ws_test.go
+++ b/internal/realtime/aggregate_ws_test.go
@@ -1,0 +1,214 @@
+package realtime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// fakePublisher is an AggregatePublisher whose identity a test drives by hand.
+type fakePublisher struct {
+	epoch atomic.Value // string
+	rev   atomic.Uint64
+	calls atomic.Int64
+}
+
+func newFakePublisher(epoch string) *fakePublisher {
+	p := &fakePublisher{}
+	p.epoch.Store(epoch)
+	return p
+}
+
+func (p *fakePublisher) Epoch() string    { return p.epoch.Load().(string) }
+func (p *fakePublisher) Revision() uint64 { return p.rev.Load() }
+func (p *fakePublisher) Snapshot(context.Context, string) *LiveSnapshot {
+	p.calls.Add(1)
+	return &LiveSnapshot{
+		Type:     "live_snapshot",
+		Epoch:    p.Epoch(),
+		Revision: p.rev.Load(),
+		Coverage: "sampled",
+	}
+}
+
+// wsFixture wires an EventHub in aggregate mode behind an httptest server.
+type wsFixture struct {
+	hub  *EventHub
+	pub  *fakePublisher
+	conn *websocket.Conn
+}
+
+func newWSFixture(t *testing.T, floor time.Duration) *wsFixture {
+	t.Helper()
+	hub := NewEventHub(nil, nil, nil)
+	pub := newFakePublisher("epoch-1")
+	hub.SetAggregatePublisher(pub, floor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go hub.Start(ctx, time.Hour, time.Hour)
+
+	srv := httptest.NewServer(http.HandlerFunc(hub.HandleWebSocket))
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer dialCancel()
+	conn, resp, err := websocket.Dial(dialCtx, "ws"+srv.URL[len("http"):], nil)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close(websocket.StatusNormalClosure, "test")
+		cancel()
+		hub.Stop()
+		srv.Close()
+	})
+	return &wsFixture{hub: hub, pub: pub, conn: conn}
+}
+
+// read waits for one snapshot message.
+func (f *wsFixture) read(t *testing.T, within time.Duration) LiveSnapshot {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), within)
+	defer cancel()
+	_, msg, err := f.conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	var snap LiveSnapshot
+	if err := json.Unmarshal(msg, &snap); err != nil {
+		t.Fatalf("decode snapshot: %v (%s)", err, msg)
+	}
+	return snap
+}
+
+// TestAggregateWSSendsFullSnapshotOnConnect: a fresh client has nothing to
+// merge into, so the first message is a full snapshot flagged reset.
+func TestAggregateWSSendsFullSnapshotOnConnect(t *testing.T) {
+	f := newWSFixture(t, 50*time.Millisecond)
+	snap := f.read(t, 2*time.Second)
+	if !snap.Reset {
+		t.Error("connect snapshot is not flagged reset")
+	}
+	if snap.Epoch != "epoch-1" {
+		t.Errorf("epoch = %q, want epoch-1", snap.Epoch)
+	}
+	if snap.Coverage == "" {
+		t.Error("connect snapshot carries no coverage")
+	}
+}
+
+// TestAggregateWSTrailingEdgeDelivery is the acceptance criterion: a revision
+// change landing INSIDE the spacing interval is still delivered — it must not
+// disappear for want of a later event.
+func TestAggregateWSTrailingEdgeDelivery(t *testing.T) {
+	f := newWSFixture(t, 80*time.Millisecond)
+	_ = f.read(t, 2*time.Second) // connect snapshot
+
+	// A single change, then silence. Nothing else will ever arrive to "carry"
+	// it, so if the publication were leading-edge-only it would be lost.
+	f.pub.rev.Store(7)
+
+	snap := f.read(t, 3*time.Second)
+	if snap.Revision != 7 {
+		t.Fatalf("revision = %d, want 7", snap.Revision)
+	}
+	if snap.Reset {
+		t.Error("a revision change inside the same epoch must not ask the client to reset")
+	}
+}
+
+// TestAggregateWSPublishesOnlyOnRevisionChange: an idle engine produces no
+// data messages, however many spacing intervals elapse.
+func TestAggregateWSPublishesOnlyOnRevisionChange(t *testing.T) {
+	hub := NewEventHub(nil, nil, nil)
+	pub := newFakePublisher("epoch-1")
+	hub.SetAggregatePublisher(pub, time.Hour)
+
+	pub.rev.Store(3)
+	hub.publishIfChanged()
+	first := pub.calls.Load()
+
+	hub.publishIfChanged()
+	hub.publishIfChanged()
+	if got := pub.calls.Load(); got != first {
+		t.Fatalf("snapshot built %d times for an unchanged revision, want %d", got, first)
+	}
+
+	pub.rev.Store(4)
+	hub.publishIfChanged()
+	if hub.lastRev != 4 {
+		t.Fatalf("lastRev = %d after a change, want 4", hub.lastRev)
+	}
+}
+
+// TestAggregateWSEpochChangeResetsClients: the revision counter restarts at
+// zero on a new process generation, so a client must be told to drop state
+// rather than merge a lower revision into a higher one.
+func TestAggregateWSEpochChangeResetsClients(t *testing.T) {
+	f := newWSFixture(t, 80*time.Millisecond)
+	_ = f.read(t, 2*time.Second)
+
+	f.pub.rev.Store(9)
+	if snap := f.read(t, 3*time.Second); snap.Reset {
+		t.Fatal("same-epoch publication asked for a reset")
+	}
+
+	// New process generation: epoch changes and revision goes BACKWARDS.
+	f.pub.epoch.Store("epoch-2")
+	f.pub.rev.Store(1)
+
+	snap := f.read(t, 3*time.Second)
+	if !snap.Reset {
+		t.Fatal("epoch change did not flag reset")
+	}
+	if snap.Epoch != "epoch-2" {
+		t.Errorf("epoch = %q, want epoch-2", snap.Epoch)
+	}
+}
+
+// TestAggregateModeDisablesPerEventBroadcasts covers both hubs: in aggregate
+// mode the coalesced snapshot is the only data message.
+func TestAggregateModeDisablesPerEventBroadcasts(t *testing.T) {
+	hub := NewEventHub(nil, nil, nil)
+	hub.SetAggregatePublisher(newFakePublisher("epoch-1"), time.Hour)
+	hub.BroadcastLog(LogEntry{Body: "hello"})
+	hub.BroadcastMetric(MetricEntry{Name: "m"})
+	if len(hub.logsCh) != 0 || len(hub.metricsCh) != 0 {
+		t.Fatalf("event hub buffered per-event broadcasts in aggregate mode: logs=%d metrics=%d",
+			len(hub.logsCh), len(hub.metricsCh))
+	}
+
+	h := NewHub(nil)
+	h.SetAggregateMode(true)
+	h.Broadcast(LogEntry{Body: "hello"})
+	h.BroadcastMetric(MetricEntry{Name: "m"})
+	if len(h.broadcast) != 0 || len(h.metricsCh) != 0 {
+		t.Fatalf("hub buffered per-event broadcasts in aggregate mode: logs=%d metrics=%d",
+			len(h.broadcast), len(h.metricsCh))
+	}
+
+	// Legacy mode is unchanged.
+	legacy := NewHub(nil)
+	legacy.Broadcast(LogEntry{Body: "hello"})
+	if len(legacy.broadcast) != 1 {
+		t.Fatalf("legacy hub dropped a broadcast: %d buffered", len(legacy.broadcast))
+	}
+}
+
+// TestAggregateSnapshotNeverCarriesTraces pins the "no 7-day resend" rule at
+// its practical edge: the coalesced payload is summary/traffic/topology, never
+// a list of raw traces.
+func TestAggregateSnapshotNeverCarriesTraces(t *testing.T) {
+	pub := newFakePublisher("epoch-1")
+	snap := pub.Snapshot(context.Background(), "")
+	if snap.Traces != nil {
+		t.Fatal("coalesced aggregate snapshot carries raw traces")
+	}
+}

--- a/internal/realtime/events_ws.go
+++ b/internal/realtime/events_ws.go
@@ -14,13 +14,45 @@ import (
 )
 
 // LiveSnapshot is the data payload pushed to all event WS clients.
+//
+// The identity and coverage fields are ADDITIVE and only populated in
+// aggregate mode; `omitempty` keeps the legacy payload unchanged.
+//
+// A client replaces state by (series, window_start, revision) and RESETS
+// wholesale when Epoch changes: the revision counter restarts at zero on every
+// process generation, so revision alone cannot be trusted across a restart.
 type LiveSnapshot struct {
 	Type       string                     `json:"type"`
 	Dashboard  *storage.DashboardStats    `json:"dashboard"`
 	Traffic    []storage.TrafficPoint     `json:"traffic"`
 	Traces     *storage.TracesResponse    `json:"traces"`
 	ServiceMap *storage.ServiceMapMetrics `json:"service_map"`
+
+	Epoch        string `json:"epoch,omitempty"`
+	Revision     uint64 `json:"revision,omitempty"`
+	Reset        bool   `json:"reset,omitempty"`
+	Coverage     string `json:"coverage,omitempty"`
+	CoverageNote string `json:"coverage_note,omitempty"`
 }
+
+// AggregatePublisher supplies revision-driven snapshots in aggregate mode. It
+// is an interface so the hub needs neither the aggregate engine nor a live
+// store to be tested.
+type AggregatePublisher interface {
+	// Epoch identifies the process generation of Revision.
+	Epoch() string
+	// Revision is the aggregate engine's monotonic revision.
+	Revision() uint64
+	// Snapshot builds the coalesced payload for one service filter (empty
+	// means all services). It is summary, recent traffic, service health and
+	// topology — never the seven-day history.
+	Snapshot(ctx context.Context, service string) *LiveSnapshot
+}
+
+// DefaultPublishFloor is the minimum spacing between aggregate publications.
+// Frozen at 2 s in #164: fast enough to feel live, slow enough that a busy
+// engine cannot turn every commit into a broadcast.
+const DefaultPublishFloor = 2 * time.Second
 
 // clientFilter tracks a client's active service filter.
 // Empty string = all services (no filter).
@@ -48,6 +80,16 @@ type EventHub struct {
 
 	stopOnce sync.Once
 	stopCh   chan struct{}
+
+	// aggPub, when set, switches the hub to revision-driven publication.
+	// Per-event log/metric broadcasts are disabled in that mode: the
+	// coalesced snapshot is the only data message.
+	aggPub       AggregatePublisher
+	publishFloor time.Duration
+	// lastEpoch and lastRev are what was last published to every client.
+	lastEpoch string
+	lastRev   uint64
+	published bool
 }
 
 // NewEventHub creates a new event notification hub.
@@ -65,8 +107,36 @@ func NewEventHub(repo *storage.Repository, onConnect, onDisconnect func()) *Even
 	}
 }
 
+// SetAggregatePublisher switches the hub to revision-driven publication. Pass
+// a zero floor to take DefaultPublishFloor. Call once at startup, before the
+// hub takes connections.
+func (h *EventHub) SetAggregatePublisher(p AggregatePublisher, floor time.Duration) {
+	if p == nil {
+		return
+	}
+	if floor <= 0 {
+		floor = DefaultPublishFloor
+	}
+	h.mu.Lock()
+	h.aggPub = p
+	h.publishFloor = floor
+	h.mu.Unlock()
+}
+
+// aggregatePublisher returns the configured publisher, or nil in legacy mode.
+func (h *EventHub) aggregatePublisher() AggregatePublisher {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.aggPub
+}
+
 // Start begins the periodic flush loops. Call in a goroutine.
 func (h *EventHub) Start(ctx context.Context, snapshotInterval, batchInterval time.Duration) {
+	if h.aggregatePublisher() != nil {
+		h.runAggregate(ctx)
+		return
+	}
+
 	snapshotTicker := time.NewTicker(snapshotInterval)
 	batchTicker := time.NewTicker(batchInterval)
 	defer snapshotTicker.Stop()
@@ -108,16 +178,25 @@ func (h *EventHub) NotifyRefresh() {
 	h.mu.Unlock()
 }
 
-// BroadcastLog adds a log entry to the real-time buffer.
+// BroadcastLog adds a log entry to the real-time buffer. In aggregate mode
+// per-event broadcasts are disabled and this is a no-op: the coalesced
+// revision-driven snapshot is the only data message clients receive.
 func (h *EventHub) BroadcastLog(l LogEntry) {
+	if h.aggregatePublisher() != nil {
+		return
+	}
 	select {
 	case h.logsCh <- l:
 	default:
 	}
 }
 
-// BroadcastMetric adds a metric entry to the real-time buffer.
+// BroadcastMetric adds a metric entry to the real-time buffer. Disabled in
+// aggregate mode, for the same reason as BroadcastLog.
 func (h *EventHub) BroadcastMetric(m MetricEntry) {
+	if h.aggregatePublisher() != nil {
+		return
+	}
 	select {
 	case h.metricsCh <- m:
 	default:
@@ -139,7 +218,9 @@ func (h *EventHub) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 	initialService := r.URL.Query().Get("service")
 	h.addClient(conn, initialService)
 
-	// Send immediate snapshot so the client has data right away
+	// Send immediate FULL snapshot so the client has data right away. In
+	// aggregate mode it carries {epoch, revision} and reset=true: a fresh
+	// client has nothing to merge into and must adopt the snapshot whole.
 	h.sendSnapshotTo(conn, initialService)
 
 	// Read loop: client can send {"service":"xxx"} to change filter
@@ -215,7 +296,7 @@ func (h *EventHub) flushSnapshots() {
 	for service := range groups {
 		// Capture
 		g.Go(func() error {
-			snap := h.computeSnapshot(service)
+			snap := h.snapshotFor(service)
 			if snap != nil {
 				snapMu.Lock()
 				snapshotMap[service] = snap
@@ -310,9 +391,12 @@ func (h *EventHub) sendBatch(conn *websocket.Conn, batchType string, data any) {
 
 // sendSnapshotTo sends a snapshot to a single client.
 func (h *EventHub) sendSnapshotTo(conn *websocket.Conn, service string) {
-	snapshot := h.computeSnapshot(service)
+	snapshot := h.snapshotFor(service)
 	if snapshot == nil {
 		return
+	}
+	if h.aggregatePublisher() != nil {
+		snapshot.Reset = true
 	}
 	msg, err := json.Marshal(snapshot)
 	if err != nil {
@@ -321,6 +405,97 @@ func (h *EventHub) sendSnapshotTo(conn *websocket.Conn, service string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	_ = conn.Write(ctx, websocket.MessageText, msg)
+}
+
+// snapshotFor produces the payload for one service filter from whichever
+// source owns the numbers in this mode.
+func (h *EventHub) snapshotFor(service string) *LiveSnapshot {
+	if pub := h.aggregatePublisher(); pub != nil {
+		return pub.Snapshot(context.Background(), service)
+	}
+	return h.computeSnapshot(service)
+}
+
+// runAggregate is the revision-driven publication loop.
+//
+// Publication happens only on a revision (or epoch) change, at most once per
+// publishFloor, with TRAILING-EDGE delivery: the loop re-reads the revision at
+// every tick, so a change that lands inside a spacing interval is published at
+// the end of that interval instead of disappearing for want of a later event.
+func (h *EventHub) runAggregate(ctx context.Context) {
+	h.mu.Lock()
+	floor := h.publishFloor
+	h.mu.Unlock()
+
+	slog.Info("🌐 EventHub started in aggregate mode", "publish_floor", floor)
+
+	tick := time.NewTicker(floor)
+	defer tick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("🌐 EventHub stopping via context...")
+			return
+		case <-h.stopCh:
+			slog.Info("🌐 EventHub stopping via signal...")
+			return
+		case <-tick.C:
+			h.publishIfChanged()
+		}
+	}
+}
+
+// publishIfChanged publishes one coalesced snapshot per service filter when
+// the engine's {epoch, revision} identity has moved since the last
+// publication. It is exported behaviour only through the loop; tests drive it
+// directly so the 2 s floor does not become a 2 s test.
+func (h *EventHub) publishIfChanged() {
+	pub := h.aggregatePublisher()
+	if pub == nil {
+		return
+	}
+	epoch, rev := pub.Epoch(), pub.Revision()
+
+	h.mu.Lock()
+	if h.published && h.lastEpoch == epoch && h.lastRev == rev {
+		h.mu.Unlock()
+		return
+	}
+	// An epoch change means the revision counter restarted: clients cannot
+	// merge across it and are told to reset.
+	reset := h.published && h.lastEpoch != epoch
+	h.lastEpoch, h.lastRev, h.published = epoch, rev, true
+	if len(h.clients) == 0 {
+		h.mu.Unlock()
+		return
+	}
+	groups := make(map[string][]*websocket.Conn)
+	for c, cf := range h.clients {
+		groups[cf.service] = append(groups[cf.service], c)
+	}
+	h.mu.Unlock()
+
+	for service, clients := range groups {
+		snap := pub.Snapshot(context.Background(), service)
+		if snap == nil {
+			continue
+		}
+		snap.Reset = reset
+		msg, err := json.Marshal(snap)
+		if err != nil {
+			slog.Error("Event WS marshal failed", "error", err)
+			continue
+		}
+		for _, conn := range clients {
+			writeCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			if err := conn.Write(writeCtx, websocket.MessageText, msg); err != nil {
+				slog.Debug("Event WS send failed, removing client", "error", err)
+				h.removeClient(conn)
+				_ = conn.Close(websocket.StatusGoingAway, "write error")
+			}
+			cancel()
+		}
+	}
 }
 
 // computeSnapshot queries the DB for the last 15 minutes of data,

--- a/internal/realtime/hub.go
+++ b/internal/realtime/hub.go
@@ -66,6 +66,12 @@ type Hub struct {
 	maxClients  int
 	clientCount atomic.Int64
 
+	// aggregateMode disables per-event broadcasts. In aggregate mode the raw
+	// log/metric stream is no longer the source of truth for the UI, and
+	// re-broadcasting every event would contradict the coalesced,
+	// revision-driven publication the event hub performs (#164).
+	aggregateMode atomic.Bool
+
 	stopCh   chan struct{}
 	stopped  atomic.Bool
 	wg       sync.WaitGroup
@@ -280,8 +286,15 @@ func (h *Hub) SetWSMetrics(onMessageSent func(string), onSlowClientDrop func()) 
 	h.onSlowClientDrop = onSlowClientDrop
 }
 
-// Broadcast adds a log entry to the broadcast buffer.
+// SetAggregateMode disables per-event log and metric broadcasts. Keepalive and
+// connection handling are unaffected.
+func (h *Hub) SetAggregateMode(on bool) { h.aggregateMode.Store(on) }
+
+// Broadcast adds a log entry to the broadcast buffer. No-op in aggregate mode.
 func (h *Hub) Broadcast(entry LogEntry) {
+	if h.aggregateMode.Load() {
+		return
+	}
 	select {
 	case h.broadcast <- entry:
 	default:
@@ -289,8 +302,12 @@ func (h *Hub) Broadcast(entry LogEntry) {
 	}
 }
 
-// BroadcastMetric adds a metric entry to the broadcast buffer.
+// BroadcastMetric adds a metric entry to the broadcast buffer. No-op in
+// aggregate mode.
 func (h *Hub) BroadcastMetric(entry MetricEntry) {
+	if h.aggregateMode.Load() {
+		return
+	}
 	select {
 	case h.metricsCh <- entry:
 	default:

--- a/main.go
+++ b/main.go
@@ -335,9 +335,10 @@ func main() {
 		metrics.IncrementActiveConns,
 		metrics.DecrementActiveConns,
 	)
+	// The hub is STARTED further down, after the aggregate engine exists: in
+	// AGGREGATE_MODE=aggregate its publication loop is revision-driven and
+	// needs the publisher wired before the first tick.
 	ctxEvents, cancelEvents := context.WithCancel(context.Background())
-	go eventHub.Start(ctxEvents, 5*time.Second, 500*time.Millisecond)
-	slog.Info("⚡ Event notification hub started (5s snapshots, 500ms batches)")
 
 	// 4c. Initialize TSDB Aggregator + Ring Buffer
 	tsdbAgg := tsdb.NewAggregator(repo, 30*time.Second)
@@ -467,6 +468,7 @@ func main() {
 		aggStore     *aggregate.SQLiteStore
 		aggWriter    *aggregate.Writer
 		aggRecovery  *aggregate.RecoveryGate
+		aggEngine    *aggregate.Engine
 		aggStoreMetr = aggregate.NewPrometheusStoreMetrics(metrics)
 	)
 	if cfg.AggregateMode != aggregate.ModeLegacy {
@@ -499,7 +501,7 @@ func main() {
 			fatal("❌ Aggregate dictionary could not be loaded", err, "path", cfg.AggregateDBPath)
 		}
 
-		aggEngine, err := aggregate.NewEngine(aggregate.EngineConfig{
+		aggEngine, err = aggregate.NewEngine(aggregate.EngineConfig{
 			Mode:      cfg.AggregateMode,
 			Registrar: registrar,
 			Limiter: aggregate.LimiterConfig{
@@ -581,6 +583,32 @@ func main() {
 			aggStore.Analyze,
 		)
 	}
+
+	// Aggregate READ path (#175). Only AGGREGATE_MODE=aggregate switches the
+	// dashboard, the WebSocket publisher and the MCP coverage metadata over;
+	// shadow mode writes aggregates but keeps serving the legacy reads.
+	if cfg.AggregateMode == aggregate.ModeAggregate && aggEngine != nil {
+		apiServer.SetAggregateEngine(aggEngine)
+		mcpServer.SetAggregateMode(true)
+		// Per-event log/metric broadcasts are replaced by the coalesced,
+		// revision-driven snapshot.
+		hub.SetAggregateMode(true)
+		eventHub.SetAggregatePublisher(realtime.NewEnginePublisher(realtime.EnginePublisherConfig{
+			Engine: aggEngine,
+			Tenant: cfg.DefaultTenant,
+			Edges: func(ctx context.Context) []storage.ServiceMapEdge {
+				return graphRAGServiceEdges(ctx, graphRAG)
+			},
+		}), realtime.DefaultPublishFloor)
+		slog.Info("📊 Aggregate read path enabled",
+			"epoch", aggEngine.Epoch(),
+			"ws_publish_floor", realtime.DefaultPublishFloor,
+			"note", "dashboard, topology and WebSocket snapshots are served from the aggregate engine",
+		)
+	}
+
+	go eventHub.Start(ctxEvents, 5*time.Second, 500*time.Millisecond)
+	slog.Info("⚡ Event notification hub started (5s snapshots, 500ms batches)")
 
 	retention.Start(ctxRetention)
 	slog.Info("🧹 Retention scheduler started",
@@ -1271,4 +1299,29 @@ func printBanner() {
   version: %s
 `
 	fmt.Printf(banner, Version)
+}
+
+// graphRAGServiceEdges projects the GraphRAG service store's CALLS edges into
+// the storage topology shape. Caller/callee identity is not part of an
+// aggregate SeriesKey, so the aggregate read path sources edges here — which is
+// also why any response carrying them is marked "sampled" rather than "full".
+func graphRAGServiceEdges(ctx context.Context, g *graphrag.GraphRAG) []storage.ServiceMapEdge {
+	if g == nil {
+		return nil
+	}
+	all := g.AllServiceEdges(ctx)
+	edges := make([]storage.ServiceMapEdge, 0, len(all))
+	for _, e := range all {
+		if e.Type != "CALLS" {
+			continue
+		}
+		edges = append(edges, storage.ServiceMapEdge{
+			Source:       e.FromID,
+			Target:       e.ToID,
+			CallCount:    e.CallCount,
+			AvgLatencyMs: e.AvgMs,
+			ErrorRate:    e.ErrorRate,
+		})
+	}
+	return edges
 }


### PR DESCRIPTION
Part of #175 (backend; UI increment follows)

Backend phase 4 of the aggregate-first epic. Everything new is gated on `AGGREGATE_MODE=aggregate`; legacy and shadow responses are unchanged (additive fields are all `omitempty`, and a contract test asserts none of them leak into the legacy payload).

## Engine as sole query facade

- `ownership` record `{mutable set, finalized watermark, revision, epoch}` on the engine, with the ownership mutex as the **outer** lock (a shard mutex is only ever taken while it is held). Memory-owned windows are read exclusively from the shards even when crash-recovery checkpoint rows exist; store-owned windows exclusively from the store. Ownership, not row presence, is the dedup rule.
- `Writer.FinalizeDue` calls `Engine.MarkFinalized` after a committed `FinalizeWindow`, so the shard eviction and the watermark advance happen in one critical section.
- `QueryBuckets` / `QueryDashboard` / `QueryTopology` — purpose-built for broad requests, one bounded store read per query. Nothing outside the engine touches `aggregate.db`.
- New `Resolver` seam on the dictionary so the read path can reverse an ID back to a service/operation name (`MemRegistrar` already could; `DurableRegistrar` gained a reverse index).

## Dashboard migration

- `/api/metrics/dashboard`, `/api/metrics/traffic` and `/api/metrics/service-map` are served from engine queries in aggregate mode. The raw `COUNT`/`AVG`/`DISTINCT` scans and the `sqliteP99RowCap` in-memory sort are retired on that path.
- Accuracy metadata `{approximate, sketch_scale, relative_error_bound, degraded}` is computed from the **final merged sketch** on every response. Merging mismatched scales downscales to the coarser one, so the advertised bound can exceed the scale-4 2.17% — that is exactly why it is not a constant.

## WebSocket

- Full snapshot on connect, flagged `reset`.
- Thereafter publication only on `{epoch, revision}` change, at most once per 2 s, with **trailing-edge** delivery: the loop re-reads the revision each tick, so a change landing inside a spacing interval is published at the end of it.
- Clients reset on epoch change (the revision counter restarts at zero per process generation).
- Per-event log/metric broadcasts disabled in aggregate mode on both hubs. Keepalive and connection handling untouched.
- The coalesced payload is summary/traffic/topology — never raw traces, never the 7-day history.

## Coverage vocabulary `full | sampled | exemplar`

- Additive `coverage` + `coverage_note` on object responses.
- `OtelContext-Data-Coverage` response header on bare-array endpoints (`/api/metrics/traffic`, `/api/metrics/latency_heatmap`) — no silent envelope wrapping.
- MCP results carry coverage as an **additional content item**, so bodies that are bare JSON arrays keep their shape.
- Exemplar surfaces say outright that a missing exemplar is not evidence of zero matching events.

## Tests

`go build ./...`, `go vet ./...`, `gofmt` clean. `golangci-lint run ./...` introduces no new findings (remaining ones are pre-existing, in files this PR does not touch).

- `go test ./internal/api/ ./internal/realtime/ ./internal/aggregate/ ./internal/mcp/ -count=1 -race` — 444 passed
- `go test ./... -count=1` — 1083 passed, 28 packages

New coverage:

| Acceptance criterion | Test |
|---|---|
| Legacy vs aggregate field compatibility | `TestDashboardContractLegacyVsAggregate`, `TestServiceMapContractLegacyVsAggregate` |
| No raw trace/log table scans (query counter) | `TestNoRawTableScansBehindDashboardInAggregateMode` (with a legacy control so the counter cannot be vacuous) |
| WS trailing edge | `TestAggregateWSTrailingEdgeDelivery` |
| Epoch reset | `TestAggregateWSEpochChangeResetsClients` |
| Percentile metadata across merged/downscaled sketches | `TestQueryDashboardPercentileWithinReportedBound`, `TestAccuracyMetadataTracksDownscaledMerge`, `TestAccuracyMetadataReportsCollapse` |
| Ownership exclusivity | `TestOwnershipIsExclusivePerWindow`, `TestRolloverHandsOwnershipToTheStore` |
| Bare-array coverage header | `TestTrafficUsesCoverageHeaderNotAnEnvelope`, `TestLatencyHeatmapDeclaresExemplarCoverage` |
| MCP body metadata | `internal/mcp/coverage_test.go` |

## Deviations from the spec

1. **Topology edges are not aggregate data.** Caller/callee identity is not part of a `SeriesKey` and no reducer emits a `SignalServiceEdge` series today, so `QueryTopology` returns nodes only and the handler sources edges from the GraphRAG topology store. The response is marked `sampled`, not `full` — node counts are complete, edges are not.
2. **Traffic bucket width changes from 1 min to 5 min** in aggregate mode. The window is the engine's tumbling window; field names, units and array shape are unchanged.
3. **`AccuracyMetadata` carries a fourth field, `degraded`** (additive, `omitempty`). A collapsed or saturated sketch has estimates outside `relative_error_bound`; reporting only the three specified fields would advertise a bound the sketch does not honour.
4. **`coverage_note` accompanies `coverage`** on object responses. The frozen decision requires that surfaces say a missing exemplar is not zero events; the note is where they say it.
5. **`/api/metrics/latency_heatmap` keeps its raw-row data path** and only declares `exemplar` coverage. It plots individual span durations, which no aggregate can reconstruct.