### PR TITLE
fix(aggregate): commit-failure semantics — staged baselines, admission rollback, finalize-gated eviction

### DIFF
--- a/internal/aggregate/cardinality.go
+++ b/internal/aggregate/cardinality.go
@@ -188,6 +188,12 @@ type Admission struct {
 	Overflowed bool
 	// Reason names the cap that triggered overflow.
 	Reason OverflowReason
+	// Reserved reports that THIS call created (Key, window) presence, and so
+	// that a matching Release is the exact undo. It is false when the pair was
+	// already present, which is what lets a rolled-back group commit release
+	// only the occupancy it charged and never occupancy an earlier committed
+	// batch is still using (#194 blocker 3).
+	Reserved bool
 }
 
 // LimiterStats is a snapshot of Limiter occupancy.
@@ -271,16 +277,16 @@ func (l *Limiter) Admit(key SeriesKey, window int64) Admission {
 	if l.windows[key] > 0 {
 		// Already active in another mutable window: it holds budget already.
 		l.addLocked(key, window, false)
-		return Admission{Key: key}
+		return Admission{Key: key, Reserved: true}
 	}
 	if reason := l.checkLocked(key); reason != OverflowNone {
 		l.overflowCounts[reason]++
 		other := l.overflowKey(key)
-		l.admitOverflowLocked(other, window)
-		return Admission{Key: other, Overflowed: true, Reason: reason}
+		reserved := l.admitOverflowLocked(other, window)
+		return Admission{Key: other, Overflowed: true, Reason: reason, Reserved: reserved}
 	}
 	l.addLocked(key, window, false)
-	return Admission{Key: key}
+	return Admission{Key: key, Reserved: true}
 }
 
 // checkLocked applies the frozen enforcement order and returns the first cap
@@ -339,11 +345,14 @@ func (l *Limiter) checkLocked(key SeriesKey) OverflowReason {
 // active log series against a 500 sub-cap the wave-5 run measured (#173). The
 // reserve is reported through OverflowSeriesBySignal instead, so its cost is
 // visible without being laundered through a bounded-looking number.
-func (l *Limiter) admitOverflowLocked(other SeriesKey, window int64) {
+// It returns whether this call created the presence, so a rolled-back commit
+// can release exactly what it reserved.
+func (l *Limiter) admitOverflowLocked(other SeriesKey, window int64) bool {
 	if _, ok := l.present[SeriesWindowKey{Key: other, WindowStart: window}]; ok {
-		return
+		return false
 	}
 	l.addLocked(other, window, true)
+	return true
 }
 
 // addLocked records presence of key in window and, on the series' first window,

--- a/internal/aggregate/commit_failure_test.go
+++ b/internal/aggregate/commit_failure_test.go
@@ -1,0 +1,407 @@
+package aggregate
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Acceptance tests for #194 blockers 2, 3 and 6 — what a failed group commit
+// and a closed-but-unfinalized window must leave behind.
+//
+// All three defects share one shape: a resource was taken at reduction or
+// admission time and released on the assumption that the write would land.
+// These tests drive the write failing and assert on what is left.
+
+var errCommitRefused = errors.New("aggregate: commit refused (test)")
+
+// failableStore is a Store whose commits and finalizations can be switched off
+// and on, so one test can drive a failure and then the retry through the same
+// writer.
+type failableStore struct {
+	Store
+	failCommit   atomic.Bool
+	failFinalize atomic.Bool
+	commits      atomic.Int64
+	finalizes    atomic.Int64
+}
+
+func (f *failableStore) CommitGroup(b *GroupBatch) error {
+	f.commits.Add(1)
+	if f.failCommit.Load() {
+		return errCommitRefused
+	}
+	return f.Store.CommitGroup(b)
+}
+
+func (f *failableStore) FinalizeWindow(window int64) (FinalizeStats, error) {
+	f.finalizes.Add(1)
+	if f.failFinalize.Load() {
+		return FinalizeStats{}, errCommitRefused
+	}
+	return f.Store.FinalizeWindow(window)
+}
+
+// cumulativeFixture is an engine and writer over a store whose commits can be
+// refused on demand.
+type cumulativeFixture struct {
+	clock *fixedClock
+	base  *SQLiteStore
+	store *failableStore
+	eng   *Engine
+	w     *Writer
+}
+
+func newCumulativeFixture(t *testing.T) *cumulativeFixture {
+	t.Helper()
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	store := &failableStore{Store: base}
+	eng := newTestEngine(t, clock, nil)
+	w := newTestWriter(t, store, eng, clock, WriterConfig{})
+	return &cumulativeFixture{clock: clock, base: base, store: store, eng: eng, w: w}
+}
+
+// observe reduces and applies one cumulative monotonic point, returning the
+// applier's refusal so a test can assert the durable-ACK contract.
+func (f *cumulativeFixture) observe(start, ts time.Time, value float64) error {
+	r := f.eng.NewReducer(f.clock.Now())
+	r.ReduceMetricPoint(MetricInput{
+		Tenant:      "acme",
+		Service:     "svc",
+		Name:        "requests",
+		Value:       value,
+		Timestamp:   ts,
+		StartTime:   start,
+		Temporality: TemporalityCumulative,
+		Monotonic:   true,
+		Resource:    ResourceIdentity{ServiceInstanceID: "pod-1"},
+	})
+	_, err := f.eng.ApplyReducerErr(r)
+	return err
+}
+
+func (f *cumulativeFixture) mustObserve(t *testing.T, start, ts time.Time, value float64) {
+	t.Helper()
+	if err := f.observe(start, ts, value); err != nil {
+		t.Fatalf("observe(%v) = %v, want success", value, err)
+	}
+}
+
+// durableCounterDelta sums the counter increase that actually reached the
+// store. It is the only number that matters: memory can be as clever as it
+// likes, the delta log is what survives a restart.
+func durableCounterDelta(t *testing.T, s *SQLiteStore) float64 {
+	t.Helper()
+	rows, err := s.ReplayMutable(0)
+	if err != nil {
+		t.Fatalf("ReplayMutable: %v", err)
+	}
+	var total float64
+	for _, r := range rows {
+		total += r.Delta.CounterDelta
+	}
+	return total
+}
+
+// --- blocker 2: baselines must not advance past the durable commit ---
+
+// TestCommitFailureThenIdenticalRetryPreservesTheDelta is the exact failure
+// #194 describes: baseline 100, point 125, commit fails, client retries 125.
+// Before the fix the retry classified as stale and the increase of 25 was gone.
+func TestCommitFailureThenIdenticalRetryPreservesTheDelta(t *testing.T) {
+	f := newCumulativeFixture(t)
+	start := f.clock.Now().Add(-time.Hour)
+	t0 := f.clock.Now()
+
+	f.mustObserve(t, start, t0, 100) // seed: no delta is attributed
+	if got := durableCounterDelta(t, f.base); got != 0 {
+		t.Fatalf("seed attributed %v, want 0", got)
+	}
+
+	f.store.failCommit.Store(true)
+	if err := f.observe(start, t0.Add(10*time.Second), 125); !errors.Is(err, errCommitRefused) {
+		t.Fatalf("failed commit = %v, want the commit error — it must not be acknowledged", err)
+	}
+
+	// The client retries the identical Export.
+	f.store.failCommit.Store(false)
+	f.mustObserve(t, start, t0.Add(10*time.Second), 125)
+
+	if got := durableCounterDelta(t, f.base); got != 25 {
+		t.Fatalf("durable increase = %v, want 25 — the retry must reproduce the lost delta", got)
+	}
+	if owed := f.eng.Baselines().Stats().Owed; owed != 0 {
+		t.Errorf("%d baselines still owed after a successful retry", owed)
+	}
+}
+
+// TestCommitFailureThenNewerPointNeitherLosesNorDuplicates covers the case a
+// naive baseline rewind gets wrong: nothing retries the failed point, a newer
+// one arrives instead, and the totals must still be exact afterwards.
+func TestCommitFailureThenNewerPointNeitherLosesNorDuplicates(t *testing.T) {
+	f := newCumulativeFixture(t)
+	start := f.clock.Now().Add(-time.Hour)
+	t0 := f.clock.Now()
+
+	f.mustObserve(t, start, t0, 100)
+
+	// Every point stays inside MaxFutureSkew of the fixed arrival clock, so
+	// the reducer accepts them all into the same window.
+	f.store.failCommit.Store(true)
+	if err := f.observe(start, t0.Add(10*time.Second), 125); err == nil {
+		t.Fatal("failed commit was acknowledged")
+	}
+
+	// No retry: a newer point arrives. 100 -> 150 is an increase of 50.
+	f.store.failCommit.Store(false)
+	f.mustObserve(t, start, t0.Add(20*time.Second), 150)
+	if got := durableCounterDelta(t, f.base); got != 50 {
+		t.Fatalf("durable increase = %v, want 50 (100 -> 150)", got)
+	}
+
+	// And the ledger must be settled exactly once: the next point contributes
+	// only its own increase.
+	f.mustObserve(t, start, t0.Add(30*time.Second), 175)
+	if got := durableCounterDelta(t, f.base); got != 75 {
+		t.Fatalf("durable increase = %v, want 75 (100 -> 175) — the stranded delta was counted twice", got)
+	}
+
+	// A late duplicate of the failed point must now be inert.
+	f.mustObserve(t, start, t0.Add(10*time.Second), 125)
+	if got := durableCounterDelta(t, f.base); got != 75 {
+		t.Fatalf("durable increase = %v after a stale duplicate, want 75", got)
+	}
+}
+
+// TestConcurrentCumulativePointsCommitDeterministically drives many concurrent
+// Exports of one cumulative series. Whatever order the tracker serializes them
+// in, the accepted chain telescopes: the durable increase is last value minus
+// the seed, exactly, with no dependence on interleaving.
+func TestConcurrentCumulativePointsCommitDeterministically(t *testing.T) {
+	f := newCumulativeFixture(t)
+	start := f.clock.Now().Add(-time.Hour)
+	t0 := f.clock.Now()
+	f.mustObserve(t, start, t0, 100)
+
+	const points = 64
+	var wg sync.WaitGroup
+	errs := make([]error, points)
+	for i := 0; i < points; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = f.observe(start, t0.Add(time.Duration(i+1)*time.Millisecond), float64(101+i))
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("point %d: %v", i, err)
+		}
+	}
+	if got := durableCounterDelta(t, f.base); got != points {
+		t.Fatalf("durable increase = %v, want %d (100 -> %d)", got, points, 100+points)
+	}
+}
+
+// --- blocker 3: cardinality admission must not leak on commit failure ---
+
+// occupancy is the limiter census a rolled-back commit must leave untouched.
+func occupancy(e *Engine) (active, overflow int) {
+	ls := e.Limiter().Stats()
+	return ls.Active, ls.OverflowSeries
+}
+
+func TestAdmissionOccupancyIsExactAfterRepeatedCommitFailures(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	store := &failableStore{Store: base}
+	eng := newTestEngine(t, clock, nil)
+	newTestWriter(t, store, eng, clock, WriterConfig{})
+
+	store.failCommit.Store(true)
+	for i := 0; i < 20; i++ {
+		if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), uint32(i%3)+1, 1)); err == nil {
+			t.Fatalf("apply %d was acknowledged despite a refused commit", i)
+		}
+	}
+	if active, overflow := occupancy(eng); active != 0 || overflow != 0 {
+		t.Fatalf("occupancy after 20 refused commits = (%d active, %d overflow), want (0, 0) — "+
+			"a series that never reached a shard has no window to be released from", active, overflow)
+	}
+}
+
+func TestAdmissionOccupancyIsExactAfterFailureThenRetry(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	store := &failableStore{Store: base}
+	eng := newTestEngine(t, clock, nil)
+	newTestWriter(t, store, eng, clock, WriterConfig{})
+
+	store.failCommit.Store(true)
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 1)); err == nil {
+		t.Fatal("refused commit was acknowledged")
+	}
+	store.failCommit.Store(false)
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 1)); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+	if active, _ := occupancy(eng); active != 1 {
+		t.Fatalf("active series after failure-then-retry = %d, want 1", active)
+	}
+
+	// A later failure on the SAME series must not release the occupancy the
+	// committed batch is still using: the reservation only covers presence the
+	// failed plan itself created.
+	store.failCommit.Store(true)
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 1)); err == nil {
+		t.Fatal("refused commit was acknowledged")
+	}
+	if active, _ := occupancy(eng); active != 1 {
+		t.Fatalf("active series = %d after a failure on a live series, want 1 — "+
+			"rollback released budget belonging to committed data", active)
+	}
+}
+
+func TestAdmissionOccupancyIsExactAcrossWindowRollover(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	store := &failableStore{Store: base}
+	eng := newTestEngine(t, clock, nil)
+	w := newTestWriter(t, store, eng, clock, WriterConfig{})
+
+	first := WindowStart(clock.Now())
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 1)); err != nil {
+		t.Fatalf("first window: %v", err)
+	}
+	// The same series in the next window: one series, two windows, one charge.
+	clock.Advance(WindowSize)
+	second := WindowStart(clock.Now())
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 1)); err != nil {
+		t.Fatalf("second window: %v", err)
+	}
+	if active, _ := occupancy(eng); active != 1 {
+		t.Fatalf("active series across two windows = %d, want 1", active)
+	}
+
+	// A refused commit for a new series in the live window leaves nothing.
+	store.failCommit.Store(true)
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 2, 1)); err == nil {
+		t.Fatal("refused commit was acknowledged")
+	}
+	store.failCommit.Store(false)
+	if active, _ := occupancy(eng); active != 1 {
+		t.Fatalf("active series = %d after a refused commit, want 1", active)
+	}
+
+	// Finalizing the first window does not release a series still live in the
+	// second; finalizing the second does.
+	clock.Advance(AllowedLateness + time.Minute)
+	if n := w.FinalizeDue(clock.Now()); n != 1 {
+		t.Fatalf("finalized %d windows, want 1 (%d)", n, first)
+	}
+	if active, _ := occupancy(eng); active != 1 {
+		t.Fatalf("active series = %d after finalizing the older window, want 1", active)
+	}
+	clock.Advance(WindowSize)
+	if n := w.FinalizeDue(clock.Now()); n != 1 {
+		t.Fatalf("finalized %d windows, want 1 (%d)", n, second)
+	}
+	if active, overflow := occupancy(eng); active != 0 || overflow != 0 {
+		t.Fatalf("occupancy after both windows finalized = (%d, %d), want (0, 0)", active, overflow)
+	}
+}
+
+// --- blocker 6: only a committed finalize may evict and advance ownership ---
+
+// seedTraceWindow lands `spans` spans for one service through the writer and
+// returns the window they landed in.
+func seedTraceWindow(t *testing.T, f *cumulativeFixture, spans int) int64 {
+	t.Helper()
+	r := f.eng.NewReducer(f.clock.Now())
+	for i := 0; i < spans; i++ {
+		r.ReduceSpan(SpanInput{
+			Tenant:         "acme",
+			Service:        "svc",
+			SpanName:       "GET /orders",
+			Timestamp:      f.clock.Now(),
+			DurationMicros: 250,
+		})
+	}
+	if _, err := f.eng.ApplyReducerErr(r); err != nil {
+		t.Fatalf("seed spans: %v", err)
+	}
+	return WindowStart(f.clock.Now())
+}
+
+// dashboardTraces queries the whole retained range and returns TotalTraces.
+func dashboardTraces(t *testing.T, e *Engine, from, to time.Time) int64 {
+	t.Helper()
+	res, err := e.QueryDashboard(Query{Tenant: "acme", Start: from, End: to})
+	if err != nil {
+		t.Fatalf("QueryDashboard: %v", err)
+	}
+	return res.TotalTraces
+}
+
+// TestQueryDuringRolloverFinalizeGapReturnsTheWindow is the read-side proof of
+// blocker 6: between the lateness horizon expiring and the finalizer committing
+// buckets, the window must still answer queries. It used to vanish, because
+// rollover had already handed ownership to a store with nothing in it.
+func TestQueryDuringRolloverFinalizeGapReturnsTheWindow(t *testing.T) {
+	f := newCumulativeFixture(t)
+	from := f.clock.Now().Add(-time.Minute)
+	seedTraceWindow(t, f, 5)
+
+	f.clock.Advance(WindowSize + AllowedLateness + time.Minute)
+	// The gap: closed, not finalized.
+	if forced := f.eng.Rollover(f.clock.Now()); forced != 0 {
+		t.Fatalf("rollover force-evicted %d windows, want 0", forced)
+	}
+	if got := dashboardTraces(t, f.eng, from, f.clock.Now()); got != 5 {
+		t.Fatalf("TotalTraces in the rollover-to-finalize gap = %d, want 5 — the window vanished", got)
+	}
+
+	// After the finalize commits, the same query is served from the store.
+	if n := f.w.FinalizeDue(f.clock.Now()); n != 1 {
+		t.Fatalf("finalized %d windows, want 1", n)
+	}
+	if got := dashboardTraces(t, f.eng, from, f.clock.Now()); got != 5 {
+		t.Fatalf("TotalTraces after finalize = %d, want 5", got)
+	}
+}
+
+// TestFinalizerFailureKeepsTheWindowReadable is the same property against a
+// finalizer that keeps failing: memory holds the window until materialization
+// actually commits, however long that takes.
+func TestFinalizerFailureKeepsTheWindowReadable(t *testing.T) {
+	f := newCumulativeFixture(t)
+	from := f.clock.Now().Add(-time.Minute)
+	seedTraceWindow(t, f, 7)
+
+	f.clock.Advance(WindowSize + AllowedLateness + time.Minute)
+	f.store.failFinalize.Store(true)
+	for i := 0; i < 5; i++ {
+		if n := f.w.FinalizeDue(f.clock.Now()); n != 0 {
+			t.Fatalf("pass %d finalized %d windows against a failing store", i, n)
+		}
+		if got := dashboardTraces(t, f.eng, from, f.clock.Now()); got != 7 {
+			t.Fatalf("TotalTraces after %d failed finalizes = %d, want 7", i+1, got)
+		}
+	}
+	if own := f.eng.Ownership(); !own.OwnsInMemory(WindowStart(from.Add(time.Minute))) {
+		t.Error("a window the finalizer never materialized lost memory ownership")
+	}
+
+	// The finalizer recovers and the handover happens exactly once.
+	f.store.failFinalize.Store(false)
+	if n := f.w.FinalizeDue(f.clock.Now()); n != 1 {
+		t.Fatalf("finalized %d windows after recovery, want 1", n)
+	}
+	if got := dashboardTraces(t, f.eng, from, f.clock.Now()); got != 7 {
+		t.Fatalf("TotalTraces after the finalizer recovered = %d, want 7", got)
+	}
+}

--- a/internal/aggregate/engine.go
+++ b/internal/aggregate/engine.go
@@ -17,14 +17,23 @@ import (
 // mutable set is the current window plus the windows still inside the lateness
 // horizon; everything older is finalized and never re-enters memory.
 //
-// ROLLOVER IS AN EVICTION, NOT A DELETION — once the durable store is wired
-// (#173). A window leaving the mutable set is dropped from the shards, and the
-// writer's finalize pass has already materialized it from the delta log into
-// aggregate_buckets; finalized history lives on disk and never comes back into
-// RAM. WITHOUT a store (no writer installed, engine constructed directly in a
-// test) rollover really is loss: the counts in the expiring window are gone,
-// which is why nothing may be presented to a user as authoritative unless the
-// group-commit writer is the applier.
+// ROLLOVER CLOSES A WINDOW; FINALIZATION EVICTS IT (#194 blocker 6). A window
+// past its lateness horizon stops accepting points but keeps its shard
+// contents, its memory ownership and its readability until the writer's
+// finalize pass has materialized it from the delta log into aggregate_buckets
+// and called MarkFinalized. Rolling ownership forward at close time instead —
+// what this engine used to do — pointed reads at a store that had no buckets
+// yet, so the window silently disappeared from every query until the next
+// successful finalize, and permanently while the finalizer was failing.
+//
+// The exception is the closed-window cap: memory may not grow without bound
+// behind a wedged finalizer, so past DefaultMaxClosedWindows the oldest closed
+// windows are evicted anyway. That is loss, and it is counted — see
+// Snapshot.ClosedWindowsForced and otelcontext_aggregate_closed_windows_*.
+// WITHOUT a store (no writer installed, engine constructed directly in a test)
+// nothing ever finalizes, so the cap is the only thing bounding memory and
+// every window it drops is gone: nothing may be presented to a user as
+// authoritative unless the group-commit writer is the applier.
 //
 // Shards are four plain mutex-guarded maps (hash & 3). No shard goroutines, no
 // channels. Two shard locks are NEVER held at once: a delta touches exactly one
@@ -44,6 +53,16 @@ const (
 	MaxFutureSkew = 2 * time.Minute
 	// NumShards is the shard count. Fixed at four per #160.
 	NumShards = 4
+	// DefaultMaxClosedWindows bounds how many closed-but-unfinalized windows
+	// the engine keeps in RAM (#194 blocker 6).
+	//
+	// A window closes one lateness horizon after it opens and the writer's
+	// finalize pass runs every 30 s, so the steady state is one closed window
+	// or none. Twelve is an hour of finalizer backlog: enough that a slow or
+	// briefly failing store never costs data, small enough that a wedged
+	// finalizer cannot grow memory without bound. Past it the engine falls
+	// back to the old lossy eviction and counts every window it drops.
+	DefaultMaxClosedWindows = 12
 )
 
 // Modes. Phase 1 ships legacy and aggregate-shadow; ModeAggregate is accepted
@@ -143,6 +162,11 @@ type EngineConfig struct {
 	// edge's caller service. Zero takes DefaultEdgeResolverSpans.
 	EdgeResolverSpans int
 
+	// MaxClosedWindows bounds the closed-but-unfinalized windows held in
+	// memory. Zero takes DefaultMaxClosedWindows; negative is unbounded and
+	// is for tests only.
+	MaxClosedWindows int
+
 	// Epoch identifies this engine instance. A consumer that sees a new epoch
 	// knows the revision counter restarted and must replace its state rather
 	// than reconcile against it. Zero derives one from the clock.
@@ -182,8 +206,11 @@ type Engine struct {
 	applier  atomic.Pointer[Applier]
 	revision atomic.Uint64
 
+	maxClosedWindows int
+
 	windowsDiscarded atomic.Uint64
 	seriesDiscarded  atomic.Uint64
+	closedForced     atomic.Uint64
 }
 
 // shard is one mutex-guarded slice of the mutable window set.
@@ -209,6 +236,13 @@ type ownership struct {
 	mu sync.RWMutex
 	// mutable is the set of window starts the shards own.
 	mutable map[int64]struct{}
+	// closed is the subset of mutable whose lateness horizon has expired.
+	// A closed window refuses NEW points but is still memory-owned and still
+	// readable: only a committed FinalizeWindow may take it out of memory
+	// (#194 blocker 6). Evicting at rollover instead made the window vanish
+	// from queries until the next successful finalize — indefinitely while the
+	// finalizer was failing.
+	closed map[int64]struct{}
 	// watermark is the newest window start handed to the store. Every window
 	// at or below it is store-owned.
 	watermark int64
@@ -273,6 +307,10 @@ func NewEngine(cfg EngineConfig) (*Engine, error) {
 		dims:    cfg.MetricDims,
 		epoch:   epoch,
 	}
+	e.maxClosedWindows = cfg.MaxClosedWindows
+	if e.maxClosedWindows == 0 {
+		e.maxClosedWindows = DefaultMaxClosedWindows
+	}
 	e.topology = newTopologyProjection(cfg.Topology, epoch)
 	e.edges = NewEdgeResolver(cfg.EdgeResolverSpans)
 	if e.metrics == nil {
@@ -299,6 +337,7 @@ func NewEngine(cfg EngineConfig) (*Engine, error) {
 		e.shards[i].windows = make(map[int64]map[SeriesKey]*AggregateDelta)
 	}
 	e.own.mutable = make(map[int64]struct{})
+	e.own.closed = make(map[int64]struct{})
 	e.own.epoch = newEpoch(cfg.Now())
 	var a Applier = directApplier{e}
 	e.applier.Store(&a)
@@ -417,14 +456,21 @@ func (e *Engine) ownershipLocked() Ownership {
 // the handover is exactly as atomic as the transaction that materialized the
 // buckets: a query either sees the window in memory or in the store, never in
 // both and never in neither.
+//
+// It is the ONLY path that may evict a window from the shards, drop its mutable
+// ownership and advance the watermark — with one counted exception, the closed
+// window cap in Rollover (#194 blocker 6).
 func (e *Engine) MarkFinalized(windowStart int64) {
 	e.own.mu.Lock()
 	released := e.evictWindowLocked(windowStart)
 	delete(e.own.mutable, windowStart)
+	delete(e.own.closed, windowStart)
 	if windowStart > e.own.watermark {
 		e.own.watermark = windowStart
 	}
+	closed := len(e.own.closed)
 	e.own.mu.Unlock()
+	e.metrics.SetClosedWindows(closed)
 	for _, swk := range released {
 		e.limiter.Release(swk.Key, swk.WindowStart)
 	}
@@ -586,16 +632,86 @@ func (e *Engine) ApplyCommitted(m DeltaMap) uint64 {
 	if len(m) == 0 {
 		return e.revision.Load()
 	}
-	resolved := e.Admit(m)
+	return e.CommitAdmission(e.PlanAdmission(m))
+}
 
+// AdmissionPlan is one batch's cardinality reservation: the identities the
+// shards will hold, plus the occupancy this plan charged the limiter for.
+//
+// It exists because admission has to precede the durable write — the row that
+// becomes durable must carry the identity the shards will hold — while the
+// charge must not survive a write that never happened (#194 blocker 3). Before
+// it, a failed CommitGroup left the occupancy charged with no shard window to
+// release it from, so a store that kept refusing writes ate the cardinality
+// budget permanently and forced live telemetry into __other__.
+type AdmissionPlan struct {
+	// Resolved is the batch keyed by the identity to record under.
+	Resolved DeltaMap
+	// reserved is the (series, window) presence this plan created. Pairs that
+	// were already present belong to an earlier committed batch and are not
+	// listed: releasing those would take budget from data that is still live.
+	reserved []SeriesWindowKey
+}
+
+// PlanAdmission rolls the mutable window set forward and reserves one batch of
+// deltas against the cardinality budget WITHOUT touching the shards.
+//
+// The durable writer (#173) calls it before its COMMIT so the row that becomes
+// durable carries the same identity the shards will later hold: admitting after
+// the write would let the store accumulate series the in-memory caps already
+// rerouted to __other__. Exactly one of CommitAdmission or RollbackAdmission
+// must follow.
+func (e *Engine) PlanAdmission(m DeltaMap) *AdmissionPlan {
+	plan := &AdmissionPlan{Resolved: m}
+	if len(m) == 0 {
+		return plan
+	}
+	e.Rollover(e.now())
+
+	cutoff := e.now().Unix() - int64(WindowSize/time.Second) - int64(AllowedLateness/time.Second)
+	resolved := make(DeltaMap, len(m))
+	for swk, d := range m {
+		if swk.WindowStart <= cutoff {
+			// The window's lateness horizon expired between reduction and
+			// apply, so it is closed and no longer accepts points.
+			e.seriesDiscarded.Add(1)
+			continue
+		}
+		adm := e.limiter.Admit(swk.Key, swk.WindowStart)
+		if adm.Overflowed {
+			e.metrics.RecordOverflow(swk.Key.Signal, adm.Reason)
+		}
+		target := SeriesWindowKey{Key: adm.Key, WindowStart: swk.WindowStart}
+		if adm.Reserved {
+			plan.reserved = append(plan.reserved, target)
+		}
+		if existing, ok := resolved[target]; ok {
+			// Two source series collapsed onto the same overflow series.
+			// Totals are preserved; only identity detail is gone.
+			existing.Merge(d)
+			continue
+		}
+		resolved[target] = d
+	}
+	plan.Resolved = resolved
+	return plan
+}
+
+// CommitAdmission folds a committed plan into the mutable windows and returns
+// the new revision. The reservations become ordinary occupancy, released later
+// by MarkFinalized like any other series in the window.
+func (e *Engine) CommitAdmission(plan *AdmissionPlan) uint64 {
+	if plan == nil || len(plan.Resolved) == 0 {
+		return e.revision.Load()
+	}
 	// The shard writes and the ownership registration happen inside one
 	// ownership critical section so a concurrent Ownership() never reports a
 	// window as memory-owned before memory holds it, nor the reverse.
 	e.own.mu.Lock()
 	for i := range e.shards {
-		e.applyShard(i, resolved)
+		e.applyShard(i, plan.Resolved)
 	}
-	for swk := range resolved {
+	for swk := range plan.Resolved {
 		e.own.mutable[swk.WindowStart] = struct{}{}
 	}
 	rev := e.revision.Add(1)
@@ -605,45 +721,17 @@ func (e *Engine) ApplyCommitted(m DeltaMap) uint64 {
 	return rev
 }
 
-// Admit rolls the mutable window set forward and resolves one batch of deltas
-// against the cardinality budget WITHOUT touching the shards.
-//
-// The durable writer (#173) calls it before its COMMIT so the row that becomes
-// durable carries the same identity the shards will later hold: admitting after
-// the write would let the store accumulate series the in-memory caps already
-// rerouted to __other__. Admission is idempotent for a series already present
-// in a window, so the ApplyCommitted that follows the commit re-resolves the
-// same map to itself.
-func (e *Engine) Admit(m DeltaMap) DeltaMap {
-	if len(m) == 0 {
-		return m
+// RollbackAdmission releases the occupancy a plan charged after its commit
+// failed. Nothing reached the shards, so there is no window eviction that would
+// ever release it — this is the only undo there is.
+func (e *Engine) RollbackAdmission(plan *AdmissionPlan) {
+	if plan == nil || len(plan.reserved) == 0 {
+		return
 	}
-	e.Rollover(e.now())
-
-	cutoff := e.now().Unix() - int64(WindowSize/time.Second) - int64(AllowedLateness/time.Second)
-	resolved := make(DeltaMap, len(m))
-	for swk, d := range m {
-		if swk.WindowStart <= cutoff {
-			// The window's lateness horizon expired between reduction and
-			// apply. Recreating it here would only have it discarded at the
-			// next rollover.
-			e.seriesDiscarded.Add(1)
-			continue
-		}
-		adm := e.limiter.Admit(swk.Key, swk.WindowStart)
-		if adm.Overflowed {
-			e.metrics.RecordOverflow(swk.Key.Signal, adm.Reason)
-		}
-		target := SeriesWindowKey{Key: adm.Key, WindowStart: swk.WindowStart}
-		if existing, ok := resolved[target]; ok {
-			// Two source series collapsed onto the same overflow series.
-			// Totals are preserved; only identity detail is gone.
-			existing.Merge(d)
-			continue
-		}
-		resolved[target] = d
+	for _, swk := range plan.reserved {
+		e.limiter.Release(swk.Key, swk.WindowStart)
 	}
-	return resolved
+	e.publishActiveSeries()
 }
 
 // applyShard folds every entry belonging to shard i into it, under that shard's
@@ -677,56 +765,75 @@ func (e *Engine) applyShard(i int, resolved DeltaMap) {
 	}
 }
 
-// Rollover evicts every window whose lateness horizon has expired and returns
-// how many it dropped.
+// Rollover CLOSES every window whose lateness horizon has expired and returns
+// how many windows the closed-window cap forced out of memory — which is loss,
+// and is normally zero.
 //
-// With the durable store wired, the window has already been finalized into
-// aggregate_buckets by the writer's finalize pass, so this is an eviction from
-// RAM. Without a store it is loss. See the file header.
+// It does not evict. A closed window refuses new points (Admit drops deltas at
+// or below the cutoff) but keeps its shard contents, its mutable ownership and
+// its place below the watermark until a committed FinalizeWindow hands it over
+// through MarkFinalized. Evicting here — the pre-#194 behaviour — advanced
+// ownership to a store that had not yet materialized aggregate_buckets, so
+// every read of that window skipped the delta log and returned nothing until
+// the next successful finalize, and forever while the finalizer was failing.
+//
+// The one thing memory cannot do is grow without bound behind a wedged
+// finalizer, so the closed set is capped. Past the cap the oldest closed
+// windows are evicted the old way and counted: lossy, but no longer silent.
 func (e *Engine) Rollover(now time.Time) int {
 	cutoff := now.Unix() - int64(WindowSize/time.Second) - int64(AllowedLateness/time.Second)
-	dropped := 0
+	forced := 0
 	var released []SeriesWindowKey
 	e.own.mu.Lock()
-	for i := range e.shards {
-		sh := &e.shards[i]
-		sh.mu.Lock()
-		for start, w := range sh.windows {
-			if start > cutoff {
-				continue
-			}
-			for key := range w {
-				released = append(released, SeriesWindowKey{Key: key, WindowStart: start})
-			}
-			delete(sh.windows, start)
-			dropped++
-		}
-		sh.mu.Unlock()
-	}
-	// A window whose lateness horizon expired is no longer memory-owned even
-	// if the writer has not finalized it yet: the shards no longer hold it, so
-	// claiming memory ownership would report zero for a window that has data.
-	// Handing it to the store is the honest transition — the delta rows are
-	// already durable and the next finalize pass materializes them.
 	for start := range e.own.mutable {
 		if start > cutoff {
 			continue
 		}
+		e.own.closed[start] = struct{}{}
+	}
+	for _, start := range e.overCapClosedLocked() {
+		released = append(released, e.evictWindowLocked(start)...)
+		delete(e.own.closed, start)
 		delete(e.own.mutable, start)
 		if start > e.own.watermark {
 			e.own.watermark = start
 		}
+		forced++
 	}
+	closed := len(e.own.closed)
 	e.own.mu.Unlock()
 	for _, swk := range released {
 		e.limiter.Release(swk.Key, swk.WindowStart)
 	}
-	if dropped > 0 {
-		e.windowsDiscarded.Add(uint64(dropped))
+	e.metrics.SetClosedWindows(closed)
+	if forced > 0 {
+		e.windowsDiscarded.Add(uint64(forced))
 		e.seriesDiscarded.Add(uint64(len(released)))
+		e.closedForced.Add(uint64(forced))
+		for i := 0; i < forced; i++ {
+			e.metrics.RecordClosedWindowEvicted()
+		}
 		e.publishActiveSeries()
 	}
-	return dropped
+	return forced
+}
+
+// overCapClosedLocked returns the oldest closed windows that exceed the closed
+// window cap, oldest first. e.own.mu must be held for writing.
+func (e *Engine) overCapClosedLocked() []int64 {
+	if e.maxClosedWindows < 0 {
+		return nil
+	}
+	over := len(e.own.closed) - e.maxClosedWindows
+	if over <= 0 {
+		return nil
+	}
+	starts := make([]int64, 0, len(e.own.closed))
+	for start := range e.own.closed {
+		starts = append(starts, start)
+	}
+	sort.Slice(starts, func(i, j int) bool { return starts[i] < starts[j] })
+	return starts[:over]
 }
 
 // publishActiveSeries pushes the limiter's occupancy into the active-series
@@ -764,9 +871,15 @@ type Snapshot struct {
 	ActiveBySignal map[Signal]int
 	// Overflow counts admissions rerouted to an __other__ series, per reason.
 	Overflow map[OverflowReason]uint64
-	// WindowsDiscarded and SeriesDiscarded count Phase 1 rollover loss.
+	// WindowsDiscarded and SeriesDiscarded count rollover loss.
 	WindowsDiscarded uint64
 	SeriesDiscarded  uint64
+	// ClosedWindowsForced counts closed-but-unfinalized windows the cap
+	// forced out of memory. Every one is data the finalizer never
+	// materialized, so a non-zero value means the finalizer is behind.
+	ClosedWindowsForced uint64
+	// ClosedWindows is how many closed-but-unfinalized windows memory holds.
+	ClosedWindows int
 }
 
 // Snapshot returns a copy of the mutable window set.
@@ -803,14 +916,19 @@ func (e *Engine) Snapshot() Snapshot {
 	}
 
 	ls := e.limiter.Stats()
+	e.own.mu.RLock()
+	closed := len(e.own.closed)
+	e.own.mu.RUnlock()
 	return Snapshot{
-		Revision:         e.revision.Load(),
-		Windows:          windows,
-		ActiveSeries:     ls.Active,
-		ActiveBySignal:   ls.ActiveBySignal,
-		Overflow:         ls.Overflow,
-		WindowsDiscarded: e.windowsDiscarded.Load(),
-		SeriesDiscarded:  e.seriesDiscarded.Load(),
+		Revision:            e.revision.Load(),
+		Windows:             windows,
+		ActiveSeries:        ls.Active,
+		ActiveBySignal:      ls.ActiveBySignal,
+		Overflow:            ls.Overflow,
+		WindowsDiscarded:    e.windowsDiscarded.Load(),
+		SeriesDiscarded:     e.seriesDiscarded.Load(),
+		ClosedWindowsForced: e.closedForced.Load(),
+		ClosedWindows:       closed,
 	}
 }
 

--- a/internal/aggregate/engine_test.go
+++ b/internal/aggregate/engine_test.go
@@ -140,7 +140,10 @@ func TestLatePointLandsInItsOwnWindow(t *testing.T) {
 	}
 }
 
-func TestRolloverDiscardsExpiredWindowsAndReleasesBudget(t *testing.T) {
+// TestRolloverClosesWithoutEvicting pins #194 blocker 6: a window past its
+// lateness horizon stops accepting points but stays in memory, readable and
+// still holding its budget, until a committed finalize hands it to the store.
+func TestRolloverClosesWithoutEvicting(t *testing.T) {
 	base := mustTime(t, "2026-08-21T12:00:00Z")
 	clock := base
 	e, err := NewEngine(EngineConfig{Mode: ModeShadow, Now: func() time.Time { return clock }})
@@ -158,21 +161,77 @@ func TestRolloverDiscardsExpiredWindowsAndReleasesBudget(t *testing.T) {
 
 	// Advance past the window's close plus the full lateness horizon.
 	clock = base.Add(WindowSize + AllowedLateness + time.Second)
-	if dropped := e.Rollover(clock); dropped != 1 {
-		t.Fatalf("rollover dropped %d windows, want 1", dropped)
+	if forced := e.Rollover(clock); forced != 0 {
+		t.Fatalf("rollover force-evicted %d windows under the cap, want 0", forced)
 	}
 
 	snap := e.Snapshot()
-	if len(snap.Windows) != 0 {
-		t.Errorf("windows = %d, want 0", len(snap.Windows))
+	if len(snap.Windows) != 1 {
+		t.Fatalf("windows = %d after rollover, want 1 — a closed window must stay readable", len(snap.Windows))
 	}
-	if snap.ActiveSeries != 0 {
-		t.Errorf("active series = %d after rollover, want 0 — budget must be released", snap.ActiveSeries)
+	if snap.ClosedWindows != 1 {
+		t.Errorf("closed windows = %d, want 1", snap.ClosedWindows)
 	}
-	// Phase 1 loses the window rather than finalizing it. The counters exist so
-	// the loss is visible instead of silent.
-	if snap.WindowsDiscarded != 1 || snap.SeriesDiscarded != 1 {
-		t.Errorf("discard counters = (%d, %d), want (1, 1)", snap.WindowsDiscarded, snap.SeriesDiscarded)
+	if snap.ActiveSeries != 1 {
+		t.Errorf("active series = %d, want 1 — a closed window still occupies budget", snap.ActiveSeries)
+	}
+	if snap.WindowsDiscarded != 0 || snap.ClosedWindowsForced != 0 {
+		t.Errorf("discard counters = (%d, %d), want (0, 0) — nothing was lost", snap.WindowsDiscarded, snap.ClosedWindowsForced)
+	}
+
+	// Finalization is the only thing that may evict it and release the budget.
+	e.MarkFinalized(WindowStart(base))
+	snap = e.Snapshot()
+	if len(snap.Windows) != 0 || snap.ActiveSeries != 0 || snap.ClosedWindows != 0 {
+		t.Errorf("after MarkFinalized: windows=%d active=%d closed=%d, want 0/0/0",
+			len(snap.Windows), snap.ActiveSeries, snap.ClosedWindows)
+	}
+}
+
+// TestRolloverCapForcesLossyEvictionAndCountsIt pins the memory bound: a wedged
+// finalizer must not grow RAM without limit, and the fallback to the old lossy
+// eviction must be counted rather than silent.
+func TestRolloverCapForcesLossyEvictionAndCountsIt(t *testing.T) {
+	base := mustTime(t, "2026-08-21T12:00:00Z")
+	clock := base
+	const cap = 2
+	e, err := NewEngine(EngineConfig{
+		Mode:             ModeShadow,
+		MaxClosedWindows: cap,
+		Now:              func() time.Time { return clock },
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	// Four windows, one point each, no finalizer ever running.
+	const windows = 4
+	for i := 0; i < windows; i++ {
+		clock = base.Add(time.Duration(i) * WindowSize)
+		r := e.NewReducer(clock)
+		r.ReduceSpan(SpanInput{Tenant: "t", Service: "svc", SpanName: "op", Timestamp: clock, DurationMicros: 1})
+		e.ApplyReducer(r)
+	}
+
+	clock = base.Add(time.Duration(windows)*WindowSize + AllowedLateness + time.Second)
+	forced := e.Rollover(clock)
+	snap := e.Snapshot()
+	if snap.ClosedWindows > cap {
+		t.Fatalf("holding %d closed windows against a cap of %d", snap.ClosedWindows, cap)
+	}
+	if forced != windows-cap {
+		t.Fatalf("rollover force-evicted %d windows, want %d", forced, windows-cap)
+	}
+	if snap.ClosedWindowsForced != uint64(windows-cap) {
+		t.Errorf("ClosedWindowsForced = %d, want %d — forced loss must be counted",
+			snap.ClosedWindowsForced, windows-cap)
+	}
+	// The oldest windows are the ones that go, and only they.
+	if own := e.Ownership(); own.OwnsInMemory(WindowStart(base)) {
+		t.Error("the oldest closed window survived the cap")
+	}
+	if own := e.Ownership(); !own.OwnsInMemory(WindowStart(base.Add((windows - 1) * WindowSize))) {
+		t.Error("the newest closed window was evicted before older ones")
 	}
 }
 

--- a/internal/aggregate/metrics.go
+++ b/internal/aggregate/metrics.go
@@ -29,6 +29,13 @@ type MetricsRecorder interface {
 	// __other__ reserve occupancy, both per signal. They are separate numbers
 	// because only the first is bounded by the AGGREGATE_MAX_SERIES* caps.
 	SetActiveSeries(active, overflow map[Signal]int)
+	// SetClosedWindows publishes how many closed-but-unfinalized windows the
+	// engine is holding. It is the finalizer-backlog signal: a value that does
+	// not return to zero means finalization is failing.
+	SetClosedWindows(held int)
+	// RecordClosedWindowEvicted counts one closed window the cap forced out of
+	// memory before it was finalized. Every one is lost data.
+	RecordClosedWindowEvicted()
 }
 
 // noopRecorder is the default when no metrics are wired.
@@ -37,6 +44,8 @@ type noopRecorder struct{}
 func (noopRecorder) RecordReduction(ReducerStats, map[Signal]uint64) {}
 func (noopRecorder) RecordOverflow(Signal, OverflowReason)           {}
 func (noopRecorder) SetActiveSeries(_, _ map[Signal]int)             {}
+func (noopRecorder) SetClosedWindows(int)                            {}
+func (noopRecorder) RecordClosedWindowEvicted()                      {}
 
 // promRecorder bridges the engine onto the platform's Prometheus metrics.
 type promRecorder struct{ m *telemetry.Metrics }
@@ -96,6 +105,16 @@ func (r promRecorder) SetActiveSeries(active, overflow map[Signal]int) {
 		r.m.AggregateSeriesActive.WithLabelValues(label).Set(float64(active[sig]))
 		r.m.AggregateOverflowSeriesActive.WithLabelValues(label).Set(float64(overflow[sig]))
 	}
+}
+
+// SetClosedWindows implements MetricsRecorder.
+func (r promRecorder) SetClosedWindows(held int) {
+	r.m.AggregateClosedWindows.Set(float64(held))
+}
+
+// RecordClosedWindowEvicted implements MetricsRecorder.
+func (r promRecorder) RecordClosedWindowEvicted() {
+	r.m.AggregateClosedWindowsEvictedTotal.Inc()
 }
 
 // promStoreRecorder bridges the durable store and the group-commit writer onto

--- a/internal/aggregate/query_test.go
+++ b/internal/aggregate/query_test.go
@@ -368,10 +368,11 @@ func TestQueryRejectsUnboundedRange(t *testing.T) {
 	}
 }
 
-// TestRolloverHandsOwnershipToTheStore pins that an evicted window stops
-// claiming memory ownership: claiming it would report zero for a window whose
-// deltas are already durable.
-func TestRolloverHandsOwnershipToTheStore(t *testing.T) {
+// TestFinalizeHandsOwnershipToTheStore pins #194 blocker 6: rollover closes an
+// expired window but keeps it memory-owned, and only a committed finalize moves
+// ownership and the watermark. Advancing at rollover routed reads to a store
+// that had no buckets yet, so the window silently vanished from queries.
+func TestFinalizeHandsOwnershipToTheStore(t *testing.T) {
 	f := newQueryFixture(t)
 	old := f.window() - int64((WindowSize+AllowedLateness+WindowSize)/time.Second)
 	f.engine.own.mu.Lock()
@@ -380,8 +381,17 @@ func TestRolloverHandsOwnershipToTheStore(t *testing.T) {
 
 	f.engine.Rollover(f.now)
 	own := f.engine.Ownership()
+	if !own.OwnsInMemory(old) {
+		t.Fatal("closed window lost memory ownership before it was finalized")
+	}
+	if own.FinalizedWatermark >= old {
+		t.Errorf("FinalizedWatermark = %d, want below %d until finalize commits", own.FinalizedWatermark, old)
+	}
+
+	f.engine.MarkFinalized(old)
+	own = f.engine.Ownership()
 	if own.OwnsInMemory(old) {
-		t.Fatal("expired window is still memory-owned after rollover")
+		t.Fatal("finalized window is still memory-owned")
 	}
 	if own.FinalizedWatermark < old {
 		t.Errorf("FinalizedWatermark = %d, want at least %d", own.FinalizedWatermark, old)

--- a/internal/aggregate/temporality.go
+++ b/internal/aggregate/temporality.go
@@ -155,6 +155,10 @@ type CumulativeOutcome struct {
 	// Degraded is true when the point was attributed to the per-series shared
 	// baseline because the producer bound was exhausted.
 	Degraded bool
+	// Recovered is true when Delta also carries an increase whose group commit
+	// failed earlier and which this point re-attributes (#194 blocker 2). It is
+	// informational: the stranded amount is already folded into Delta.
+	Recovered bool
 }
 
 // BaselineStats is a snapshot of BaselineTracker counters.
@@ -178,6 +182,15 @@ type BaselineStats struct {
 	// GlobalOverflow counts points that could not take a dedicated baseline
 	// because the global baseline budget was exhausted.
 	GlobalOverflow uint64
+	// Owed is the number of records currently carrying an increase whose
+	// group commit failed. A number that does not return to zero means the
+	// store is refusing writes, not that accounting is drifting.
+	Owed int
+	// Recovered counts points that re-attributed a stranded increase.
+	Recovered uint64
+	// Stranded counts stranded increases dropped by a downtime re-seed,
+	// which is the one place the owed ledger is deliberately not honoured.
+	Stranded uint64
 }
 
 // BaselineTrackerConfig bounds the tracker.
@@ -204,6 +217,11 @@ type DirtyBaseline struct {
 	Key      SeriesKey
 	Producer ProducerID
 	Baseline Baseline
+	// Inflight is the increase this record emitted as deltas since its last
+	// drain. It rides the drain so a failed commit can hand the amount back
+	// as owed instead of stranding it (#194 blocker 2). It is not part of the
+	// durable BaselineRow — the store never sees it.
+	Inflight float64
 }
 
 // baselineRef identifies one baseline record.
@@ -212,15 +230,39 @@ type baselineRef struct {
 	producer ProducerID
 }
 
+// baselineState is one live baseline plus the ledger that makes a failed group
+// commit exactly recoverable (#194 blocker 2).
+//
+// The baseline VALUE is never rewound on commit failure. Rewinding looks like
+// the obvious fix and is wrong: between the drain and the commit result another
+// point may already have chained off the advanced value, and rewinding then
+// either fabricates the next increment or swallows it depending on which point
+// lands first. What a failed commit actually loses is an AMOUNT — the increase
+// whose delta rows never became durable — so that amount is carried forward and
+// re-attributed to the first point that can carry it. An identical client retry
+// (stale by timestamp, and therefore normally ignored) is such a point, which is
+// what makes "commit fails, client retries, delta survives" hold without
+// duplicating anything when a newer point arrives instead.
+type baselineState struct {
+	Baseline
+	// pending is the increase emitted as deltas since the last drain. The
+	// drain moves it into DirtyBaseline.Inflight and clears it.
+	pending float64
+	// owed is in-flight increase whose commit failed. The next point that
+	// moves this record adds it to its own delta and clears it.
+	owed float64
+}
+
 // BaselineTracker converts cumulative monotonic points into deltas and detects
 // resets. It is safe for concurrent use.
 type BaselineTracker struct {
 	cfg BaselineTrackerConfig
 
 	mu      sync.Mutex
-	series  map[SeriesKey]map[ProducerID]*Baseline
+	series  map[SeriesKey]map[ProducerID]*baselineState
 	dirty   map[baselineRef]struct{}
 	entries int
+	owed    int
 
 	stale            uint64
 	seeded           uint64
@@ -229,6 +271,8 @@ type BaselineTracker struct {
 	resetsRegression uint64
 	producerOverflow uint64
 	globalOverflow   uint64
+	recovered        uint64
+	stranded         uint64
 }
 
 // NewBaselineTracker returns a tracker bounded by cfg. Zero or negative bounds
@@ -245,7 +289,7 @@ func NewBaselineTracker(cfg BaselineTrackerConfig) *BaselineTracker {
 	}
 	return &BaselineTracker{
 		cfg:    cfg,
-		series: make(map[SeriesKey]map[ProducerID]*Baseline),
+		series: make(map[SeriesKey]map[ProducerID]*baselineState),
 		dirty:  make(map[baselineRef]struct{}),
 	}
 }
@@ -259,14 +303,13 @@ func (t *BaselineTracker) Seed(key SeriesKey, producer ProducerID, b Baseline) {
 	defer t.mu.Unlock()
 	byProducer, ok := t.series[key]
 	if !ok {
-		byProducer = make(map[ProducerID]*Baseline, 1)
+		byProducer = make(map[ProducerID]*baselineState, 1)
 		t.series[key] = byProducer
 	}
 	if _, exists := byProducer[producer]; !exists {
 		t.entries++
 	}
-	cp := b
-	byProducer[producer] = &cp
+	byProducer[producer] = &baselineState{Baseline: b}
 }
 
 // DrainDirty returns the baselines mutated since the last drain and clears the
@@ -274,6 +317,9 @@ func (t *BaselineTracker) Seed(key SeriesKey, producer ProducerID, b Baseline) {
 // record is at least as new as the deltas in that batch: on a crash a baseline
 // can be ahead of the durable deltas (the next point under-counts by one
 // interval) but never behind them (which would double-count).
+//
+// Each drained row also carries the increase that record emitted since the
+// previous drain, so Rollback can hand it back if the commit fails.
 func (t *BaselineTracker) DrainDirty() []DirtyBaseline {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -282,18 +328,31 @@ func (t *BaselineTracker) DrainDirty() []DirtyBaseline {
 	}
 	out := make([]DirtyBaseline, 0, len(t.dirty))
 	for ref := range t.dirty {
-		b, ok := t.series[ref.key][ref.producer]
+		st, ok := t.series[ref.key][ref.producer]
 		if !ok {
 			continue
 		}
-		out = append(out, DirtyBaseline{Key: ref.key, Producer: ref.producer, Baseline: *b})
+		out = append(out, DirtyBaseline{
+			Key:      ref.key,
+			Producer: ref.producer,
+			Baseline: st.Baseline,
+			Inflight: st.pending,
+		})
+		st.pending = 0
 	}
 	clear(t.dirty)
 	return out
 }
 
-// Redirty puts drained baselines back after a failed commit.
-func (t *BaselineTracker) Redirty(rows []DirtyBaseline) {
+// Rollback puts drained baselines back after a failed commit AND hands each
+// record the increase that commit was carrying, so the amount is re-attributed
+// to the next point instead of being lost (#194 blocker 2).
+//
+// Re-dirtying alone was the bug: the in-memory baseline had already advanced at
+// reduction time, so an identical client retry classified as stale and its delta
+// vanished. See baselineState for why the amount is carried forward rather than
+// the value rewound.
+func (t *BaselineTracker) Rollback(rows []DirtyBaseline) {
 	if len(rows) == 0 {
 		return
 	}
@@ -301,6 +360,14 @@ func (t *BaselineTracker) Redirty(rows []DirtyBaseline) {
 	defer t.mu.Unlock()
 	for _, r := range rows {
 		t.dirty[baselineRef{key: r.Key, producer: r.Producer}] = struct{}{}
+		st, ok := t.series[r.Key][r.Producer]
+		if !ok || r.Inflight == 0 {
+			continue
+		}
+		if st.owed == 0 {
+			t.owed++
+		}
+		st.owed += r.Inflight
 	}
 }
 
@@ -330,7 +397,7 @@ func (t *BaselineTracker) ObserveCumulative(key SeriesKey, producer ProducerID, 
 
 	byProducer, ok := t.series[key]
 	if !ok {
-		byProducer = make(map[ProducerID]*Baseline, 1)
+		byProducer = make(map[ProducerID]*baselineState, 1)
 		t.series[key] = byProducer
 	}
 
@@ -354,7 +421,9 @@ func (t *BaselineTracker) ObserveCumulative(key SeriesKey, producer ProducerID, 
 	}
 
 	if !ok {
-		byProducer[producer] = &Baseline{StartTime: startTime, LastTimestamp: ts, Value: value}
+		byProducer[producer] = &baselineState{
+			Baseline: Baseline{StartTime: startTime, LastTimestamp: ts, Value: value},
+		}
 		t.entries++
 		t.seeded++
 		t.markDirtyLocked(key, producer)
@@ -362,19 +431,38 @@ func (t *BaselineTracker) ObserveCumulative(key SeriesKey, producer ProducerID, 
 		return out
 	}
 
-	// (1) Stale or duplicate: never moves the baseline, never a reset.
+	// (1) Stale or duplicate: never moves the baseline, never a reset. It may
+	// still settle an owed increase — an identical retry after a failed commit
+	// is exactly this case, and refusing it there is what lost the delta.
 	if !ts.After(b.LastTimestamp) {
 		t.stale++
+		if b.owed > 0 {
+			out.Delta = b.owed
+			out.Recovered = true
+			b.pending += b.owed
+			b.owed = 0
+			t.owed--
+			t.recovered++
+			t.markDirtyLocked(key, producer)
+			return out
+		}
 		out.Ignored = true
 		return out
 	}
 
 	// Downtime gap: the increase spans more than the mutable-window horizon,
-	// so it cannot be attributed to any window we still own. Re-seed.
+	// so it cannot be attributed to any window we still own. Re-seed. An owed
+	// increase belongs to a window that is equally gone, so it is dropped here
+	// too — counted, not silent (#166 downtime handling).
 	if ts.Sub(b.LastTimestamp) > t.cfg.GapThreshold {
 		b.StartTime = startTime
 		b.LastTimestamp = ts
 		b.Value = value
+		if b.owed > 0 {
+			b.owed = 0
+			t.owed--
+			t.stranded++
+		}
 		t.gaps++
 		t.markDirtyLocked(key, producer)
 		out.Gap = true
@@ -399,6 +487,18 @@ func (t *BaselineTracker) ObserveCumulative(key SeriesKey, producer ProducerID, 
 		out.Delta = value - b.Value
 	}
 
+	// Settle any increase a failed commit stranded on this record. Totals stay
+	// exact across a commit failure whichever point arrives first: an identical
+	// retry settles it above, a newer point settles it here, and only one of
+	// them can, because settling clears the ledger.
+	if b.owed > 0 {
+		out.Delta += b.owed
+		out.Recovered = true
+		b.owed = 0
+		t.owed--
+		t.recovered++
+	}
+	b.pending += out.Delta
 	b.StartTime = startTime
 	b.LastTimestamp = ts
 	b.Value = value
@@ -411,11 +511,11 @@ func (t *BaselineTracker) ObserveCumulative(key SeriesKey, producer ProducerID, 
 func (t *BaselineTracker) Baseline(key SeriesKey, producer ProducerID) (Baseline, bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	b, ok := t.series[key][producer]
+	st, ok := t.series[key][producer]
 	if !ok {
 		return Baseline{}, false
 	}
-	return *b, true
+	return st.Baseline, true
 }
 
 // Stats returns a snapshot of the tracker counters.
@@ -432,6 +532,9 @@ func (t *BaselineTracker) Stats() BaselineStats {
 		ResetsRegression: t.resetsRegression,
 		ProducerOverflow: t.producerOverflow,
 		GlobalOverflow:   t.globalOverflow,
+		Owed:             t.owed,
+		Recovered:        t.recovered,
+		Stranded:         t.stranded,
 	}
 }
 

--- a/internal/aggregate/writer.go
+++ b/internal/aggregate/writer.go
@@ -383,11 +383,13 @@ func (w *Writer) commit(batch []*submission) {
 	// Admission against the cardinality budget happens BEFORE the write so the
 	// row that becomes durable carries the same identity the shards will hold.
 	// Doing it after the commit would let the store accumulate series the
-	// in-memory caps already rejected.
-	resolved := w.engine.Admit(merged)
+	// in-memory caps already rejected. It is a RESERVATION, not a charge:
+	// exactly one of CommitAdmission or RollbackAdmission settles it below, so
+	// a commit that never lands cannot keep eating cardinality budget (#194).
+	plan := w.engine.PlanAdmission(merged)
 
-	gb := &GroupBatch{Deltas: make([]DeltaRow, 0, len(resolved))}
-	for swk, d := range resolved {
+	gb := &GroupBatch{Deltas: make([]DeltaRow, 0, len(plan.Resolved))}
+	for swk, d := range plan.Resolved {
 		gb.Deltas = append(gb.Deltas, DeltaRow{
 			SeriesID:    w.series.Resolve(swk.Key),
 			WindowStart: swk.WindowStart,
@@ -419,9 +421,12 @@ func (w *Writer) commit(batch []*submission) {
 	w.commits.Add(1)
 	if err != nil {
 		w.commitErrors.Add(1)
-		// Nothing became durable: put the baselines back so the next commit
-		// carries them, and leave the staged registrations staged.
-		w.engine.Baselines().Redirty(dirty)
+		// Nothing became durable, so nothing may keep the resources the write
+		// would have justified: release the cardinality reservation, hand the
+		// drained baselines back the increase this batch was carrying, and
+		// leave the staged registrations staged.
+		w.engine.RollbackAdmission(plan)
+		w.engine.Baselines().Rollback(dirty)
 		w.finish(batch, commitResult{revision: w.engine.Revision(), err: err})
 		return
 	}
@@ -432,7 +437,7 @@ func (w *Writer) commit(batch []*submission) {
 	}
 
 	// Commit-then-apply: the shards only ever see committed state.
-	rev := w.engine.ApplyCommitted(resolved)
+	rev := w.engine.CommitAdmission(plan)
 	w.finish(batch, commitResult{revision: rev})
 }
 

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -187,6 +187,15 @@ type Metrics struct {
 	// AggregateShadowErrorsTotal — errors accounted on the aggregate side per
 	// service. Cheap invariant only (#165): no per-series comparison.
 	AggregateShadowErrorsTotal *prometheus.CounterVec
+	// AggregateClosedWindows — windows past their lateness horizon that
+	// memory still holds because the finalizer has not materialized them into
+	// aggregate_buckets yet. Steady state is 0 or 1; a value that stays high
+	// means finalization is behind or failing.
+	AggregateClosedWindows prometheus.Gauge
+	// AggregateClosedWindowsEvictedTotal — closed windows the closed-window
+	// cap forced out of memory before finalization. Each one is lost data:
+	// alert on any increase.
+	AggregateClosedWindowsEvictedTotal prometheus.Counter
 
 	// --- Durable aggregate store (#173) ---
 	// AggregateCommitDurationSeconds — group-commit wall time. This IS the
@@ -548,6 +557,14 @@ func New() *Metrics {
 		Name: "otelcontext_aggregate_shadow_errors_total",
 		Help: "Errors accounted on the aggregate side, per service. Cheap shadow-mode invariant only.",
 	}, []string{"service"})
+	m.AggregateClosedWindows = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "otelcontext_aggregate_closed_windows",
+		Help: "Windows past their lateness horizon still held in memory awaiting finalization. Steady state is 0 or 1.",
+	})
+	m.AggregateClosedWindowsEvictedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_closed_windows_evicted_total",
+		Help: "Closed windows forced out of memory by the closed-window cap before finalization. Each one is lost data.",
+	})
 	m.AggregateCommitDurationSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "otelcontext_aggregate_commit_duration_seconds",
 		Help:    "Group-commit wall time on the aggregate store. This is the floor of OTLP ACK latency under durable ACK.",


### PR DESCRIPTION
Part of #194 (blockers 2, 3, 6) — wave 1 of map #195

All three defects share one shape: a resource is taken before the durable write and released on the assumption that the write will land. Each fix settles the resource on the actual commit result.

Frozen contracts untouched: delta-log pre-merge keying, group-commit coalescing, schema version rules (#162), commit-then-apply. No schema change.

---

## Blocker 2 — cumulative baselines advanced before the durable commit

**Root cause.** `BaselineTracker.ObserveCumulative` mutates the shared baseline at reduction time. On `CommitGroup` failure `writer.go` only called `Redirty`, which re-marks the *already advanced* record dirty. An identical client retry then compared against the advanced `LastTimestamp`, classified as stale, and the increase was gone.

**Approach.** Not a value rewind. Rewinding is wrong under interleaving: between the drain and the commit result another point may already have chained off the advanced value, and rewinding then either fabricates the next increment or swallows it depending on which point lands first. What a failed commit loses is an *amount*, so the amount is carried forward:

- `baselineState` wraps each `Baseline` with `pending` (increase emitted since the last drain) and `owed` (increase whose commit failed).
- `DrainDirty` moves `pending` into `DirtyBaseline.Inflight` and clears it. `Inflight` is not part of the durable `BaselineRow`; the store never sees it.
- `Redirty` becomes `Rollback`: it re-dirties *and* credits `Inflight` back as `owed`.
- The next point that can carry it settles the ledger exactly once — an identical retry (normally ignored as stale) settles it in the stale branch, a newer point settles it on the normal/reset path. Only one of them can, because settling clears `owed`.
- A downtime re-seed drops `owed` deliberately (that window is gone either way) and counts it as `BaselineStats.Stranded`.

`BaselineStats` gains `Owed`, `Recovered`, `Stranded`. `CumulativeOutcome` gains `Recovered`.

## Blocker 3 — cardinality admission leaked on commit failure

**Root cause.** `Writer.commit` charged the limiter via `Engine.Admit` before `CommitGroup`. The failure path never released the occupancy, and because `ApplyCommitted` never ran there was no shard window for eviction to release it from later. Repeated failures permanently ate budget and forced live telemetry into `__other__`.

**Approach.** The reservation lifecycle #194 names, exactly:

```
PlanAdmission -> CommitGroup -> CommitAdmission     (success)
                             -> RollbackAdmission   (failure)
```

- `Limiter.Admit` now reports `Admission.Reserved` — whether *this* call created `(key, window)` presence.
- `AdmissionPlan` carries the resolved identities plus only the presence the plan itself created. A pair that was already present belongs to an earlier committed batch and is never released, so a failure on a live series cannot take budget from committed data.
- `Engine.Admit` is replaced by `PlanAdmission` / `CommitAdmission` / `RollbackAdmission`; `ApplyCommitted` is now `CommitAdmission(PlanAdmission(m))`, so the direct (Phase 1) applier is unchanged.

The invariant that the durable row carries the same identity the shards will hold is preserved: admission still runs before the write, it is just no longer charged unconditionally.

## Blocker 6 — only `MarkFinalized` may evict and advance ownership

**Root cause.** `Engine.Rollover` deleted shard windows and advanced the ownership watermark for windows the finalizer had not materialized into `aggregate_buckets`. Reads then routed to the store, found no buckets, skipped the delta log, and the window silently vanished from queries — indefinitely while the finalizer was failing.

**Approach.**

- `ownership` gains a `closed` set. `Rollover` no longer evicts: it marks expired windows closed. A closed window rejects new points (`PlanAdmission` already drops deltas at or below the cutoff) but keeps its shard contents, its mutable ownership and its readability.
- `MarkFinalized` — after a committed `FinalizeWindow` — remains the only path that evicts the shard window, drops mutable ownership, releases limiter budget and advances the watermark.
- **Memory bound:** the closed set is capped at `DefaultMaxClosedWindows = 12` (~1h of finalizer backlog; steady state is 0–1 closed windows). Past the cap the oldest closed windows are evicted the old lossy way and counted, never silently: `Snapshot.ClosedWindowsForced`, `otelcontext_aggregate_closed_windows_evicted_total`, plus the backlog gauge `otelcontext_aggregate_closed_windows`. `EngineConfig.MaxClosedWindows` overrides it.

---

## Test evidence

New acceptance tests in `internal/aggregate/commit_failure_test.go`, one per acceptance criterion in #194:

| Test | Criterion |
|---|---|
| `TestCommitFailureThenIdenticalRetryPreservesTheDelta` | commit failure + identical retry preserves the delta |
| `TestCommitFailureThenNewerPointNeitherLosesNorDuplicates` | commit failure + newer point neither loses nor duplicates |
| `TestConcurrentCumulativePointsCommitDeterministically` | concurrent cumulative points commit deterministically |
| `TestAdmissionOccupancyIsExactAfterRepeatedCommitFailures` | occupancy exact after repeated failures |
| `TestAdmissionOccupancyIsExactAfterFailureThenRetry` | occupancy exact after failure-then-retry |
| `TestAdmissionOccupancyIsExactAcrossWindowRollover` | occupancy exact across rollover |
| `TestQueryDuringRolloverFinalizeGapReturnsTheWindow` | query in the rollover→finalize gap returns the window |
| `TestFinalizerFailureKeepsTheWindowReadable` | finalizer failure keeps data readable |
| `TestRolloverCapForcesLossyEvictionAndCountsIt` (engine_test.go) | closed-window cap enforced and counted |

**Every one of these was verified to fail against the pre-fix behaviour** (temporarily reverting the three fixes in place):

```
commit_failure_test.go:134: durable increase = 0, want 25 — the retry must reproduce the lost delta
commit_failure_test.go:162: durable increase = 25, want 50 (100 -> 150)
commit_failure_test.go:232: occupancy after 20 refused commits = (3 active, 0 overflow), want (0, 0)
commit_failure_test.go:297: active series = 2 after a refused commit, want 1
commit_failure_test.go:362: rollover force-evicted 1 windows, want 0
```

Two existing tests pinned the behaviour blocker 6 says is wrong and were rewritten to pin the fixed contract: `TestRolloverDiscardsExpiredWindowsAndReleasesBudget` → `TestRolloverClosesWithoutEvicting`, `TestRolloverHandsOwnershipToTheStore` → `TestFinalizeHandsOwnershipToTheStore`.

**Runs:**

- ✅ `gofmt -l internal/ main.go` — clean for every file this PR touches
- ✅ `go vet ./...`
- ✅ `go build ./...`
- ✅ `go test ./internal/aggregate/ -count=1 -race` — 319 passed
- ✅ `go test ./... -count=1` — 1121 passed, 28 packages
- ⚠️ `go test ./internal/ingest/ -count=1 -race` — flaky, **pre-existing**: `TestPipeline_PerTenantCap_ReleasedAfterProcess` and `TestPipeline_StoreMinSeverity_DropsBelowThresholdFromPersist` fail intermittently under `-race`. Reproduced 3/5 runs on a clean `origin/main` worktree with no changes; not touched by this PR. Worth its own issue — they are timing-dependent and will bite the starved 2-core CI runners.
