### PR TITLE
feat(graphrag): aggregate consumption — retire the raw-span rebuild

### DIFF
--- a/internal/aggregate/edges.go
+++ b/internal/aggregate/edges.go
@@ -1,0 +1,156 @@
+package aggregate
+
+import (
+	"container/list"
+	"hash/fnv"
+	"sync"
+)
+
+// Caller resolution for service-edge series (#174, deferred from #183).
+//
+// #183 shipped SignalServiceEdge — its sub-cap, its overflow path and its
+// encoding — but emitted nothing into it, because a single span does not know
+// who called it. The caller is recovered the only way it can be: by joining a
+// child span's ParentSpanID against the service of the parent span, which
+// arrives in a different Export request from a different process.
+//
+// The join needs a bounded memory of recently-seen spans. Spans of one trace
+// arrive close together, so a per-tenant LRU of recent span IDs covers
+// in-flight traces while bounding memory by recent span volume rather than by
+// total spans seen. This is the same shape as the legacy graphrag topology
+// observer it replaces in aggregate mode — with two differences: it is sharded
+// by span ID so 100+ services do not funnel through one mutex, and it holds
+// only the mapping, never a graph.
+//
+// The resolver is consulted for EVERY received span, before the exemplar
+// policy, because an edge must exist whether or not the spans forming it were
+// retained as raw exemplars.
+
+// DefaultEdgeResolverSpans bounds the span-ID memory across all shards. Each
+// entry is two short strings plus map and list overhead (~0.1 KiB), so the
+// default is a few tens of MiB at worst.
+const DefaultEdgeResolverSpans = 100_000
+
+// edgeResolverShards is the shard count. Fixed and small: the map is touched
+// once per span, and every operation holds exactly one shard lock.
+const edgeResolverShards = 16
+
+// EdgeResolver recovers the caller service of a span from its parent span ID.
+// Safe for concurrent use.
+type EdgeResolver struct {
+	shards [edgeResolverShards]edgeShard
+}
+
+type edgeShard struct {
+	mu    sync.Mutex
+	cap   int
+	byID  map[edgeSpanKey]string
+	order *list.List
+	elems map[edgeSpanKey]*list.Element
+}
+
+// edgeSpanKey is (tenant, span ID). Span IDs are unique within a tenant; the
+// tenant is part of the key so one tenant's span can never resolve another
+// tenant's caller.
+type edgeSpanKey struct {
+	tenant string
+	spanID string
+}
+
+// NewEdgeResolver builds a resolver whose total span memory is capped at
+// maxSpans across all shards. Zero or negative takes DefaultEdgeResolverSpans.
+func NewEdgeResolver(maxSpans int) *EdgeResolver {
+	if maxSpans <= 0 {
+		maxSpans = DefaultEdgeResolverSpans
+	}
+	per := maxSpans / edgeResolverShards
+	if per < 1 {
+		per = 1
+	}
+	r := &EdgeResolver{}
+	for i := range r.shards {
+		r.shards[i] = edgeShard{
+			cap:   per,
+			byID:  make(map[edgeSpanKey]string),
+			order: list.New(),
+			elems: make(map[edgeSpanKey]*list.Element),
+		}
+	}
+	return r
+}
+
+// Observe records this span's service and resolves its caller.
+//
+// It returns the parent's service and true only when the parent span is still
+// remembered AND belongs to a different service — a same-service parent is an
+// internal call, not a topology edge. Recording and lookup touch different
+// shards and never hold two locks at once.
+func (r *EdgeResolver) Observe(tenant, spanID, parentSpanID, service string) (string, bool) {
+	if r == nil || spanID == "" || service == "" {
+		return "", false
+	}
+	r.put(edgeSpanKey{tenant, spanID}, service)
+	if parentSpanID == "" {
+		return "", false
+	}
+	caller, ok := r.get(edgeSpanKey{tenant, parentSpanID})
+	if !ok || caller == service {
+		return "", false
+	}
+	return caller, true
+}
+
+// Len reports how many span mappings are currently held. Test and diagnostic
+// accessor only.
+func (r *EdgeResolver) Len() int {
+	n := 0
+	for i := range r.shards {
+		sh := &r.shards[i]
+		sh.mu.Lock()
+		n += len(sh.byID)
+		sh.mu.Unlock()
+	}
+	return n
+}
+
+func (r *EdgeResolver) shardFor(key edgeSpanKey) *edgeShard {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(key.spanID))
+	return &r.shards[h.Sum32()%edgeResolverShards]
+}
+
+func (r *EdgeResolver) put(key edgeSpanKey, service string) {
+	sh := r.shardFor(key)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if el, ok := sh.elems[key]; ok {
+		sh.byID[key] = service
+		sh.order.MoveToFront(el)
+		return
+	}
+	sh.byID[key] = service
+	sh.elems[key] = sh.order.PushFront(key)
+	for len(sh.byID) > sh.cap {
+		back := sh.order.Back()
+		if back == nil {
+			return
+		}
+		victim, _ := back.Value.(edgeSpanKey)
+		sh.order.Remove(back)
+		delete(sh.elems, victim)
+		delete(sh.byID, victim)
+	}
+}
+
+func (r *EdgeResolver) get(key edgeSpanKey) (string, bool) {
+	sh := r.shardFor(key)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	service, ok := sh.byID[key]
+	if ok {
+		if el, found := sh.elems[key]; found {
+			sh.order.MoveToFront(el)
+		}
+	}
+	return service, ok
+}

--- a/internal/aggregate/engine.go
+++ b/internal/aggregate/engine.go
@@ -134,6 +134,19 @@ type EngineConfig struct {
 	// Nil or empty means no metrics are configured for custom dimensions.
 	MetricDims DimsConfig
 
+	// Topology bounds the per-tenant topology projection GraphRAG consumes in
+	// aggregate mode (#174). Zero values take the package defaults.
+	Topology TopologyConfig
+
+	// EdgeResolverSpans bounds the span-ID memory used to recover a call
+	// edge's caller service. Zero takes DefaultEdgeResolverSpans.
+	EdgeResolverSpans int
+
+	// Epoch identifies this engine instance. A consumer that sees a new epoch
+	// knows the revision counter restarted and must replace its state rather
+	// than reconcile against it. Zero derives one from the clock.
+	Epoch uint64
+
 	// Now is the clock, injectable for tests. Defaults to time.Now.
 	Now func() time.Time
 }
@@ -149,6 +162,9 @@ type Engine struct {
 	baselines *BaselineTracker
 	metrics   MetricsRecorder
 	dims      DimsConfig
+	topology  *topologyProjection
+	edges     *EdgeResolver
+	epoch     uint64
 
 	shards [NumShards]shard
 
@@ -182,6 +198,10 @@ func NewEngine(cfg EngineConfig) (*Engine, error) {
 	if reg == nil {
 		reg = NewMemRegistrar(nil)
 	}
+	epoch := cfg.Epoch
+	if epoch == 0 {
+		epoch = uint64(cfg.Now().UnixNano()) // #nosec G115 -- wall clock as an opaque instance tag
+	}
 	e := &Engine{
 		mode:    cfg.Mode,
 		now:     cfg.Now,
@@ -189,7 +209,10 @@ func NewEngine(cfg EngineConfig) (*Engine, error) {
 		miner:   cfg.Miner,
 		metrics: cfg.Metrics,
 		dims:    cfg.MetricDims,
+		epoch:   epoch,
 	}
+	e.topology = newTopologyProjection(cfg.Topology, epoch)
+	e.edges = NewEdgeResolver(cfg.EdgeResolverSpans)
 	if e.metrics == nil {
 		e.metrics = noopRecorder{}
 	}
@@ -235,6 +258,39 @@ func (e *Engine) Baselines() *BaselineTracker { return e.baselines }
 
 // MetricDims returns the configured metric dimension keys for aggregation.
 func (e *Engine) MetricDims() DimsConfig { return e.dims }
+
+// EdgeResolver returns the caller-resolution memory used to derive service
+// edges. The OTLP trace receiver feeds every received span through it.
+func (e *Engine) EdgeResolver() *EdgeResolver { return e.edges }
+
+// TopologyEpoch returns this engine instance's epoch.
+func (e *Engine) TopologyEpoch() uint64 { return e.epoch }
+
+// TopologyTenants returns the tenants the projection currently holds.
+func (e *Engine) TopologyTenants() []string { return e.topology.Tenants() }
+
+// TopologyRevision returns a tenant's topology revision without rendering a
+// snapshot, so an unchanged tenant costs one map lookup.
+func (e *Engine) TopologyRevision(tenant string) uint64 { return e.topology.Revision(tenant) }
+
+// TopologySnapshot renders one tenant's replacement-by-revision topology.
+func (e *Engine) TopologySnapshot(tenant string) TopologySnapshot {
+	return e.topology.Snapshot(tenant, e.now())
+}
+
+// PruneTopology drops topology windows past the retention horizon. The fold
+// path prunes the tenants it touches; this is what bounds a tenant that has
+// gone silent.
+func (e *Engine) PruneTopology() { e.topology.Prune(e.now()) }
+
+// SetTemplateFactSink installs the log-fact consumer on the ingest-owned
+// template miner (#163). GraphRAG performs no mining of its own in shadow and
+// aggregate modes; it consumes these facts. Passing nil detaches the sink.
+func (e *Engine) SetTemplateFactSink(fn func(TemplateFact)) {
+	if e.miner != nil {
+		e.miner.SetFactSink(fn)
+	}
+}
 
 // Revision returns the current revision. It increases by one on every applied
 // batch and never decreases, so a consumer can tell "nothing changed" from
@@ -308,11 +364,8 @@ func Classify(arrival, pointTime time.Time) (int64, PointDisposition) {
 // ApplyReducer records the reduction metrics for one Export request and applies
 // its deltas. This is the entry point the OTLP servers call.
 func (e *Engine) ApplyReducer(r *Reducer) uint64 {
-	if r == nil {
-		return e.revision.Load()
-	}
-	e.recordReduction(r)
-	return e.ApplyDeltas(r.Deltas())
+	rev, _ := e.ApplyReducerErr(r)
+	return rev
 }
 
 // ApplyDeltas applies one reducer's output through the configured applier.
@@ -329,7 +382,14 @@ func (e *Engine) ApplyReducerErr(r *Reducer) (uint64, error) {
 		return e.revision.Load(), nil
 	}
 	e.recordReduction(r)
-	return e.ApplyDeltasErr(r.Deltas())
+	rev, err := e.ApplyDeltasErr(r.Deltas())
+	if err != nil {
+		// Nothing became durable, so nothing may enter the topology a
+		// consumer will present as accounted-for.
+		return rev, err
+	}
+	e.topology.fold(e.now(), rev, r.topologyIDs(), r.Deltas())
+	return rev, nil
 }
 
 // ApplyDeltasErr applies one reducer's output and surfaces any refusal. When

--- a/internal/aggregate/reducer.go
+++ b/internal/aggregate/reducer.go
@@ -133,6 +133,12 @@ type Reducer struct {
 	arrival time.Time
 	deltas  DeltaMap
 	stats   ReducerStats
+	// ids carries the STRING identity of each delta for the engine's topology
+	// projection (#174). It is one small struct per delta, not per point, and
+	// it exists so the projection never has to reverse a dictionary ID — after
+	// a restart the durable dictionary is warm but the intern cache is empty,
+	// so a reverse lookup would silently render an unnamed topology.
+	ids map[SeriesWindowKey]topoIdentity
 }
 
 // NewReducer returns a reducer for one Export request. arrival is the single
@@ -171,6 +177,12 @@ func (r *Reducer) MergeFrom(other *Reducer) {
 		}
 		r.deltas[swk] = d
 	}
+	for swk, id := range other.ids {
+		if r.ids == nil {
+			r.ids = make(map[SeriesWindowKey]topoIdentity, len(other.ids))
+		}
+		r.ids[swk] = id
+	}
 	r.stats.merge(&other.stats)
 }
 
@@ -197,6 +209,20 @@ func (r *Reducer) delta(key SeriesKey, window int64) *AggregateDelta {
 	r.deltas[swk] = d
 	return d
 }
+
+// identify records the string identity of one (series, window) for the
+// topology projection. Repeated calls for the same key are idempotent.
+func (r *Reducer) identify(key SeriesKey, window int64, id topoIdentity) {
+	swk := SeriesWindowKey{Key: key, WindowStart: window}
+	if r.ids == nil {
+		r.ids = make(map[SeriesWindowKey]topoIdentity, 8)
+	}
+	r.ids[swk] = id
+}
+
+// topologyIDs returns the reducer's identity map. The engine folds it into the
+// topology projection after a successful apply.
+func (r *Reducer) topologyIDs() map[SeriesWindowKey]topoIdentity { return r.ids }
 
 // admitPoint applies the window/lateness rules and updates the per-signal
 // counters. It reports ok=false when the point is excluded.
@@ -243,10 +269,71 @@ func (r *Reducer) ReduceSpan(in SpanInput) {
 	}
 	isError := key.StatusClass == StatusError
 	r.delta(key, window).ObserveSpan(in.DurationMicros, isError)
+	r.identify(key, window, topoIdentity{Kind: topoTrace, Tenant: in.Tenant, A: in.Service, B: operation})
 	r.stats.Accepted[SignalTraceOp]++
 	if isError {
 		r.countError(in.Service)
 	}
+}
+
+// EdgeInput is one resolved caller/callee call, derived from a child span whose
+// parent span belongs to a different service. Everything except Caller comes
+// from the child span, matching what the edge measures: the callee's work as
+// observed by this call.
+type EdgeInput struct {
+	Tenant string
+	// Caller is the service that owns the parent span.
+	Caller string
+	// Callee is the service that owns this span.
+	Callee string
+	// HTTPRoute, URLPath and SpanName resolve the callee's operation for
+	// route normalization; only the callee service name enters edge identity.
+	HTTPRoute string
+	URLPath   string
+	SpanName  string
+
+	Method         string
+	HTTPStatusCode int
+	SpanKind       int32
+	StatusCode     int32
+
+	Timestamp      time.Time
+	DurationMicros float64
+}
+
+// ReduceEdge folds one resolved cross-service call into its service-edge series.
+//
+// #183 shipped SignalServiceEdge but emitted nothing into it: a single span
+// does not know its caller. #174 supplies the caller through the engine's
+// EdgeResolver and this is where it lands. Edge identity is
+// (caller service, callee service) plus the callee's status/HTTP/kind
+// dimensions — never a span ID, never an operation of the caller.
+func (r *Reducer) ReduceEdge(in EdgeInput) {
+	if in.Caller == "" || in.Callee == "" || in.Caller == in.Callee {
+		return
+	}
+	window, ok := r.admitPoint(SignalServiceEdge, in.Timestamp)
+	if !ok {
+		return
+	}
+	tenantID := r.eng.cache.InternTenant(in.Tenant)
+	key := SeriesKey{
+		TenantID:  tenantID,
+		ServiceID: r.eng.cache.Intern(tenantID, KindService, in.Caller),
+		// NameKind(SignalServiceEdge) is KindOperation: the callee service
+		// name is the edge's "name" within the caller's namespace, so
+		// MAX_OPERATIONS_PER_SERVICE bounds a caller's fan-out.
+		NameID:      r.eng.cache.Intern(tenantID, KindOperation, in.Callee),
+		Signal:      SignalServiceEdge,
+		StatusClass: TraceStatusFromCode(in.StatusCode),
+		HTTPClass:   HTTPClassFromStatus(in.HTTPStatusCode),
+		Method:      ParseMethod(in.Method),
+		Variant:     VariantFromSpanKind(in.SpanKind),
+	}
+	isError := key.StatusClass == StatusError
+	r.delta(key, window).ObserveSpan(in.DurationMicros, isError)
+	r.identify(key, window, topoIdentity{Kind: topoEdge, Tenant: in.Tenant, A: in.Caller, B: in.Callee})
+	r.stats.Accepted[SignalServiceEdge]++
 }
 
 // ReduceLog folds one log record into its log series. The template is mined
@@ -314,6 +401,7 @@ func (r *Reducer) ReduceMetricPoint(in MetricInput) {
 		d := r.delta(key, window)
 		d.ObserveCounter(out.Delta, out.Reset)
 	}
+	r.identify(key, window, topoIdentity{Kind: topoMetric, Tenant: in.Tenant, A: in.Service, B: in.Name})
 	r.stats.Accepted[SignalMetric]++
 }
 

--- a/internal/aggregate/template_miner.go
+++ b/internal/aggregate/template_miner.go
@@ -170,8 +170,11 @@ type TemplateMiner struct {
 	maxChildren  int
 	maxTokens    int
 
-	reg    TemplateRegistrar
-	onFact func(TemplateFact)
+	reg TemplateRegistrar
+	// onFact is swapped atomically: the engine installs GraphRAG's sink after
+	// construction (the miner has to exist before the engine that owns the
+	// dictionary it mints IDs from), while MineAt reads it on the hot path.
+	onFact atomic.Pointer[func(TemplateFact)]
 
 	// mu guards the partition map only. It is taken for writing exactly once
 	// per new (tenant, service) pair; mining an existing partition takes it
@@ -195,7 +198,6 @@ func NewTemplateMiner(cfg TemplateMinerConfig) *TemplateMiner {
 		maxChildren:  cfg.MaxChildren,
 		maxTokens:    cfg.MaxTokens,
 		reg:          cfg.Registrar,
-		onFact:       cfg.OnFact,
 		parts:        make(map[tmPartKey]*tmPartition),
 		text:         make(map[uint32]string),
 		alias:        make(map[uint32]uint32),
@@ -218,7 +220,26 @@ func NewTemplateMiner(cfg TemplateMinerConfig) *TemplateMiner {
 	if m.reg == nil {
 		m.reg = NewInMemoryTemplateRegistrar()
 	}
+	m.SetFactSink(cfg.OnFact)
 	return m
+}
+
+// SetFactSink installs (or, with nil, removes) the log-fact consumer. Safe to
+// call while mining is in flight.
+func (m *TemplateMiner) SetFactSink(fn func(TemplateFact)) {
+	if fn == nil {
+		m.onFact.Store(nil)
+		return
+	}
+	m.onFact.Store(&fn)
+}
+
+// factSink returns the installed sink, or nil.
+func (m *TemplateMiner) factSink() func(TemplateFact) {
+	if p := m.onFact.Load(); p != nil {
+		return *p
+	}
+	return nil
 }
 
 // Mine clusters one log body and returns its template ID. isOther is true when
@@ -235,11 +256,11 @@ func (m *TemplateMiner) MineAt(tenant, service, severity, body string, at time.T
 	p := m.partition(tenant, service)
 	tokens := tmSplitTokens(body, m.maxTokens)
 
-	wantText := m.onFact != nil
-	id, isOther, text := m.mine(p, tokens, body, at, wantText)
+	onFact := m.factSink()
+	id, isOther, text := m.mine(p, tokens, body, at, onFact != nil)
 
-	if m.onFact != nil {
-		m.onFact(TemplateFact{
+	if onFact != nil {
+		onFact(TemplateFact{
 			Tenant:     tenant,
 			Service:    service,
 			Severity:   severity,

--- a/internal/aggregate/topology.go
+++ b/internal/aggregate/topology.go
@@ -1,0 +1,724 @@
+package aggregate
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// Bounded per-tenant topology projection (#163, #174).
+//
+// GraphRAG in aggregate mode must not scan the spans table and must not query
+// aggregate.db. It consumes a snapshot published by the engine instead:
+// {revision, services, operations, edges} over the mutable windows plus a
+// configured recent finalized horizon. The consumer REPLACES its state per
+// revision — it never re-applies a cumulative snapshot through incrementing
+// upserts, which is what made the old 60 s rebuild double-count.
+//
+// The projection is fed from the same AggregateDelta values the shards receive,
+// keyed by the identity STRINGS the reducer already resolved. Nothing is
+// aggregated twice and no dictionary ID is ever reversed: reversing IDs would
+// be unreadable after a restart, when the durable dictionary is warm but the
+// in-memory intern cache is empty.
+//
+// Every map is bounded. Past a cap the fact is dropped and counted, and the
+// count is published on the snapshot so a consumer can say "topology is
+// truncated" instead of quietly showing a partial graph as complete.
+
+// Topology projection defaults.
+const (
+	// DefaultTopologyMaxServices bounds distinct services per tenant.
+	DefaultTopologyMaxServices = 512
+	// DefaultTopologyMaxOperationsPerService bounds distinct operations per
+	// (tenant, service).
+	DefaultTopologyMaxOperationsPerService = 64
+	// DefaultTopologyMaxEdges bounds distinct caller/callee pairs per tenant.
+	DefaultTopologyMaxEdges = 4096
+	// DefaultTopologyMaxMetrics bounds distinct (service, metric) pairs per
+	// tenant. Metric windows carry the baselines the anomaly detector needs.
+	DefaultTopologyMaxMetrics = 4096
+	// DefaultTopologyHorizon is how much finalized history the projection
+	// retains behind the mutable set. Six five-minute windows is enough for a
+	// rolling mean/variance baseline without pinning a day of state in RAM.
+	DefaultTopologyHorizon = 30 * time.Minute
+)
+
+// TopologyConfig bounds the projection. Zero values take the defaults above.
+type TopologyConfig struct {
+	MaxServices             int
+	MaxOperationsPerService int
+	MaxEdges                int
+	MaxMetrics              int
+	// Horizon is the finalized history retained behind the mutable windows.
+	Horizon time.Duration
+}
+
+func (c TopologyConfig) withDefaults() TopologyConfig {
+	if c.MaxServices <= 0 {
+		c.MaxServices = DefaultTopologyMaxServices
+	}
+	if c.MaxOperationsPerService <= 0 {
+		c.MaxOperationsPerService = DefaultTopologyMaxOperationsPerService
+	}
+	if c.MaxEdges <= 0 {
+		c.MaxEdges = DefaultTopologyMaxEdges
+	}
+	if c.MaxMetrics <= 0 {
+		c.MaxMetrics = DefaultTopologyMaxMetrics
+	}
+	if c.Horizon <= 0 {
+		c.Horizon = DefaultTopologyHorizon
+	}
+	return c
+}
+
+// TopologyWindow is one five-minute window of one topology entity.
+//
+// Closed and Final are the partial-window guard the anomaly detector needs:
+// Closed means the wall clock has passed the window's end, Final means the
+// lateness horizon has expired too and no further point can land in it. A
+// detector that compares the current, still-filling window against a baseline
+// without consulting Elapsed and Count is the "anomaly storm from a nearly
+// empty window" #163 removed.
+type TopologyWindow struct {
+	Start   time.Time     `json:"start"`
+	End     time.Time     `json:"end"`
+	Closed  bool          `json:"closed"`
+	Final   bool          `json:"final"`
+	Elapsed time.Duration `json:"elapsed"`
+
+	Count      uint64 `json:"count"`
+	ErrorCount uint64 `json:"error_count"`
+
+	DurationCount     uint64  `json:"duration_count,omitempty"`
+	DurationSumMicros float64 `json:"duration_sum_micros,omitempty"`
+	DurationMinMicros float64 `json:"duration_min_micros,omitempty"`
+	DurationMaxMicros float64 `json:"duration_max_micros,omitempty"`
+	// P95Micros and P99Micros come from the merged latency sketch. They are
+	// zero when the entity carries no sketch (operations, edges and metrics
+	// deliberately do not, so a 2 KiB sketch is not multiplied by every
+	// operation of every service of every window).
+	P95Micros float64 `json:"p95_micros,omitempty"`
+	P99Micros float64 `json:"p99_micros,omitempty"`
+
+	// Value* carry metric samples: gauge samples plus counter deltas, which
+	// is what a rolling mean/variance baseline is computed over.
+	ValueCount uint64  `json:"value_count,omitempty"`
+	ValueSum   float64 `json:"value_sum,omitempty"`
+	ValueMin   float64 `json:"value_min,omitempty"`
+	ValueMax   float64 `json:"value_max,omitempty"`
+}
+
+// Mean returns the mean observed value, or 0 when the window holds none.
+func (w TopologyWindow) Mean() float64 {
+	if w.ValueCount == 0 {
+		return 0
+	}
+	return w.ValueSum / float64(w.ValueCount)
+}
+
+// ErrorRate returns errors/count, or 0 for an empty window.
+func (w TopologyWindow) ErrorRate() float64 {
+	if w.Count == 0 {
+		return 0
+	}
+	return float64(w.ErrorCount) / float64(w.Count)
+}
+
+// AvgLatencyMs returns the mean duration in milliseconds, or 0 when the window
+// carries no duration observations.
+func (w TopologyWindow) AvgLatencyMs() float64 {
+	if w.DurationCount == 0 {
+		return 0
+	}
+	return w.DurationSumMicros / float64(w.DurationCount) / 1000.0
+}
+
+// TopologyService is one service and its retained windows, oldest first.
+type TopologyService struct {
+	Name      string           `json:"name"`
+	FirstSeen time.Time        `json:"first_seen"`
+	LastSeen  time.Time        `json:"last_seen"`
+	Windows   []TopologyWindow `json:"windows"`
+}
+
+// TopologyOperation is one (service, operation) and its retained windows.
+type TopologyOperation struct {
+	Service   string           `json:"service"`
+	Operation string           `json:"operation"`
+	FirstSeen time.Time        `json:"first_seen"`
+	LastSeen  time.Time        `json:"last_seen"`
+	Windows   []TopologyWindow `json:"windows"`
+}
+
+// TopologyEdge is one caller/callee service pair and its retained windows.
+type TopologyEdge struct {
+	Caller    string           `json:"caller"`
+	Callee    string           `json:"callee"`
+	FirstSeen time.Time        `json:"first_seen"`
+	LastSeen  time.Time        `json:"last_seen"`
+	Windows   []TopologyWindow `json:"windows"`
+}
+
+// TopologyMetric is one (service, metric) series and its retained windows.
+type TopologyMetric struct {
+	Service   string           `json:"service"`
+	Metric    string           `json:"metric"`
+	FirstSeen time.Time        `json:"first_seen"`
+	LastSeen  time.Time        `json:"last_seen"`
+	Windows   []TopologyWindow `json:"windows"`
+}
+
+// TopologySnapshot is one tenant's replacement-by-revision topology view.
+//
+// Revision is the engine revision at the last fold that CHANGED this tenant.
+// A consumer that already applied the same (Epoch, Revision) pair must do
+// nothing. Epoch changes when the engine's identity resets — a restart — after
+// which Revision starts over and the consumer must replace rather than
+// reconcile.
+type TopologySnapshot struct {
+	Tenant   string    `json:"tenant"`
+	Epoch    uint64    `json:"epoch"`
+	Revision uint64    `json:"revision"`
+	Now      time.Time `json:"now"`
+
+	Horizon time.Duration `json:"horizon"`
+
+	Services   []TopologyService   `json:"services"`
+	Operations []TopologyOperation `json:"operations"`
+	Edges      []TopologyEdge      `json:"edges"`
+	Metrics    []TopologyMetric    `json:"metrics"`
+
+	// Dropped* count facts refused by the projection caps since startup.
+	// Non-zero means the topology is truncated and must be presented as such.
+	DroppedServices   uint64 `json:"dropped_services,omitempty"`
+	DroppedOperations uint64 `json:"dropped_operations,omitempty"`
+	DroppedEdges      uint64 `json:"dropped_edges,omitempty"`
+	DroppedMetrics    uint64 `json:"dropped_metrics,omitempty"`
+}
+
+// Truncated reports whether any projection cap has refused a fact for this
+// tenant. A consumer must not present a truncated topology as complete.
+func (s TopologySnapshot) Truncated() bool {
+	return s.DroppedServices+s.DroppedOperations+s.DroppedEdges+s.DroppedMetrics > 0
+}
+
+// Empty reports whether the snapshot carries no topology at all.
+func (s TopologySnapshot) Empty() bool {
+	return len(s.Services) == 0 && len(s.Operations) == 0 && len(s.Edges) == 0 && len(s.Metrics) == 0
+}
+
+// --- internal state ---
+
+// topoKind selects which maps a fact lands in.
+type topoKind uint8
+
+const (
+	// topoTrace is a per-operation trace series. It folds into BOTH the
+	// service entry and the (service, operation) entry: a service's counters
+	// are the sum over its operations, computed once here rather than twice
+	// in the reducer.
+	topoTrace topoKind = iota
+	// topoEdge is a caller/callee service pair.
+	topoEdge
+	// topoMetric is a (service, metric) series.
+	topoMetric
+)
+
+// topoIdentity is the string identity of one reduced series, recorded by the
+// reducer alongside its delta so the projection never reverses a dictionary ID.
+type topoIdentity struct {
+	Kind topoKind
+	// Tenant is the tenant name. The series key carries only the interned
+	// tenant ID, and the projection is keyed by name so a consumer never has
+	// to resolve one.
+	Tenant string
+	// A is the service for services, operations and metrics, and the CALLER
+	// for edges. B is the operation, metric name, or CALLEE.
+	A string
+	B string
+}
+
+type topoPair struct{ a, b string }
+
+type topoWindowState struct {
+	count      uint64
+	errors     uint64
+	durCount   uint64
+	durSum     float64
+	durMin     float64
+	durMax     float64
+	sketch     *Sketch
+	valueCount uint64
+	valueSum   float64
+	valueMin   float64
+	valueMax   float64
+}
+
+type topoEntry struct {
+	first   time.Time
+	last    time.Time
+	windows map[int64]*topoWindowState
+}
+
+func newTopoEntry() *topoEntry {
+	return &topoEntry{windows: make(map[int64]*topoWindowState, 4)}
+}
+
+type tenantTopology struct {
+	services map[string]*topoEntry
+	ops      map[topoPair]*topoEntry
+	edges    map[topoPair]*topoEntry
+	metrics  map[topoPair]*topoEntry
+
+	opsPerService map[string]int
+
+	revision uint64
+
+	droppedServices   uint64
+	droppedOperations uint64
+	droppedEdges      uint64
+	droppedMetrics    uint64
+}
+
+func newTenantTopology() *tenantTopology {
+	return &tenantTopology{
+		services:      make(map[string]*topoEntry),
+		ops:           make(map[topoPair]*topoEntry),
+		edges:         make(map[topoPair]*topoEntry),
+		metrics:       make(map[topoPair]*topoEntry),
+		opsPerService: make(map[string]int),
+	}
+}
+
+// topologyProjection is the engine's per-tenant topology state. One mutex
+// guards the whole projection: folding happens once per Export (a handful of
+// map writes per reduced delta, not per point) and snapshots once per consumer
+// tick, so contention is nowhere near the shard path's.
+type topologyProjection struct {
+	cfg   TopologyConfig
+	epoch uint64
+
+	mu      sync.Mutex
+	tenants map[string]*tenantTopology
+}
+
+func newTopologyProjection(cfg TopologyConfig, epoch uint64) *topologyProjection {
+	return &topologyProjection{
+		cfg:     cfg.withDefaults(),
+		epoch:   epoch,
+		tenants: make(map[string]*tenantTopology),
+	}
+}
+
+// fold merges one reduced Export request into the projection. revision is the
+// engine revision the deltas were applied under; a tenant's snapshot revision
+// advances only when one of its facts actually landed.
+func (p *topologyProjection) fold(now time.Time, revision uint64, ids map[SeriesWindowKey]topoIdentity, deltas DeltaMap) {
+	if len(ids) == 0 {
+		return
+	}
+	cutoff := p.retainCutoff(now)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	touched := make(map[*tenantTopology]struct{}, 1)
+	for swk, id := range ids {
+		d, ok := deltas[swk]
+		if !ok || d == nil {
+			continue
+		}
+		if swk.WindowStart < cutoff {
+			continue
+		}
+		tt := p.tenants[id.Tenant]
+		if tt == nil {
+			tt = newTenantTopology()
+			p.tenants[id.Tenant] = tt
+		}
+		if p.foldOne(tt, id, swk.WindowStart, d) {
+			touched[tt] = struct{}{}
+		}
+	}
+	for tt := range touched {
+		tt.revision = revision
+		p.pruneTenantLocked(tt, cutoff)
+	}
+}
+
+func (p *topologyProjection) retainCutoff(now time.Time) int64 {
+	return WindowStart(now.Add(-p.cfg.Horizon)) - int64(WindowSize/time.Second) - int64(AllowedLateness/time.Second)
+}
+
+// foldOne merges one delta into every entity its identity names, enforcing the
+// caps. It reports whether the projection actually changed.
+func (p *topologyProjection) foldOne(tt *tenantTopology, id topoIdentity, window int64, d *AggregateDelta) bool {
+	changed := false
+	switch id.Kind {
+	case topoTrace:
+		if e, ok := p.serviceEntry(tt, id.A); ok {
+			// Services carry the latency sketch: percentile detection needs
+			// one, and one per service per window is the bound that keeps
+			// 512 services affordable at 2 KiB a sketch.
+			foldEntry(e, window, d, true)
+			changed = true
+		}
+		if id.B != "" {
+			if e, ok := p.operationEntry(tt, id.A, id.B); ok {
+				foldEntry(e, window, d, false)
+				changed = true
+			}
+		}
+	case topoEdge:
+		if e, ok := p.edgeEntry(tt, id.A, id.B); ok {
+			foldEntry(e, window, d, false)
+			changed = true
+		}
+	case topoMetric:
+		if e, ok := p.metricEntry(tt, id.A, id.B); ok {
+			foldEntry(e, window, d, false)
+			changed = true
+		}
+	}
+	return changed
+}
+
+// foldEntry merges one delta into one entity's window bucket.
+func foldEntry(entry *topoEntry, window int64, d *AggregateDelta, withSketch bool) {
+	w := entry.windows[window]
+	if w == nil {
+		w = &topoWindowState{}
+		entry.windows[window] = w
+	}
+	mergeTopoWindow(w, d, withSketch)
+	touchTimes(entry, d, window)
+}
+
+func (p *topologyProjection) serviceEntry(tt *tenantTopology, service string) (*topoEntry, bool) {
+	if e, ok := tt.services[service]; ok {
+		return e, true
+	}
+	if len(tt.services) >= p.cfg.MaxServices {
+		tt.droppedServices++
+		return nil, false
+	}
+	e := newTopoEntry()
+	tt.services[service] = e
+	return e, true
+}
+
+func (p *topologyProjection) operationEntry(tt *tenantTopology, service, operation string) (*topoEntry, bool) {
+	key := topoPair{service, operation}
+	if e, ok := tt.ops[key]; ok {
+		return e, true
+	}
+	if tt.opsPerService[service] >= p.cfg.MaxOperationsPerService {
+		tt.droppedOperations++
+		return nil, false
+	}
+	e := newTopoEntry()
+	tt.ops[key] = e
+	tt.opsPerService[service]++
+	return e, true
+}
+
+func (p *topologyProjection) edgeEntry(tt *tenantTopology, caller, callee string) (*topoEntry, bool) {
+	key := topoPair{caller, callee}
+	if e, ok := tt.edges[key]; ok {
+		return e, true
+	}
+	if len(tt.edges) >= p.cfg.MaxEdges {
+		tt.droppedEdges++
+		return nil, false
+	}
+	e := newTopoEntry()
+	tt.edges[key] = e
+	return e, true
+}
+
+func (p *topologyProjection) metricEntry(tt *tenantTopology, service, metric string) (*topoEntry, bool) {
+	key := topoPair{service, metric}
+	if e, ok := tt.metrics[key]; ok {
+		return e, true
+	}
+	if len(tt.metrics) >= p.cfg.MaxMetrics {
+		tt.droppedMetrics++
+		return nil, false
+	}
+	e := newTopoEntry()
+	tt.metrics[key] = e
+	return e, true
+}
+
+// mergeTopoWindow folds a delta's aggregates into one window bucket. withSketch
+// is true only for services: percentile detection needs a sketch, and one per
+// service per window is the bound that keeps 512 services affordable.
+func mergeTopoWindow(w *topoWindowState, d *AggregateDelta, withSketch bool) {
+	w.count += d.Count
+	w.errors += d.ErrorCount
+	if d.DurationCount > 0 {
+		if w.durCount == 0 || d.DurationMin < w.durMin {
+			w.durMin = d.DurationMin
+		}
+		if w.durCount == 0 || d.DurationMax > w.durMax {
+			w.durMax = d.DurationMax
+		}
+		w.durCount += d.DurationCount
+		w.durSum += d.DurationSum
+		if withSketch && d.Sketch != nil {
+			if w.sketch == nil {
+				w.sketch = NewSketch()
+			}
+			w.sketch.Merge(d.Sketch)
+		}
+	}
+	if d.GaugeCount > 0 {
+		if w.valueCount == 0 || d.GaugeMin < w.valueMin {
+			w.valueMin = d.GaugeMin
+		}
+		if w.valueCount == 0 || d.GaugeMax > w.valueMax {
+			w.valueMax = d.GaugeMax
+		}
+		w.valueCount += d.GaugeCount
+		w.valueSum += d.GaugeSum
+	} else if d.CounterDelta != 0 {
+		// A counter contributes one observation per window: its increase.
+		// Min/max track the per-fold increase, which is what a rolling
+		// baseline over windows compares.
+		if w.valueCount == 0 || d.CounterDelta < w.valueMin {
+			w.valueMin = d.CounterDelta
+		}
+		if w.valueCount == 0 || d.CounterDelta > w.valueMax {
+			w.valueMax = d.CounterDelta
+		}
+		w.valueCount++
+		w.valueSum += d.CounterDelta
+	}
+}
+
+// touchTimes advances an entry's first/last seen. Log deltas carry real
+// timestamps; span and metric deltas do not, so the window bounds stand in.
+func touchTimes(entry *topoEntry, d *AggregateDelta, window int64) {
+	first := d.FirstTimestamp
+	last := d.LastTimestamp
+	if first.IsZero() {
+		first = time.Unix(window, 0).UTC()
+	}
+	if last.IsZero() {
+		last = time.Unix(window+int64(WindowSize/time.Second), 0).UTC()
+	}
+	if entry.first.IsZero() || first.Before(entry.first) {
+		entry.first = first
+	}
+	if last.After(entry.last) {
+		entry.last = last
+	}
+}
+
+// pruneTenantLocked drops windows behind the retention cutoff and forgets
+// entities that no longer hold any window.
+func (p *topologyProjection) pruneTenantLocked(tt *tenantTopology, cutoff int64) {
+	for name, e := range tt.services {
+		if pruneEntry(e, cutoff) {
+			delete(tt.services, name)
+		}
+	}
+	for key, e := range tt.ops {
+		if pruneEntry(e, cutoff) {
+			delete(tt.ops, key)
+			if n := tt.opsPerService[key.a]; n > 1 {
+				tt.opsPerService[key.a] = n - 1
+			} else {
+				delete(tt.opsPerService, key.a)
+			}
+		}
+	}
+	for key, e := range tt.edges {
+		if pruneEntry(e, cutoff) {
+			delete(tt.edges, key)
+		}
+	}
+	for key, e := range tt.metrics {
+		if pruneEntry(e, cutoff) {
+			delete(tt.metrics, key)
+		}
+	}
+}
+
+// pruneEntry drops expired windows and reports whether the entry is now empty.
+func pruneEntry(e *topoEntry, cutoff int64) bool {
+	for start := range e.windows {
+		if start < cutoff {
+			delete(e.windows, start)
+		}
+	}
+	return len(e.windows) == 0
+}
+
+// Prune drops windows past the retention horizon for every tenant. The fold
+// path prunes the tenants it touches; this is what keeps a tenant that has gone
+// silent from holding its last windows forever.
+func (p *topologyProjection) Prune(now time.Time) {
+	cutoff := p.retainCutoff(now)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for tenant, tt := range p.tenants {
+		p.pruneTenantLocked(tt, cutoff)
+		if len(tt.services) == 0 && len(tt.ops) == 0 && len(tt.edges) == 0 && len(tt.metrics) == 0 {
+			delete(p.tenants, tenant)
+		}
+	}
+}
+
+// Tenants returns the tenants the projection currently holds topology for.
+func (p *topologyProjection) Tenants() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, 0, len(p.tenants))
+	for tenant := range p.tenants {
+		out = append(out, tenant)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Revision returns the revision of a tenant's topology without building a
+// snapshot, so a consumer can skip an unchanged tenant for the cost of one map
+// lookup.
+func (p *topologyProjection) Revision(tenant string) uint64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if tt, ok := p.tenants[tenant]; ok {
+		return tt.revision
+	}
+	return 0
+}
+
+// Snapshot renders one tenant's topology. The result shares nothing with the
+// projection: every window is copied by value and percentiles are read out of
+// the sketch here, so the consumer never touches engine state.
+func (p *topologyProjection) Snapshot(tenant string, now time.Time) TopologySnapshot {
+	snap := TopologySnapshot{
+		Tenant:  tenant,
+		Epoch:   p.epoch,
+		Now:     now,
+		Horizon: p.cfg.Horizon,
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	tt, ok := p.tenants[tenant]
+	if !ok {
+		return snap
+	}
+	snap.Revision = tt.revision
+	snap.DroppedServices = tt.droppedServices
+	snap.DroppedOperations = tt.droppedOperations
+	snap.DroppedEdges = tt.droppedEdges
+	snap.DroppedMetrics = tt.droppedMetrics
+
+	snap.Services = make([]TopologyService, 0, len(tt.services))
+	for name, e := range tt.services {
+		snap.Services = append(snap.Services, TopologyService{
+			Name:      name,
+			FirstSeen: e.first,
+			LastSeen:  e.last,
+			Windows:   renderWindows(e, now),
+		})
+	}
+	sort.Slice(snap.Services, func(i, j int) bool { return snap.Services[i].Name < snap.Services[j].Name })
+
+	snap.Operations = make([]TopologyOperation, 0, len(tt.ops))
+	for key, e := range tt.ops {
+		snap.Operations = append(snap.Operations, TopologyOperation{
+			Service:   key.a,
+			Operation: key.b,
+			FirstSeen: e.first,
+			LastSeen:  e.last,
+			Windows:   renderWindows(e, now),
+		})
+	}
+	sort.Slice(snap.Operations, func(i, j int) bool {
+		if snap.Operations[i].Service != snap.Operations[j].Service {
+			return snap.Operations[i].Service < snap.Operations[j].Service
+		}
+		return snap.Operations[i].Operation < snap.Operations[j].Operation
+	})
+
+	snap.Edges = make([]TopologyEdge, 0, len(tt.edges))
+	for key, e := range tt.edges {
+		snap.Edges = append(snap.Edges, TopologyEdge{
+			Caller:    key.a,
+			Callee:    key.b,
+			FirstSeen: e.first,
+			LastSeen:  e.last,
+			Windows:   renderWindows(e, now),
+		})
+	}
+	sort.Slice(snap.Edges, func(i, j int) bool {
+		if snap.Edges[i].Caller != snap.Edges[j].Caller {
+			return snap.Edges[i].Caller < snap.Edges[j].Caller
+		}
+		return snap.Edges[i].Callee < snap.Edges[j].Callee
+	})
+
+	snap.Metrics = make([]TopologyMetric, 0, len(tt.metrics))
+	for key, e := range tt.metrics {
+		snap.Metrics = append(snap.Metrics, TopologyMetric{
+			Service:   key.a,
+			Metric:    key.b,
+			FirstSeen: e.first,
+			LastSeen:  e.last,
+			Windows:   renderWindows(e, now),
+		})
+	}
+	sort.Slice(snap.Metrics, func(i, j int) bool {
+		if snap.Metrics[i].Service != snap.Metrics[j].Service {
+			return snap.Metrics[i].Service < snap.Metrics[j].Service
+		}
+		return snap.Metrics[i].Metric < snap.Metrics[j].Metric
+	})
+
+	return snap
+}
+
+// renderWindows copies one entry's windows, oldest first, stamping the
+// closed/final/elapsed metadata the partial-window guard reads.
+func renderWindows(e *topoEntry, now time.Time) []TopologyWindow {
+	starts := make([]int64, 0, len(e.windows))
+	for start := range e.windows {
+		starts = append(starts, start)
+	}
+	sort.Slice(starts, func(i, j int) bool { return starts[i] < starts[j] })
+
+	out := make([]TopologyWindow, 0, len(starts))
+	for _, start := range starts {
+		w := e.windows[start]
+		tw := TopologyWindow{
+			Start:             time.Unix(start, 0).UTC(),
+			End:               time.Unix(start+int64(WindowSize/time.Second), 0).UTC(),
+			Count:             w.count,
+			ErrorCount:        w.errors,
+			DurationCount:     w.durCount,
+			DurationSumMicros: w.durSum,
+			DurationMinMicros: w.durMin,
+			DurationMaxMicros: w.durMax,
+			ValueCount:        w.valueCount,
+			ValueSum:          w.valueSum,
+			ValueMin:          w.valueMin,
+			ValueMax:          w.valueMax,
+		}
+		tw.Closed = !now.Before(tw.End)
+		tw.Final = now.Unix() >= start+int64(WindowSize/time.Second)+int64(AllowedLateness/time.Second)
+		if tw.Closed {
+			tw.Elapsed = WindowSize
+		} else if el := now.Sub(tw.Start); el > 0 {
+			tw.Elapsed = el
+		}
+		if w.sketch != nil && w.sketch.Count() > 0 {
+			tw.P95Micros = w.sketch.Quantile(0.95)
+			tw.P99Micros = w.sketch.Quantile(0.99)
+		}
+		out = append(out, tw)
+	}
+	return out
+}

--- a/internal/aggregate/topology.go
+++ b/internal/aggregate/topology.go
@@ -151,8 +151,8 @@ type TopologyOperation struct {
 	Windows   []TopologyWindow `json:"windows"`
 }
 
-// TopologyEdge is one caller/callee service pair and its retained windows.
-type TopologyEdge struct {
+// SnapshotEdge is one caller/callee service pair and its retained windows.
+type SnapshotEdge struct {
 	Caller    string           `json:"caller"`
 	Callee    string           `json:"callee"`
 	FirstSeen time.Time        `json:"first_seen"`
@@ -186,7 +186,7 @@ type TopologySnapshot struct {
 
 	Services   []TopologyService   `json:"services"`
 	Operations []TopologyOperation `json:"operations"`
-	Edges      []TopologyEdge      `json:"edges"`
+	Edges      []SnapshotEdge      `json:"edges"`
 	Metrics    []TopologyMetric    `json:"metrics"`
 
 	// Dropped* count facts refused by the projection caps since startup.
@@ -644,9 +644,9 @@ func (p *topologyProjection) Snapshot(tenant string, now time.Time) TopologySnap
 		return snap.Operations[i].Operation < snap.Operations[j].Operation
 	})
 
-	snap.Edges = make([]TopologyEdge, 0, len(tt.edges))
+	snap.Edges = make([]SnapshotEdge, 0, len(tt.edges))
 	for key, e := range tt.edges {
-		snap.Edges = append(snap.Edges, TopologyEdge{
+		snap.Edges = append(snap.Edges, SnapshotEdge{
 			Caller:    key.a,
 			Callee:    key.b,
 			FirstSeen: e.first,

--- a/internal/aggregate/topology_test.go
+++ b/internal/aggregate/topology_test.go
@@ -1,0 +1,225 @@
+package aggregate
+
+import (
+	"testing"
+	"time"
+)
+
+// reduceSpanAt folds one span into r at ts.
+func reduceSpanAt(r *Reducer, tenant, service, op string, status int32, durMicros float64, ts time.Time) {
+	r.ReduceSpan(SpanInput{
+		Tenant:         tenant,
+		Service:        service,
+		SpanName:       op,
+		StatusCode:     status,
+		Timestamp:      ts,
+		DurationMicros: durMicros,
+	})
+}
+
+func findService(t *testing.T, snap TopologySnapshot, name string) TopologyService {
+	t.Helper()
+	for _, s := range snap.Services {
+		if s.Name == name {
+			return s
+		}
+	}
+	t.Fatalf("service %q not in snapshot %+v", name, snap.Services)
+	return TopologyService{}
+}
+
+func totalCount(windows []TopologyWindow) (count, errors uint64) {
+	for _, w := range windows {
+		count += w.Count
+		errors += w.ErrorCount
+	}
+	return count, errors
+}
+
+// TestTopologySnapshotCarriesServicesOperationsAndEdges proves the projection
+// records all three entity kinds from a single Export, with the edge derived
+// from a caller the reducer was handed explicitly.
+func TestTopologySnapshotCarriesServicesOperationsAndEdges(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:02:00Z")
+	e := testEngine(t, now)
+
+	r := e.NewReducer(now)
+	reduceSpanAt(r, "acme", "checkout", "/pay", 0, 5000, now)
+	reduceSpanAt(r, "acme", "checkout", "/pay", 2, 9000, now)
+	r.ReduceEdge(EdgeInput{
+		Tenant: "acme", Caller: "gateway", Callee: "checkout",
+		SpanName: "/pay", Timestamp: now, DurationMicros: 5000,
+	})
+	if _, err := e.ApplyReducerErr(r); err != nil {
+		t.Fatalf("ApplyReducerErr: %v", err)
+	}
+
+	snap := e.TopologySnapshot("acme")
+	if snap.Revision == 0 {
+		t.Fatalf("snapshot revision did not advance: %+v", snap)
+	}
+	svc := findService(t, snap, "checkout")
+	count, errs := totalCount(svc.Windows)
+	if count != 2 || errs != 1 {
+		t.Fatalf("checkout totals = (%d, %d), want (2, 1)", count, errs)
+	}
+	if len(snap.Operations) != 1 || snap.Operations[0].Operation != "/pay" {
+		t.Fatalf("operations = %+v, want one /pay entry", snap.Operations)
+	}
+	if len(snap.Edges) != 1 || snap.Edges[0].Caller != "gateway" || snap.Edges[0].Callee != "checkout" {
+		t.Fatalf("edges = %+v, want one gateway->checkout entry", snap.Edges)
+	}
+	if snap.Truncated() {
+		t.Fatalf("snapshot reports truncation with generous caps: %+v", snap)
+	}
+}
+
+// TestTopologyRevisionUnchangedWithoutFacts proves an Export that produces no
+// topology facts does not move a tenant's revision — the property the GraphRAG
+// consumer's "skip unchanged revision" gate rests on.
+func TestTopologyRevisionUnchangedWithoutFacts(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:02:00Z")
+	e := testEngine(t, now)
+
+	r := e.NewReducer(now)
+	reduceSpanAt(r, "acme", "checkout", "/pay", 0, 1000, now)
+	if _, err := e.ApplyReducerErr(r); err != nil {
+		t.Fatalf("ApplyReducerErr: %v", err)
+	}
+	first := e.TopologyRevision("acme")
+
+	// A second Export carrying only another tenant's traffic must not move
+	// acme's revision, even though the engine revision advances.
+	r2 := e.NewReducer(now)
+	reduceSpanAt(r2, "other", "billing", "/charge", 0, 1000, now)
+	if _, err := e.ApplyReducerErr(r2); err != nil {
+		t.Fatalf("ApplyReducerErr: %v", err)
+	}
+	if got := e.TopologyRevision("acme"); got != first {
+		t.Fatalf("acme revision moved on another tenant's traffic: %d -> %d", first, got)
+	}
+	if e.TopologyRevision("other") == 0 {
+		t.Fatalf("other tenant revision did not advance")
+	}
+}
+
+// TestTopologyLatePointsExcludedFromProjection proves the projection honours
+// the same lateness horizon the shards do: a point the reducer excluded never
+// reaches the topology.
+func TestTopologyLatePointsExcludedFromProjection(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:02:00Z")
+	e := testEngine(t, now)
+
+	r := e.NewReducer(now)
+	reduceSpanAt(r, "acme", "checkout", "/pay", 0, 1000, now.Add(-2*time.Hour))
+	if _, err := e.ApplyReducerErr(r); err != nil {
+		t.Fatalf("ApplyReducerErr: %v", err)
+	}
+	if snap := e.TopologySnapshot("acme"); !snap.Empty() {
+		t.Fatalf("late point entered the topology: %+v", snap)
+	}
+}
+
+// TestTopologyPartialWindowMetadata proves a still-open window reports Closed
+// false with a real Elapsed, and a window past the lateness horizon reports
+// Final. This metadata is the entire partial-window guard.
+func TestTopologyPartialWindowMetadata(t *testing.T) {
+	start := mustTime(t, "2026-08-21T12:00:00Z")
+	clock := start.Add(2 * time.Minute)
+	e, err := NewEngine(EngineConfig{Mode: ModeShadow, Now: func() time.Time { return clock }})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	r := e.NewReducer(clock)
+	reduceSpanAt(r, "acme", "checkout", "/pay", 0, 1000, clock)
+	if _, err := e.ApplyReducerErr(r); err != nil {
+		t.Fatalf("ApplyReducerErr: %v", err)
+	}
+
+	svc := findService(t, e.TopologySnapshot("acme"), "checkout")
+	w := svc.Windows[len(svc.Windows)-1]
+	if w.Closed || w.Final {
+		t.Fatalf("window reported closed/final while still open: %+v", w)
+	}
+	if w.Elapsed != 2*time.Minute {
+		t.Fatalf("elapsed = %v, want 2m", w.Elapsed)
+	}
+
+	// Advance past window end + lateness: the same window is now final.
+	clock = start.Add(WindowSize + AllowedLateness + time.Minute)
+	svc = findService(t, e.TopologySnapshot("acme"), "checkout")
+	w = svc.Windows[0]
+	if !w.Closed || !w.Final {
+		t.Fatalf("window not closed/final past the lateness horizon: %+v", w)
+	}
+	if w.Elapsed != WindowSize {
+		t.Fatalf("closed window elapsed = %v, want %v", w.Elapsed, WindowSize)
+	}
+}
+
+// TestTopologyServiceCapTruncatesAndReports proves the projection caps are
+// enforced and that breaching one is REPORTED rather than silently producing a
+// partial topology a consumer would present as complete.
+func TestTopologyServiceCapTruncatesAndReports(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:02:00Z")
+	e, err := NewEngine(EngineConfig{
+		Mode:     ModeShadow,
+		Now:      func() time.Time { return now },
+		Topology: TopologyConfig{MaxServices: 2},
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	r := e.NewReducer(now)
+	for _, svc := range []string{"a", "b", "c", "d"} {
+		reduceSpanAt(r, "acme", svc, "/op", 0, 1000, now)
+	}
+	if _, err := e.ApplyReducerErr(r); err != nil {
+		t.Fatalf("ApplyReducerErr: %v", err)
+	}
+	snap := e.TopologySnapshot("acme")
+	if len(snap.Services) != 2 {
+		t.Fatalf("services = %d, want 2 (capped)", len(snap.Services))
+	}
+	if !snap.Truncated() || snap.DroppedServices == 0 {
+		t.Fatalf("cap breach not reported: %+v", snap)
+	}
+}
+
+// TestEdgeResolverJoinsParentToCaller proves the caller-resolution join: a
+// child span whose parent was seen in a different service resolves, a
+// same-service parent does not (an internal call is not a topology edge), and
+// an unknown parent does not invent one.
+func TestEdgeResolverJoinsParentToCaller(t *testing.T) {
+	r := NewEdgeResolver(1000)
+
+	if _, ok := r.Observe("acme", "parent-1", "", "gateway"); ok {
+		t.Fatalf("a root span resolved a caller")
+	}
+	caller, ok := r.Observe("acme", "child-1", "parent-1", "checkout")
+	if !ok || caller != "gateway" {
+		t.Fatalf("caller = (%q, %v), want (gateway, true)", caller, ok)
+	}
+	if _, ok := r.Observe("acme", "child-2", "parent-1", "gateway"); ok {
+		t.Fatalf("same-service parent produced an edge")
+	}
+	if _, ok := r.Observe("acme", "child-3", "unknown", "checkout"); ok {
+		t.Fatalf("unknown parent invented a caller")
+	}
+	// Tenant isolation: another tenant's span ID must not resolve.
+	if _, ok := r.Observe("other", "child-4", "parent-1", "checkout"); ok {
+		t.Fatalf("cross-tenant parent resolved")
+	}
+}
+
+// TestEdgeResolverEvictsPastCap proves the span memory is bounded.
+func TestEdgeResolverEvictsPastCap(t *testing.T) {
+	r := NewEdgeResolver(edgeResolverShards) // one slot per shard
+	for i := 0; i < 500; i++ {
+		r.Observe("acme", string(rune('a'+i%26))+string(rune('0'+i/26)), "", "svc")
+	}
+	if got := r.Len(); got > edgeResolverShards {
+		t.Fatalf("resolver held %d entries, cap is %d", got, edgeResolverShards)
+	}
+}

--- a/internal/graphrag/aggregate.go
+++ b/internal/graphrag/aggregate.go
@@ -1,0 +1,289 @@
+package graphrag
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+// Aggregate consumption (#174, decisions frozen in #163).
+//
+// In AGGREGATE_MODE=aggregate the in-memory service topology is no longer
+// derived from a 60-second rescan of the spans table. It is REPLACED from the
+// aggregate engine's per-tenant topology snapshot, keyed by revision:
+//
+//   - GraphRAG never queries the spans table (the ~27M-row/min scan at target
+//     load dies here) and never opens aggregate.db;
+//   - an unchanged revision is skipped outright;
+//   - a changed epoch — the engine restarted — replaces rather than reconciles,
+//     because the revision counter began again;
+//   - nothing is ever re-applied through incrementing upserts, which is what
+//     made the old rebuild multiply counters by the number of ticks a window
+//     survived.
+//
+// What the refresh loop keeps in aggregate mode: pruning, tenant eviction,
+// anomaly cleanup and investigation-cooldown maintenance. Nothing else.
+
+// AggregateSource is the read side of the aggregate engine that GraphRAG
+// consumes. It is an interface so the coordinator depends on the four calls it
+// makes rather than on the engine's whole surface, and so tests can drive
+// reconciliation without building a store.
+type AggregateSource interface {
+	// TopologyEpoch identifies the engine instance. A change means the
+	// revision counter restarted.
+	TopologyEpoch() uint64
+	// TopologyTenants lists the tenants the projection holds topology for.
+	TopologyTenants() []string
+	// TopologyRevision reports a tenant's revision without rendering a
+	// snapshot.
+	TopologyRevision(tenant string) uint64
+	// TopologySnapshot renders one tenant's topology.
+	TopologySnapshot(tenant string) aggregate.TopologySnapshot
+	// PruneTopology drops projection windows past the retention horizon.
+	PruneTopology()
+}
+
+// AggregateMode reports whether this coordinator consumes aggregate snapshots
+// instead of rebuilding from raw spans.
+func (g *GraphRAG) AggregateMode() bool { return g.mode == aggregate.ModeAggregate }
+
+// externalTemplates reports whether log templates are mined by the
+// ingest-owned miner rather than by GraphRAG's Drain. True in shadow and
+// aggregate modes so two template ID spaces never exist (#163).
+func (g *GraphRAG) externalTemplates() bool { return g.mode != aggregate.ModeLegacy }
+
+// SetAggregateSource wires the aggregate engine's topology projection. It is
+// only consulted in aggregate mode; wiring it in any other mode is a no-op by
+// construction, so main.go can call it unconditionally.
+func (g *GraphRAG) SetAggregateSource(src AggregateSource) { g.aggSource = src }
+
+// reconcileTopology replaces each tenant's service topology from the aggregate
+// snapshot whose revision it has not already applied. It is the aggregate-mode
+// stand-in for rebuildAllTenantsFromDB and issues no database query at all.
+func (g *GraphRAG) reconcileTopology() {
+	if !g.AggregateMode() || g.aggSource == nil {
+		return
+	}
+	epoch := g.aggSource.TopologyEpoch()
+	applied := 0
+	for _, tenant := range g.aggSource.TopologyTenants() {
+		if tenant == "" {
+			tenant = storage.DefaultTenantID
+		}
+		rev := g.aggSource.TopologyRevision(tenant)
+		// NoTouch: reconciliation is bookkeeping. It must not refresh the
+		// idle-eviction clock, or a dormant tenant would never age out.
+		stores := g.tenantStoresNoTouch(tenant)
+		if stores.topoEpoch.Load() == epoch && stores.topoRevision.Load() == rev {
+			continue
+		}
+		snap := g.aggSource.TopologySnapshot(tenant)
+		applyTopologySnapshot(stores, snap)
+		stores.topoEpoch.Store(snap.Epoch)
+		stores.topoRevision.Store(snap.Revision)
+		stores.lastTopology.Store(&snap)
+		applied++
+	}
+	g.aggSource.PruneTopology()
+	if applied > 0 {
+		slog.Debug("GraphRAG reconciled aggregate topology", "tenants", applied, "epoch", epoch)
+	}
+}
+
+// applyTopologySnapshot projects one snapshot onto a tenant's stores. Every
+// counter is an absolute value taken from the snapshot's retained windows, so
+// applying the same snapshot twice yields the same state.
+func applyTopologySnapshot(stores *tenantStores, snap aggregate.TopologySnapshot) {
+	services := make([]*ServiceNode, 0, len(snap.Services))
+	for _, svc := range snap.Services {
+		services = append(services, serviceNodeFrom(svc))
+	}
+	operations := make([]*OperationNode, 0, len(snap.Operations))
+	for _, op := range snap.Operations {
+		operations = append(operations, operationNodeFrom(op))
+	}
+	edges := make([]*Edge, 0, len(snap.Edges))
+	for _, e := range snap.Edges {
+		edges = append(edges, callEdgeFrom(e))
+	}
+	stores.service.ReplaceTopology(services, operations, edges)
+
+	metrics := make([]*MetricNode, 0, len(snap.Metrics))
+	for _, m := range snap.Metrics {
+		metrics = append(metrics, metricNodeFrom(m))
+	}
+	stores.signals.ReplaceMetrics(metrics)
+}
+
+// windowTotals sums a snapshot entity's retained windows into the absolute
+// counters a graph node carries.
+type windowTotals struct {
+	count      uint64
+	errors     uint64
+	durCount   uint64
+	durSumMs   float64
+	p95Ms      float64
+	p99Ms      float64
+	valueCount uint64
+	valueSum   float64
+	valueMin   float64
+	valueMax   float64
+}
+
+func totalsOf(windows []aggregate.TopologyWindow) windowTotals {
+	var t windowTotals
+	for i, w := range windows {
+		t.count += w.Count
+		t.errors += w.ErrorCount
+		t.durCount += w.DurationCount
+		t.durSumMs += w.DurationSumMicros / 1000.0
+		t.valueCount += w.ValueCount
+		t.valueSum += w.ValueSum
+		if i == 0 || w.ValueMin < t.valueMin {
+			t.valueMin = w.ValueMin
+		}
+		if i == 0 || w.ValueMax > t.valueMax {
+			t.valueMax = w.ValueMax
+		}
+		// Percentiles do not sum. The most recent window that carries a
+		// sketch is the current picture; older windows are baseline material
+		// for the anomaly detector, not for the node's displayed latency.
+		if w.P95Micros > 0 {
+			t.p95Ms = w.P95Micros / 1000.0
+		}
+		if w.P99Micros > 0 {
+			t.p99Ms = w.P99Micros / 1000.0
+		}
+	}
+	return t
+}
+
+func (t windowTotals) errorRate() float64 {
+	if t.count == 0 {
+		return 0
+	}
+	return float64(t.errors) / float64(t.count)
+}
+
+func (t windowTotals) avgLatencyMs() float64 {
+	if t.durCount == 0 {
+		return 0
+	}
+	return t.durSumMs / float64(t.durCount)
+}
+
+func serviceNodeFrom(svc aggregate.TopologyService) *ServiceNode {
+	t := totalsOf(svc.Windows)
+	node := &ServiceNode{
+		ID:         svc.Name,
+		Name:       svc.Name,
+		FirstSeen:  svc.FirstSeen,
+		LastSeen:   svc.LastSeen,
+		CallCount:  int64(t.count), // #nosec G115 -- counts are bounded by ingest volume
+		ErrorCount: int64(t.errors),
+		TotalMs:    t.durSumMs,
+	}
+	node.ErrorRate = t.errorRate()
+	node.AvgLatency = t.avgLatencyMs()
+	node.HealthScore = computeHealth(node.ErrorRate, node.AvgLatency)
+	return node
+}
+
+func operationNodeFrom(op aggregate.TopologyOperation) *OperationNode {
+	t := totalsOf(op.Windows)
+	node := &OperationNode{
+		ID:         op.Service + "|" + op.Operation,
+		Service:    op.Service,
+		Operation:  op.Operation,
+		FirstSeen:  op.FirstSeen,
+		LastSeen:   op.LastSeen,
+		CallCount:  int64(t.count), // #nosec G115 -- counts are bounded by ingest volume
+		ErrorCount: int64(t.errors),
+		TotalMs:    t.durSumMs,
+	}
+	node.ErrorRate = t.errorRate()
+	node.AvgLatency = t.avgLatencyMs()
+	node.HealthScore = computeHealth(node.ErrorRate, node.AvgLatency)
+	return node
+}
+
+func callEdgeFrom(e aggregate.TopologyEdge) *Edge {
+	t := totalsOf(e.Windows)
+	edge := &Edge{
+		Type:       EdgeCalls,
+		FromID:     e.Caller,
+		ToID:       e.Callee,
+		CallCount:  int64(t.count), // #nosec G115 -- counts are bounded by ingest volume
+		ErrorCount: int64(t.errors),
+		TotalMs:    t.durSumMs,
+		UpdatedAt:  e.LastSeen,
+	}
+	edge.ErrorRate = t.errorRate()
+	edge.AvgMs = t.avgLatencyMs()
+	edge.Weight = float64(edge.CallCount)
+	return edge
+}
+
+func metricNodeFrom(m aggregate.TopologyMetric) *MetricNode {
+	t := totalsOf(m.Windows)
+	node := &MetricNode{
+		ID:          m.Metric + "|" + m.Service,
+		MetricName:  m.Metric,
+		Service:     m.Service,
+		RollingMin:  t.valueMin,
+		RollingMax:  t.valueMax,
+		SampleCount: int64(t.valueCount), // #nosec G115 -- counts are bounded by ingest volume
+		LastSeen:    m.LastSeen,
+	}
+	if t.valueCount > 0 {
+		node.RollingAvg = t.valueSum / float64(t.valueCount)
+	}
+	return node
+}
+
+// OnTemplateFact consumes one ingest-mined log template fact. It is the
+// aggregate/shadow replacement for GraphRAG's own Drain miner: the template ID
+// is minted once, on the ingest path, so a template never has two identities
+// (#163).
+//
+// The miner calls this SYNCHRONOUSLY on the OTLP goroutine, once per log line,
+// so it must not take a store lock. It enqueues onto the same best-effort
+// channel every other ingest callback uses and returns; a full channel drops
+// the fact, exactly as a full channel drops a span.
+func (g *GraphRAG) OnTemplateFact(fact aggregate.TemplateFact) {
+	if g == nil || fact.Service == "" {
+		return
+	}
+	if fact.Tenant == "" {
+		fact.Tenant = storage.DefaultTenantID
+	}
+	if fact.Timestamp.IsZero() {
+		fact.Timestamp = time.Now()
+	}
+	select {
+	case g.eventCh <- event{tmpl: &fact}:
+	default:
+		g.recordEventDrop("log")
+	}
+}
+
+// processTemplateFact folds one template fact into its tenant's log clusters.
+// Runs on an event worker, never on the OTLP goroutine.
+func (g *GraphRAG) processTemplateFact(fact *aggregate.TemplateFact) {
+	stores := g.storesForTenant(fact.Tenant)
+	stores.lastEventAt.Store(time.Now().UnixNano())
+	clusterID := fmt.Sprintf("lc_%s_%x", fact.Service, fact.TemplateID)
+	stores.signals.UpsertLogClusterWithTemplate(
+		clusterID,
+		fact.Template,
+		fact.Severity,
+		fact.Service,
+		uint64(fact.TemplateID),
+		nil,
+		"",
+		fact.Timestamp,
+	)
+}

--- a/internal/graphrag/aggregate.go
+++ b/internal/graphrag/aggregate.go
@@ -210,7 +210,7 @@ func operationNodeFrom(op aggregate.TopologyOperation) *OperationNode {
 	return node
 }
 
-func callEdgeFrom(e aggregate.TopologyEdge) *Edge {
+func callEdgeFrom(e aggregate.SnapshotEdge) *Edge {
 	t := totalsOf(e.Windows)
 	edge := &Edge{
 		Type:       EdgeCalls,

--- a/internal/graphrag/aggregate_test.go
+++ b/internal/graphrag/aggregate_test.go
@@ -1,0 +1,330 @@
+package graphrag
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"gorm.io/gorm"
+)
+
+// fakeAggregateSource is a scripted AggregateSource. It counts snapshot renders
+// so a test can prove the revision gate actually skips work rather than merely
+// producing the same answer twice.
+type fakeAggregateSource struct {
+	epoch    uint64
+	snaps    map[string]aggregate.TopologySnapshot
+	renders  atomic.Int64
+	prunes   atomic.Int64
+	tenantsF func() []string
+}
+
+func (f *fakeAggregateSource) TopologyEpoch() uint64 { return f.epoch }
+
+func (f *fakeAggregateSource) TopologyTenants() []string {
+	if f.tenantsF != nil {
+		return f.tenantsF()
+	}
+	out := make([]string, 0, len(f.snaps))
+	for tenant := range f.snaps {
+		out = append(out, tenant)
+	}
+	return out
+}
+
+func (f *fakeAggregateSource) TopologyRevision(tenant string) uint64 {
+	return f.snaps[tenant].Revision
+}
+
+func (f *fakeAggregateSource) TopologySnapshot(tenant string) aggregate.TopologySnapshot {
+	f.renders.Add(1)
+	snap := f.snaps[tenant]
+	snap.Epoch = f.epoch
+	return snap
+}
+
+func (f *fakeAggregateSource) PruneTopology() { f.prunes.Add(1) }
+
+// aggWindow builds one finalized topology window.
+func aggWindow(start time.Time, count, errors uint64, p99Micros float64) aggregate.TopologyWindow {
+	return aggregate.TopologyWindow{
+		Start:             start,
+		End:               start.Add(aggregate.WindowSize),
+		Closed:            true,
+		Final:             true,
+		Elapsed:           aggregate.WindowSize,
+		Count:             count,
+		ErrorCount:        errors,
+		DurationCount:     count,
+		DurationSumMicros: float64(count) * 1000,
+		P95Micros:         p99Micros * 0.8,
+		P99Micros:         p99Micros,
+	}
+}
+
+// aggregateGraphRAG builds a coordinator in aggregate mode wired to src.
+func aggregateGraphRAG(t *testing.T, repo *storage.Repository, src AggregateSource) *GraphRAG {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.Mode = aggregate.ModeAggregate
+	g := New(repo, nil, nil, cfg)
+	g.SetAggregateSource(src)
+	t.Cleanup(g.Stop)
+	return g
+}
+
+func oneServiceSnapshot(revision uint64, count, errors uint64) aggregate.TopologySnapshot {
+	now := time.Now().UTC().Truncate(aggregate.WindowSize)
+	return aggregate.TopologySnapshot{
+		Tenant:   storage.DefaultTenantID,
+		Revision: revision,
+		Now:      now,
+		Services: []aggregate.TopologyService{{
+			Name:      "checkout",
+			FirstSeen: now,
+			LastSeen:  now.Add(aggregate.WindowSize),
+			Windows:   []aggregate.TopologyWindow{aggWindow(now, count, errors, 4000)},
+		}},
+		Operations: []aggregate.TopologyOperation{{
+			Service:   "checkout",
+			Operation: "/pay",
+			FirstSeen: now,
+			LastSeen:  now.Add(aggregate.WindowSize),
+			Windows:   []aggregate.TopologyWindow{aggWindow(now, count, errors, 4000)},
+		}},
+		Edges: []aggregate.TopologyEdge{{
+			Caller:    "gateway",
+			Callee:    "checkout",
+			FirstSeen: now,
+			LastSeen:  now.Add(aggregate.WindowSize),
+			Windows:   []aggregate.TopologyWindow{aggWindow(now, count, errors, 4000)},
+		}},
+	}
+}
+
+// TestReconcileReplacesRatherThanAccumulates is the whole point of
+// replacement-by-revision: re-applying the SAME snapshot must leave the
+// counters where they were. The old rebuild multiplied them by the number of
+// ticks a window survived.
+func TestReconcileReplacesRatherThanAccumulates(t *testing.T) {
+	src := &fakeAggregateSource{
+		epoch: 7,
+		snaps: map[string]aggregate.TopologySnapshot{
+			storage.DefaultTenantID: oneServiceSnapshot(1, 100, 5),
+		},
+	}
+	g := aggregateGraphRAG(t, newTestRepo(t), src)
+
+	g.reconcileTopology()
+	stores := g.storesForTenant(storage.DefaultTenantID)
+	svc, ok := stores.service.GetService("checkout")
+	if !ok || svc.CallCount != 100 || svc.ErrorCount != 5 {
+		t.Fatalf("after first reconcile: %+v, want CallCount 100 / ErrorCount 5", svc)
+	}
+
+	// Force a re-render of the identical snapshot by bumping only the epoch's
+	// revision bookkeeping on the consumer side.
+	stores.topoRevision.Store(0)
+	g.reconcileTopology()
+	svc, _ = stores.service.GetService("checkout")
+	if svc.CallCount != 100 || svc.ErrorCount != 5 {
+		t.Fatalf("identical snapshot accumulated: CallCount=%d ErrorCount=%d, want 100/5",
+			svc.CallCount, svc.ErrorCount)
+	}
+	if len(stores.service.AllEdges()) == 0 {
+		t.Fatalf("edges were lost by the replacement")
+	}
+}
+
+// TestReconcileSkipsUnchangedRevision proves an unchanged (epoch, revision)
+// pair costs one map lookup and renders nothing.
+func TestReconcileSkipsUnchangedRevision(t *testing.T) {
+	src := &fakeAggregateSource{
+		epoch: 7,
+		snaps: map[string]aggregate.TopologySnapshot{
+			storage.DefaultTenantID: oneServiceSnapshot(3, 10, 0),
+		},
+	}
+	g := aggregateGraphRAG(t, newTestRepo(t), src)
+
+	g.reconcileTopology()
+	if got := src.renders.Load(); got != 1 {
+		t.Fatalf("first reconcile rendered %d snapshots, want 1", got)
+	}
+	for i := 0; i < 5; i++ {
+		g.reconcileTopology()
+	}
+	if got := src.renders.Load(); got != 1 {
+		t.Fatalf("unchanged revision rendered %d snapshots, want 1", got)
+	}
+
+	// A moved revision is applied again.
+	src.snaps[storage.DefaultTenantID] = oneServiceSnapshot(4, 20, 1)
+	g.reconcileTopology()
+	if got := src.renders.Load(); got != 2 {
+		t.Fatalf("changed revision rendered %d snapshots, want 2", got)
+	}
+	svc, _ := g.storesForTenant(storage.DefaultTenantID).service.GetService("checkout")
+	if svc.CallCount != 20 {
+		t.Fatalf("CallCount = %d after revision 4, want 20", svc.CallCount)
+	}
+}
+
+// TestReconcileHandlesEpochReset proves a restarted engine — new epoch, revision
+// counter back to a LOWER number — is applied rather than skipped as "already
+// seen".
+func TestReconcileHandlesEpochReset(t *testing.T) {
+	src := &fakeAggregateSource{
+		epoch: 7,
+		snaps: map[string]aggregate.TopologySnapshot{
+			storage.DefaultTenantID: oneServiceSnapshot(99, 900, 9),
+		},
+	}
+	g := aggregateGraphRAG(t, newTestRepo(t), src)
+	g.reconcileTopology()
+	stores := g.storesForTenant(storage.DefaultTenantID)
+	if svc, _ := stores.service.GetService("checkout"); svc.CallCount != 900 {
+		t.Fatalf("pre-reset CallCount = %d, want 900", svc.CallCount)
+	}
+
+	// Engine restarted: new epoch, revision restarts at 1 with fresh counters.
+	src.epoch = 8
+	src.snaps[storage.DefaultTenantID] = oneServiceSnapshot(1, 12, 0)
+	g.reconcileTopology()
+
+	if stores.topoEpoch.Load() != 8 || stores.topoRevision.Load() != 1 {
+		t.Fatalf("consumer did not adopt the new epoch/revision: %d/%d",
+			stores.topoEpoch.Load(), stores.topoRevision.Load())
+	}
+	svc, _ := stores.service.GetService("checkout")
+	if svc.CallCount != 12 {
+		t.Fatalf("post-reset CallCount = %d, want 12 (replaced, not merged)", svc.CallCount)
+	}
+}
+
+// countSpanQueries registers a GORM callback that counts every query touching
+// the spans table and returns the counter.
+func countSpanQueries(t *testing.T, db *gorm.DB) *atomic.Int64 {
+	t.Helper()
+	var n atomic.Int64
+	err := db.Callback().Query().After("gorm:query").Register("test:count_span_scans", func(tx *gorm.DB) {
+		sql := strings.ToLower(tx.Statement.SQL.String())
+		if strings.Contains(sql, "`spans`") || strings.Contains(sql, " spans ") ||
+			strings.Contains(sql, "\"spans\"") || strings.EqualFold(tx.Statement.Table, "spans") {
+			n.Add(1)
+		}
+	})
+	if err != nil {
+		t.Fatalf("register query callback: %v", err)
+	}
+	return &n
+}
+
+// TestAggregateModeIssuesNoSpanQueries is the acceptance criterion: in
+// aggregate mode GraphRAG's refresh path must not touch the spans table at
+// all. The counter is proven non-vacuous by running the same assertion in
+// legacy mode, where it must fire.
+func TestAggregateModeIssuesNoSpanQueries(t *testing.T) {
+	ctx := context.Background()
+
+	repo := newTestRepo(t)
+	counter := countSpanQueries(t, repo.DB())
+	src := &fakeAggregateSource{
+		epoch: 1,
+		snaps: map[string]aggregate.TopologySnapshot{
+			storage.DefaultTenantID: oneServiceSnapshot(1, 50, 2),
+		},
+	}
+	g := aggregateGraphRAG(t, repo, src)
+	for i := 0; i < 10; i++ {
+		g.refreshTopology(ctx)
+	}
+	if got := counter.Load(); got != 0 {
+		t.Fatalf("aggregate mode issued %d spans-table queries, want 0", got)
+	}
+	if svc, ok := g.storesForTenant(storage.DefaultTenantID).service.GetService("checkout"); !ok || svc.CallCount != 50 {
+		t.Fatalf("aggregate topology was not applied: %+v", svc)
+	}
+
+	// Non-vacuity: the same driver in legacy mode DOES scan spans.
+	legacyRepo := newTestRepo(t)
+	legacyCounter := countSpanQueries(t, legacyRepo.DB())
+	legacy := New(legacyRepo, nil, nil, DefaultConfig())
+	t.Cleanup(legacy.Stop)
+	legacy.refreshTopology(ctx)
+	if legacyCounter.Load() == 0 {
+		t.Fatalf("legacy mode issued no spans-table queries; the counter is vacuous")
+	}
+}
+
+// TestAggregateModeSkipsPerSpanTopologyUpserts proves an exemplar span still
+// populates the trace store (so error chains work) without touching the
+// service topology the snapshot owns.
+func TestAggregateModeSkipsPerSpanTopologyUpserts(t *testing.T) {
+	src := &fakeAggregateSource{epoch: 1, snaps: map[string]aggregate.TopologySnapshot{}}
+	g := aggregateGraphRAG(t, newTestRepo(t), src)
+
+	now := time.Now()
+	g.processSpan(&spanEvent{
+		Tenant:  storage.DefaultTenantID,
+		TraceID: "t-1",
+		Status:  storage.StatusCodeError,
+		Span: storage.Span{
+			TenantID:      storage.DefaultTenantID,
+			TraceID:       "t-1",
+			SpanID:        "s-1",
+			ServiceName:   "checkout",
+			OperationName: "/pay",
+			StartTime:     now,
+			Duration:      1000,
+		},
+	})
+
+	stores := g.storesForTenant(storage.DefaultTenantID)
+	if _, ok := stores.service.GetService("checkout"); ok {
+		t.Fatalf("aggregate mode upserted a service node from a raw span")
+	}
+	if _, ok := stores.traces.GetSpan("s-1"); !ok {
+		t.Fatalf("exemplar span did not reach the trace store")
+	}
+}
+
+// TestOnTemplateFactPopulatesLogClusters proves the ingest-owned miner's facts
+// land as log clusters and that GraphRAG runs no miner of its own outside
+// legacy mode.
+func TestOnTemplateFactPopulatesLogClusters(t *testing.T) {
+	src := &fakeAggregateSource{epoch: 1, snaps: map[string]aggregate.TopologySnapshot{}}
+	g := aggregateGraphRAG(t, newTestRepo(t), src)
+	if g.drain != nil {
+		t.Fatalf("aggregate mode constructed a GraphRAG-owned Drain miner")
+	}
+
+	now := time.Now()
+	// The fact rides the event channel, so drain it on this goroutine rather
+	// than starting the worker pool.
+	g.OnTemplateFact(aggregate.TemplateFact{
+		Tenant:     storage.DefaultTenantID,
+		Service:    "checkout",
+		Severity:   "ERROR",
+		TemplateID: 42,
+		Template:   "payment <*> declined",
+		Timestamp:  now,
+	})
+	ev := <-g.eventCh
+	if ev.tmpl == nil {
+		t.Fatalf("template fact did not reach the event channel: %+v", ev)
+	}
+	g.processTemplateFact(ev.tmpl)
+
+	clusters := g.storesForTenant(storage.DefaultTenantID).signals.LogClustersForService("checkout")
+	if len(clusters) != 1 || clusters[0].Template != "payment <*> declined" {
+		t.Fatalf("template fact did not become a log cluster: %+v", clusters)
+	}
+	if clusters[0].TemplateID != 42 {
+		t.Fatalf("template ID = %d, want the ingest-minted 42", clusters[0].TemplateID)
+	}
+}

--- a/internal/graphrag/aggregate_test.go
+++ b/internal/graphrag/aggregate_test.go
@@ -96,7 +96,7 @@ func oneServiceSnapshot(revision uint64, count, errors uint64) aggregate.Topolog
 			LastSeen:  now.Add(aggregate.WindowSize),
 			Windows:   []aggregate.TopologyWindow{aggWindow(now, count, errors, 4000)},
 		}},
-		Edges: []aggregate.TopologyEdge{{
+		Edges: []aggregate.SnapshotEdge{{
 			Caller:    "gateway",
 			Callee:    "checkout",
 			FirstSeen: now,

--- a/internal/graphrag/anomaly.go
+++ b/internal/graphrag/anomaly.go
@@ -19,10 +19,23 @@ func (g *GraphRAG) detectAnomalies(ctx context.Context) {
 		// previous scan cannot have changed stats — skip the whole walk.
 		// The first scan after startup (prevScan == 0) always runs so
 		// DB-rebuilt state is examined at least once.
-		if prevScan != 0 && stores.lastEventAt.Load() < prevScan {
+		//
+		// Aggregate mode uses the topology revision instead: only retained
+		// exemplars reach the event path there, so a busy service can be
+		// event-quiet while its aggregate counters move.
+		if !g.AggregateMode() && prevScan != 0 && stores.lastEventAt.Load() < prevScan {
 			continue
 		}
 		tctx := storage.WithTenantContext(ctx, tenant)
+		if g.AggregateMode() {
+			// Aggregate mode: the detector reads the engine's topology
+			// snapshot and is gated on its revision (anomaly_aggregate.go).
+			// The legacy walk below is retired there along with its
+			// hard-coded 2% baseline, avg>500ms threshold and min/max
+			// pseudo-z-score (#163).
+			g.detectAnomaliesFromTopology(tctx, tenant, stores)
+			continue
+		}
 		g.detectAnomaliesForTenant(tctx, tenant, stores)
 	}
 }

--- a/internal/graphrag/anomaly_aggregate.go
+++ b/internal/graphrag/anomaly_aggregate.go
@@ -1,0 +1,316 @@
+package graphrag
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+)
+
+// Aggregate-mode anomaly detection (#163's "source change plus math
+// correction", implemented by #174).
+//
+// The legacy detector hard-coded a 2% error baseline, thresholded on average
+// latency above 500 ms, and called a min/max range calculation a z-score. None
+// of that survives here. What replaces it:
+//
+//   - reads happen only when the topology revision has moved;
+//   - error detection compares a window's error RATE against the rate of the
+//     prior FINALIZED windows, and fires only when the excess clears three
+//     standard errors of that baseline proportion — so a baseline of 0.4% and
+//     a baseline of 12% both behave correctly, and neither is written down
+//     anywhere;
+//   - latency detection reads p95/p99 out of the window's sketch, never an
+//     average;
+//   - metric anomalies use a real rolling mean and variance over a bounded
+//     finalized-window baseline;
+//   - the current, still-filling window has to clear an elapsed-time AND a
+//     count guard before it is compared to anything, which is what stops a
+//     near-empty window from producing a storm.
+//
+// The baseline horizon is whatever the engine's topology projection retains
+// (30 minutes by default). Startup never loads seven days of history because
+// there is no history to load: the projection is built from live traffic.
+
+const (
+	// minWindowRequests is the smallest request count a window must carry
+	// before its error rate or latency means anything at all.
+	minWindowRequests = 20
+	// minBaselineRequests is the smallest total request count the prior
+	// finalized windows must carry to serve as a baseline.
+	minBaselineRequests = 100
+	// minBaselineWindows is the smallest number of finalized windows a
+	// baseline is computed from. Two windows cannot describe variance.
+	minBaselineWindows = 2
+	// minPartialWindowFraction is how much of a still-open window must have
+	// elapsed before it is evaluated. A window one second old holds one
+	// second of traffic and says nothing about a five-minute rate.
+	minPartialWindowFraction = 0.25
+	// anomalySigma is how many standard errors (error rate) or standard
+	// deviations (latency, metrics) the current value must clear.
+	anomalySigma = 3.0
+)
+
+// detectAnomaliesFromTopology is the aggregate-mode detection pass for one
+// tenant. It reads the last applied topology snapshot and nothing else — no
+// database, no aggregate store.
+func (g *GraphRAG) detectAnomaliesFromTopology(ctx context.Context, tenant string, stores *tenantStores) {
+	snapPtr := stores.lastTopology.Load()
+	if snapPtr == nil {
+		return
+	}
+	snap := *snapPtr
+	// Revision gate: an unchanged topology cannot have produced a new
+	// anomaly, and re-running detection on it would only re-stamp timestamps.
+	if stores.anomalyRevision.Load() == snap.Revision {
+		return
+	}
+	stores.anomalyRevision.Store(snap.Revision)
+
+	now := time.Now()
+	for _, svc := range snap.Services {
+		g.detectServiceAnomalies(ctx, tenant, stores, svc, now)
+	}
+	for _, m := range snap.Metrics {
+		detectMetricAnomaly(stores, m, now)
+	}
+}
+
+// detectServiceAnomalies evaluates one service's error rate and latency.
+func (g *GraphRAG) detectServiceAnomalies(ctx context.Context, tenant string, stores *tenantStores, svc aggregate.TopologyService, now time.Time) {
+	current, baseline, ok := splitWindows(svc.Windows, now)
+	if !ok {
+		return
+	}
+
+	if a, fired := errorRateAnomaly(svc.Name, current, baseline, now); fired {
+		stores.anomalies.AddAnomaly(a)
+		correlateWithRecent(stores, a)
+
+		// Investigation trigger, unchanged from legacy: an error chain over
+		// the retained exemplars plus the service's recent anomalies.
+		chains := g.ErrorChain(ctx, svc.Name, now.Add(-5*time.Minute), 5)
+		if len(chains) > 0 {
+			anomalies := stores.anomalies.AnomaliesForService(svc.Name, now.Add(-1*time.Minute))
+			g.PersistInvestigation(tenant, svc.Name, chains, anomalies)
+		}
+	}
+
+	if a, fired := latencyAnomaly(svc.Name, current, baseline, now); fired {
+		stores.anomalies.AddAnomaly(a)
+		correlateWithRecent(stores, a)
+	}
+}
+
+// splitWindows separates the window to evaluate from the finalized windows that
+// form its baseline.
+//
+// The evaluated window is the most recent one that clears the partial-window
+// guard: fully closed windows always qualify, a still-open window only once
+// enough of it has elapsed AND it carries enough requests. Baseline windows are
+// strictly older and strictly finalized — a window still inside its lateness
+// horizon can still gain points and is not yet a fact.
+func splitWindows(windows []aggregate.TopologyWindow, now time.Time) (aggregate.TopologyWindow, []aggregate.TopologyWindow, bool) {
+	var current aggregate.TopologyWindow
+	idx := -1
+	for i := len(windows) - 1; i >= 0; i-- {
+		w := windows[i]
+		if w.Count < minWindowRequests {
+			continue
+		}
+		if !w.Closed && float64(w.Elapsed) < minPartialWindowFraction*float64(aggregate.WindowSize) {
+			continue
+		}
+		current, idx = w, i
+		break
+	}
+	if idx < 0 {
+		return current, nil, false
+	}
+	baseline := make([]aggregate.TopologyWindow, 0, idx)
+	for _, w := range windows[:idx] {
+		if w.Final {
+			baseline = append(baseline, w)
+		}
+	}
+	return current, baseline, true
+}
+
+// baselineErrorRate pools the prior finalized windows into one proportion.
+func baselineErrorRate(baseline []aggregate.TopologyWindow) (rate float64, n uint64, ok bool) {
+	if len(baseline) < minBaselineWindows {
+		return 0, 0, false
+	}
+	var errs uint64
+	for _, w := range baseline {
+		n += w.Count
+		errs += w.ErrorCount
+	}
+	if n < minBaselineRequests {
+		return 0, 0, false
+	}
+	return float64(errs) / float64(n), n, true
+}
+
+// errorRateAnomaly fires when a window's error rate exceeds the prior
+// finalized baseline by more than anomalySigma standard errors.
+//
+// The standard error is that of the baseline proportion measured over the
+// CURRENT window's sample size, which is what makes the test scale-free: a
+// jump from 0.4% to 1.2% over 5000 requests is significant, the same jump over
+// 25 requests is not, and no absolute threshold is written down anywhere.
+func errorRateAnomaly(service string, current aggregate.TopologyWindow, baseline []aggregate.TopologyWindow, now time.Time) (AnomalyNode, bool) {
+	p, baseN, ok := baselineErrorRate(baseline)
+	if !ok {
+		return AnomalyNode{}, false
+	}
+	rate := current.ErrorRate()
+	if rate <= p {
+		return AnomalyNode{}, false
+	}
+	stderr := math.Sqrt(p * (1 - p) / float64(current.Count))
+	if stderr <= 0 {
+		// A baseline of exactly zero errors has no spread; any error at all
+		// in a window that cleared the count guard is the signal.
+		if current.ErrorCount == 0 {
+			return AnomalyNode{}, false
+		}
+	} else if rate < p+anomalySigma*stderr {
+		return AnomalyNode{}, false
+	}
+
+	return AnomalyNode{
+		// Stable per (service, type): each pass UPSERTS the same evolving
+		// node rather than minting one per tick.
+		ID:       fmt.Sprintf("anom_%s_err", service),
+		Type:     AnomalyErrorSpike,
+		Severity: relativeSeverity(rate, p),
+		Service:  service,
+		Evidence: fmt.Sprintf(
+			"error rate %.2f%% over %d requests vs %.2f%% baseline over %d requests in %d finalized windows",
+			rate*100, current.Count, p*100, baseN, len(baseline),
+		),
+		Timestamp: now,
+	}, true
+}
+
+// latencyAnomaly fires when a window's p99 clears the mean plus anomalySigma
+// standard deviations of the prior finalized windows' p99s. Falls back to a
+// doubling test when the baseline has no spread at all.
+func latencyAnomaly(service string, current aggregate.TopologyWindow, baseline []aggregate.TopologyWindow, now time.Time) (AnomalyNode, bool) {
+	if current.P99Micros <= 0 {
+		return AnomalyNode{}, false
+	}
+	samples := make([]float64, 0, len(baseline))
+	for _, w := range baseline {
+		if w.P99Micros > 0 && w.Count >= minWindowRequests {
+			samples = append(samples, w.P99Micros)
+		}
+	}
+	if len(samples) < minBaselineWindows {
+		return AnomalyNode{}, false
+	}
+	mean, stddev := meanStdDev(samples)
+	threshold := mean + anomalySigma*stddev
+	if stddev == 0 {
+		threshold = mean * 2
+	}
+	if current.P99Micros <= threshold || mean <= 0 {
+		return AnomalyNode{}, false
+	}
+	return AnomalyNode{
+		ID:       fmt.Sprintf("anom_%s_lat", service),
+		Type:     AnomalyLatencySpike,
+		Severity: relativeSeverity(current.P99Micros, mean),
+		Service:  service,
+		Evidence: fmt.Sprintf(
+			"p99 %.0fms (p95 %.0fms) vs %.0fms baseline (sd %.0fms) over %d finalized windows",
+			current.P99Micros/1000, current.P95Micros/1000, mean/1000, stddev/1000, len(samples),
+		),
+		Timestamp: now,
+	}, true
+}
+
+// detectMetricAnomaly applies a rolling mean/variance z-score to one metric
+// series. This is a real z-score: mean and standard deviation of the prior
+// finalized windows' means, not a min/max range ratio.
+func detectMetricAnomaly(stores *tenantStores, m aggregate.TopologyMetric, now time.Time) {
+	var current aggregate.TopologyWindow
+	idx := -1
+	for i := len(m.Windows) - 1; i >= 0; i-- {
+		if m.Windows[i].ValueCount > 0 {
+			current, idx = m.Windows[i], i
+			break
+		}
+	}
+	if idx < 0 {
+		return
+	}
+	samples := make([]float64, 0, idx)
+	for _, w := range m.Windows[:idx] {
+		if w.Final && w.ValueCount > 0 {
+			samples = append(samples, w.Mean())
+		}
+	}
+	if len(samples) < minBaselineWindows {
+		return
+	}
+	mean, stddev := meanStdDev(samples)
+	if stddev <= 0 {
+		return
+	}
+	z := (current.Mean() - mean) / stddev
+	if math.Abs(z) < anomalySigma {
+		return
+	}
+	anomaly := AnomalyNode{
+		ID:       fmt.Sprintf("anom_%s_metric_%s", m.Service, m.Metric),
+		Type:     AnomalyMetricZScore,
+		Severity: SeverityWarning,
+		Service:  m.Service,
+		Evidence: fmt.Sprintf(
+			"metric %s z-score %.1f (window mean %.3f vs baseline %.3f, sd %.3f over %d finalized windows)",
+			m.Metric, z, current.Mean(), mean, stddev, len(samples),
+		),
+		Timestamp: now,
+	}
+	stores.anomalies.AddAnomaly(anomaly)
+	correlateWithRecent(stores, anomaly)
+}
+
+// meanStdDev returns the sample mean and population standard deviation.
+func meanStdDev(values []float64) (float64, float64) {
+	if len(values) == 0 {
+		return 0, 0
+	}
+	var sum float64
+	for _, v := range values {
+		sum += v
+	}
+	mean := sum / float64(len(values))
+	var sq float64
+	for _, v := range values {
+		d := v - mean
+		sq += d * d
+	}
+	return mean, math.Sqrt(sq / float64(len(values)))
+}
+
+// relativeSeverity grades how far a measurement sits above its own baseline.
+// It is deliberately relative: an absolute cut-off is exactly the hard-coded
+// threshold #163 removed.
+func relativeSeverity(current, baseline float64) AnomalySeverity {
+	if baseline <= 0 {
+		return SeverityWarning
+	}
+	switch ratio := current / baseline; {
+	case ratio >= 4:
+		return SeverityCritical
+	case ratio >= 2:
+		return SeverityWarning
+	default:
+		return SeverityInfo
+	}
+}

--- a/internal/graphrag/anomaly_aggregate_test.go
+++ b/internal/graphrag/anomaly_aggregate_test.go
@@ -1,0 +1,225 @@
+package graphrag
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+// baselineWindows builds n finalized windows each carrying count requests and
+// errors errors, ending just before the current window.
+func baselineWindows(base time.Time, n int, count, errors uint64, p99 float64) []aggregate.TopologyWindow {
+	out := make([]aggregate.TopologyWindow, 0, n)
+	for i := n; i > 0; i-- {
+		out = append(out, aggWindow(base.Add(-time.Duration(i)*aggregate.WindowSize), count, errors, p99))
+	}
+	return out
+}
+
+// openWindow builds the still-filling current window.
+func openWindow(start time.Time, elapsed time.Duration, count, errors uint64, p99 float64) aggregate.TopologyWindow {
+	return aggregate.TopologyWindow{
+		Start:             start,
+		End:               start.Add(aggregate.WindowSize),
+		Closed:            false,
+		Final:             false,
+		Elapsed:           elapsed,
+		Count:             count,
+		ErrorCount:        errors,
+		DurationCount:     count,
+		DurationSumMicros: float64(count) * 1000,
+		P95Micros:         p99 * 0.8,
+		P99Micros:         p99,
+	}
+}
+
+// runDetector installs snap as the tenant's topology and runs one aggregate
+// detection pass, returning the anomalies it produced.
+func runDetector(t *testing.T, snap aggregate.TopologySnapshot) []*AnomalyNode {
+	t.Helper()
+	src := &fakeAggregateSource{epoch: 1, snaps: map[string]aggregate.TopologySnapshot{}}
+	g := aggregateGraphRAG(t, newTestRepo(t), src)
+	stores := g.storesForTenant(storage.DefaultTenantID)
+	stores.lastTopology.Store(&snap)
+	g.detectAnomaliesFromTopology(context.Background(), storage.DefaultTenantID, stores)
+	return stores.anomalies.AnomaliesSince(time.Now().Add(-time.Hour))
+}
+
+func serviceSnapshot(revision uint64, windows []aggregate.TopologyWindow) aggregate.TopologySnapshot {
+	return aggregate.TopologySnapshot{
+		Tenant:   storage.DefaultTenantID,
+		Revision: revision,
+		Services: []aggregate.TopologyService{{Name: "checkout", Windows: windows}},
+	}
+}
+
+func findAnomaly(anomalies []*AnomalyNode, kind AnomalyType) *AnomalyNode {
+	for _, a := range anomalies {
+		if a.Type == kind {
+			return a
+		}
+	}
+	return nil
+}
+
+// TestErrorSpikeFiresAgainstFinalizedBaseline proves the detector compares a
+// window's error rate against the PRIOR FINALIZED windows and fires when the
+// excess clears three standard errors — with no 2% constant anywhere.
+func TestErrorSpikeFiresAgainstFinalizedBaseline(t *testing.T) {
+	now := time.Now().UTC().Truncate(aggregate.WindowSize)
+	windows := baselineWindows(now, 4, 1000, 10, 3000) // 1% baseline
+	windows = append(windows, aggWindow(now, 500, 100, 3000))
+
+	got := runDetector(t, serviceSnapshot(1, windows))
+	a := findAnomaly(got, AnomalyErrorSpike)
+	if a == nil {
+		t.Fatalf("no error-spike anomaly for 20%% vs a 1%% baseline: %+v", got)
+	}
+	if a.Service != "checkout" {
+		t.Fatalf("anomaly service = %q", a.Service)
+	}
+	if a.Evidence == "" {
+		t.Fatalf("anomaly carries no evidence")
+	}
+}
+
+// TestErrorSpikeRespectsMinimumRequestCount proves a window too small to mean
+// anything cannot fire, no matter how bad its rate looks.
+func TestErrorSpikeRespectsMinimumRequestCount(t *testing.T) {
+	now := time.Now().UTC().Truncate(aggregate.WindowSize)
+	windows := baselineWindows(now, 4, 1000, 10, 3000)
+	windows = append(windows, aggWindow(now, minWindowRequests-1, minWindowRequests-1, 3000)) // 100% errors
+
+	if got := runDetector(t, serviceSnapshot(1, windows)); findAnomaly(got, AnomalyErrorSpike) != nil {
+		t.Fatalf("a %d-request window fired an anomaly: %+v", minWindowRequests-1, got)
+	}
+}
+
+// TestPartialWindowGuardSuppressesNearEmptyWindow proves a window that has
+// barely opened is not compared to anything — the "anomaly storm from a nearly
+// empty window" this replaces.
+func TestPartialWindowGuardSuppressesNearEmptyWindow(t *testing.T) {
+	now := time.Now().UTC().Truncate(aggregate.WindowSize)
+	windows := baselineWindows(now, 4, 1000, 10, 3000)
+	windows = append(windows, openWindow(now, 5*time.Second, 400, 200, 3000))
+
+	if got := runDetector(t, serviceSnapshot(1, windows)); findAnomaly(got, AnomalyErrorSpike) != nil {
+		t.Fatalf("a 5s-old window fired an anomaly: %+v", got)
+	}
+
+	// The same window, once enough of it has elapsed, does fire.
+	windows[len(windows)-1] = openWindow(now, 3*time.Minute, 400, 200, 3000)
+	if got := runDetector(t, serviceSnapshot(1, windows)); findAnomaly(got, AnomalyErrorSpike) == nil {
+		t.Fatalf("a 3m-old window with 50%% errors did not fire: %+v", got)
+	}
+}
+
+// TestNoBaselineNoAnomaly proves the detector refuses to invent a baseline: a
+// service with too little finalized history produces nothing.
+func TestNoBaselineNoAnomaly(t *testing.T) {
+	now := time.Now().UTC().Truncate(aggregate.WindowSize)
+	windows := []aggregate.TopologyWindow{
+		aggWindow(now.Add(-aggregate.WindowSize), 30, 0, 3000),
+		aggWindow(now, 500, 400, 3000),
+	}
+	if got := runDetector(t, serviceSnapshot(1, windows)); len(got) != 0 {
+		t.Fatalf("anomalies produced without a baseline: %+v", got)
+	}
+}
+
+// TestLatencySpikeUsesSketchPercentiles proves latency detection reads p99 and
+// not an average: a window whose AVERAGE is unremarkable but whose p99 has
+// blown out still fires, and the reverse does not.
+func TestLatencySpikeUsesSketchPercentiles(t *testing.T) {
+	now := time.Now().UTC().Truncate(aggregate.WindowSize)
+	windows := baselineWindows(now, 4, 1000, 0, 20_000) // p99 20ms
+	spike := aggWindow(now, 1000, 0, 400_000)           // p99 400ms
+	// Average duration is identical to the baseline windows by construction.
+	windows = append(windows, spike)
+
+	got := runDetector(t, serviceSnapshot(1, windows))
+	if findAnomaly(got, AnomalyLatencySpike) == nil {
+		t.Fatalf("p99 20ms -> 400ms did not fire: %+v", got)
+	}
+
+	// A steady p99 does not fire even at an absolute value the retired
+	// avg>500ms rule would have flagged.
+	steady := baselineWindows(now, 4, 1000, 0, 900_000)
+	steady = append(steady, aggWindow(now, 1000, 0, 900_000))
+	if got := runDetector(t, serviceSnapshot(1, steady)); findAnomaly(got, AnomalyLatencySpike) != nil {
+		t.Fatalf("a steady 900ms p99 fired: %+v", got)
+	}
+}
+
+// TestMetricZScoreUsesRollingMeanAndVariance proves the metric detector is a
+// real z-score over finalized window means, and that a baseline with no spread
+// produces nothing rather than dividing by zero.
+func TestMetricZScoreUsesRollingMeanAndVariance(t *testing.T) {
+	now := time.Now().UTC().Truncate(aggregate.WindowSize)
+	mkMetric := func(means []float64, current float64) aggregate.TopologySnapshot {
+		windows := make([]aggregate.TopologyWindow, 0, len(means)+1)
+		for i, m := range means {
+			windows = append(windows, aggregate.TopologyWindow{
+				Start:      now.Add(-time.Duration(len(means)-i) * aggregate.WindowSize),
+				Final:      true,
+				Closed:     true,
+				ValueCount: 10,
+				ValueSum:   m * 10,
+			})
+		}
+		windows = append(windows, aggregate.TopologyWindow{
+			Start: now, Closed: true, Final: false, Elapsed: aggregate.WindowSize,
+			ValueCount: 10, ValueSum: current * 10,
+		})
+		return aggregate.TopologySnapshot{
+			Tenant:   storage.DefaultTenantID,
+			Revision: 1,
+			Metrics: []aggregate.TopologyMetric{{
+				Service: "checkout", Metric: "queue_depth", Windows: windows,
+			}},
+		}
+	}
+
+	got := runDetector(t, mkMetric([]float64{10, 11, 9, 10, 11}, 90))
+	if findAnomaly(got, AnomalyMetricZScore) == nil {
+		t.Fatalf("a 9-sigma metric excursion did not fire: %+v", got)
+	}
+
+	// Zero variance: no spread means no z-score, not an infinite one.
+	if got := runDetector(t, mkMetric([]float64{10, 10, 10, 10}, 10)); findAnomaly(got, AnomalyMetricZScore) != nil {
+		t.Fatalf("a flat baseline fired a z-score anomaly: %+v", got)
+	}
+}
+
+// TestAggregateDetectionIsRevisionGated proves an unchanged topology revision
+// does no detection work at all.
+func TestAggregateDetectionIsRevisionGated(t *testing.T) {
+	now := time.Now().UTC().Truncate(aggregate.WindowSize)
+	windows := baselineWindows(now, 4, 1000, 10, 3000)
+	windows = append(windows, aggWindow(now, 500, 100, 3000))
+	snap := serviceSnapshot(5, windows)
+
+	src := &fakeAggregateSource{epoch: 1, snaps: map[string]aggregate.TopologySnapshot{}}
+	g := aggregateGraphRAG(t, newTestRepo(t), src)
+	stores := g.storesForTenant(storage.DefaultTenantID)
+	stores.lastTopology.Store(&snap)
+
+	ctx := context.Background()
+	g.detectAnomaliesFromTopology(ctx, storage.DefaultTenantID, stores)
+	first := findAnomaly(stores.anomalies.AnomaliesSince(now.Add(-time.Hour)), AnomalyErrorSpike)
+	if first == nil {
+		t.Fatalf("first pass produced no anomaly")
+	}
+	stamp := first.Timestamp
+
+	// Second pass at the same revision must not re-stamp the anomaly.
+	time.Sleep(2 * time.Millisecond)
+	g.detectAnomaliesFromTopology(ctx, storage.DefaultTenantID, stores)
+	again := findAnomaly(stores.anomalies.AnomaliesSince(now.Add(-time.Hour)), AnomalyErrorSpike)
+	if !again.Timestamp.Equal(stamp) {
+		t.Fatalf("unchanged revision re-ran detection: %v -> %v", stamp, again.Timestamp)
+	}
+}

--- a/internal/graphrag/builder.go
+++ b/internal/graphrag/builder.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"github.com/RandomCodeSpace/otelcontext/internal/telemetry"
 	"github.com/RandomCodeSpace/otelcontext/internal/tsdb"
@@ -86,6 +87,10 @@ type event struct {
 	span   *spanEvent
 	log    *logEvent
 	metric *metricEvent
+	// tmpl carries an ingest-mined log template fact (shadow and aggregate
+	// modes). It rides the same channel as everything else so the miner's
+	// synchronous callback never does a store write on the OTLP goroutine.
+	tmpl *aggregate.TemplateFact
 }
 
 // GraphRAG is the main coordinator for the layered graph system.
@@ -148,6 +153,16 @@ type GraphRAG struct {
 	// detectAnomalies pass. Tenants whose lastEventAt predates it are
 	// skipped — no events means their stats cannot have changed.
 	lastAnomalyScan atomic.Int64
+
+	// mode is the aggregate mode this coordinator runs under: one of
+	// aggregate.ModeLegacy, ModeShadow or ModeAggregate. Legacy behaviour is
+	// the default and is unchanged in every respect; everything the aggregate
+	// phase adds is gated on this field (see aggregate.go).
+	mode string
+
+	// aggSource is the aggregate engine's topology projection, consulted only
+	// in aggregate mode.
+	aggSource AggregateSource
 }
 
 // SetMetrics wires the Prometheus registry so GraphRAG event drops are
@@ -231,6 +246,13 @@ type Config struct {
 	// without any ingest event or query. 0 = defaultTenantIdleTTL;
 	// negative disables eviction.
 	TenantIdleTTL time.Duration
+
+	// Mode is the aggregate mode (AGGREGATE_MODE): aggregate.ModeLegacy,
+	// ModeShadow or ModeAggregate. Empty means legacy. In shadow mode the only
+	// change is that log templates come from the ingest-owned miner; in
+	// aggregate mode the raw-span rebuild and the per-span topology upserts
+	// are retired in favour of engine snapshots (#163, #174).
+	Mode string
 }
 
 // DefaultConfig returns sensible defaults.
@@ -244,6 +266,7 @@ func DefaultConfig() Config {
 		ChannelSize:       defaultChannelSize,
 		MaxSpansPerTenant: defaultMaxSpansPerTenant,
 		TenantIdleTTL:     defaultTenantIdleTTL,
+		Mode:              aggregate.ModeLegacy,
 	}
 }
 
@@ -277,6 +300,9 @@ func New(repo *storage.Repository, tsdbAgg *tsdb.Aggregator, ringBuf *tsdb.RingB
 	if cfg.TenantIdleTTL == 0 {
 		cfg.TenantIdleTTL = defaultTenantIdleTTL
 	}
+	if cfg.Mode == "" {
+		cfg.Mode = aggregate.ModeLegacy
+	}
 
 	g := &GraphRAG{
 		tenants:           make(map[string]*tenantStores),
@@ -293,7 +319,15 @@ func New(repo *storage.Repository, tsdbAgg *tsdb.Aggregator, ringBuf *tsdb.RingB
 		workerCount:       cfg.WorkerCount,
 		maxSpansPerTenant: cfg.MaxSpansPerTenant,
 		tenantIdleTTL:     cfg.TenantIdleTTL,
+		mode:              cfg.Mode,
 		invCooldown:       newInvestigationCooldown(5 * time.Minute),
+	}
+	if g.externalTemplates() {
+		// Shadow and aggregate modes mine templates on the ingest path. A
+		// second miner here would mint a second ID space for the same log
+		// shapes (#163), so there is no Drain instance to construct, restore
+		// or persist.
+		g.drain = nil
 	}
 
 	// Bootstrap the default tenant slice so refresh/snapshot loops have a
@@ -309,7 +343,7 @@ func New(repo *storage.Repository, tsdbAgg *tsdb.Aggregator, ringBuf *tsdb.RingB
 	// learned templates as belonging to DefaultTenantID. The persistence layer
 	// is already keyed by (tenant_id, id) so a future per-tenant Drain miner
 	// can load each tenant's slice without colliding cluster IDs.
-	if repo != nil && repo.DB() != nil {
+	if repo != nil && repo.DB() != nil && g.drain != nil {
 		if tpls, err := LoadDrainTemplates(repo.DB(), storage.DefaultTenantID); err != nil {
 			slog.Info("GraphRAG: drain template restore skipped", "reason", err)
 		} else if len(tpls) > 0 {
@@ -471,6 +505,9 @@ func (g *GraphRAG) eventWorker(ctx context.Context) {
 			if ev.metric != nil {
 				g.processMetric(ev.metric)
 			}
+			if ev.tmpl != nil {
+				g.processTemplateFact(ev.tmpl)
+			}
 		}
 	}
 }
@@ -489,12 +526,18 @@ func (g *GraphRAG) processSpan(ev *spanEvent) {
 	stores := g.storesForTenant(ev.Tenant)
 	stores.lastEventAt.Store(time.Now().UnixNano())
 
-	// 1. Upsert ServiceNode
-	stores.service.UpsertService(span.ServiceName, durationMs, isError, span.StartTime)
-
-	// 2. Upsert OperationNode + EXPOSES edge
-	if span.OperationName != "" {
-		stores.service.UpsertOperation(span.ServiceName, span.OperationName, durationMs, isError, span.StartTime)
+	// 1./2./4. Service, operation and CALLS-edge aggregates.
+	//
+	// In aggregate mode these are owned by the engine's topology snapshot and
+	// replaced per revision (see aggregate.go). Folding a retained exemplar's
+	// span in here as well would double-count it against a snapshot that
+	// already accounted for every accepted span, sampled or not. Only the
+	// exemplar detail below is GraphRAG's to record.
+	if !g.AggregateMode() {
+		stores.service.UpsertService(span.ServiceName, durationMs, isError, span.StartTime)
+		if span.OperationName != "" {
+			stores.service.UpsertOperation(span.ServiceName, span.OperationName, durationMs, isError, span.StartTime)
+		}
 	}
 
 	// 3. Create TraceNode + SpanNode + CONTAINS + CHILD_OF edges
@@ -516,7 +559,7 @@ func (g *GraphRAG) processSpan(ev *spanEvent) {
 	}
 
 	// 4. If parent span exists and belongs to different service, create CALLS edge
-	if span.ParentSpanID != "" {
+	if !g.AggregateMode() && span.ParentSpanID != "" {
 		if parentSpan, ok := stores.traces.GetSpan(span.ParentSpanID); ok {
 			if parentSpan.Service != span.ServiceName {
 				stores.service.UpsertCallEdge(parentSpan.Service, span.ServiceName, durationMs, isError, span.StartTime)
@@ -534,6 +577,15 @@ func (g *GraphRAG) processLog(ev *logEvent) {
 
 	stores := g.storesForTenant(ev.Tenant)
 	stores.lastEventAt.Store(time.Now().UnixNano())
+
+	// Shadow and aggregate modes: templates are mined once, on the ingest
+	// path, and arrive through OnTemplateFact. Mining here as well would mint
+	// a second ID space for the same log shapes (#163). A template fact
+	// carries no span ID, so the LOGGED_DURING correlation edge is not formed
+	// in those modes; nothing in the 7-tool surface reads it.
+	if g.externalTemplates() {
+		return
+	}
 
 	// Drain-based clustering (replaces hash+TF-IDF clustering). The Drain
 	// miner is shared across tenants — its template tokens describe log shape,
@@ -558,6 +610,11 @@ func (g *GraphRAG) processMetric(ev *metricEvent) {
 	}
 	stores := g.storesForTenant(ev.Tenant)
 	stores.lastEventAt.Store(time.Now().UnixNano())
+	// Aggregate mode: metric nodes are replaced from the engine snapshot per
+	// revision, so a per-point upsert here would fight the projection.
+	if g.AggregateMode() {
+		return
+	}
 	stores.signals.UpsertMetric(m.Name, m.ServiceName, m.Value, m.Timestamp)
 }
 

--- a/internal/graphrag/queries.go
+++ b/internal/graphrag/queries.go
@@ -2,6 +2,7 @@ package graphrag
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sort"
 	"time"
@@ -31,7 +32,7 @@ func (g *GraphRAG) ErrorChain(ctx context.Context, service string, since time.Ti
 		}
 		seen[span.TraceID] = true
 
-		chain := traceErrorChainUpstream(stores, span)
+		chain, rooted := traceErrorChainUpstream(stores, span)
 		if len(chain) == 0 {
 			continue
 		}
@@ -46,6 +47,7 @@ func (g *GraphRAG) ErrorChain(ctx context.Context, service string, since time.Ti
 			},
 			SpanChain: chain,
 			TraceID:   span.TraceID,
+			Coverage:  chainCoverage(rooted, len(chain)),
 		}
 
 		// Gather correlated logs
@@ -68,8 +70,12 @@ func (g *GraphRAG) ErrorChain(ctx context.Context, service string, since time.Ti
 
 // traceErrorChainUpstream walks CHILD_OF edges upstream from an error span to
 // the root within a single tenant's TraceStore.
-func traceErrorChainUpstream(stores *tenantStores, span *SpanNode) []SpanNode {
-	var chain []SpanNode
+//
+// rooted reports whether the walk actually reached a span with no parent. A
+// walk that stopped because the parent span was never retained produces a
+// chain whose last element is NOT the root cause, and the caller must present
+// it as partial coverage rather than as an answer (#163).
+func traceErrorChainUpstream(stores *tenantStores, span *SpanNode) (chain []SpanNode, rooted bool) {
 	visited := make(map[string]bool)
 	current := span
 
@@ -78,16 +84,79 @@ func traceErrorChainUpstream(stores *tenantStores, span *SpanNode) []SpanNode {
 		chain = append(chain, *current)
 
 		if current.ParentSpanID == "" {
-			break
+			return chain, true
 		}
 		parent, ok := stores.traces.GetSpan(current.ParentSpanID)
 		if !ok {
-			break
+			return chain, false
 		}
 		current = parent
 	}
 
-	return chain
+	return chain, false
+}
+
+// chainCoverage renders the quality contract for one upstream walk.
+func chainCoverage(rooted bool, spans int) Coverage {
+	if rooted {
+		return Coverage{Complete: true, RetainedSpans: spans, Source: CoverageRetained}
+	}
+	return Coverage{
+		Complete:      false,
+		Truncated:     true,
+		RetainedSpans: spans,
+		Source:        CoveragePartial,
+		Note:          "upstream walk stopped at a span that was not retained; the last element is not proven to be the root",
+	}
+}
+
+// TraceGraph returns the retained span tree for a trace together with an
+// explicit statement of what it covers.
+//
+// The tree is assembled solely from retained exemplars. A trace nobody retained
+// returns CoverageNone and an empty span list — "not retained or not found" is
+// the honest answer, and it is a successful response, not an error.
+func (g *GraphRAG) TraceGraph(ctx context.Context, traceID string) TraceGraphResult {
+	spans := g.DependencyChain(ctx, traceID)
+	res := TraceGraphResult{TraceID: traceID, Spans: spans}
+	if len(spans) == 0 {
+		res.Coverage = Coverage{
+			Source: CoverageNone,
+			Note:   "no retained exemplar for this trace in the in-memory window",
+		}
+		return res
+	}
+
+	ids := make(map[string]struct{}, len(spans))
+	for _, s := range spans {
+		ids[s.ID] = struct{}{}
+	}
+	dangling, roots := 0, 0
+	for _, s := range spans {
+		if s.ParentSpanID == "" {
+			roots++
+			continue
+		}
+		if _, ok := ids[s.ParentSpanID]; !ok {
+			dangling++
+		}
+	}
+	res.Coverage = Coverage{
+		Complete:      roots > 0 && dangling == 0,
+		Truncated:     dangling > 0,
+		RetainedSpans: len(spans),
+		Source:        CoverageRetained,
+	}
+	if !res.Coverage.Complete {
+		res.Coverage.Source = CoveragePartial
+		res.Coverage.Note = fmt.Sprintf(
+			"%d span(s) reference a parent that was not retained; the tree is incomplete", dangling,
+		)
+		if roots == 0 && dangling == 0 {
+			res.Coverage.Note = "no root span was retained; the tree is incomplete"
+		}
+	}
+	return res
 }
 
 // ImpactAnalysis performs BFS downstream from a service to find affected services.
@@ -169,6 +238,11 @@ func (g *GraphRAG) RootCauseAnalysis(ctx context.Context, service string, since 
 		rc.Evidence = append(rc.Evidence, "error chain from trace "+ec.TraceID)
 		if len(ec.SpanChain) > 0 {
 			rc.ErrorChain = ec.SpanChain
+			// The ranking is only as good as the weakest chain behind it: one
+			// partial chain makes the whole cause partial.
+			if rc.Coverage.Source == "" || !ec.Coverage.Complete {
+				rc.Coverage = ec.Coverage
+			}
 		}
 	}
 
@@ -189,6 +263,10 @@ func (g *GraphRAG) RootCauseAnalysis(ctx context.Context, service string, since 
 				Score:     2.0,
 				Anomalies: []AnomalyNode{*a},
 				Evidence:  []string{"anomaly: " + a.Evidence},
+				Coverage: Coverage{
+					Source: CoverageNone,
+					Note:   "ranked from aggregate anomaly evidence only; no retained exemplar chain backs this cause",
+				},
 			}
 		}
 	}

--- a/internal/graphrag/refresh.go
+++ b/internal/graphrag/refresh.go
@@ -40,8 +40,9 @@ func (g *GraphRAG) refreshLoop(ctx context.Context) {
 	ticker := time.NewTicker(g.refreshEvery)
 	defer ticker.Stop()
 
-	// Initial rebuild on startup.
-	g.rebuildAllTenantsFromDB(ctx)
+	// Initial topology load on startup. In aggregate mode this is a snapshot
+	// read from the engine's projection, not a spans-table scan.
+	g.refreshTopology(ctx)
 
 	for {
 		select {
@@ -50,7 +51,7 @@ func (g *GraphRAG) refreshLoop(ctx context.Context) {
 		case <-g.stopCh:
 			return
 		case <-ticker.C:
-			g.rebuildAllTenantsFromDB(ctx)
+			g.refreshTopology(ctx)
 			pruned := 0
 			prunedSignals := 0
 			signalCutoff := time.Now().Add(-signalRetention)
@@ -79,6 +80,20 @@ func (g *GraphRAG) refreshLoop(ctx context.Context) {
 			}
 		}
 	}
+}
+
+// refreshTopology brings the in-memory topology up to date for one tick.
+//
+// Aggregate mode: replace from the engine's per-tenant snapshot, skipping any
+// tenant whose revision has not moved. It issues no database query — the
+// raw-span rebuild and the legacy internal/graph scanner are both retired
+// there (#163, #174). Every other mode keeps the historical rebuild verbatim.
+func (g *GraphRAG) refreshTopology(ctx context.Context) {
+	if g.AggregateMode() {
+		g.reconcileTopology()
+		return
+	}
+	g.rebuildAllTenantsFromDB(ctx)
 }
 
 // evictIdleTenants drops tenant store slices whose lastAccess is older than
@@ -132,6 +147,8 @@ func (g *GraphRAG) snapshotLoop(ctx context.Context) {
 		case <-g.stopCh:
 			return
 		case <-ticker.C:
+			// No-op when the miner lives on the ingest path (shadow and
+			// aggregate modes); persistDrainTemplates guards on g.drain.
 			g.persistDrainTemplates()
 		}
 	}
@@ -160,6 +177,12 @@ func (g *GraphRAG) persistDrainTemplates() {
 // spans — this catches historical tenants that have not yet ingested via
 // live callbacks since startup.
 func (g *GraphRAG) rebuildAllTenantsFromDB(ctx context.Context) {
+	// Hard guard, not just a caller-side branch: the raw-span rebuild is the
+	// scan #174 retires, and no future caller may reintroduce it in aggregate
+	// mode by accident.
+	if g.AggregateMode() {
+		return
+	}
 	if g.repo == nil || g.repo.DB() == nil {
 		return
 	}
@@ -215,6 +238,9 @@ func incrementalSince(stores *tenantStores, since time.Time) time.Time {
 // merges it into that tenant's slice of the graph. Catches data from before
 // callbacks started (e.g., restart recovery).
 func (g *GraphRAG) rebuildFromDBForTenant(_ context.Context, tenant string, since time.Time) {
+	if g.AggregateMode() {
+		return
+	}
 	type spanRow struct {
 		SpanID        string
 		ParentSpanID  string

--- a/internal/graphrag/schema.go
+++ b/internal/graphrag/schema.go
@@ -169,6 +169,47 @@ type Edge struct {
 
 // --- Query Result Types ---
 
+// --- Causal-analysis quality contract (#163) ---
+
+// Coverage source values. They are part of the MCP response contract: a client
+// reads Source to know whether an answer is a fact about a complete retained
+// exemplar, a fact about a deliberately truncated one, or an admission that
+// nothing was retained.
+const (
+	// CoverageRetained — the complete parent/child chain was retained.
+	CoverageRetained = "retained_exemplar"
+	// CoveragePartial — the exemplar exists but its chain is incomplete:
+	// truncated by the per-trace span/byte bound, or still arriving, or aged
+	// out of the in-memory trace TTL.
+	CoveragePartial = "partial_exemplar"
+	// CoverageNone — no exemplar. The honest answer is "not retained or not
+	// found", never a chain assembled from whatever happened to be around.
+	CoverageNone = "not_retained_or_not_found"
+)
+
+// Coverage states what a causal-analysis answer is actually backed by.
+//
+// Errors are always ELIGIBLE for retention; they are never all PERSISTED
+// (#161, #163). ErrorChain, RootCauseAnalysis, DependencyChain and the
+// trace_graph tool are guaranteed only for complete retained exemplars. A
+// truncated exemplar reports explicit partial coverage and an absent one says
+// so — fabricated certainty is the one answer that is never acceptable.
+type Coverage struct {
+	// Complete is true only for a chain that reaches a root span with every
+	// parent link resolved.
+	Complete bool `json:"complete"`
+	// Truncated marks a chain cut short by the per-trace span or byte bound.
+	Truncated bool `json:"truncated"`
+	// RetainedSpans and ObservedSpans are the retained/observed counts when
+	// they are known.
+	RetainedSpans int `json:"retained_spans,omitempty"`
+	ObservedSpans int `json:"observed_spans,omitempty"`
+	// Source is one of the Coverage* constants.
+	Source string `json:"source"`
+	// Note explains a non-complete answer in plain words.
+	Note string `json:"note,omitempty"`
+}
+
 // ErrorChainResult is the output of an error chain query.
 type ErrorChainResult struct {
 	RootCause        *RootCauseInfo   `json:"root_cause"`
@@ -176,6 +217,18 @@ type ErrorChainResult struct {
 	CorrelatedLogs   []LogClusterNode `json:"correlated_logs,omitempty"`
 	AnomalousMetrics []MetricNode     `json:"anomalous_metrics,omitempty"`
 	TraceID          string           `json:"trace_id"`
+	// Coverage states whether this chain is backed by a complete retained
+	// exemplar. A chain whose upstream walk stopped at a missing parent is
+	// reported as partial, not presented as a root cause.
+	Coverage Coverage `json:"coverage"`
+}
+
+// TraceGraphResult is the trace_graph tool's response shape: the retained span
+// tree plus an explicit statement of what it covers.
+type TraceGraphResult struct {
+	TraceID  string     `json:"trace_id"`
+	Spans    []SpanNode `json:"spans"`
+	Coverage Coverage   `json:"coverage"`
 }
 
 // RootCauseInfo identifies the responsible service and operation.
@@ -210,6 +263,9 @@ type RankedCause struct {
 	Evidence   []string      `json:"evidence"`
 	ErrorChain []SpanNode    `json:"error_chain,omitempty"`
 	Anomalies  []AnomalyNode `json:"anomalies,omitempty"`
+	// Coverage states what the ranking rests on: a complete retained
+	// exemplar, a partial one, or aggregate anomaly evidence with no chain.
+	Coverage Coverage `json:"coverage"`
 }
 
 // --- Drain Template Persistence ---

--- a/internal/graphrag/store.go
+++ b/internal/graphrag/store.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 )
 
 // tenantStores bundles one tenant's slice of the four layered in-memory
@@ -42,6 +44,25 @@ type tenantStores struct {
 	// trailing window. Zero on a fresh slice (first build / post-eviction)
 	// forces a full-window rebuild.
 	lastRebuildMax atomic.Int64
+
+	// --- aggregate mode (#174) ---
+
+	// topoEpoch and topoRevision record the aggregate topology snapshot this
+	// slice currently reflects. A snapshot whose pair matches is a no-op; a
+	// changed epoch means the engine restarted and the revision counter began
+	// again, so the slice is replaced rather than reconciled.
+	topoEpoch    atomic.Uint64
+	topoRevision atomic.Uint64
+
+	// lastTopology is the most recently applied snapshot, kept so the
+	// aggregate anomaly detector reads windowed history without going back to
+	// the engine (and never to a database).
+	lastTopology atomic.Pointer[aggregate.TopologySnapshot]
+
+	// anomalyRevision is the topology revision the aggregate anomaly detector
+	// last evaluated. Detection is revision-gated: an unchanged topology
+	// cannot produce a new anomaly.
+	anomalyRevision atomic.Uint64
 }
 
 func newTenantStores(traceTTL time.Duration, maxSpans int) *tenantStores {
@@ -802,4 +823,84 @@ func computeHealth(errorRate, avgLatencyMs float64) float64 {
 		score = 1
 	}
 	return score
+}
+
+// --- replacement-by-revision (aggregate mode) ---
+
+// ReplaceTopology swaps the entire service topology for a new one under a
+// single write lock.
+//
+// Aggregate mode consumes a per-revision snapshot from the aggregate engine
+// rather than accumulating per-span upserts, so the only correct way to apply
+// it is replacement: re-applying a cumulative snapshot through UpsertService /
+// UpsertCallEdge would multiply every counter by the number of ticks it
+// survived. Rebuilding the adjacency indexes here (rather than mutating them)
+// is what keeps their append-only invariant intact — after the swap they
+// describe exactly the maps they were built from.
+func (s *ServiceStore) ReplaceTopology(services []*ServiceNode, operations []*OperationNode, edges []*Edge) {
+	svcMap := make(map[string]*ServiceNode, len(services))
+	for _, svc := range services {
+		if svc == nil || svc.Name == "" {
+			continue
+		}
+		svcMap[svc.Name] = svc
+	}
+
+	opMap := make(map[string]*OperationNode, len(operations))
+	opsByService := make(map[string][]*OperationNode, len(svcMap))
+	edgeMap := make(map[string]*Edge, len(edges)+len(operations))
+	for _, op := range operations {
+		if op == nil || op.Service == "" || op.Operation == "" {
+			continue
+		}
+		opMap[op.ID] = op
+		opsByService[op.Service] = append(opsByService[op.Service], op)
+		ek := edgeKey(EdgeExposes, op.Service, op.ID)
+		edgeMap[ek] = &Edge{Type: EdgeExposes, FromID: op.Service, ToID: op.ID, UpdatedAt: op.LastSeen}
+	}
+
+	edgesByFrom := make(map[string][]*Edge, len(svcMap))
+	edgesByTo := make(map[string][]*Edge, len(svcMap))
+	for _, e := range edges {
+		if e == nil || e.Type != EdgeCalls || e.FromID == "" || e.ToID == "" {
+			continue
+		}
+		edgeMap[edgeKey(EdgeCalls, e.FromID, e.ToID)] = e
+		edgesByFrom[e.FromID] = append(edgesByFrom[e.FromID], e)
+		edgesByTo[e.ToID] = append(edgesByTo[e.ToID], e)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Services = svcMap
+	s.Operations = opMap
+	s.Edges = edgeMap
+	s.edgesByFrom = edgesByFrom
+	s.edgesByTo = edgesByTo
+	s.opsByService = opsByService
+}
+
+// ReplaceMetrics swaps the metric nodes (and their MEASURED_BY edges) for a new
+// set. Same reasoning as ReplaceTopology: aggregate-mode metric state is a
+// projection of a revision, not an accumulation. Log-cluster nodes and their
+// edges are untouched — they arrive as ingest-owned template facts on their own
+// schedule.
+func (ss *SignalStore) ReplaceMetrics(metrics []*MetricNode) {
+	metricMap := make(map[string]*MetricNode, len(metrics))
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	for ek, e := range ss.Edges {
+		if e.Type == EdgeMeasuredBy {
+			delete(ss.Edges, ek)
+		}
+	}
+	for _, m := range metrics {
+		if m == nil || m.ID == "" {
+			continue
+		}
+		metricMap[m.ID] = m
+		ek := edgeKey(EdgeMeasuredBy, m.ID, m.Service)
+		ss.Edges[ek] = &Edge{Type: EdgeMeasuredBy, FromID: m.ID, ToID: m.Service, UpdatedAt: m.LastSeen}
+	}
+	ss.Metrics = metricMap
 }

--- a/internal/ingest/aggregate_bridge.go
+++ b/internal/ingest/aggregate_bridge.go
@@ -96,6 +96,26 @@ func aggregateSpanInput(tenantID, serviceName string, span *tracepb.Span, start,
 	return in
 }
 
+// aggregateEdgeInput derives the service-edge reducer input from a resolved
+// caller and the callee's own span input. Everything except the caller comes
+// from the callee: an edge measures the callee's work as observed by this call.
+func aggregateEdgeInput(caller string, in aggregate.SpanInput) aggregate.EdgeInput {
+	return aggregate.EdgeInput{
+		Tenant:         in.Tenant,
+		Caller:         caller,
+		Callee:         in.Service,
+		HTTPRoute:      in.HTTPRoute,
+		URLPath:        in.URLPath,
+		SpanName:       in.SpanName,
+		Method:         in.Method,
+		HTTPStatusCode: in.HTTPStatusCode,
+		SpanKind:       in.SpanKind,
+		StatusCode:     in.StatusCode,
+		Timestamp:      in.Timestamp,
+		DurationMicros: in.DurationMicros,
+	}
+}
+
 // aggregateResourceIdentity extracts the stable resource identity used to
 // derive a metric producer's ProducerID (#166). Only the first-present value
 // per slot is taken: attributes that vary per export would fragment baselines.

--- a/internal/ingest/aggregate_edges_test.go
+++ b/internal/ingest/aggregate_edges_test.go
@@ -1,0 +1,136 @@
+package ingest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// edgeExport builds one resource-spans block for service with the given spans.
+func edgeExport(service string, spans ...*tracepb.Span) *tracepb.ResourceSpans {
+	return &tracepb.ResourceSpans{
+		Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{{
+			Key:   "service.name",
+			Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: service}},
+		}}},
+		ScopeSpans: []*tracepb.ScopeSpans{{Spans: spans}},
+	}
+}
+
+func edgeSpan(traceID, spanID, parentID, name string, ts time.Time) *tracepb.Span {
+	sp := &tracepb.Span{
+		TraceId:           []byte(traceID),
+		SpanId:            []byte(spanID),
+		Name:              name,
+		Kind:              tracepb.Span_SPAN_KIND_SERVER,
+		StartTimeUnixNano: uint64(ts.UnixNano()), // #nosec G115 -- test timestamps are positive
+		EndTimeUnixNano:   uint64(ts.Add(2 * time.Millisecond).UnixNano()),
+		Status:            &tracepb.Status{Code: tracepb.Status_STATUS_CODE_OK},
+	}
+	if parentID != "" {
+		sp.ParentSpanId = []byte(parentID)
+	}
+	return sp
+}
+
+// TestExportEmitsServiceEdgeSeries proves the deferred half of #183 landed:
+// a child span whose parent lives in another service produces a caller->callee
+// edge in the aggregate topology, and an internal (same-service) parent does
+// not.
+func TestExportEmitsServiceEdgeSeries(t *testing.T) {
+	now := time.Now()
+	engine := newAggregateEngine(t, now)
+	repo, _ := newAggregateTestRepo(t)
+	srv := NewTraceServer(repo, nil, aggTestConfig())
+	srv.SetAggregateEngine(engine)
+
+	// The gateway's span arrives first, in its own Export, exactly as it would
+	// from a different process.
+	req := &coltracepb.ExportTraceServiceRequest{ResourceSpans: []*tracepb.ResourceSpans{
+		edgeExport("gateway", edgeSpan("trace-0000000001", "span-001", "", "GET /checkout", now)),
+	}}
+	if _, err := srv.Export(context.Background(), req); err != nil {
+		t.Fatalf("gateway Export: %v", err)
+	}
+
+	req = &coltracepb.ExportTraceServiceRequest{ResourceSpans: []*tracepb.ResourceSpans{
+		edgeExport("checkout",
+			edgeSpan("trace-0000000001", "span-002", "span-001", "POST /pay", now),
+			// Same-service child: an internal call, never a topology edge.
+			edgeSpan("trace-0000000001", "span-003", "span-002", "POST /pay/inner", now),
+		),
+	}}
+	if _, err := srv.Export(context.Background(), req); err != nil {
+		t.Fatalf("checkout Export: %v", err)
+	}
+
+	snap := engine.TopologySnapshot(storage.DefaultTenantID)
+	if len(snap.Edges) != 1 {
+		t.Fatalf("edges = %+v, want exactly one gateway->checkout edge", snap.Edges)
+	}
+	edge := snap.Edges[0]
+	if edge.Caller != "gateway" || edge.Callee != "checkout" {
+		t.Fatalf("edge = %s -> %s, want gateway -> checkout", edge.Caller, edge.Callee)
+	}
+	var count uint64
+	for _, w := range edge.Windows {
+		count += w.Count
+	}
+	if count != 1 {
+		t.Fatalf("edge call count = %d, want 1", count)
+	}
+
+	// The edge must be a real series in the shards, not just a projection.
+	shardCount, _ := engine.Snapshot().Totals(aggregate.SignalServiceEdge)
+	if shardCount != 1 {
+		t.Fatalf("service-edge series count = %d, want 1", shardCount)
+	}
+}
+
+// TestExportEdgesSurviveSampling proves the edge is derived before the
+// retention gate: at a sampling rate that drops everything, the topology still
+// carries the edge, because aggregate counts describe accepted telemetry.
+func TestExportEdgesSurviveSampling(t *testing.T) {
+	now := time.Now()
+	engine := newAggregateEngine(t, now)
+	repo, _ := newAggregateTestRepo(t)
+	srv := NewTraceServer(repo, nil, aggTestConfig())
+	srv.SetAggregateEngine(engine)
+	// Rate 0 with always-on-errors: every healthy span is dropped from raw
+	// persistence.
+	srv.SetSampler(NewSampler(0, true, 500))
+
+	reqs := []*coltracepb.ExportTraceServiceRequest{
+		{ResourceSpans: []*tracepb.ResourceSpans{
+			edgeExport("gateway", edgeSpan("trace-0000000002", "span-101", "", "GET /x", now)),
+		}},
+		{ResourceSpans: []*tracepb.ResourceSpans{
+			edgeExport("orders", edgeSpan("trace-0000000002", "span-102", "span-101", "POST /y", now)),
+		}},
+	}
+	for _, req := range reqs {
+		if _, err := srv.Export(context.Background(), req); err != nil {
+			t.Fatalf("Export: %v", err)
+		}
+	}
+
+	var persisted int64
+	if err := repo.DB().Table("spans").Count(&persisted).Error; err != nil {
+		t.Fatalf("count spans: %v", err)
+	}
+	if persisted != 0 {
+		t.Fatalf("sampler persisted %d spans; the test is no longer about sampling", persisted)
+	}
+
+	snap := engine.TopologySnapshot(storage.DefaultTenantID)
+	if len(snap.Edges) != 1 || snap.Edges[0].Caller != "gateway" || snap.Edges[0].Callee != "orders" {
+		t.Fatalf("edge lost to sampling: %+v", snap.Edges)
+	}
+}

--- a/internal/ingest/otlp.go
+++ b/internal/ingest/otlp.go
@@ -476,7 +476,17 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 					// sampling rate (#153 §8) — that invariant is the entire
 					// reason the engine sits at this point in the path.
 					if reducer != nil {
-						reducer.ReduceSpan(aggregateSpanInput(tenantID, serviceName, span, startTime, endTime))
+						spanIn := aggregateSpanInput(tenantID, serviceName, span, startTime, endTime)
+						reducer.ReduceSpan(spanIn)
+						// Recover this call's caller from its parent span and
+						// emit the caller->callee edge series. #183 shipped
+						// SignalServiceEdge but emitted nothing into it; the
+						// caller join was explicitly deferred to #174.
+						if caller, ok := s.aggregateEngine.EdgeResolver().Observe(
+							tenantID, spanIDHex, parentSpanIDHex, serviceName,
+						); ok {
+							reducer.ReduceEdge(aggregateEdgeInput(caller, spanIn))
+						}
 					}
 
 					// Raw-retention gate. Exactly one policy governs this per

--- a/internal/mcp/honesty_test.go
+++ b/internal/mcp/honesty_test.go
@@ -1,0 +1,168 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+// honestyServer wires an MCP server against an in-memory repo and a GraphRAG
+// whose background loops never fire inside the test window.
+func honestyServer(t *testing.T) (*Server, *graphrag.GraphRAG, *storage.Repository) {
+	t.Helper()
+	db, err := storage.NewDatabase("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	if err := storage.AutoMigrateModels(db, "sqlite"); err != nil {
+		t.Fatalf("AutoMigrateModels: %v", err)
+	}
+	repo := storage.NewRepositoryFromDB(db, "sqlite")
+	t.Cleanup(func() { _ = repo.Close() })
+
+	cfg := graphrag.DefaultConfig()
+	cfg.RefreshEvery = 24 * time.Hour
+	cfg.SnapshotEvery = 24 * time.Hour
+	cfg.AnomalyEvery = 24 * time.Hour
+	g := graphrag.New(repo, nil, nil, cfg)
+	bgCtx, cancel := context.WithCancel(context.Background())
+	go g.Start(bgCtx)
+	t.Cleanup(func() {
+		cancel()
+		g.Stop()
+	})
+
+	srv := New(storage.DefaultTenantID, repo, nil, nil)
+	srv.SetGraphRAG(g)
+	return srv, g, repo
+}
+
+// decodeTraceGraph pulls the TraceGraphResult out of a tool result.
+func decodeTraceGraph(t *testing.T, res ToolCallResult) graphrag.TraceGraphResult {
+	t.Helper()
+	if res.IsError {
+		t.Fatalf("trace_graph returned an error result: %+v", res.Content)
+	}
+	if len(res.Content) == 0 {
+		t.Fatalf("trace_graph returned no content")
+	}
+	payload := res.Content[0].Text
+	if res.Content[0].Resource != nil {
+		payload = res.Content[0].Resource.Text
+	}
+	var out graphrag.TraceGraphResult
+	if err := json.Unmarshal([]byte(payload), &out); err != nil {
+		t.Fatalf("unmarshal trace_graph payload %q: %v", payload, err)
+	}
+	return out
+}
+
+// TestTraceGraphSaysNotRetainedRatherThanFabricating is the honesty contract:
+// a trace nobody retained gets a definitive "not retained or not found", as a
+// SUCCESSFUL response, never an invented tree.
+func TestTraceGraphSaysNotRetainedRatherThanFabricating(t *testing.T) {
+	srv, _, _ := honestyServer(t)
+
+	res := srv.toolHandler(context.Background(), "trace_graph", map[string]any{"trace_id": "ghost-trace"})
+	out := decodeTraceGraph(t, res)
+
+	if out.Coverage.Source != graphrag.CoverageNone {
+		t.Fatalf("coverage source = %q, want %q", out.Coverage.Source, graphrag.CoverageNone)
+	}
+	if out.Coverage.Complete {
+		t.Fatalf("an absent trace was reported complete: %+v", out.Coverage)
+	}
+	if len(out.Spans) != 0 {
+		t.Fatalf("an absent trace returned %d spans", len(out.Spans))
+	}
+	if out.Coverage.Note == "" {
+		t.Fatalf("no explanation for the absent trace")
+	}
+}
+
+// TestTraceGraphReportsCompleteRetainedExemplar proves a fully retained trace
+// is reported as complete.
+func TestTraceGraphReportsCompleteRetainedExemplar(t *testing.T) {
+	srv, g, _ := honestyServer(t)
+	now := time.Now()
+	for _, sp := range []storage.Span{
+		{TenantID: storage.DefaultTenantID, TraceID: "tr-1", SpanID: "root", ServiceName: "gateway", OperationName: "/in", StartTime: now, Duration: 1000},
+		{TenantID: storage.DefaultTenantID, TraceID: "tr-1", SpanID: "leaf", ParentSpanID: "root", ServiceName: "checkout", OperationName: "/pay", StartTime: now, Duration: 1000},
+	} {
+		g.OnSpanIngested(sp)
+	}
+	waitForSpans(t, g, "tr-1", 2)
+
+	out := decodeTraceGraph(t, srv.toolHandler(context.Background(), "trace_graph", map[string]any{"trace_id": "tr-1"}))
+	if !out.Coverage.Complete || out.Coverage.Source != graphrag.CoverageRetained {
+		t.Fatalf("complete retained trace reported as %+v", out.Coverage)
+	}
+	if out.Coverage.RetainedSpans != 2 {
+		t.Fatalf("retained spans = %d, want 2", out.Coverage.RetainedSpans)
+	}
+}
+
+// TestTraceGraphReportsPartialWhenParentMissing proves a trace whose parent
+// span was never retained is reported as partial, not presented as a tree.
+func TestTraceGraphReportsPartialWhenParentMissing(t *testing.T) {
+	srv, g, _ := honestyServer(t)
+	now := time.Now()
+	g.OnSpanIngested(storage.Span{
+		TenantID: storage.DefaultTenantID, TraceID: "tr-2", SpanID: "orphan",
+		ParentSpanID: "never-retained", ServiceName: "checkout", OperationName: "/pay",
+		StartTime: now, Duration: 1000,
+	})
+	waitForSpans(t, g, "tr-2", 1)
+
+	out := decodeTraceGraph(t, srv.toolHandler(context.Background(), "trace_graph", map[string]any{"trace_id": "tr-2"}))
+	if out.Coverage.Complete {
+		t.Fatalf("a trace with a dangling parent was reported complete: %+v", out.Coverage)
+	}
+	if out.Coverage.Source != graphrag.CoveragePartial || !out.Coverage.Truncated {
+		t.Fatalf("coverage = %+v, want partial + truncated", out.Coverage)
+	}
+}
+
+// TestToolDescriptionsStateTheirCoverageLimits proves the descriptions the
+// 7-tool surface advertises actually carry the contract, so a client is told
+// the limits before it calls anything.
+func TestToolDescriptionsStateTheirCoverageLimits(t *testing.T) {
+	byName := map[string]string{}
+	for _, tool := range toolDefs {
+		byName[tool.Name] = tool.Description
+	}
+	if len(byName) != 7 {
+		t.Fatalf("tool surface has %d tools, want 7", len(byName))
+	}
+	for name, want := range map[string]string{
+		"trace_graph":          "not_retained_or_not_found",
+		"root_cause_analysis":  "partial_exemplar",
+		"get_service_map":      "aggregate retention",
+		"impact_analysis":      "aggregate retention",
+		"get_anomaly_timeline": "aggregate retention",
+	} {
+		if !strings.Contains(byName[name], want) {
+			t.Errorf("%s description does not state %q: %s", name, want, byName[name])
+		}
+	}
+}
+
+// waitForSpans blocks until GraphRAG's async workers have folded n spans of
+// traceID into the trace store.
+func waitForSpans(t *testing.T, g *graphrag.GraphRAG, traceID string, n int) {
+	t.Helper()
+	ctx := storage.WithTenantContext(context.Background(), storage.DefaultTenantID)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(g.DependencyChain(ctx, traceID)) >= n {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("trace %s never reached %d spans in the trace store", traceID, n)
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -51,29 +51,29 @@ func mkTool(name, desc string, opts ...schemaOpt) Tool {
 }
 
 var toolDefs = []Tool{
-	mkTool("get_anomaly_timeline", "Returns recent anomalies with temporal causal links, optionally filtered by service. The triage entry point — answers \"what's wrong right now\".",
+	mkTool("get_anomaly_timeline", "Returns recent anomalies with temporal causal links, optionally filtered by service. The triage entry point — answers \"what's wrong right now\". Aggregate-backed: complete within aggregate retention, independent of which traces were retained as raw exemplars.",
 		param("since", "string", "Start time RFC3339. Defaults to 1h ago."),
 		param("service", "string", "Filter by service."),
 	),
-	mkTool("get_service_map", "Returns the service topology with health scores, error rates, call counts, and dependency edges. Powered by the live GraphRAG.",
+	mkTool("get_service_map", "Returns the service topology with health scores, error rates, call counts, and dependency edges. Aggregate-backed: counts describe ALL accepted telemetry, not the sampled subset, and are complete within aggregate retention.",
 		param("depth", "number", "Max traversal depth (default 3)."),
 		param("service", "string", "Focus on a specific service and its neighbors."),
 	),
-	mkTool("get_service_health", "Returns detailed health metrics for a specific service: error rate, latency percentiles, request rate, and active alerts.",
+	mkTool("get_service_health", "Returns detailed health metrics for a specific service: error rate, latency, request counts and dependency edges. Aggregate-backed and complete within aggregate retention. Returns an explicit \"not found in the current tenant window\" message rather than an empty guess.",
 		required("service_name"),
 		param("service_name", "string", "The service name to query."),
 	),
-	mkTool("root_cause_analysis", "Ranked probable root causes with evidence: error chains, anomalous metrics, correlated logs.",
+	mkTool("root_cause_analysis", "Ranked probable root causes with evidence: error chains, anomalous metrics, correlated logs. Each ranked cause carries a `coverage` block: `source=retained_exemplar` means a complete retained error chain backs it, `partial_exemplar` means the upstream walk stopped at a span that was not retained (the named service is NOT proven to be the root), and `not_retained_or_not_found` means the ranking rests on aggregate anomaly evidence with no chain behind it. Errors are always eligible for retention but never all retained — treat a partial cause as a lead, not a conclusion.",
 		required("service"),
 		param("service", "string", "Service experiencing issues."),
 		param("time_range", "string", "Lookback window. Defaults to '15m'."),
 	),
-	mkTool("impact_analysis", "BFS downstream from a service to find all affected services and impact scores.",
+	mkTool("impact_analysis", "BFS downstream from a service to find all affected services and impact scores. Aggregate-backed: edges come from the aggregate topology snapshot and are complete within aggregate retention.",
 		required("service"),
 		param("service", "string", "Service to analyze blast radius for."),
 		param("depth", "number", "Max traversal depth (default 5)."),
 	),
-	mkTool("trace_graph", "Returns the full span tree for a trace with service names, durations, errors, and linked logs.",
+	mkTool("trace_graph", "Returns the retained span tree for a trace with service names, durations and errors, plus a `coverage` block stating what it covers. `coverage.source=retained_exemplar` with `complete=true` is a complete retained trace; `partial_exemplar` means spans reference parents that were not retained (per-trace span/byte bound or TTL) and `retained_spans`/`observed_spans` quantify the gap; `not_retained_or_not_found` means no exemplar exists for this trace — that is a definitive answer, not an error, and the trace should not be assumed to have been error-free. Only a fraction of healthy traces are retained by design; errors are always eligible but capped.",
 		required("trace_id"),
 		param("trace_id", "string", "The trace ID to visualize."),
 	),
@@ -272,6 +272,11 @@ func (s *Server) toolGetServiceMap(ctx context.Context, args map[string]any) Too
 	return textResult(string(data))
 }
 
+// toolTraceGraph answers with the retained span tree and an explicit coverage
+// block (#163's causal-analysis quality contract). A trace nobody retained is
+// answered "not retained or not found" — a definitive, successful response.
+// Fabricating certainty about a trace that was never persisted is the failure
+// mode this replaces.
 func (s *Server) toolTraceGraph(ctx context.Context, args map[string]any) ToolCallResult {
 	if s.graphRAG == nil {
 		return errorResult(errGraphRAGNotInit)
@@ -280,24 +285,55 @@ func (s *Server) toolTraceGraph(ctx context.Context, args map[string]any) ToolCa
 	if traceID == "" {
 		return errorResult("trace_id is required")
 	}
-	spans := s.graphRAG.DependencyChain(mcpCtx(ctx), traceID)
-	if len(spans) == 0 {
-		// Fallback to DB
-		trace, err := s.repo.GetTrace(mcpCtx(ctx), traceID)
-		if err != nil {
-			return errorResult(fmt.Sprintf("trace not found: %v", err))
+	tctx := mcpCtx(ctx)
+	res := s.graphRAG.TraceGraph(tctx, traceID)
+	if len(res.Spans) == 0 {
+		// The in-memory trace TTL is shorter than raw retention, so a trace
+		// that WAS retained can still be absent from the graph. The DB row
+		// carries the truncation counters the exemplar policy stamped on it.
+		if enriched, ok := s.traceGraphFromDB(tctx, traceID); ok {
+			res = enriched
 		}
-		data, err := json.Marshal(trace)
-		if err != nil {
-			return errorResult(fmt.Sprintf("failed to marshal trace: %v", err))
-		}
-		return resourceResult(resourceURIPrefix+"traces/"+traceID, httpconst.ContentTypeJSON, string(data))
 	}
-	data, err := json.Marshal(spans)
+	data, err := json.Marshal(res)
 	if err != nil {
 		return errorResult(fmt.Sprintf("failed to marshal trace graph: %v", err))
 	}
-	return textResult(string(data))
+	return resourceResult(resourceURIPrefix+"traces/"+traceID, httpconst.ContentTypeJSON, string(data))
+}
+
+// traceGraphFromDB reads the persisted trace row for a trace the in-memory
+// window no longer holds and renders its coverage from the retained/observed
+// counters the exemplar policy stamped on it.
+func (s *Server) traceGraphFromDB(ctx context.Context, traceID string) (graphrag.TraceGraphResult, bool) {
+	if s.repo == nil {
+		return graphrag.TraceGraphResult{}, false
+	}
+	trace, err := s.repo.GetTrace(ctx, traceID)
+	if err != nil {
+		return graphrag.TraceGraphResult{}, false
+	}
+	out := graphrag.TraceGraphResult{
+		TraceID: traceID,
+		Coverage: graphrag.Coverage{
+			Complete: true,
+			Source:   graphrag.CoverageRetained,
+			Note:     "trace row retained; its spans are outside the in-memory trace window",
+		},
+	}
+	if trace.Truncated != nil && *trace.Truncated {
+		out.Coverage.Complete = false
+		out.Coverage.Truncated = true
+		out.Coverage.Source = graphrag.CoveragePartial
+		out.Coverage.Note = "trace was truncated by the per-trace span/byte bound"
+	}
+	if trace.RetainedSpanCount != nil {
+		out.Coverage.RetainedSpans = *trace.RetainedSpanCount
+	}
+	if trace.ObservedSpanCount != nil {
+		out.Coverage.ObservedSpans = *trace.ObservedSpanCount
+	}
+	return out, true
 }
 
 func (s *Server) toolImpactAnalysis(ctx context.Context, args map[string]any) ToolCallResult {

--- a/main.go
+++ b/main.go
@@ -388,8 +388,16 @@ func main() {
 		return out, nil
 	}, 5*time.Minute, 30*time.Second)
 	ctxGraph, cancelGraph := context.WithCancel(context.Background())
-	go svcGraph.Start(ctxGraph)
-	slog.Info("🕸️  In-memory service graph started (5m window, 30s refresh)")
+	// The legacy graph is a raw-span scanner. In aggregate mode the topology
+	// comes from the aggregate engine's snapshot and this scan is retired
+	// outright (#174) — the object stays wired so the nil-tolerant handlers
+	// keep their shape, but nothing refreshes it.
+	if cfg.AggregateMode != aggregate.ModeAggregate {
+		go svcGraph.Start(ctxGraph)
+		slog.Info("🕸️  In-memory service graph started (5m window, 30s refresh)")
+	} else {
+		slog.Info("🕸️  Legacy in-memory service graph disabled (AGGREGATE_MODE=aggregate)")
+	}
 
 	// 4g. Initialize GraphRAG (replaces simple graph for advanced queries)
 	graphrag.SetPanicMetrics(metrics)
@@ -397,6 +405,9 @@ func main() {
 	graphRAGCfg.WorkerCount = cfg.GraphRAGWorkerCount
 	graphRAGCfg.ChannelSize = cfg.GraphRAGEventQueueSize
 	graphRAGCfg.MaxSpansPerTenant = cfg.GraphRAGMaxSpansPerTenant
+	// Aggregate mode retires the raw-span rebuild and the GraphRAG-owned
+	// Drain miner; shadow mode retires only the miner (#163).
+	graphRAGCfg.Mode = cfg.AggregateMode
 	// Duration knobs follow the DLQ_REPLAY_INTERVAL pattern: unparsable
 	// values fall back to the package default rather than aborting startup.
 	if ttl, err := time.ParseDuration(cfg.GraphRAGTraceTTL); err == nil && ttl > 0 {
@@ -415,6 +426,7 @@ func main() {
 		"trace_ttl", graphRAGCfg.TraceTTL,
 		"max_spans_per_tenant", graphRAGCfg.MaxSpansPerTenant,
 		"tenant_idle_ttl", graphRAGCfg.TenantIdleTTL,
+		"mode", graphRAGCfg.Mode,
 	)
 
 	// Auto-migrate GraphRAG models (Investigation, DrainTemplateRow)
@@ -519,6 +531,13 @@ func main() {
 			MaxBaselines:                  cfg.ResolvedAggregateMaxBaselines(),
 			Metrics:                       aggregate.NewPrometheusRecorder(metrics),
 			MetricDims:                    aggregate.DimsConfig(cfg.AggregateMetricDims),
+			// Keep the topology projection's caps in step with the series
+			// budget: an operation the limiter would collapse into __other__
+			// must not survive as a named topology entry.
+			Topology: aggregate.TopologyConfig{
+				MaxOperationsPerService: cfg.AggregateMaxOperationsPerService,
+				MaxEdges:                cfg.AggregateMaxSeriesEdges,
+			},
 		})
 		if err != nil {
 			fatal("❌ Aggregate engine configuration rejected", err, "mode", cfg.AggregateMode)
@@ -560,6 +579,20 @@ func main() {
 		traceServer.SetAggregateEngine(aggEngine)
 		logsServer.SetAggregateEngine(aggEngine)
 		metricsServer.SetAggregateEngine(aggEngine)
+
+		// Shadow and aggregate modes: log templates are mined once, on the
+		// ingest path, and handed to GraphRAG as facts. GraphRAG runs no
+		// miner of its own in either mode, so the two never disagree about a
+		// template's identity (#163).
+		aggEngine.SetTemplateFactSink(graphRAG.OnTemplateFact)
+		// Aggregate mode: GraphRAG replaces its topology from the engine's
+		// per-revision snapshot instead of rescanning the spans table (#174).
+		if cfg.AggregateMode == aggregate.ModeAggregate {
+			graphRAG.SetAggregateSource(aggEngine)
+			slog.Info("🧭 GraphRAG consuming aggregate topology snapshots (raw-span rebuild retired)",
+				"epoch", aggEngine.TopologyEpoch(),
+			)
+		}
 		slog.Info("🧮 Aggregate engine enabled",
 			"mode", cfg.AggregateMode,
 			"max_series", cfg.AggregateMaxSeries,
@@ -740,9 +773,13 @@ func main() {
 
 	// Observe cross-service call topology pre-sample so the service map keeps
 	// flow direction even when sampling drops the spans forming each edge.
-	traceServer.SetTopologyObserver(func(tenant, traceID, spanID, parentSpanID, service string) {
-		graphRAG.ObserveSpanTopology(tenant, traceID, spanID, parentSpanID, service)
-	})
+	// In aggregate mode edges come from the engine's service-edge series and
+	// this observer would fight the snapshot, so it is not wired.
+	if cfg.AggregateMode != aggregate.ModeAggregate {
+		traceServer.SetTopologyObserver(func(tenant, traceID, spanID, parentSpanID, service string) {
+			graphRAG.ObserveSpanTopology(tenant, traceID, spanID, parentSpanID, service)
+		})
+	}
 
 	metricsServer.SetMetricCallback(func(m tsdb.RawMetric) {
 		eventHub.BroadcastMetric(realtime.MetricEntry{


### PR DESCRIPTION
Closes #174

Phase 3 of the aggregate-first epic (#153), decisions frozen in #163. In `AGGREGATE_MODE=aggregate` the in-memory topology stops being derived from a 60-second rescan of the `spans` table — the ~27M-row/min scan at target load — and becomes a replacement-by-revision projection of the aggregate engine.

## What changed

### `internal/aggregate`

| File | What it adds |
|---|---|
| `topology.go` (new) | Bounded per-tenant `{revision, services, operations, edges, metrics}` projection over the mutable windows plus a configured finalized horizon (30 m default). Fed from the same `AggregateDelta` values the shards receive, keyed by the identity **strings** the reducer already resolved — nothing is aggregated twice and no dictionary ID is ever reversed (after a restart the durable dictionary is warm but the intern cache is empty, so a reverse lookup would render an unnamed topology). Every map is capped; a cap breach is counted and published on the snapshot as `Dropped*`/`Truncated()`. Windows carry `Closed`/`Final`/`Elapsed` — the partial-window guard. |
| `edges.go` (new) | `EdgeResolver`: a sharded, bounded span-ID → service memory that recovers a call's caller by joining a child span's `ParentSpanID` against the parent's service. |
| `reducer.go` | `EdgeInput` + `ReduceEdge` — **the `SignalServiceEdge` emission PR #183 explicitly deferred to this issue.** Plus a per-delta identity map (one small struct per delta, not per point) for the projection. |
| `engine.go` | `Epoch` (a consumer can tell a restart from a rollback), `TopologySnapshot`/`TopologyRevision`/`TopologyTenants`/`PruneTopology`, `EdgeResolver()`, `SetTemplateFactSink`. Topology folding happens after a **successful** apply only — nothing that failed to become durable enters a topology a consumer will present as accounted-for. |
| `template_miner.go` | `SetFactSink` (atomic swap) so the engine can install GraphRAG's log-fact sink after construction. |

### `internal/ingest`

Edge derivation runs inside the trace `Export()` loop, next to `ReduceSpan` and **ahead of the retention gate**, so an edge exists whether or not the spans forming it were retained.

### `internal/graphrag`

- `aggregate.go` (new) — `AggregateSource` interface, per-revision reconciliation, snapshot→graph projection, ingest-mined template facts. An unchanged `(epoch, revision)` pair costs one map lookup; a changed epoch replaces rather than reconciles.
- `store.go` — `ServiceStore.ReplaceTopology` / `SignalStore.ReplaceMetrics`. Replacement, not upserts: re-applying a cumulative snapshot through `UpsertService`/`UpsertCallEdge` would multiply every counter by the number of ticks a window survived. The adjacency indexes are rebuilt with the maps, so their append-only invariant stays intact.
- `refresh.go` — `rebuildAllTenantsFromDB` and `rebuildFromDBForTenant` **hard-return** in aggregate mode (a guard, not just a caller-side branch). The refresh loop keeps only pruning, tenant eviction, anomaly cleanup and investigation-cooldown maintenance, at the unchanged 60 s cadence.
- `builder.go` — per-span service/operation/CALLS upserts and per-point metric upserts are skipped in aggregate mode (the snapshot owns them); retained exemplars still populate the `TraceStore`, which is what error chains read. Shadow **and** aggregate stop running a GraphRAG-owned Drain miner (`g.drain == nil`), consuming ingest-mined template facts instead — routed through the existing best-effort event channel so the miner's synchronous callback never takes a store lock on the OTLP goroutine.
- `anomaly_aggregate.go` (new) — revision-gated detection. Error rate compares a window against the **prior finalized** windows and must clear three standard errors of that baseline proportion (scale-free: 0.4% → 1.2% over 5000 requests is significant, the same jump over 25 is not). Latency reads sketch **p95/p99**. Metrics use a real rolling mean and variance over finalized-window means. The hard-coded 2% baseline, the `avg > 500 ms` threshold and the min/max pseudo-z-score are gone. Baseline horizon is bounded by the projection; startup loads nothing.
- Quality contract: `ErrorChainResult`, `RankedCause` and the new `TraceGraphResult` carry a `Coverage` block — `retained_exemplar` / `partial_exemplar` / `not_retained_or_not_found`. `traceErrorChainUpstream` now reports whether it actually reached a root, so a walk that stopped at an unretained parent is presented as partial rather than as a root cause.

### `internal/mcp`

`trace_graph` returns `{trace_id, spans, coverage}` and answers **"not retained or not found" as a successful response** instead of fabricating certainty; the DB fallback renders coverage from the exemplar policy's `truncated`/`retained_span_count`/`observed_span_count` columns. All seven tool descriptions state their coverage limits.

### `main.go`

`AGGREGATE_MODE` threads into `graphrag.Config.Mode`. In aggregate mode the legacy `internal/graph` raw-span scanner is not started and the pre-sample topology observer is not wired (it would fight the snapshot). Projection caps are derived from the existing series budget — no new environment variables.

**Legacy mode is unchanged.** Shadow mode changes only in that it no longer runs a second template miner (#163).

## Acceptance criteria

| Criterion | Test |
|---|---|
| Zero spans-table scans from GraphRAG in aggregate mode | `TestAggregateModeIssuesNoSpanQueries` — GORM query-callback counter over 10 refresh ticks asserts 0, and the **same assertion in legacy mode asserts non-zero** so the counter can never go vacuous |
| Replayed identical snapshot is a no-op | `TestReconcileReplacesRatherThanAccumulates`, `TestReconcileSkipsUnchangedRevision` (counts snapshot renders, not just results) |
| Epoch reset handled | `TestReconcileHandlesEpochReset` — new epoch with the revision counter restarted at a **lower** number is applied, not skipped |
| Min-count guard | `TestErrorSpikeRespectsMinimumRequestCount` — a 19-request window at 100% errors does not fire |
| Partial-window guard | `TestPartialWindowGuardSuppressesNearEmptyWindow` — a 5 s-old window is suppressed, the same window at 3 min fires |
| No anomaly storms from near-empty windows | `TestNoBaselineNoAnomaly` — the detector refuses to invent a baseline |
| Sketch-based latency | `TestLatencySpikeUsesSketchPercentiles` — p99 20 ms → 400 ms fires at an unchanged average; a steady 900 ms p99 does **not** fire (the retired `avg>500` rule would have) |
| Real z-score | `TestMetricZScoreUsesRollingMeanAndVariance` — 9σ fires, a flat baseline does not divide by zero |
| MCP honesty contract | `TestTraceGraphSaysNotRetainedRatherThanFabricating`, `TestTraceGraphReportsCompleteRetainedExemplar`, `TestTraceGraphReportsPartialWhenParentMissing`, `TestToolDescriptionsStateTheirCoverageLimits` |
| Edge emission (deferred from #183) | `TestExportEmitsServiceEdgeSeries` (cross-service edge yes, same-service parent no, real series in the shards), `TestExportEdgesSurviveSampling` (0 spans persisted, edge still present) |

## Test results

```
gofmt -l <changed files>   -> clean
go vet ./...               -> clean
go build ./...             -> ok
golangci-lint run ./internal/{aggregate,graphrag,mcp,ingest}/... .
   -> 1 pre-existing issue only (see "Not fixed" below)

go test ./internal/graphrag/ ./internal/aggregate/ ./internal/mcp/ ./internal/ingest/ -count=1 -race
   ok  internal/graphrag  94.2s
   ok  internal/aggregate  4.5s
   ok  internal/mcp       27.6s
   ok  internal/ingest    25.5s

go test ./... -count=1     -> 1085 tests, 28 packages, all pass
```

## Deviations from the brief

1. **Topology parity vs legacy on the 150-service load corpus is not measured here.** It needs a running load corpus, which this environment cannot host. The projection is unit-tested for correctness (counts, caps, lateness exclusion, window metadata); the parity run belongs to a soak, and I have not run it — treat that acceptance criterion as **unverified**.
2. **The projection is a parallel string-keyed structure, not a reverse-lookup over `SeriesKey`s.** Reversing dictionary IDs is unusable after a restart: the durable dictionary is warm but the in-memory intern cache is empty, so recovered mutable windows would render as unnamed services. The projection is fed from the same delta values, so nothing is double-aggregated.
3. **Edge identity is `(caller service, callee service)` with the callee name interned in the `KindOperation` namespace.** That is what `NameKind(SignalServiceEdge)` already fixed in #183/#159; it also makes `MAX_OPERATIONS_PER_SERVICE` bound a caller's fan-out, which is the right bound.
4. **Latency sketches are kept per service per window only**, not per operation or per edge. A `Sketch` is a fixed 2 KiB; one per operation per window per service does not fit the target deployment. Service-level p95/p99 is what the detector needs and what #163 asks for; `OperationNode.P95/P99` stay zero in aggregate mode.
5. **`LOGGED_DURING` edges are not formed in shadow/aggregate mode.** A `TemplateFact` carries no span ID by design (#163's fact shape). Nothing in the 7-tool surface reads that edge type — verified by grep — so this costs nothing observable.
6. **No new environment variables.** The projection's caps are derived from `AGGREGATE_MAX_OPERATIONS_PER_SERVICE` and `AGGREGATE_MAX_SERIES_EDGES`; the finalized horizon is a package default (30 m). Adding a config surface for it was not in scope.
7. **The legacy `internal/graph` object is still constructed in aggregate mode, just never started.** It keeps the nil-tolerant handler wiring unchanged; only the scan is retired.

## Not fixed (pre-existing)

`internal/mcp/tenant_isolation_test.go:310` — `copyloopvar`: a redundant `caller := caller` loop-variable copy. Present on `main`, untouched here. Low severity, lint-only.
