### PR TITLE
fix(test): widen per-tenant cap wait deadlines for starved CI runners

### DIFF
--- a/internal/ingest/pipeline_test.go
+++ b/internal/ingest/pipeline_test.go
@@ -497,17 +497,17 @@ func TestPipeline_PerTenantCap_ReleasedAfterProcess(t *testing.T) {
 	if err := p.Submit(mk()); err != nil {
 		t.Fatalf("submit 1: %v", err)
 	}
-	// Wait for the worker to drain it (and release the slot). 5s tolerates
-	// the race detector's overhead on slow CI runners — the test passes
-	// locally in milliseconds.
-	if !waitFor(t, 5*time.Second, func() bool { return p.Stats().Processed == 1 }) {
+	// Wait for the worker to drain it (and release the slot). The test
+	// passes locally in milliseconds; 30s is for the race detector on
+	// starved shared CI runners, where 5s was observed to expire.
+	if !waitFor(t, 30*time.Second, func() bool { return p.Stats().Processed == 1 }) {
 		t.Fatalf("worker did not process first batch")
 	}
 	// Second batch must succeed because the slot was released.
 	if err := p.Submit(mk()); err != nil {
 		t.Fatalf("submit 2 after release: %v", err)
 	}
-	if !waitFor(t, 5*time.Second, func() bool { return p.Stats().Processed == 2 }) {
+	if !waitFor(t, 30*time.Second, func() bool { return p.Stats().Processed == 2 }) {
 		t.Fatalf("worker did not process second batch")
 	}
 	if got := p.TenantDropped(); got != 0 {


### PR DESCRIPTION
The 5s waitFor deadlines in TestPipeline_PerTenantCap_ReleasedAfterProcess expired twice under -race on loaded runners (PR #103's branch, PR #192's CI run) while passing locally in milliseconds. Deadline bumped to 30s; it only bounds hang time on a genuinely broken pipeline.