### PR TITLE
test(loadsim): direct OTLP engine with ACK-latency percentiles

### DIFF
--- a/test/aggprefill/main.go
+++ b/test/aggprefill/main.go
@@ -1,0 +1,593 @@
+//go:build prefill
+
+// Command aggprefill fills an aggregate store with a fully populated seven-day
+// history for the release-gate disk-sizing measurement.
+//
+// It writes 6,000 materialized series x 288 windows/day x 7 days = 2,016
+// windows = 12,096,000 rows in aggregate_buckets, using only the public
+// aggregate store API: one CommitGroup per window followed by FinalizeWindow of
+// that window. Latency series carry real sketches built from a per-series
+// lognormal distribution, so the encoded blob sizes are representative rather
+// than uniform.
+//
+// Build tag: prefill. Run with:
+//
+//	go run -tags prefill ./test/aggprefill -db /path/to/aggregate.db
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"math"
+	"math/rand/v2"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+)
+
+// Series mix, matching the configured per-signal caps in internal/config.
+const (
+	numTraceSeries  = 2400
+	numEdgeSeries   = 500
+	numLogSeries    = 500
+	numMetricSeries = 2400
+	numSystemSeries = 200
+	totalSeries     = numTraceSeries + numEdgeSeries + numLogSeries + numMetricSeries + numSystemSeries
+
+	numServices = 120
+
+	windowsPerDay = 288
+	days          = 7
+	totalWindows  = windowsPerDay * days
+	windowSecs    = 300
+
+	// sizeHistBuckets bounds the encoded-sketch-size histogram. Any blob at or
+	// above it lands in the final bucket and is also tracked by maxSize.
+	sizeHistBuckets = 8192
+
+	// diskGuardBytes stops the run before the host fills up.
+	diskGuardBytes = int64(20) << 30
+)
+
+// series kinds.
+const (
+	kindLatency = iota // trace ops and service edges: counters + sketch
+	kindLog
+	kindGauge
+	kindCounter
+)
+
+type seriesSpec struct {
+	id   aggregate.SeriesID
+	key  aggregate.SeriesKey
+	kind int
+
+	// latency distribution (microseconds), lognormal.
+	logMu    float64
+	logSigma float64
+
+	// nominal observations per window; jittered per window.
+	baseRate int
+	errRate  float64
+}
+
+type workerStats struct {
+	sketchN      int64
+	sketchBytes  int64
+	binCountSum  int64
+	maxSize      int
+	maxBins      int
+	sizeHist     [sizeHistBuckets]int64
+	observations int64
+}
+
+func main() {
+	dbPath := flag.String("db", "./data/aggregate.db", "aggregate database path")
+	workers := flag.Int("workers", 8, "delta-building worker goroutines")
+	numWindows := flag.Int("windows", totalWindows, "windows to fill (default is the full 7-day gate: 2016)")
+	flag.Parse()
+
+	if err := os.MkdirAll(filepath.Dir(*dbPath), 0o755); err != nil {
+		log.Fatalf("mkdir: %v", err)
+	}
+
+	store, err := aggregate.OpenSQLiteStore(aggregate.StoreConfig{
+		Path:        *dbPath,
+		Synchronous: "NORMAL",
+	})
+	if err != nil {
+		log.Fatalf("open store: %v", err)
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			_ = store.Close()
+		}
+	}()
+
+	dicts, specs := buildIdentities()
+	log.Printf("identities: %d dict rows, %d series", len(dicts), len(specs))
+
+	seriesRows := make([]aggregate.SeriesRow, len(specs))
+	for i := range specs {
+		if err := specs[i].key.Validate(); err != nil {
+			log.Fatalf("series %d key invalid: %v", i, err)
+		}
+		seriesRows[i] = aggregate.SeriesRow{ID: specs[i].id, Key: specs[i].key}
+	}
+
+	// Reusable per-window state. Sketches are pre-attached so ObserveSpan never
+	// allocates and the per-window allocation cost stays flat.
+	deltas := make([]aggregate.AggregateDelta, totalSeries)
+	rows := make([]aggregate.DeltaRow, totalSeries)
+	numLatency := numTraceSeries + numEdgeSeries
+	sketches := make([]aggregate.Sketch, numLatency)
+	freshSketch := *aggregate.NewSketch()
+
+	// Window range: 2016 aligned five-minute windows ending at the current one.
+	endWindow := aggregate.WindowStart(time.Now().UTC())
+	firstWindow := endWindow - int64(*numWindows-1)*windowSecs
+
+	if *workers < 1 {
+		*workers = 1
+	}
+	stats := make([]*workerStats, *workers)
+	rngs := make([]*rand.Rand, *workers)
+	bounds := partition(totalSeries, *workers)
+	for w := 0; w < *workers; w++ {
+		stats[w] = &workerStats{}
+		rngs[w] = rand.New(rand.NewPCG(uint64(w)+1, 0x9e3779b97f4a7c15))
+	}
+
+	// Cumulative baselines for the counter series, committed once with the
+	// first window's deltas (the baseline table holds one row per counter
+	// series regardless of window count, so re-upserting every window would
+	// cost time without changing the measured size).
+	baselines := make([]aggregate.BaselineRow, 0, numMetricSeries/2)
+	baseTime := time.Unix(firstWindow, 0).UTC()
+	for i := range specs {
+		if specs[i].kind != kindCounter {
+			continue
+		}
+		baselines = append(baselines, aggregate.BaselineRow{
+			SeriesID: specs[i].id,
+			Producer: aggregate.ProducerID(uint64(i)%97 + 1),
+			Baseline: aggregate.Baseline{
+				StartTime:     baseTime,
+				LastTimestamp: baseTime,
+				Value:         float64(i) * 13.5,
+			},
+		})
+	}
+
+	start := time.Now()
+	var (
+		totalDeltaRows int
+		totalBuckets   int
+	)
+
+	for wi := 0; wi < *numWindows; wi++ {
+		windowStart := firstWindow + int64(wi)*windowSecs
+		ts := time.Unix(windowStart, 0).UTC()
+
+		var wg sync.WaitGroup
+		for w := 0; w < len(bounds)-1; w++ {
+			wg.Add(1)
+			go func(w int) {
+				defer wg.Done()
+				buildRange(specs, deltas, sketches, rows, freshSketch,
+					bounds[w], bounds[w+1], wi, windowStart, ts, rngs[w], stats[w])
+			}(w)
+		}
+		wg.Wait()
+
+		batch := &aggregate.GroupBatch{Deltas: rows}
+		if wi == 0 {
+			batch.Dicts = dicts
+			batch.Series = seriesRows
+			batch.Baselines = baselines
+		}
+		if err := store.CommitGroup(batch); err != nil {
+			log.Fatalf("window %d (%d): commit: %v", wi, windowStart, err)
+		}
+		fs, err := store.FinalizeWindow(windowStart)
+		if err != nil {
+			log.Fatalf("window %d (%d): finalize: %v", wi, windowStart, err)
+		}
+		totalDeltaRows += fs.DeltaRows
+		totalBuckets += fs.Buckets
+		if fs.Buckets != totalSeries {
+			log.Fatalf("window %d (%d): finalized %d buckets, want %d", wi, windowStart, fs.Buckets, totalSeries)
+		}
+
+		if (wi+1)%100 == 0 || wi == *numWindows-1 {
+			db, wal, shm, sum := dbSizes(*dbPath)
+			el := time.Since(start)
+			rate := float64(totalBuckets) / el.Seconds()
+			eta := time.Duration(float64(*numWindows-wi-1) / float64(wi+1) * float64(el))
+			log.Printf("windows %d/%d buckets=%d deltas=%d elapsed=%s rate=%.0f rows/s eta=%s db=%s wal=%s shm=%s sum=%s",
+				wi+1, *numWindows, totalBuckets, totalDeltaRows,
+				el.Truncate(time.Second), rate, eta.Truncate(time.Second),
+				human(db), human(wal), human(shm), human(sum))
+			if sum > diskGuardBytes {
+				log.Printf("DISK GUARD TRIPPED: %d bytes > %d; stopping early", sum, diskGuardBytes)
+				break
+			}
+		}
+	}
+
+	elapsed := time.Since(start)
+
+	// Pre-checkpoint sizes, store still open.
+	db, wal, shm, sum := dbSizes(*dbPath)
+	fmt.Printf("\n=== PREFILL DONE ===\n")
+	fmt.Printf("wall_time_seconds: %.1f (%s)\n", elapsed.Seconds(), elapsed.Truncate(time.Second))
+	fmt.Printf("windows_finalized: %d\n", *numWindows)
+	fmt.Printf("bucket_rows_written: %d\n", totalBuckets)
+	fmt.Printf("delta_rows_incorporated: %d\n", totalDeltaRows)
+	fmt.Printf("first_window: %d  last_window: %d\n", firstWindow, endWindow)
+	fmt.Printf("PRE-CLOSE sizes: db=%d wal=%d shm=%d sum=%d\n", db, wal, shm, sum)
+
+	if err := store.Close(); err != nil {
+		log.Fatalf("close: %v", err)
+	}
+	closed = true
+	db, wal, shm, sum = dbSizes(*dbPath)
+	fmt.Printf("POST-CLOSE sizes: db=%d wal=%d shm=%d sum=%d\n", db, wal, shm, sum)
+
+	reportSketchStats(stats)
+}
+
+// partition splits n items into w contiguous ranges, returned as w+1 bounds.
+func partition(n, w int) []int {
+	out := make([]int, 0, w+1)
+	for i := 0; i <= w; i++ {
+		out = append(out, n*i/w)
+	}
+	return out
+}
+
+// buildRange fills deltas[lo:hi] for one window and refreshes rows[lo:hi].
+func buildRange(specs []seriesSpec, deltas []aggregate.AggregateDelta, sketches []aggregate.Sketch,
+	rows []aggregate.DeltaRow, fresh aggregate.Sketch,
+	lo, hi, windowIdx int, windowStart int64, ts time.Time, r *rand.Rand, st *workerStats) {
+
+	numLatency := numTraceSeries + numEdgeSeries
+	for i := lo; i < hi; i++ {
+		sp := &specs[i]
+		d := &deltas[i]
+		*d = aggregate.AggregateDelta{}
+
+		switch sp.kind {
+		case kindLatency:
+			sketches[i] = fresh
+			d.Sketch = &sketches[i]
+			// Per-window drift plus an occasional degraded window, so the
+			// populated bin count and therefore the encoded size vary.
+			mu := sp.logMu + 0.30*(r.Float64()-0.5)
+			sigma := sp.logSigma
+			if (windowIdx+i)%37 == 0 {
+				mu += 0.8
+				sigma *= 1.25
+			}
+			n := sp.baseRate + r.IntN(sp.baseRate/2+1) - sp.baseRate/4
+			if n < 1 {
+				n = 1
+			}
+			for k := 0; k < n; k++ {
+				v := math.Exp(mu + sigma*r.NormFloat64())
+				if v < 1 {
+					v = 1
+				} else if v > 60e6 {
+					v = 60e6
+				}
+				d.ObserveSpan(v, r.Float64() < sp.errRate)
+			}
+			st.observations += int64(n)
+			sz := len(d.Sketch.Encode())
+			bins := d.Sketch.PopulatedBins()
+			st.sketchN++
+			st.sketchBytes += int64(sz)
+			st.binCountSum += int64(bins)
+			if sz > st.maxSize {
+				st.maxSize = sz
+			}
+			if bins > st.maxBins {
+				st.maxBins = bins
+			}
+			idx := sz
+			if idx >= sizeHistBuckets {
+				idx = sizeHistBuckets - 1
+			}
+			st.sizeHist[idx]++
+
+		case kindLog:
+			n := sp.baseRate + r.IntN(sp.baseRate/2+1) - sp.baseRate/4
+			if n < 1 {
+				n = 1
+			}
+			isErr := sp.key.StatusClass >= aggregate.SeverityTierError
+			for k := 0; k < n; k++ {
+				off := time.Duration(r.IntN(windowSecs*1000)) * time.Millisecond
+				d.ObserveLog(ts.Add(off), isErr)
+			}
+			st.observations += int64(n)
+
+		case kindGauge:
+			n := 30 + r.IntN(31)
+			for k := 0; k < n; k++ {
+				off := time.Duration(k) * 10 * time.Second
+				d.ObserveGauge(sp.logMu+sp.logSigma*r.NormFloat64(), ts.Add(off))
+			}
+			st.observations += int64(n)
+
+		case kindCounter:
+			n := 30 + r.IntN(31)
+			for k := 0; k < n; k++ {
+				reset := r.IntN(4096) == 0
+				d.ObserveCounter(math.Abs(r.NormFloat64())*sp.logSigma+1, reset)
+			}
+			st.observations += int64(n)
+		}
+
+		if sp.kind != kindLatency && i < numLatency {
+			d.Sketch = nil
+		}
+		rows[i] = aggregate.DeltaRow{SeriesID: sp.id, WindowStart: windowStart, Delta: d}
+	}
+}
+
+// buildIdentities mints the dictionary rows and the 6,000 series specs. Dict
+// IDs are globally unique because aggregate_dict.id is the primary key; values
+// are unique within (tenant, kind) because of idx_aggregate_dict_scope.
+func buildIdentities() ([]aggregate.DictRow, []seriesSpec) {
+	var dicts []aggregate.DictRow
+	nextDict := uint32(0)
+	add := func(tenant uint32, kind aggregate.Kind, value string) uint32 {
+		nextDict++
+		dicts = append(dicts, aggregate.DictRow{
+			ID: nextDict, TenantID: tenant, Kind: kind, Value: []byte(value),
+		})
+		return nextDict
+	}
+
+	tenantID := add(aggregate.GlobalTenant, aggregate.KindTenant, "default")
+
+	serviceIDs := make([]uint32, numServices)
+	for i := range serviceIDs {
+		serviceIDs[i] = add(tenantID, aggregate.KindService, fmt.Sprintf("checkout-svc-%03d", i))
+	}
+
+	// Deterministic per-series distribution parameters.
+	r := rand.New(rand.NewPCG(0x5eed, 0xc0ffee))
+	drawLatency := func() (mu, sigma float64) {
+		// median between 5 ms and 500 ms, expressed in microseconds.
+		lo, hi := math.Log(5000.0), math.Log(500000.0)
+		mu = lo + r.Float64()*(hi-lo)
+		sigma = 0.40 + r.Float64()*1.00
+		return mu, sigma
+	}
+
+	specs := make([]seriesSpec, 0, totalSeries)
+	nextSeries := aggregate.SeriesID(0)
+	newID := func() aggregate.SeriesID { nextSeries++; return nextSeries }
+
+	// 2,400 trace-operation series.
+	for i := 0; i < numTraceSeries; i++ {
+		svc := i % numServices
+		nameID := add(tenantID, aggregate.KindOperation,
+			fmt.Sprintf("GET /api/v%d/resource-%04d", i%3+1, i))
+		mu, sigma := drawLatency()
+		specs = append(specs, seriesSpec{
+			id:   newID(),
+			kind: kindLatency,
+			key: aggregate.SeriesKey{
+				TenantID:    tenantID,
+				ServiceID:   serviceIDs[svc],
+				NameID:      nameID,
+				Signal:      aggregate.SignalTraceOp,
+				StatusClass: traceStatus(i),
+				HTTPClass:   aggregate.HTTPClass(i % 6),
+				Method:      aggregate.Method(i % 11),
+				Variant:     aggregate.Variant(i % 6),
+			},
+			logMu: mu, logSigma: sigma,
+			baseRate: 200 + (i*7)%401,
+			errRate:  0.005 + float64(i%20)/400.0,
+		})
+	}
+
+	// 500 service-edge series. NameID resolves through KindOperation.
+	for i := 0; i < numEdgeSeries; i++ {
+		svc := i % numServices
+		callee := (i*7 + 3) % numServices
+		nameID := add(tenantID, aggregate.KindOperation,
+			fmt.Sprintf("edge:checkout-svc-%03d->checkout-svc-%03d#%03d", svc, callee, i))
+		mu, sigma := drawLatency()
+		specs = append(specs, seriesSpec{
+			id:   newID(),
+			kind: kindLatency,
+			key: aggregate.SeriesKey{
+				TenantID:    tenantID,
+				ServiceID:   serviceIDs[svc],
+				NameID:      nameID,
+				Signal:      aggregate.SignalServiceEdge,
+				StatusClass: traceStatus(i),
+				HTTPClass:   aggregate.HTTPClass(i % 6),
+				Method:      aggregate.Method(i % 11),
+				Variant:     aggregate.Variant(i%2 + 2), // server / client
+			},
+			logMu: mu, logSigma: sigma,
+			baseRate: 200 + (i*13)%401,
+			errRate:  0.01 + float64(i%15)/300.0,
+		})
+	}
+
+	// 500 log series. No sketch.
+	for i := 0; i < numLogSeries; i++ {
+		svc := i % numServices
+		nameID := add(tenantID, aggregate.KindLogTemplate,
+			fmt.Sprintf("template-%04d: request <*> failed with <*> after <*> ms", i))
+		specs = append(specs, seriesSpec{
+			id:   newID(),
+			kind: kindLog,
+			key: aggregate.SeriesKey{
+				TenantID:    tenantID,
+				ServiceID:   serviceIDs[svc],
+				NameID:      nameID,
+				Signal:      aggregate.SignalLog,
+				StatusClass: aggregate.StatusClass(i%6 + 1),
+			},
+			baseRate: 20 + (i*11)%181,
+		})
+	}
+
+	// 2,400 native metric series: half gauge-like, half cumulative counter.
+	for i := 0; i < numMetricSeries; i++ {
+		svc := i % numServices
+		nameID := add(tenantID, aggregate.KindMetricName,
+			fmt.Sprintf("otelcontext.app.metric.%04d", i))
+		kind := kindGauge
+		if i >= numMetricSeries/2 {
+			kind = kindCounter
+		}
+		specs = append(specs, seriesSpec{
+			id:   newID(),
+			kind: kind,
+			key: aggregate.SeriesKey{
+				TenantID:  tenantID,
+				ServiceID: serviceIDs[svc],
+				NameID:    nameID,
+				Signal:    aggregate.SignalMetric,
+			},
+			logMu:    100 + float64(i%500),
+			logSigma: 5 + float64(i%40),
+		})
+	}
+
+	// 200 "system" series: metrics under a distinct dims tuple.
+	sysDims := add(tenantID, aggregate.KindDimTuple, "scope=system\x00tier=platform")
+	for i := 0; i < numSystemSeries; i++ {
+		svc := i % numServices
+		nameID := add(tenantID, aggregate.KindMetricName,
+			fmt.Sprintf("otelcontext.system.metric.%04d", i))
+		specs = append(specs, seriesSpec{
+			id:   newID(),
+			kind: kindGauge,
+			key: aggregate.SeriesKey{
+				TenantID:  tenantID,
+				ServiceID: serviceIDs[svc],
+				NameID:    nameID,
+				DimsID:    sysDims,
+				Signal:    aggregate.SignalMetric,
+			},
+			logMu:    50 + float64(i%200),
+			logSigma: 3 + float64(i%20),
+		})
+	}
+
+	if len(specs) != totalSeries {
+		log.Fatalf("built %d series, want %d", len(specs), totalSeries)
+	}
+	return dicts, specs
+}
+
+func traceStatus(i int) aggregate.StatusClass {
+	switch i % 5 {
+	case 0, 1:
+		return aggregate.StatusOK
+	case 2:
+		return aggregate.StatusError
+	default:
+		return aggregate.StatusUnset
+	}
+}
+
+func dbSizes(path string) (db, wal, shm, sum int64) {
+	db = fileSize(path)
+	wal = fileSize(path + "-wal")
+	shm = fileSize(path + "-shm")
+	return db, wal, shm, db + wal + shm
+}
+
+func fileSize(p string) int64 {
+	fi, err := os.Stat(p)
+	if err != nil {
+		return 0
+	}
+	return fi.Size()
+}
+
+func human(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%dB", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.2f%ciB", float64(b)/float64(div), "KMGTP"[exp])
+}
+
+func reportSketchStats(stats []*workerStats) {
+	var (
+		n       int64
+		bytes   int64
+		bins    int64
+		maxSize int
+		maxBins int
+		obs     int64
+		hist    [sizeHistBuckets]int64
+	)
+	for _, s := range stats {
+		n += s.sketchN
+		bytes += s.sketchBytes
+		bins += s.binCountSum
+		obs += s.observations
+		if s.maxSize > maxSize {
+			maxSize = s.maxSize
+		}
+		if s.maxBins > maxBins {
+			maxBins = s.maxBins
+		}
+		for i := range s.sizeHist {
+			hist[i] += s.sizeHist[i]
+		}
+	}
+	fmt.Printf("\n=== SKETCH STATS (in-process, len(Sketch.Encode())) ===\n")
+	if n == 0 {
+		fmt.Printf("no sketches recorded\n")
+		return
+	}
+	fmt.Printf("sketches_encoded: %d\n", n)
+	fmt.Printf("total_observations_all_signals: %d\n", obs)
+	fmt.Printf("avg_encoded_bytes: %.2f\n", float64(bytes)/float64(n))
+	fmt.Printf("total_encoded_bytes: %d\n", bytes)
+	fmt.Printf("avg_populated_bins: %.2f\n", float64(bins)/float64(n))
+	fmt.Printf("max_populated_bins: %d\n", maxBins)
+	fmt.Printf("max_encoded_bytes: %d\n", maxSize)
+	for _, q := range []float64{0.50, 0.90, 0.99, 0.999} {
+		fmt.Printf("%s: %d\n", fmt.Sprintf("p%g_encoded_bytes", q*100), percentile(&hist, n, q))
+	}
+}
+
+func percentile(hist *[sizeHistBuckets]int64, total int64, q float64) int {
+	target := int64(math.Ceil(q * float64(total)))
+	if target < 1 {
+		target = 1
+	}
+	var cum int64
+	for i := 0; i < sizeHistBuckets; i++ {
+		cum += hist[i]
+		if cum >= target {
+			return i
+		}
+	}
+	return sizeHistBuckets - 1
+}

--- a/test/loadsim/main.go
+++ b/test/loadsim/main.go
@@ -583,6 +583,11 @@ func main() {
 	insecure := flag.Bool("insecure", true, "Use insecure gRPC connection")
 	tenantID := flag.String("tenant-id", "", "x-tenant-id gRPC metadata value (empty = omit)")
 	warmup := flag.Duration("warmup", 5*time.Second, "Stagger window for producer startup")
+	direct := flag.Bool("direct", false, "Use the direct OTLP emission engine (measures per-Export ACK latency; required for the #173 release gates)")
+	settle := flag.Duration("settle", 60*time.Second, "Direct engine: unmeasured settle window before the sustained phase")
+	batchInterval := flag.Duration("batch-interval", 250*time.Millisecond, "Direct engine: per-emitter batch tick")
+	callTimeout := flag.Duration("call-timeout", 30*time.Second, "Direct engine: per-Export deadline")
+	reportPath := flag.String("report", "", "Direct engine: write the JSON latency/throughput report to this path")
 	flag.Parse()
 
 	// Apply profile if set.
@@ -612,6 +617,44 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	// Direct engine: one synchronous Export per batch tick, timed. This is the
+	// only path that produces ACK-latency percentiles, and the only one that
+	// can reach 10k points/s (the SDK path sleeps the simulated span duration
+	// in its emit loop). See otlpdirect.go for why.
+	if *direct {
+		sustainedDur := *duration
+		burstDur := time.Duration(0)
+		if burstConfig.multiplier > 0 {
+			burstDur = burstConfig.duration
+		}
+		mul := burstConfig.multiplier
+		if mul <= 0 {
+			mul = 1
+		}
+		cfg := directConfig{
+			endpoint:   *endpoint,
+			tenantID:   *tenantID,
+			insecure:   *insecure,
+			services:   *numServices,
+			spanRate:   float64(*rps),
+			logRate:    float64(*logsRate),
+			metricRate: float64(*metricsRate),
+			interval:   *batchInterval,
+			burstMul:   mul,
+			callTimout: *callTimeout,
+		}
+		fmt.Printf("direct engine: %d services -> %s | per-service %.1f span/s %.1f log/s %.1f metric/s\n",
+			cfg.services, cfg.endpoint, cfg.spanRate, cfg.logRate, cfg.metricRate)
+		fmt.Printf("offered load: %.0f pts/s sustained, %.0f pts/s burst | settle %s, sustained %s, burst %s\n",
+			float64(cfg.services)*(cfg.spanRate+cfg.logRate+cfg.metricRate),
+			float64(cfg.services)*(cfg.spanRate+cfg.logRate+cfg.metricRate)*mul,
+			*settle, sustainedDur, burstDur)
+		if _, err := runDirect(ctx, cfg, *settle, sustainedDur, burstDur, *reportPath); err != nil {
+			log.Fatalf("direct run failed: %v", err)
+		}
+		return
+	}
 
 	// Suppress default OTel global TracerProvider noise.
 	otel.SetTracerProvider(sdktrace.NewTracerProvider())

--- a/test/loadsim/otlpdirect.go
+++ b/test/loadsim/otlpdirect.go
@@ -1,0 +1,839 @@
+//go:build loadtest
+
+package main
+
+// Direct OTLP emission with ACK-latency measurement.
+//
+// The SDK-based producer in main.go cannot answer the question the #173
+// release gate asks. Two reasons, both structural:
+//
+//   1. The SDK's BatchSpanProcessor exports asynchronously on its own
+//      schedule, so the caller never observes the Export RPC round trip. In
+//      aggregate mode that round trip IS the durable ACK — the server returns
+//      only after the reduced deltas are in a committed transaction and
+//      applied to the shards — so ACK p99 is exactly the client-side Export
+//      latency and nothing else measures it.
+//   2. The SDK producer sleeps for the simulated span duration inside its
+//      emit loop, which caps a producer at roughly 1/mean(5..500ms) ~= 4
+//      spans/s. 150 producers therefore top out near 600 points/s, not the
+//      10,000 the gate requires.
+//
+// This file adds a second emission engine that talks the OTLP collector
+// protobuf services directly, batches points per tick the way a real agent
+// does, times every Export, and keeps per-phase latency samples for exact
+// percentiles. It is selected with -direct (default on for the
+// aggregate-acceptance profile).
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	grpcstatus "google.golang.org/grpc/status"
+
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	mrand "math/rand"
+)
+
+// Measurement phases. Latency samples are bucketed by the phase in effect when
+// the Export started, so the settle window never pollutes the sustained
+// percentiles the gate is scored on.
+const (
+	phaseSettle    int32 = 0
+	phaseSustained int32 = 1
+	phaseBurst     int32 = 2
+	phaseCount     int   = 3
+)
+
+var phaseNames = [phaseCount]string{"settle", "sustained", "burst"}
+
+// currentPhase is read by every emitter on every tick.
+var currentPhase atomic.Int32
+
+// signalKind identifies which OTLP service an emitter drives.
+type signalKind int
+
+const (
+	kindSpans signalKind = iota
+	kindLogs
+	kindMetrics
+	kindCount int = 3
+)
+
+var signalNames = [kindCount]string{"spans", "logs", "metrics"}
+
+// routes are the (method, route) pairs the synthetic services serve. They are
+// derived from the existing operations pool so span names stay identical to
+// the SDK producer's.
+var routes = []struct {
+	method string
+	route  string
+}{
+	{"GET", "/api/items"},
+	{"POST", "/api/orders"},
+	{"GET", "/health"},
+	{"GET", "/api/users"},
+	{"POST", "/api/payments"},
+}
+
+// severityNumbers maps the existing severity strings onto OTLP severity
+// numbers.
+var severityNumbers = map[string]int32{
+	"TRACE": 1,
+	"DEBUG": 5,
+	"INFO":  9,
+	"WARN":  13,
+	"ERROR": 17,
+	"FATAL": 21,
+}
+
+// emitterResult is one emitter goroutine's contribution to the final report.
+type emitterResult struct {
+	kind signalKind
+	// lat holds raw Export durations in nanoseconds, bucketed by phase.
+	lat [phaseCount][]int64
+	// reqOK, reqErr count Export calls by outcome, per phase.
+	reqOK  [phaseCount]int64
+	reqErr [phaseCount]int64
+	// exhausted counts RESOURCE_EXHAUSTED refusals (the backpressure the
+	// gate forbids at sustained load), unavailable counts UNAVAILABLE.
+	exhausted   [phaseCount]int64
+	unavailable [phaseCount]int64
+	other       [phaseCount]int64
+	// pointsSent counts points handed to Export; pointsAcked counts points in
+	// Exports that returned nil.
+	pointsSent  [phaseCount]int64
+	pointsAcked [phaseCount]int64
+	// firstErr is the first non-nil Export error, verbatim.
+	firstErr string
+}
+
+// live counters for the progress line.
+var (
+	liveAcked     [kindCount]atomic.Int64
+	liveSent      [kindCount]atomic.Int64
+	liveErrs      atomic.Int64
+	liveExhausted atomic.Int64
+	liveInflight  atomic.Int64
+)
+
+// directConfig is the emission engine's configuration.
+type directConfig struct {
+	endpoint   string
+	tenantID   string
+	insecure   bool
+	services   int
+	spanRate   float64 // per service, per second
+	logRate    float64
+	metricRate float64
+	interval   time.Duration // batch tick
+	burstMul   float64
+	callTimout time.Duration
+}
+
+// directEmitter drives one (service, signal) pair.
+type directEmitter struct {
+	svcIdx   int
+	svcName  string
+	instance string
+	kind     signalKind
+	rate     float64
+	cfg      directConfig
+	rng      *mrand.Rand
+
+	traceClient  coltracepb.TraceServiceClient
+	logClient    collogspb.LogsServiceClient
+	metricClient colmetricspb.MetricsServiceClient
+
+	res *resourcepb.Resource
+
+	seq       int
+	carry     float64
+	startNano uint64 // metric start_time_unix_nano for cumulative points
+	counter   int64  // cumulative request counter value
+	resetCtr  int64  // cumulative counter that resets every ~5 minutes
+	resetAt   time.Time
+
+	out emitterResult
+}
+
+// newResource builds the per-service OTLP resource. service.instance.id is
+// present so the aggregate engine derives a stable metric ProducerID (#166)
+// rather than fragmenting cumulative baselines.
+func newResource(svcName, instance string) *resourcepb.Resource {
+	return &resourcepb.Resource{
+		Attributes: []*commonpb.KeyValue{
+			strAttr("service.name", svcName),
+			strAttr("service.instance.id", instance),
+		},
+	}
+}
+
+func strAttr(k, v string) *commonpb.KeyValue {
+	return &commonpb.KeyValue{Key: k, Value: &commonpb.AnyValue{
+		Value: &commonpb.AnyValue_StringValue{StringValue: v},
+	}}
+}
+
+func intAttr(k string, v int64) *commonpb.KeyValue {
+	return &commonpb.KeyValue{Key: k, Value: &commonpb.AnyValue{
+		Value: &commonpb.AnyValue_IntValue{IntValue: v},
+	}}
+}
+
+func randomID(n int) []byte {
+	b := make([]byte, n)
+	// crypto/rand is used only because it needs no seeding here; the IDs are
+	// synthetic and carry no security meaning.
+	_, _ = rand.Read(b)
+	return b
+}
+
+// run is the emitter loop: one batch per tick, sized from the phase-adjusted
+// rate, sent synchronously so the Export round trip is the measured ACK.
+func (e *directEmitter) run(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+	ticker := time.NewTicker(e.cfg.interval)
+	defer ticker.Stop()
+	secs := e.cfg.interval.Seconds()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		ph := currentPhase.Load()
+		mul := 1.0
+		if ph == phaseBurst {
+			mul = e.cfg.burstMul
+		}
+		e.carry += e.rate * mul * secs
+		n := int(e.carry)
+		if n <= 0 {
+			continue
+		}
+		e.carry -= float64(n)
+
+		var send func(context.Context) error
+		switch e.kind {
+		case kindSpans:
+			req := e.buildSpans(n)
+			send = func(c context.Context) error {
+				_, err := e.traceClient.Export(c, req)
+				return err
+			}
+		case kindLogs:
+			req := e.buildLogs(n)
+			send = func(c context.Context) error {
+				_, err := e.logClient.Export(c, req)
+				return err
+			}
+		case kindMetrics:
+			req := e.buildMetrics(n)
+			send = func(c context.Context) error {
+				_, err := e.metricClient.Export(c, req)
+				return err
+			}
+		}
+
+		// The send context is deliberately NOT derived from ctx: run
+		// teardown must not cancel an Export that is already in flight, or
+		// the last tick of every emitter shows up as a spurious CANCELED
+		// error and pollutes the error accounting the gate reads.
+		callCtx := context.Background()
+		var cancel context.CancelFunc
+		if e.cfg.callTimout > 0 {
+			callCtx, cancel = context.WithTimeout(callCtx, e.cfg.callTimout)
+		}
+		if e.cfg.tenantID != "" {
+			callCtx = metadata.AppendToOutgoingContext(callCtx, "x-tenant-id", e.cfg.tenantID)
+		}
+
+		e.out.pointsSent[ph] += int64(n)
+		liveSent[e.kind].Add(int64(n))
+		liveInflight.Add(1)
+		start := time.Now()
+		err := send(callCtx)
+		elapsed := time.Since(start)
+		liveInflight.Add(-1)
+		if cancel != nil {
+			cancel()
+		}
+
+		e.out.lat[ph] = append(e.out.lat[ph], elapsed.Nanoseconds())
+		if err == nil {
+			e.out.reqOK[ph]++
+			e.out.pointsAcked[ph] += int64(n)
+			liveAcked[e.kind].Add(int64(n))
+			continue
+		}
+
+		e.out.reqErr[ph]++
+		liveErrs.Add(1)
+		if e.out.firstErr == "" {
+			e.out.firstErr = err.Error()
+		}
+		switch grpcstatus.Code(err) {
+		case codes.ResourceExhausted:
+			e.out.exhausted[ph]++
+			liveExhausted.Add(1)
+		case codes.Unavailable:
+			e.out.unavailable[ph]++
+		default:
+			e.out.other[ph]++
+		}
+	}
+}
+
+// buildSpans generates n spans grouped into short traces (a parent plus its
+// children, matching the SDK producer's every-10th-span shape at batch scale).
+func (e *directEmitter) buildSpans(n int) *coltracepb.ExportTraceServiceRequest {
+	spans := make([]*tracepb.Span, 0, n)
+	var traceID, parentID []byte
+	inTrace := 0
+	now := time.Now()
+
+	for i := 0; i < n; i++ {
+		if inTrace == 0 {
+			traceID = randomID(16)
+			parentID = nil
+			inTrace = 1 + e.rng.Intn(3) // 1-3 spans after the root
+		}
+		spanID := randomID(8)
+		r := routes[e.seq%len(routes)]
+		dur := e.randomDur()
+		errored := isError(e.seq)
+		end := now.Add(-time.Duration(e.rng.Intn(int(e.cfg.interval) + 1)))
+		start := end.Add(-dur)
+
+		status := &tracepb.Status{Code: tracepb.Status_STATUS_CODE_OK}
+		httpStatus := int64(200)
+		if errored {
+			status = &tracepb.Status{Code: tracepb.Status_STATUS_CODE_ERROR, Message: "simulated error"}
+			httpStatus = 500
+		}
+
+		sp := &tracepb.Span{
+			TraceId:           traceID,
+			SpanId:            spanID,
+			ParentSpanId:      parentID,
+			Name:              r.method + " " + r.route,
+			Kind:              tracepb.Span_SPAN_KIND_SERVER,
+			StartTimeUnixNano: uint64(start.UnixNano()), // #nosec G115 -- wall clock, always positive
+			EndTimeUnixNano:   uint64(end.UnixNano()),   // #nosec G115 -- wall clock, always positive
+			Status:            status,
+			Attributes: []*commonpb.KeyValue{
+				strAttr("http.request.method", r.method),
+				strAttr("http.route", r.route),
+				intAttr("http.response.status_code", httpStatus),
+			},
+		}
+		spans = append(spans, sp)
+		if parentID == nil {
+			parentID = spanID
+		}
+		inTrace--
+		e.seq++
+	}
+
+	return &coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: []*tracepb.ResourceSpans{{
+			Resource: e.res,
+			ScopeSpans: []*tracepb.ScopeSpans{{
+				Scope: &commonpb.InstrumentationScope{Name: e.svcName},
+				Spans: spans,
+			}},
+		}},
+	}
+}
+
+func (e *directEmitter) randomDur() time.Duration {
+	return time.Duration(5+e.rng.Intn(496)) * time.Millisecond
+}
+
+// buildLogs generates n log records using the existing template and severity
+// mix helpers.
+func (e *directEmitter) buildLogs(n int) *collogspb.ExportLogsServiceRequest {
+	recs := make([]*logspb.LogRecord, 0, n)
+	now := time.Now()
+	for i := 0; i < n; i++ {
+		sev := pickSeverity(e.seq)
+		body := e.generateLogBodyRNG(e.seq)
+		recs = append(recs, &logspb.LogRecord{
+			TimeUnixNano:   uint64(now.UnixNano()), // #nosec G115 -- wall clock, always positive
+			SeverityNumber: logspb.SeverityNumber(severityNumbers[sev]),
+			SeverityText:   sev,
+			Body: &commonpb.AnyValue{
+				Value: &commonpb.AnyValue_StringValue{StringValue: body},
+			},
+		})
+		e.seq++
+	}
+	return &collogspb.ExportLogsServiceRequest{
+		ResourceLogs: []*logspb.ResourceLogs{{
+			Resource: e.res,
+			ScopeLogs: []*logspb.ScopeLogs{{
+				Scope:      &commonpb.InstrumentationScope{Name: e.svcName},
+				LogRecords: recs,
+			}},
+		}},
+	}
+}
+
+// generateLogBodyRNG mirrors (*producer).generateLogBody against this
+// emitter's RNG.
+func (e *directEmitter) generateLogBodyRNG(seq int) string {
+	template := logTemplates[seq%len(logTemplates)]
+	var tokens []interface{}
+	for i := 0; i < countPct(template); i++ {
+		if i%2 == 0 {
+			tokens = append(tokens, e.rng.Intn(10000)) // NOSONAR go:S2245 -- synthetic load data
+		} else {
+			tokens = append(tokens, fmt.Sprintf("id-%d", e.rng.Intn(1000))) // NOSONAR go:S2245 -- synthetic load data
+		}
+	}
+	return fmt.Sprintf(template, tokens...)
+}
+
+func countPct(s string) int {
+	c := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '%' {
+			c++
+		}
+	}
+	return c
+}
+
+// buildMetrics generates n data points spread across the three instruments the
+// SDK producer publishes: a cumulative monotonic request counter, a queue-depth
+// gauge, and a cumulative counter that resets every ~5 minutes.
+func (e *directEmitter) buildMetrics(n int) *colmetricspb.ExportMetricsServiceRequest {
+	now := uint64(time.Now().UnixNano()) // #nosec G115 -- wall clock, always positive
+	var counterPts, gaugePts, resetPts []*metricspb.NumberDataPoint
+
+	if time.Since(e.resetAt) > 5*time.Minute {
+		e.resetCtr = 0
+		e.resetAt = time.Now()
+		e.startNano = now
+	}
+
+	for i := 0; i < n; i++ {
+		switch e.seq % 3 {
+		case 0:
+			e.counter++
+			counterPts = append(counterPts, &metricspb.NumberDataPoint{
+				StartTimeUnixNano: e.startNano,
+				TimeUnixNano:      now,
+				Value:             &metricspb.NumberDataPoint_AsInt{AsInt: e.counter},
+			})
+		case 1:
+			gaugePts = append(gaugePts, &metricspb.NumberDataPoint{
+				TimeUnixNano: now,
+				Value:        &metricspb.NumberDataPoint_AsInt{AsInt: int64(e.rng.Intn(100))},
+			})
+		default:
+			e.resetCtr++
+			resetPts = append(resetPts, &metricspb.NumberDataPoint{
+				StartTimeUnixNano: e.startNano,
+				TimeUnixNano:      now,
+				Value:             &metricspb.NumberDataPoint_AsInt{AsInt: e.resetCtr},
+			})
+		}
+		e.seq++
+	}
+
+	var ms []*metricspb.Metric
+	cumulative := metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE
+	if len(counterPts) > 0 {
+		ms = append(ms, &metricspb.Metric{
+			Name: "http.server.request.count",
+			Data: &metricspb.Metric_Sum{Sum: &metricspb.Sum{
+				DataPoints:             counterPts,
+				AggregationTemporality: cumulative,
+				IsMonotonic:            true,
+			}},
+		})
+	}
+	if len(gaugePts) > 0 {
+		ms = append(ms, &metricspb.Metric{
+			Name: "queue.depth",
+			Data: &metricspb.Metric_Gauge{Gauge: &metricspb.Gauge{DataPoints: gaugePts}},
+		})
+	}
+	if len(resetPts) > 0 {
+		ms = append(ms, &metricspb.Metric{
+			Name: "custom.reset.counter",
+			Data: &metricspb.Metric_Sum{Sum: &metricspb.Sum{
+				DataPoints:             resetPts,
+				AggregationTemporality: cumulative,
+				IsMonotonic:            true,
+			}},
+		})
+	}
+
+	return &colmetricspb.ExportMetricsServiceRequest{
+		ResourceMetrics: []*metricspb.ResourceMetrics{{
+			Resource: e.res,
+			ScopeMetrics: []*metricspb.ScopeMetrics{{
+				Scope:   &commonpb.InstrumentationScope{Name: e.svcName},
+				Metrics: ms,
+			}},
+		}},
+	}
+}
+
+// -------------------------------------------------------------------------
+// Percentiles and the JSON report
+// -------------------------------------------------------------------------
+
+// phaseLatency is the latency summary of one (phase, signal) pair.
+type phaseLatency struct {
+	Samples int64   `json:"samples"`
+	MinMs   float64 `json:"min_ms"`
+	P50Ms   float64 `json:"p50_ms"`
+	P90Ms   float64 `json:"p90_ms"`
+	P95Ms   float64 `json:"p95_ms"`
+	P99Ms   float64 `json:"p99_ms"`
+	P999Ms  float64 `json:"p999_ms"`
+	MaxMs   float64 `json:"max_ms"`
+	MeanMs  float64 `json:"mean_ms"`
+}
+
+// phaseReport is one phase's full accounting.
+type phaseReport struct {
+	Phase        string                  `json:"phase"`
+	DurationSec  float64                 `json:"duration_sec"`
+	All          phaseLatency            `json:"ack_latency_all_signals"`
+	BySignal     map[string]phaseLatency `json:"ack_latency_by_signal"`
+	PointsSent   int64                   `json:"points_sent"`
+	PointsAcked  int64                   `json:"points_acked"`
+	PointsPerSec float64                 `json:"points_acked_per_sec"`
+	RequestsOK   int64                   `json:"requests_ok"`
+	RequestsErr  int64                   `json:"requests_err"`
+	Exhausted    int64                   `json:"resource_exhausted"`
+	Unavailable  int64                   `json:"unavailable"`
+	OtherErrors  int64                   `json:"other_errors"`
+}
+
+// runReport is the whole run, written as JSON for the gate scoring.
+type runReport struct {
+	StartedAt string                 `json:"started_at"`
+	EndedAt   string                 `json:"ended_at"`
+	Config    map[string]interface{} `json:"config"`
+	Phases    []phaseReport          `json:"phases"`
+	FirstErr  string                 `json:"first_error,omitempty"`
+}
+
+// percentile returns the p-th percentile (0..1) of a sorted nanosecond slice,
+// in milliseconds, using nearest-rank.
+func percentile(sorted []int64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(p * float64(len(sorted)))
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	return float64(sorted[idx]) / 1e6
+}
+
+func summarize(samples []int64) phaseLatency {
+	if len(samples) == 0 {
+		return phaseLatency{}
+	}
+	s := make([]int64, len(samples))
+	copy(s, samples)
+	sort.Slice(s, func(i, j int) bool { return s[i] < s[j] })
+	var sum int64
+	for _, v := range s {
+		sum += v
+	}
+	return phaseLatency{
+		Samples: int64(len(s)),
+		MinMs:   float64(s[0]) / 1e6,
+		P50Ms:   percentile(s, 0.50),
+		P90Ms:   percentile(s, 0.90),
+		P95Ms:   percentile(s, 0.95),
+		P99Ms:   percentile(s, 0.99),
+		P999Ms:  percentile(s, 0.999),
+		MaxMs:   float64(s[len(s)-1]) / 1e6,
+		MeanMs:  float64(sum) / float64(len(s)) / 1e6,
+	}
+}
+
+// buildReport folds every emitter's result into the per-phase report.
+func buildReport(results []emitterResult, phaseDur [phaseCount]time.Duration, cfg map[string]interface{}, started, ended time.Time) runReport {
+	rep := runReport{
+		StartedAt: started.UTC().Format(time.RFC3339Nano),
+		EndedAt:   ended.UTC().Format(time.RFC3339Nano),
+		Config:    cfg,
+	}
+	for ph := 0; ph < phaseCount; ph++ {
+		var all []int64
+		bySignal := make(map[string][]int64)
+		pr := phaseReport{Phase: phaseNames[ph], DurationSec: phaseDur[ph].Seconds()}
+		for i := range results {
+			r := &results[i]
+			all = append(all, r.lat[ph]...)
+			name := signalNames[r.kind]
+			bySignal[name] = append(bySignal[name], r.lat[ph]...)
+			pr.PointsSent += r.pointsSent[ph]
+			pr.PointsAcked += r.pointsAcked[ph]
+			pr.RequestsOK += r.reqOK[ph]
+			pr.RequestsErr += r.reqErr[ph]
+			pr.Exhausted += r.exhausted[ph]
+			pr.Unavailable += r.unavailable[ph]
+			pr.OtherErrors += r.other[ph]
+			if rep.FirstErr == "" && r.firstErr != "" {
+				rep.FirstErr = r.firstErr
+			}
+		}
+		pr.All = summarize(all)
+		pr.BySignal = make(map[string]phaseLatency, len(bySignal))
+		for k, v := range bySignal {
+			pr.BySignal[k] = summarize(v)
+		}
+		if pr.DurationSec > 0 {
+			pr.PointsPerSec = float64(pr.PointsAcked) / pr.DurationSec
+		}
+		rep.Phases = append(rep.Phases, pr)
+	}
+	return rep
+}
+
+func writeReport(path string, rep runReport) error {
+	b, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	return os.WriteFile(path, b, 0o600)
+}
+
+// -------------------------------------------------------------------------
+// Engine entry point
+// -------------------------------------------------------------------------
+
+// runDirect drives the whole measured run: settle, sustained, burst. It returns
+// the finished report.
+func runDirect(ctx context.Context, cfg directConfig, settle, sustained, burst time.Duration, reportPath string) (runReport, error) {
+	dialOpts := []grpc.DialOption{
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(16 << 20)),
+	}
+	if cfg.insecure {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+
+	conns := make([]*grpc.ClientConn, cfg.services)
+	emitters := make([]*directEmitter, 0, cfg.services*kindCount)
+	for i := 0; i < cfg.services; i++ {
+		cc, err := grpc.NewClient(cfg.endpoint, dialOpts...)
+		if err != nil {
+			return runReport{}, fmt.Errorf("service %d dial: %w", i, err)
+		}
+		conns[i] = cc
+		svc := serviceName(i)
+		inst := fmt.Sprintf("%s-instance-0", svc)
+		res := newResource(svc, inst)
+		now := uint64(time.Now().UnixNano()) // #nosec G115 -- wall clock, always positive
+		for k, rate := range map[signalKind]float64{
+			kindSpans:   cfg.spanRate,
+			kindLogs:    cfg.logRate,
+			kindMetrics: cfg.metricRate,
+		} {
+			if rate <= 0 {
+				continue
+			}
+			e := &directEmitter{
+				svcIdx:       i,
+				svcName:      svc,
+				instance:     inst,
+				kind:         k,
+				rate:         rate,
+				cfg:          cfg,
+				rng:          mrand.New(mrand.NewSource(time.Now().UnixNano() + int64(i)*13 + int64(k))), // NOSONAR go:S2245 -- synthetic load data
+				traceClient:  coltracepb.NewTraceServiceClient(cc),
+				logClient:    collogspb.NewLogsServiceClient(cc),
+				metricClient: colmetricspb.NewMetricsServiceClient(cc),
+				res:          res,
+				startNano:    now,
+				resetAt:      time.Now(),
+			}
+			e.out.kind = k
+			emitters = append(emitters, e)
+		}
+	}
+	defer func() {
+		for _, cc := range conns {
+			if cc != nil {
+				_ = cc.Close()
+			}
+		}
+	}()
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	currentPhase.Store(phaseSettle)
+	started := time.Now()
+
+	// Stagger emitter start over the settle window so 450 goroutines do not
+	// all fire their first Export in the same millisecond.
+	stagger := time.Duration(0)
+	if len(emitters) > 1 && settle > 0 {
+		stagger = settle / 4 / time.Duration(len(emitters))
+	}
+	for _, e := range emitters {
+		wg.Add(1)
+		go e.run(runCtx, &wg)
+		if stagger > 0 {
+			time.Sleep(stagger)
+		}
+	}
+
+	progressCtx, stopProgress := context.WithCancel(runCtx)
+	go directProgress(progressCtx)
+
+	var phaseDur [phaseCount]time.Duration
+
+	remainingSettle := settle - time.Since(started)
+	if remainingSettle > 0 {
+		sleepCtx(runCtx, remainingSettle)
+	}
+	phaseDur[phaseSettle] = time.Since(started)
+
+	fmt.Printf("=== phase: sustained (%s) ===\n", sustained)
+	t := time.Now()
+	currentPhase.Store(phaseSustained)
+	sleepCtx(runCtx, sustained)
+	phaseDur[phaseSustained] = time.Since(t)
+
+	if burst > 0 {
+		fmt.Printf("=== phase: burst %.1fx (%s) ===\n", cfg.burstMul, burst)
+		t = time.Now()
+		currentPhase.Store(phaseBurst)
+		sleepCtx(runCtx, burst)
+		phaseDur[phaseBurst] = time.Since(t)
+	}
+
+	stopProgress()
+	cancel()
+	wg.Wait()
+	ended := time.Now()
+
+	results := make([]emitterResult, 0, len(emitters))
+	for _, e := range emitters {
+		results = append(results, e.out)
+	}
+
+	cfgMap := map[string]interface{}{
+		"endpoint":            cfg.endpoint,
+		"services":            cfg.services,
+		"span_rate_per_svc":   cfg.spanRate,
+		"log_rate_per_svc":    cfg.logRate,
+		"metric_rate_per_svc": cfg.metricRate,
+		"batch_interval_ms":   cfg.interval.Milliseconds(),
+		"burst_multiplier":    cfg.burstMul,
+		"call_timeout_ms":     cfg.callTimout.Milliseconds(),
+		"settle_sec":          settle.Seconds(),
+		"sustained_sec":       sustained.Seconds(),
+		"burst_sec":           burst.Seconds(),
+	}
+	rep := buildReport(results, phaseDur, cfgMap, started, ended)
+	if reportPath != "" {
+		if err := writeReport(reportPath, rep); err != nil {
+			return rep, fmt.Errorf("write report: %w", err)
+		}
+	}
+	printDirectSummary(rep)
+	return rep, nil
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+	case <-t.C:
+	}
+}
+
+func directProgress(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	start := time.Now()
+	var prev int64
+	prevT := start
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		now := time.Now()
+		var total int64
+		for i := 0; i < kindCount; i++ {
+			total += liveAcked[i].Load()
+		}
+		dt := now.Sub(prevT).Seconds()
+		rate := float64(total-prev) / dt
+		prev, prevT = total, now
+		fmt.Printf("[T+%4.0fs][%s] acked spans=%d logs=%d metrics=%d | rate=%.0f pts/s | inflight=%d errors=%d exhausted=%d\n",
+			now.Sub(start).Seconds(), phaseNames[currentPhase.Load()],
+			liveAcked[kindSpans].Load(), liveAcked[kindLogs].Load(), liveAcked[kindMetrics].Load(),
+			rate, liveInflight.Load(), liveErrs.Load(), liveExhausted.Load())
+	}
+}
+
+func printDirectSummary(rep runReport) {
+	fmt.Println("-------------------------------------------------------------")
+	for _, p := range rep.Phases {
+		if p.All.Samples == 0 {
+			continue
+		}
+		fmt.Printf("phase=%-9s dur=%6.1fs  acked=%d pts (%.0f pts/s)  sent=%d\n",
+			p.Phase, p.DurationSec, p.PointsAcked, p.PointsPerSec, p.PointsSent)
+		fmt.Printf("  ACK latency (all signals): n=%d p50=%.1fms p90=%.1fms p99=%.1fms p99.9=%.1fms max=%.1fms\n",
+			p.All.Samples, p.All.P50Ms, p.All.P90Ms, p.All.P99Ms, p.All.P999Ms, p.All.MaxMs)
+		for _, name := range signalNames {
+			if l, ok := p.BySignal[name]; ok && l.Samples > 0 {
+				fmt.Printf("    %-8s n=%d p50=%.1fms p99=%.1fms max=%.1fms\n",
+					name, l.Samples, l.P50Ms, l.P99Ms, l.MaxMs)
+			}
+		}
+		fmt.Printf("  requests ok=%d err=%d resource_exhausted=%d unavailable=%d other=%d\n",
+			p.RequestsOK, p.RequestsErr, p.Exhausted, p.Unavailable, p.OtherErrors)
+	}
+	if rep.FirstErr != "" {
+		fmt.Printf("first error: %s\n", rep.FirstErr)
+	}
+	fmt.Println("-------------------------------------------------------------")
+}


### PR DESCRIPTION
Tooling required by the wave-5 acceptance benchmark for #173. No production code changes.

## Why

The `aggregate-acceptance` profile could not answer the gates it was written for.

1. **No ACK latency.** The gates score sustained ACK p99 <= 250 ms and burst p99 <= 1 s. In `AGGREGATE_MODE=aggregate` the durable ACK *is* the OTLP Export round trip — the server returns only after the group commit and the shard apply. The OTel SDK's `BatchSpanProcessor` exports asynchronously, so the caller never observes that round trip. Nothing in the repo measured it.
2. **The profile never offered 10k pts/s.** `emitSpan` sleeps the simulated span duration ([5 ms, 500 ms]) inside the emit loop, capping a producer near 4 spans/s. 150 producers top out around 600 points/s. Measured, not inferred.
3. **Logs were counted but never sent.** `emitLog` incremented `logsSent` and returned; the 15% log share of the split did not exist on the wire.

## What

`test/loadsim/otlpdirect.go` — a second emission engine behind `-direct`:

- talks `coltracepb` / `collogspb` / `colmetricspb` directly, one synchronous Export per batch tick, so the measured latency is the ACK;
- batches points per tick the way a real agent does (`-batch-interval`, default 250 ms);
- explicit settle / sustained / burst phases (`-settle`), so the settle window never pollutes the scored percentiles, and burst samples are bucketed separately;
- raw per-phase latency samples, exact percentiles (p50/p90/p95/p99/p99.9/max), per signal and combined;
- counts `RESOURCE_EXHAUSTED` separately from other failures — that is the "zero backpressure at sustained load" gate;
- JSON report via `-report` for scoring;
- emits real OTLP log records.

The SDK path, every pure helper, and `make loadtest` behave exactly as before; `main_test.go` is untouched and passes.

`test/aggprefill/main.go` (build tag `prefill`) — the throwaway generator for the gate's *fully populated* 7-day disk measurement: 6,000 series x 2,016 windows = 12,096,000 real bucket rows with realistic encoded sketch payloads, written through the public store API (`CommitGroup` + `FinalizeWindow`). Actual rows, no extrapolation.

## Verification

- `go vet -tags loadtest ./test/loadsim/...` clean
- `go vet -tags prefill ./test/aggprefill/...` clean
- `go test -tags loadtest ./test/loadsim/...` 7 tests pass
- gofmt clean on both new files

Measured results are posted on #173.