### PR TITLE
feat(auth): per-tenant bearer identity for HTTP, WebSocket, and gRPC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,7 +88,10 @@
 # TLS_CACHE_DIR=./data/tls
 
 # ---- Auth -------------------------------------------------------------------
-# API_KEY=                       # [REQUIRED IN PROD] Bearer token for /api/*, /v1/*, /mcp. Empty = auth disabled (dev only).
+# API_KEY=                       # [REQUIRED IN PROD] Operator bearer token for /api/*, /v1/*, /mcp,
+#                                # /ws*, and OTLP gRPC. Authenticates only — tenant selection keeps
+#                                # its X-Tenant-ID precedence. Empty = auth disabled (dev only).
+#                                # For per-tenant identity see API_TENANT_KEYS_FILE below.
 
 # ---- OTLP Ingest Filtering --------------------------------------------------
 # INGEST_MIN_SEVERITY=INFO       # Drop logs below this severity before storage
@@ -151,12 +154,42 @@
 #                                # a compromised SDK could forge another tenant's data. Only turn
 #                                # on in closed environments where every OTLP producer is trusted.
 #
-# API_TENANT_KEYS_FILE=          # Path to a file of `key=tenant` pairs (one per line; `#` comments).
-#                                # When set, each API bearer token is bound to a specific tenant
-#                                # and the matched tenant OVERRIDES any X-Tenant-ID header —
-#                                # callers cannot read other tenants by swapping headers.
+# API_TENANT_KEYS_FILE=          # JSON or YAML file (chosen by extension) mapping bearer key ->
+#                                # tenant ID, e.g. {"3f7c...": "acme", "9b21...": "acme"}.
+#                                # Several keys may map to one tenant (rotation, per-agent keys).
+#                                # Loaded once at startup; memory holds only SHA-256 digests and
+#                                # lookups are constant-time. The file must NOT be readable or
+#                                # writable by group/other (chmod 600) or startup refuses.
+#                                # A matched key BINDS the request: X-Tenant-ID, x-tenant-id gRPC
+#                                # metadata, the ?tenant= WebSocket parameter, and the tenant.id
+#                                # resource attribute are ignored and counted on
+#                                # OtelContext_auth_tenant_conflicts_total.
 #                                # When empty, behaviour falls back to the single shared API_KEY
 #                                # + self-asserted X-Tenant-ID header (legacy dev mode).
+#
+# AUTH_TRUST_EXTERNAL=false      # Trust a tenant identity injected by a front proxy. This is an
+#                                # AUTHENTICATION BYPASS unless the proxy authenticates callers,
+#                                # strips inbound copies of AUTH_EXTERNAL_TENANT_HEADER, and the
+#                                # application ports are unreachable except through it. Read the
+#                                # full deployment contract in CLAUDE.md before enabling.
+# AUTH_EXTERNAL_TENANT_HEADER=X-OtelContext-Tenant
+#                                # Dedicated identity header (and, lower-cased, gRPC metadata key)
+#                                # honoured only when AUTH_TRUST_EXTERNAL=true. Never X-Tenant-ID:
+#                                # that header stays client-controlled and untrusted.
+#
+# WS_ALLOWED_ORIGINS=            # Comma-separated origins ("https://app.example.com") or bare
+#                                # hosts allowed to open /ws*. Empty = same-host only. Enforced
+#                                # whenever authentication is enabled or APP_ENV=production.
+# WS_MAX_CLIENTS=0               # Admission cap on BOTH WebSocket hubs (0 = unlimited). Past the
+#                                # cap the handshake is refused with 503 before the upgrade.
+#
+# GRPC_REFLECTION=               # gRPC server reflection. Defaults to true outside production and
+#                                # false when APP_ENV=production (reflection enumerates every
+#                                # service and message type to an unauthenticated peer).
+# OTELCONTEXT_ALLOW_INSECURE_GRPC=false
+#                                # Waives the production requirement that the OTLP gRPC listener
+#                                # have both TLS and authentication. Explicit acknowledgement that
+#                                # telemetry crosses the network unprotected and unauthenticated.
 
 # ---- AI Service (optional — Azure OpenAI log insights) ----------------------
 # AI_ENABLED=false               # Master switch. When false, AI workers are not started.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,14 @@ Both paths delegate to the same `Export()` methods — zero business logic dupli
 
 ### Multi-tenancy
 
-Tenant identity flows into the request context on every write and read:
+Tenant identity flows into the request context on every write and read. An
+**authenticated tenant key outranks every one of these carriers** — see the
+Authentication section:
+- **Authenticated identity (highest):** a bearer key from `API_TENANT_KEYS_FILE`, or a proxy-injected `X-OtelContext-Tenant` under `AUTH_TRUST_EXTERNAL`. Binding is absolute; contradicting client assertions are ignored and counted on `OtelContext_auth_tenant_conflicts_total{surface,reason}`.
 - **HTTP:** `X-Tenant-ID` header (see `internal/api/tenant_middleware.go`).
 - **gRPC:** `x-tenant-id` metadata key (see `internal/ingest/otlp.go`).
-- **OTLP resource attribute:** `tenant.id` on the resource overrides the header/metadata.
+- **OTLP resource attribute:** `tenant.id` on the resource overrides the header/metadata (only when `OTLP_TRUST_RESOURCE_TENANT=true`).
+- **WebSocket:** one tenant per connection, fixed at the handshake — never a protocol message.
 
 When none are present, `DEFAULT_TENANT` (default `"default"`) is assigned. The
 resolved tenant is stamped on every async-pipeline `Batch`, so
@@ -226,7 +230,13 @@ Key settings in `internal/config/config.go`:
 - `DB_AZURE_AUTH` (false) — see Authentication below
 - `TLS_CERT_FILE`, `TLS_KEY_FILE` — explicit TLS (both or neither)
 - `TLS_AUTO_SELFSIGNED` (false), `TLS_CACHE_DIR` (`./data/tls`) — self-signed bootstrap, ignored if cert files set
-- `API_KEY` — Bearer token gate for `/api/*`, `/v1/*`, `/mcp`. Empty = auth disabled
+- `API_KEY` — operator bearer token gating `/api/*`, `/v1/*`, `/mcp`, `/ws*`, and OTLP gRPC. Empty = auth disabled
+- `API_TENANT_KEYS_FILE` — JSON or YAML (by extension) mapping bearer key → tenant; several keys per tenant allowed. Startup-only load, digest-only in memory, constant-time compare. File must not be group/other readable or writable (>0600 refuses startup, quoting the actual mode). A tenant key BINDS the request: `X-Tenant-ID`, `x-tenant-id` metadata, and `tenant.id` resource attributes are ignored and counted
+- `AUTH_TRUST_EXTERNAL` (false), `AUTH_EXTERNAL_TENANT_HEADER` (`X-OtelContext-Tenant`) — proxy-injected identity; read the mandatory deployment contract in Authentication before enabling
+- `WS_ALLOWED_ORIGINS` (`""` = same-host only) — comma-separated origins (`https://app.example.com`) or bare hosts, enforced on `/ws*` whenever authentication is enabled or `APP_ENV=production`
+- `WS_MAX_CLIENTS` (0 = unlimited) — admission cap on BOTH WebSocket hubs; past the cap the handshake gets 503 before the upgrade
+- `GRPC_REFLECTION` — defaults to true outside production, false in production; set explicitly to override
+- `OTELCONTEXT_ALLOW_INSECURE_GRPC` (false) — waives the production TLS+auth requirement on the OTLP gRPC listener
 - `OTEL_EXPORTER_OTLP_ENDPOINT` — enables self-instrumentation (empty = off)
 - `DEFAULT_TENANT` (`default`) — assigned to rows ingested without explicit tenant
 - `HOT_RETENTION_DAYS` (7) — drives `RetentionScheduler`; range 1..36500
@@ -268,7 +278,36 @@ Also at SQLite startup, `internal/storage/factory.go` applies a fail-closed PRAG
 
 ### Authentication
 
-**API auth (platform).** `API_KEY` gates `/api/*`, OTLP HTTP (`/v1/*`), and the MCP endpoint via `Authorization: Bearer <API_KEY>`. When empty, the middleware is a pass-through (dev only). Unprotected paths: `/live`, `/ready`, `/metrics*`, `/ws*`. A shared `API_KEY` grants access to every tenant — there is no per-tenant-key file in the current code; isolate tenants at the network/auth layer if that matters. (If an `API_TENANT_KEYS_FILE` override lands later, re-check `internal/api/auth.go` for the flag name.)
+Two credential classes, one authenticator (`internal/authn/`), three transports.
+
+**Operator key (`API_KEY`).** Gates `/api/*`, OTLP HTTP (`/v1/*`), the MCP endpoint, `/ws*`, and OTLP gRPC via `Authorization: Bearer <API_KEY>`. It authenticates and nothing more: tenant selection keeps its historical precedence (`X-Tenant-ID` / `x-tenant-id` → trusted `tenant.id` resource attribute → `DEFAULT_TENANT`), so a single-tenant install behaves exactly as before. When empty the middleware is a pass-through (dev only). Always-unprotected paths: `/live`, `/ready`, `/health*`, `/metrics*`, and the UI bundle.
+
+**Tenant keys (`API_TENANT_KEYS_FILE`).** JSON or YAML chosen by extension, mapping bearer key → tenant ID, several keys per tenant (rotation, per-agent keys):
+
+```json
+{"3f7c…": "acme", "9b21…": "acme", "c40d…": "beta"}
+```
+
+Loaded once at startup — a key-file swap is an explicit restart, never a live reload. The process keeps only SHA-256 digests; lookup digests the presented key and compares with `subtle.ConstantTimeCompare` against every entry without exiting early. Startup refuses: unreadable files, files with any group/other permission bit (the refusal quotes the actual mode), unknown extensions, empty files, empty keys, keys containing whitespace or control characters, tenant IDs the storage sanitizer rejects, and duplicate keys. Credentials never appear in a log line or an error message at any level.
+
+A tenant key **binds** the request or connection. Client-asserted tenancy — `X-Tenant-ID`, the `?tenant=` WebSocket parameter, `x-tenant-id` gRPC metadata, and the `tenant.id` OTLP resource attribute — is ignored and counted on `OtelContext_auth_tenant_conflicts_total{surface,reason}`. A non-zero rate means a client is asserting a tenancy it does not hold.
+
+**WebSocket (`/ws*`).** The handshake authenticates (`internal/api/ws_auth.go`) once any credential source is configured. Carriers: `Authorization: Bearer <key>` for non-browser clients, or a `Sec-WebSocket-Protocol` entry `otelcontext.v1, auth.<base64url-token>` for browsers, which cannot set headers on a WebSocket. The server validates the token and echoes **only** `otelcontext.v1`; the protocol header value is never logged. Tokens are never accepted in query strings. One tenant scope per connection: a tenant-key socket is bound, an operator socket selects exactly one tenant via `?tenant=` or `X-Tenant-ID` and otherwise gets `DEFAULT_TENANT`. There is no merged all-tenant stream. Event delivery in both hubs is filtered by that scope, and an event carrying no tenant is invisible to a scoped socket (fail closed). `WS_ALLOWED_ORIGINS` is enforced whenever authentication is enabled or `APP_ENV=production` (empty list = same-host only); a request with no `Origin` header is a non-browser client and still has to authenticate. Both hubs cap admission at `WS_MAX_CLIENTS`, and the event hub now writes through one bounded queue (256 messages) and one writer goroutine per client — **overflow disconnects the client** rather than dropping messages, because the log/metric batches are incremental and a silent gap would misreport as "nothing happened". A reconnect re-seeds with a full snapshot.
+
+**OTLP gRPC.** Unary and stream interceptors (`internal/ingest/grpc_auth.go`) read `authorization` metadata against the same key store. Refusals are `codes.Unauthenticated` with a non-specific message (a prober learns nothing) and are counted on `OtelContext_grpc_auth_failures_total{reason}`. Reflection is disabled when `APP_ENV=production` unless `GRPC_REFLECTION=true`.
+
+**Production fail-closed startup.** With `APP_ENV=production`, startup refuses unless the OTLP gRPC listener has **both** transport protection (`TLS_CERT_FILE`/`TLS_KEY_FILE` or `TLS_AUTO_SELFSIGNED=true`) and authentication (`API_KEY` or `API_TENANT_KEYS_FILE`). Two waivers, each named in the refusal: `AUTH_TRUST_EXTERNAL=true` (the proxy terminates TLS and authenticates) or `OTELCONTEXT_ALLOW_INSECURE_GRPC=true` (explicit acknowledgement that telemetry crosses the network unprotected).
+
+**`AUTH_TRUST_EXTERNAL` — mandatory proxy contract.** The flag trusts a tenant identity injected by a front proxy in `AUTH_EXTERNAL_TENANT_HEADER` (default `X-OtelContext-Tenant`; the gRPC metadata key is its lower-cased form). It is never blind trust of `X-Tenant-ID`, which stays client-controlled and untrusted. All of the following are mandatory deployment conditions:
+
+1. The proxy authenticates every caller (mTLS, OIDC, or its own credential check) before forwarding.
+2. The proxy **strips inbound copies** of the identity header from client requests and injects its own verified value. A configuration that merely appends is a bypass.
+3. The application ports (HTTP and gRPC) are unreachable except through the proxy — network policy, listener binding, or both.
+4. TLS is terminated at the proxy, and the proxy-to-application hop is on a trusted network or separately protected.
+5. The proxy forwards the WebSocket upgrade (`Connection`/`Upgrade`, and the `Sec-WebSocket-Protocol` entries) with the identity header intact.
+6. The proxy forwards gRPC metadata, injecting the identity key on the gRPC path too.
+
+**Without every one of those conditions, `AUTH_TRUST_EXTERNAL=true` is an authentication bypass wearing infrastructure terminology.** Anything that can reach the port becomes any tenant it names.
 
 **Database auth (Azure Entra).** Setting `DB_AZURE_AUTH=true` enables Azure Entra ID (AAD) authentication for PostgreSQL. The driver uses `DefaultAzureCredential`, which resolves identity via the standard probe order (env vars → workload identity → managed identity → Azure CLI → developer credentials). When Azure auth is enabled, strict TLS (`sslmode=require`, `verify-ca`, or `verify-full`) is mandatory; weaker modes are rejected at startup. `DB_CONN_MAX_LIFETIME` is internally capped to 30 minutes to stay inside the token TTL.
 

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/driver/sqlserver v1.6.3
@@ -112,7 +113,6 @@ require (
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.37.6 // indirect
 	modernc.org/mathutil v1.6.0 // indirect
 	modernc.org/memory v1.7.2 // indirect

--- a/internal/api/log_handlers.go
+++ b/internal/api/log_handlers.go
@@ -117,6 +117,7 @@ func (s *Server) handleGetLogInsight(w http.ResponseWriter, r *http.Request) {
 // BroadcastLog sends a log entry to the buffered WebSocket hub.
 func (s *Server) BroadcastLog(l storage.Log) {
 	s.hub.Broadcast(realtime.LogEntry{
+		Tenant:         l.TenantID,
 		ID:             l.ID,
 		TraceID:        l.TraceID,
 		SpanID:         l.SpanID,

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
 	"github.com/RandomCodeSpace/otelcontext/internal/config"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 )
@@ -133,25 +134,29 @@ func TestTenantMiddleware_MissingHeaderUsesDefault(t *testing.T) {
 	}
 }
 
-// TestTenantMiddleware_DoesNotOverwritePinnedTenant verifies that when
-// TenantKeyAuth.Middleware has already pinned a tenant onto the context (the
-// per-tenant API-key path), the subsequent TenantMiddleware pass-through does
-// NOT overwrite it with the client-supplied X-Tenant-ID header.
+// TestTenantMiddleware_DoesNotOverwritePinnedTenant verifies that when AuthGate
+// has already pinned a tenant onto the context (the per-tenant API-key path),
+// the subsequent TenantMiddleware pass-through does NOT overwrite it with the
+// client-supplied X-Tenant-ID header.
 //
 // This is the regression test for the middleware-ordering bypass:
 //
-//	TenantKeyAuth.Middleware(auth "alpha-key" → pins "alpha")
+//	AuthGate(auth "alpha-key" → pins "alpha")
 //	  → TenantMiddleware(reads X-Tenant-ID: "beta" → must NOT overwrite)
 //	    → handler (must see "alpha")
 func TestTenantMiddleware_DoesNotOverwritePinnedTenant(t *testing.T) {
 	// Build per-tenant key auth: key "alpha-key" → tenant "alpha".
-	auth := NewTenantKeyAuth(map[string]string{"alpha-key": "alpha"})
+	store, err := authn.NewKeyStoreFromMap(map[string]string{"alpha-key": "alpha"})
+	if err != nil {
+		t.Fatalf("NewKeyStoreFromMap: %v", err)
+	}
+	auth := authn.NewAuthenticator("", store, false)
 
 	cfg := &config.Config{DefaultTenant: "default"}
 	tc := &tenantCapture{}
 
-	// Compose: TenantKeyAuth wraps TenantMiddleware wraps handler.
-	h := auth.Middleware("/mcp", TenantMiddleware(cfg)(tc.handler()))
+	// Compose: AuthGate wraps TenantMiddleware wraps handler.
+	h := AuthGate(AuthGateOptions{Auth: auth, MCPPath: "/mcp"}, TenantMiddleware(cfg)(tc.handler()))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/logs", nil)
 	req.Header.Set("Authorization", "Bearer alpha-key")

--- a/internal/api/tenant_keys.go
+++ b/internal/api/tenant_keys.go
@@ -1,165 +1,102 @@
 package api
 
 import (
-	"bufio"
-	"crypto/subtle"
-	"fmt"
+	"context"
 	"net/http"
-	"os"
-	"strings"
-	"sync"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 )
 
-// LoadTenantKeys parses a tenant-keys file where each non-empty,
-// non-comment line is a `key=tenant` pair. The returned map is
-// keyed by bearer token (value=tenant ID) so an authenticated
-// request can be scoped to the key's bound tenant regardless of
-// any client-asserted X-Tenant-ID header.
+// DefaultExternalTenantHeader is the dedicated identity header a front proxy
+// injects when AUTH_TRUST_EXTERNAL=true. It is deliberately NOT X-Tenant-ID:
+// that header stays client-controlled and untrusted, so a proxy that forgets
+// to strip inbound copies of the dedicated header fails visibly rather than
+// silently promoting client input to an identity.
+const DefaultExternalTenantHeader = "X-OtelContext-Tenant"
+
+// AuthGateOptions configures the HTTP authentication middleware.
+type AuthGateOptions struct {
+	// Auth resolves bearer tokens. A disabled Authenticator makes the gate a
+	// pass-through — authentication arrives with configuration, not by default.
+	Auth *authn.Authenticator
+	// MCPPath is used by IsProtectedPath to gate the MCP endpoint.
+	MCPPath string
+	// ExternalTenantHeader overrides DefaultExternalTenantHeader.
+	ExternalTenantHeader string
+}
+
+func (o AuthGateOptions) externalHeader() string {
+	if o.ExternalTenantHeader != "" {
+		return o.ExternalTenantHeader
+	}
+	return DefaultExternalTenantHeader
+}
+
+// AuthGate authenticates /api/*, /v1/*, and the MCP endpoint.
 //
-// File format (YAML/INI-friendly, also accepts plain `key=tenant`):
+// Two credential classes, one gate:
 //
-//	# one mapping per line, comments start with '#'
-//	5f4dcc3b5aa765d61d8327deb882cf99=acme
-//	c20ad4d76fe97759aa27a0c99bff6710=beta
+//   - The operator key (API_KEY) authenticates and nothing more. Tenant
+//     resolution keeps its historical precedence — X-Tenant-ID header, then
+//     the OTLP resource attribute where trusted, then DEFAULT_TENANT — so an
+//     API_KEY-only deployment behaves exactly as it did before this middleware
+//     existed.
+//   - A tenant key (API_TENANT_KEYS_FILE) authenticates AND binds. The bound
+//     tenant is pinned onto the request context and a client-supplied
+//     X-Tenant-ID is ignored and counted, never honoured.
 //
-// Whitespace around tokens is ignored; duplicate keys return an error
-// so misconfiguration fails loud at startup.
-func LoadTenantKeys(path string) (map[string]string, error) {
-	if path == "" {
-		return nil, nil
-	}
-	f, err := os.Open(path) // #nosec G304 -- operator-supplied config path
-	if err != nil {
-		return nil, fmt.Errorf("tenant keys file %q: %w", path, err)
-	}
-	defer func() { _ = f.Close() }()
-
-	out := make(map[string]string)
-	sc := bufio.NewScanner(f)
-	line := 0
-	for sc.Scan() {
-		line++
-		raw := strings.TrimSpace(sc.Text())
-		if raw == "" || strings.HasPrefix(raw, "#") {
-			continue
-		}
-		// Accept both `key=tenant` and `key: tenant` (YAML-ish).
-		sep := "="
-		if !strings.Contains(raw, "=") && strings.Contains(raw, ":") {
-			sep = ":"
-		}
-		parts := strings.SplitN(raw, sep, 2)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("tenant keys file %q line %d: expected `key=tenant`, got %q", path, line, raw)
-		}
-		key := strings.TrimSpace(parts[0])
-		tenant := strings.TrimSpace(parts[1])
-		if key == "" || tenant == "" {
-			return nil, fmt.Errorf("tenant keys file %q line %d: empty key or tenant", path, line)
-		}
-		if _, dup := out[key]; dup {
-			return nil, fmt.Errorf("tenant keys file %q line %d: duplicate key", path, line)
-		}
-		out[key] = tenant
-	}
-	if err := sc.Err(); err != nil {
-		return nil, fmt.Errorf("tenant keys file %q: %w", path, err)
-	}
-	if len(out) == 0 {
-		return nil, fmt.Errorf("tenant keys file %q: no entries found", path)
-	}
-	return out, nil
-}
-
-// TenantKeyAuth holds a key→tenant map loaded from APITenantKeysFile and
-// exposes middleware that both authenticates AND pins the tenant onto the
-// request context. When enabled it OVERRIDES any X-Tenant-ID header — callers
-// cannot cross tenants by swapping headers.
-type TenantKeyAuth struct {
-	mu      sync.RWMutex
-	entries map[string]string // key → tenant
-}
-
-// NewTenantKeyAuth constructs a TenantKeyAuth from a pre-loaded map.
-// nil or empty disables the layer; callers should fall back to the shared
-// API_KEY path in that case.
-func NewTenantKeyAuth(entries map[string]string) *TenantKeyAuth {
-	cp := make(map[string]string, len(entries))
-	for k, v := range entries {
-		cp[k] = v
-	}
-	return &TenantKeyAuth{entries: cp}
-}
-
-// Enabled reports whether per-tenant keys are configured.
-func (a *TenantKeyAuth) Enabled() bool {
-	if a == nil {
-		return false
-	}
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	return len(a.entries) > 0
-}
-
-// Lookup returns the tenant bound to the given bearer key, using a
-// constant-time compare against every entry so mismatches don't leak via
-// timing.
-func (a *TenantKeyAuth) Lookup(key string) (string, bool) {
-	if a == nil || key == "" {
-		return "", false
-	}
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	got := []byte(key)
-	var matchedTenant string
-	var matched int
-	for k, tenant := range a.entries {
-		// subtle.ConstantTimeCompare requires equal length; guard before call.
-		if len(got) == len(k) && subtle.ConstantTimeCompare(got, []byte(k)) == 1 {
-			matchedTenant = tenant
-			matched = 1
-		}
-	}
-	if matched == 1 {
-		return matchedTenant, true
-	}
-	return "", false
-}
-
-// Middleware returns an http.Handler wrapper that requires an
-// `Authorization: Bearer <key>` header present in the tenant-keys map.
-// On success the matched tenant is pinned onto the request context via
-// storage.WithTenantContext, overriding any client-supplied X-Tenant-ID.
-// On mismatch (including missing header) it returns 401.
-//
-// Public paths (IsProtectedPath == false) pass through unchanged so UI
-// assets and health probes remain reachable without credentials.
-func (a *TenantKeyAuth) Middleware(mcpPath string, next http.Handler) http.Handler {
-	if !a.Enabled() {
+// When AUTH_TRUST_EXTERNAL=true and no bearer credential is presented, the
+// proxy-injected identity header supplies a bound principal.
+func AuthGate(o AuthGateOptions, next http.Handler) http.Handler {
+	if !o.Auth.Enabled() {
 		return next
 	}
+	extHeader := o.externalHeader()
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !IsProtectedPath(r.URL.Path, mcpPath) {
+		if !IsProtectedPath(r.URL.Path, o.MCPPath) {
 			next.ServeHTTP(w, r)
 			return
 		}
-		auth := r.Header.Get("Authorization")
-		const prefix = "Bearer "
-		if !strings.HasPrefix(auth, prefix) {
-			writeUnauthorized(w)
-			return
-		}
-		got := strings.TrimPrefix(auth, prefix)
-		tenant, ok := a.Lookup(got)
+		principal, reason, ok := authenticateHTTP(o.Auth, r, extHeader)
 		if !ok {
+			recordAuthFailure(reason)
 			writeUnauthorized(w)
 			return
 		}
-		// Pin tenant onto ctx. This OVERRIDES any X-Tenant-ID header a
-		// caller may have set, closing the cross-tenant read vector.
-		ctx := storage.WithTenantContext(r.Context(), tenant)
-		next.ServeHTTP(w, r.WithContext(ctx))
+		next.ServeHTTP(w, r.WithContext(bindPrincipal(r, principal)))
 	})
+}
+
+// authenticateHTTP resolves the principal for one request: bearer credential
+// first, proxy-injected identity only when no bearer credential was presented
+// at all. A presented-but-invalid credential is always a 401, even under
+// AUTH_TRUST_EXTERNAL — otherwise a bad key would silently downgrade into
+// whatever the header claimed.
+func authenticateHTTP(a *authn.Authenticator, r *http.Request, extHeader string) (authn.Principal, string, bool) {
+	token, reason := authn.TokenFromAuthorization(r.Header.Get("Authorization"))
+	if token == "" {
+		if reason == authn.ReasonMissingCredential {
+			if p, ok := a.ExternalPrincipal(r.Header.Get(extHeader)); ok {
+				return p, "", true
+			}
+		}
+		return authn.Principal{}, reason, false
+	}
+	return a.AuthenticateToken(token)
+}
+
+// bindPrincipal stashes the principal on the request context and, for bound
+// principals, pins the tenant so every downstream repository read and ingest
+// write is scoped to it. Contradicting client assertions are counted here —
+// this is the only place on the HTTP surface that sees both.
+func bindPrincipal(r *http.Request, p authn.Principal) context.Context {
+	ctx := authn.WithPrincipal(r.Context(), p)
+	if !p.Bound() {
+		return ctx
+	}
+	if asserted := r.Header.Get(TenantHeader); asserted != "" && storage.SanitizeTenantID(asserted) != p.Tenant {
+		authn.RecordConflict("http", "header")
+	}
+	return storage.WithTenantContext(ctx, p.Tenant)
 }

--- a/internal/api/tenant_keys_test.go
+++ b/internal/api/tenant_keys_test.go
@@ -7,148 +7,273 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 )
 
-func writeTempFile(t *testing.T, content string) string {
+// conflictRecorder captures the tenant-conflict metric hook for one test.
+type conflictRecorder struct{ calls [][2]string }
+
+func (c *conflictRecorder) install(t *testing.T) {
 	t.Helper()
-	dir := t.TempDir()
-	p := filepath.Join(dir, "keys.txt")
-	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
-		t.Fatalf("write temp keys: %v", err)
-	}
-	return p
-}
-
-func TestTenantKeysFile_LoadAndMatch(t *testing.T) {
-	path := writeTempFile(t, `# comment
-key-one=acme
-key-two: beta
-
-# trailing blank line allowed
-`)
-	m, err := LoadTenantKeys(path)
-	if err != nil {
-		t.Fatalf("LoadTenantKeys: %v", err)
-	}
-	if len(m) != 2 {
-		t.Fatalf("want 2 entries, got %d: %+v", len(m), m)
-	}
-	if m["key-one"] != "acme" {
-		t.Errorf("key-one => %q, want acme", m["key-one"])
-	}
-	if m["key-two"] != "beta" {
-		t.Errorf("key-two => %q, want beta", m["key-two"])
-	}
-
-	auth := NewTenantKeyAuth(m)
-	if !auth.Enabled() {
-		t.Fatal("auth should be enabled")
-	}
-	if tenant, ok := auth.Lookup("key-one"); !ok || tenant != "acme" {
-		t.Errorf("Lookup(key-one) = (%q,%v), want (acme,true)", tenant, ok)
-	}
-	if _, ok := auth.Lookup("nope"); ok {
-		t.Error("Lookup(nope) should be false")
+	prev := authn.ConflictHook
+	t.Cleanup(func() { authn.ConflictHook = prev })
+	authn.ConflictHook = func(surface, reason string) {
+		c.calls = append(c.calls, [2]string{surface, reason})
 	}
 }
 
-func TestTenantKeysFile_OverridesHeader(t *testing.T) {
-	// Key "admin" is bound to tenant acme. Caller also sets X-Tenant-ID=victim
-	// (attacker attempting cross-tenant read). The auth layer must pin ctx to
-	// acme regardless of the header.
-	path := writeTempFile(t, "admin=acme\n")
-	m, err := LoadTenantKeys(path)
-	if err != nil {
-		t.Fatalf("load: %v", err)
+func tenantKeyAuth(t *testing.T, operatorKey string, entries map[string]string) *authn.Authenticator {
+	t.Helper()
+	var store *authn.KeyStore
+	if len(entries) > 0 {
+		var err error
+		store, err = authn.NewKeyStoreFromMap(entries)
+		if err != nil {
+			t.Fatalf("NewKeyStoreFromMap: %v", err)
+		}
 	}
-	auth := NewTenantKeyAuth(m)
+	return authn.NewAuthenticator(operatorKey, store, false)
+}
 
-	var gotTenant string
-	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotTenant = storage.TenantFromContext(r.Context())
+// tenantEcho reports the tenant the request context carried into the handler.
+func tenantEcho(got *string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*got = storage.TenantFromContext(r.Context())
 		w.WriteHeader(http.StatusOK)
 	})
+}
 
-	h := auth.Middleware("/mcp", inner)
+// A tenant key binds the request: a contradicting X-Tenant-ID is ignored AND
+// counted. This is the cross-tenant read vector from #194 blocker 7.
+func TestAuthGate_TenantKeyIgnoresClientTenantHeader(t *testing.T) {
+	var rec conflictRecorder
+	rec.install(t)
+
+	var got string
+	h := AuthGate(AuthGateOptions{Auth: tenantKeyAuth(t, "", map[string]string{"acme-key": "acme"}), MCPPath: "/mcp"}, tenantEcho(&got))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/logs", nil)
-	req.Header.Set("Authorization", "Bearer admin")
-	req.Header.Set("X-Tenant-ID", "victim") // should be OVERRIDDEN
-	rec := httptest.NewRecorder()
+	req.Header.Set("Authorization", "Bearer acme-key")
+	req.Header.Set(TenantHeader, "victim")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
 
-	h.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("want 200, got %d (body=%q)", rec.Code, rec.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (%s)", w.Code, w.Body.String())
 	}
-	if gotTenant != "acme" {
-		t.Errorf("tenant not pinned from key: got %q, want acme", gotTenant)
+	if got != "acme" {
+		t.Errorf("tenant = %q, want acme (key binding must win)", got)
+	}
+	if len(rec.calls) != 1 || rec.calls[0] != [2]string{"http", "header"} {
+		t.Errorf("conflict metric = %v, want one http/header record", rec.calls)
 	}
 }
 
-func TestTenantKeysFile_UnknownKey_401(t *testing.T) {
-	path := writeTempFile(t, "admin=acme\n")
-	m, err := LoadTenantKeys(path)
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	auth := NewTenantKeyAuth(m)
+// A matching X-Tenant-ID is not a conflict: the client is simply agreeing.
+func TestAuthGate_TenantKeyAgreeingHeaderIsNotCounted(t *testing.T) {
+	var rec conflictRecorder
+	rec.install(t)
 
-	h := auth.Middleware("/mcp", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var got string
+	h := AuthGate(AuthGateOptions{Auth: tenantKeyAuth(t, "", map[string]string{"acme-key": "acme"})}, tenantEcho(&got))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs", nil)
+	req.Header.Set("Authorization", "Bearer acme-key")
+	req.Header.Set(TenantHeader, "acme")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if len(rec.calls) != 0 {
+		t.Errorf("agreeing header counted as conflict: %v", rec.calls)
+	}
+}
+
+func TestAuthGate_UnknownAndMissingCredentials(t *testing.T) {
+	auth := tenantKeyAuth(t, "", map[string]string{"acme-key": "acme"})
+	var reasons []string
+	prev := AuthFailureHook
+	t.Cleanup(func() { AuthFailureHook = prev })
+	AuthFailureHook = func(reason string) { reasons = append(reasons, reason) }
+
+	h := AuthGate(AuthGateOptions{Auth: auth, MCPPath: "/mcp"}, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	// Unknown bearer → 401.
-	req := httptest.NewRequest(http.MethodGet, "/api/logs", nil)
-	req.Header.Set("Authorization", "Bearer nope")
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("unknown key: want 401, got %d", rec.Code)
+	cases := []struct {
+		name   string
+		path   string
+		header string
+		code   int
+	}{
+		{"unknown key", "/api/logs", "Bearer nope", http.StatusUnauthorized},
+		{"missing header", "/api/logs", "", http.StatusUnauthorized},
+		{"bad scheme", "/api/logs", "Basic acme-key", http.StatusUnauthorized},
+		{"otlp http protected", "/v1/traces", "", http.StatusUnauthorized},
+		{"mcp protected", "/mcp", "", http.StatusUnauthorized},
+		{"public probe", "/live", "", http.StatusOK},
+		{"websocket handled elsewhere", "/ws/events", "", http.StatusOK},
 	}
-
-	// No Authorization header → 401.
-	req = httptest.NewRequest(http.MethodGet, "/api/logs", nil)
-	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("missing auth: want 401, got %d", rec.Code)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			if tc.header != "" {
+				req.Header.Set("Authorization", tc.header)
+			}
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			if w.Code != tc.code {
+				t.Fatalf("%s: want %d, got %d", tc.path, tc.code, w.Code)
+			}
+		})
 	}
-
-	// Public path must still pass without auth.
-	req = httptest.NewRequest(http.MethodGet, "/live", nil)
-	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("public path: want 200, got %d", rec.Code)
+	want := []string{"bad_key", "missing_header", "bad_scheme", "missing_header", "missing_header"}
+	if len(reasons) != len(want) {
+		t.Fatalf("auth-failure reasons = %v, want %v", reasons, want)
 	}
-}
-
-func TestTenantKeysFile_EmptyPathDisabled(t *testing.T) {
-	m, err := LoadTenantKeys("")
-	if err != nil {
-		t.Fatalf("empty path: %v", err)
-	}
-	if m != nil {
-		t.Errorf("empty path should return nil map, got %+v", m)
-	}
-	auth := NewTenantKeyAuth(nil)
-	if auth.Enabled() {
-		t.Error("disabled auth should report Enabled() == false")
-	}
-}
-
-func TestTenantKeysFile_Malformed(t *testing.T) {
-	cases := []string{
-		"keyonly\n",
-		"=emptykey\n",
-		"k=\n",
-		"k=t\nk=t2\n", // duplicate
-	}
-	for i, c := range cases {
-		path := writeTempFile(t, c)
-		if _, err := LoadTenantKeys(path); err == nil {
-			t.Errorf("case %d (%q): expected error", i, c)
+	for i := range want {
+		if reasons[i] != want[i] {
+			t.Errorf("reason[%d] = %q, want %q", i, reasons[i], want[i])
 		}
+	}
+}
+
+// The shared API_KEY keeps its exact pre-existing behaviour: it authenticates
+// and nothing more, so tenant resolution still follows the X-Tenant-ID header.
+// Byte-for-byte identical responses to the legacy APIKeyGate.
+func TestAuthGate_OperatorKeyMatchesLegacyAPIKeyGate(t *testing.T) {
+	inner := func() http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		})
+	}
+	legacy := APIKeyGate("secret", "/mcp", inner())
+	gate := AuthGate(AuthGateOptions{Auth: tenantKeyAuth(t, "secret", nil), MCPPath: "/mcp"}, inner())
+
+	cases := []struct{ path, header string }{
+		{"/api/logs", "Bearer secret"},
+		{"/api/logs", "Bearer wrong"},
+		{"/api/logs", ""},
+		{"/api/logs", "Basic secret"},
+		{"/v1/traces", "Bearer secret"},
+		{"/mcp", ""},
+		{"/live", ""},
+		{"/ws/events", ""},
+		{"/assets/app.js", ""},
+	}
+	for _, tc := range cases {
+		newReq := func() *http.Request {
+			r := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			if tc.header != "" {
+				r.Header.Set("Authorization", tc.header)
+			}
+			return r
+		}
+		lw, gw := httptest.NewRecorder(), httptest.NewRecorder()
+		legacy.ServeHTTP(lw, newReq())
+		gate.ServeHTTP(gw, newReq())
+		if lw.Code != gw.Code || lw.Body.String() != gw.Body.String() {
+			t.Errorf("%s %q: legacy=(%d,%q) gate=(%d,%q)", tc.path, tc.header, lw.Code, lw.Body.String(), gw.Code, gw.Body.String())
+		}
+	}
+}
+
+// Operator credentials leave tenant selection to TenantMiddleware, so the
+// X-Tenant-ID header still decides — the single-tenant install is untouched.
+func TestAuthGate_OperatorKeyDoesNotBindTenant(t *testing.T) {
+	var rec conflictRecorder
+	rec.install(t)
+
+	var got string
+	h := AuthGate(AuthGateOptions{Auth: tenantKeyAuth(t, "secret", map[string]string{"acme-key": "acme"})},
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if storage.HasTenantContext(r.Context()) {
+				got = storage.TenantFromContext(r.Context())
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set(TenantHeader, "beta")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got != "" {
+		t.Errorf("operator request pinned tenant %q; header precedence must stay with TenantMiddleware", got)
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("operator request counted a conflict: %v", rec.calls)
+	}
+}
+
+// Default deployment: no credential source at all is a pass-through, so
+// today's development behaviour survives byte-for-byte.
+func TestAuthGate_DisabledIsPassthrough(t *testing.T) {
+	var got string
+	h := AuthGate(AuthGateOptions{Auth: authn.NewAuthenticator("", nil, false)}, tenantEcho(&got))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+}
+
+// AUTH_TRUST_EXTERNAL: the dedicated header is an identity, X-Tenant-ID is not.
+func TestAuthGate_ExternalIdentityHeader(t *testing.T) {
+	auth := authn.NewAuthenticator("", nil, true)
+	var got string
+	h := AuthGate(AuthGateOptions{Auth: auth}, tenantEcho(&got))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/logs", nil)
+	req.Header.Set(DefaultExternalTenantHeader, "acme")
+	req.Header.Set(TenantHeader, "victim")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK || got != "acme" {
+		t.Fatalf("injected identity: code=%d tenant=%q, want 200/acme", w.Code, got)
+	}
+
+	// Without the dedicated header the request is unauthenticated: the
+	// client-controlled tenant header is never an identity.
+	req = httptest.NewRequest(http.MethodGet, "/api/logs", nil)
+	req.Header.Set(TenantHeader, "acme")
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("X-Tenant-ID alone: want 401, got %d", w.Code)
+	}
+
+	// A presented-but-invalid bearer credential is a 401 even under external
+	// trust — a bad key must never silently downgrade to the header identity.
+	auth2 := authn.NewAuthenticator("secret", nil, true)
+	h2 := AuthGate(AuthGateOptions{Auth: auth2}, tenantEcho(&got))
+	req = httptest.NewRequest(http.MethodGet, "/api/logs", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	req.Header.Set(DefaultExternalTenantHeader, "acme")
+	w = httptest.NewRecorder()
+	h2.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("bad key + injected header: want 401, got %d", w.Code)
+	}
+}
+
+// The key file itself is loaded by internal/authn; this only pins the wiring
+// contract main.go relies on (JSON by extension, 0600, digest-only).
+func TestAuthGate_LoadedFromKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keys.json")
+	if err := os.WriteFile(path, []byte(`{"acme-key":"acme","beta-key":"beta"}`), 0o600); err != nil {
+		t.Fatalf("write keys: %v", err)
+	}
+	store, err := authn.LoadKeyStore(path)
+	if err != nil {
+		t.Fatalf("LoadKeyStore: %v", err)
+	}
+	var got string
+	h := AuthGate(AuthGateOptions{Auth: authn.NewAuthenticator("", store, false)}, tenantEcho(&got))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs", nil)
+	req.Header.Set("Authorization", "Bearer beta-key")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	if got != "beta" {
+		t.Fatalf("tenant = %q, want beta", got)
 	}
 }

--- a/internal/api/ws_auth.go
+++ b/internal/api/ws_auth.go
@@ -1,0 +1,244 @@
+package api
+
+import (
+	"encoding/base64"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+const (
+	// WSSubprotocol is the only subprotocol the server ever echoes. Defined in
+	// authn so the realtime hubs can negotiate it without importing this
+	// package (api already imports realtime).
+	WSSubprotocol = authn.WSSubprotocol
+
+	// wsAuthProtoPrefix marks the credential-bearing subprotocol entry.
+	wsAuthProtoPrefix = authn.WSAuthProtoPrefix
+
+	// WSTenantParam is the query parameter an operator credential uses to
+	// select the single tenant a socket is scoped to.
+	WSTenantParam = "tenant"
+)
+
+// WSGateOptions configures the WebSocket handshake gate.
+type WSGateOptions struct {
+	// Auth resolves credentials. Disabled Authenticator = pass-through, which
+	// keeps /ws* open in a default development deployment exactly as before.
+	Auth *authn.Authenticator
+	// DefaultTenant scopes an operator socket that selects no tenant.
+	DefaultTenant string
+	// AllowedOrigins is WS_ALLOWED_ORIGINS: exact origins ("https://app.example.com")
+	// or bare hosts ("app.example.com"). Empty means same-host only.
+	AllowedOrigins []string
+	// EnforceOrigin turns the origin policy on. Set when authentication is
+	// enabled or APP_ENV=production.
+	EnforceOrigin bool
+	// ExternalTenantHeader overrides DefaultExternalTenantHeader.
+	ExternalTenantHeader string
+}
+
+// IsWebSocketPath reports whether a path belongs to the /ws* namespace.
+func IsWebSocketPath(path string) bool { return strings.HasPrefix(path, "/ws") }
+
+// WebSocketGate authenticates the /ws* handshake and scopes the connection to
+// exactly one tenant before the upgrade happens.
+//
+// Credential carriers, in order: `Authorization: Bearer <token>` (non-browser
+// clients), then a `Sec-WebSocket-Protocol` entry of the form
+// `auth.<base64url-token>` (browsers, which cannot set headers on a WebSocket).
+// Query-string tokens are never accepted — they land in access logs, browser
+// history, and Referer headers.
+//
+// Scope: a tenant-key or proxy-injected identity binds the socket to its
+// tenant and any client-selected tenant is ignored and counted. An operator
+// credential selects exactly one tenant via ?tenant= or X-Tenant-ID, falling
+// back to DEFAULT_TENANT. There is no merged all-tenant stream.
+func WebSocketGate(o WSGateOptions, next http.Handler) http.Handler {
+	if !o.Auth.Enabled() && !o.EnforceOrigin {
+		return next
+	}
+	extHeader := DefaultExternalTenantHeader
+	if o.ExternalTenantHeader != "" {
+		extHeader = o.ExternalTenantHeader
+	}
+	defaultTenant := o.DefaultTenant
+	if defaultTenant == "" {
+		defaultTenant = storage.DefaultTenantID
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !IsWebSocketPath(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if o.EnforceOrigin && !originAllowed(r.Header.Get("Origin"), r.Host, o.AllowedOrigins) {
+			recordAuthFailure(authn.ReasonBadOrigin)
+			// The rejected origin is attacker-controlled, so it is sanitized
+			// before it reaches a log line. The credential-bearing subprotocol
+			// header is never logged in any form.
+			slog.Warn("WebSocket handshake rejected: origin not allowed",
+				"origin", sanitizeLogValue(r.Header.Get("Origin")))
+			http.Error(w, "forbidden origin", http.StatusForbidden)
+			return
+		}
+		if !o.Auth.Enabled() {
+			next.ServeHTTP(w, r)
+			return
+		}
+		principal, reason, ok := authenticateWS(o.Auth, r, extHeader)
+		if !ok {
+			recordAuthFailure(reason)
+			writeUnauthorized(w)
+			return
+		}
+		tenant, ok := wsTenantScope(r, principal, defaultTenant)
+		if !ok {
+			recordAuthFailure(authn.ReasonBadTenant)
+			http.Error(w, "invalid tenant selection", http.StatusBadRequest)
+			return
+		}
+		ctx := authn.WithPrincipal(r.Context(), principal)
+		ctx = storage.WithTenantContext(ctx, tenant)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// authenticateWS extracts a credential from the Authorization header or the
+// subprotocol carrier and resolves it. The raw subprotocol header value never
+// reaches a log line — only its decode outcome does.
+func authenticateWS(a *authn.Authenticator, r *http.Request, extHeader string) (authn.Principal, string, bool) {
+	token, reason := authn.TokenFromAuthorization(r.Header.Get("Authorization"))
+	if token == "" {
+		if t, found := wsTokenFromSubprotocols(r.Header.Values("Sec-WebSocket-Protocol")); found {
+			token, reason = t, ""
+		}
+	}
+	if token == "" {
+		if reason == authn.ReasonMissingCredential || reason == "" {
+			if p, ok := a.ExternalPrincipal(r.Header.Get(extHeader)); ok {
+				return p, "", true
+			}
+			reason = authn.ReasonMissingCredential
+		}
+		return authn.Principal{}, reason, false
+	}
+	return a.AuthenticateToken(token)
+}
+
+// wsTokenFromSubprotocols decodes the first `auth.<base64url>` entry.
+// Both padded and unpadded base64url are accepted; anything that fails to
+// decode is reported as "no token" rather than being passed through, so a
+// malformed entry can never be compared against a key.
+func wsTokenFromSubprotocols(headers []string) (string, bool) {
+	for _, h := range headers {
+		for _, part := range strings.Split(h, ",") {
+			entry := strings.TrimSpace(part)
+			if !strings.HasPrefix(entry, wsAuthProtoPrefix) {
+				continue
+			}
+			enc := strings.TrimPrefix(entry, wsAuthProtoPrefix)
+			if enc == "" {
+				continue
+			}
+			if raw, err := base64.RawURLEncoding.DecodeString(enc); err == nil && len(raw) > 0 {
+				return string(raw), true
+			}
+			if raw, err := base64.URLEncoding.DecodeString(enc); err == nil && len(raw) > 0 {
+				return string(raw), true
+			}
+			slog.Debug("WebSocket auth subprotocol entry is not valid base64url (value redacted)")
+		}
+	}
+	return "", false
+}
+
+// wsTenantScope resolves the single tenant a socket is scoped to.
+func wsTenantScope(r *http.Request, p authn.Principal, defaultTenant string) (string, bool) {
+	asserted := r.URL.Query().Get(WSTenantParam)
+	carrier := "query"
+	if asserted == "" {
+		asserted = r.Header.Get(TenantHeader)
+		carrier = "header"
+	}
+	if p.Bound() {
+		if asserted != "" && storage.SanitizeTenantID(asserted) != p.Tenant {
+			authn.RecordConflict("ws", carrier)
+		}
+		return p.Tenant, true
+	}
+	if asserted == "" {
+		return defaultTenant, true
+	}
+	tenant := storage.SanitizeTenantID(asserted)
+	if tenant == "" {
+		return "", false
+	}
+	return tenant, true
+}
+
+// sanitizeLogValue makes an attacker-controlled string safe to put in a
+// structured log line: printable ASCII only, bounded length. Structured
+// handlers quote most of this already; this makes it true regardless of the
+// handler in use.
+func sanitizeLogValue(s string) string {
+	const maxLen = 128
+	if len(s) > maxLen {
+		s = s[:maxLen]
+	}
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		if r < 0x20 || r > 0x7e {
+			r = '?'
+		}
+		out = append(out, r)
+	}
+	return string(out)
+}
+
+// originAllowed implements the WS_ALLOWED_ORIGINS policy. A request with no
+// Origin header is a non-browser client (curl, an SDK, a collector) and is not
+// subject to browser-origin rules — it still has to authenticate.
+func originAllowed(origin, host string, allowed []string) bool {
+	if origin == "" {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	if len(allowed) == 0 {
+		return strings.EqualFold(u.Host, host)
+	}
+	for _, a := range allowed {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		if strings.EqualFold(a, origin) || strings.EqualFold(a, u.Host) {
+			return true
+		}
+	}
+	return false
+}
+
+// WSAllowedOriginHosts reduces configured origins to bare hosts, which is the
+// shape the WebSocket library's origin patterns expect.
+func WSAllowedOriginHosts(allowed []string) []string {
+	out := make([]string, 0, len(allowed))
+	for _, a := range allowed {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		if u, err := url.Parse(a); err == nil && u.Host != "" {
+			out = append(out, u.Host)
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}

--- a/internal/api/ws_auth_test.go
+++ b/internal/api/ws_auth_test.go
@@ -1,0 +1,235 @@
+package api
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+func wsAuth(t *testing.T, operatorKey string, entries map[string]string, trustExternal bool) *authn.Authenticator {
+	t.Helper()
+	var store *authn.KeyStore
+	if len(entries) > 0 {
+		var err error
+		store, err = authn.NewKeyStoreFromMap(entries)
+		if err != nil {
+			t.Fatalf("NewKeyStoreFromMap: %v", err)
+		}
+	}
+	return authn.NewAuthenticator(operatorKey, store, trustExternal)
+}
+
+// wsScopeEcho reports the tenant scope the gate pinned on the handshake.
+func wsScopeEcho(got *string, reached *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*reached = true
+		if storage.HasTenantContext(r.Context()) {
+			*got = storage.TenantFromContext(r.Context())
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestWebSocketGate_CredentialCarriers(t *testing.T) {
+	auth := wsAuth(t, "operator-key", map[string]string{"acme-key": "acme"}, false)
+	cases := []struct {
+		name       string
+		header     string
+		subproto   string
+		query      string
+		wantCode   int
+		wantTenant string
+	}{
+		{"authorization header", "Bearer acme-key", "", "", http.StatusOK, "acme"},
+		{
+			"subprotocol carrier", "",
+			WSSubprotocol + ", " + wsAuthProtoPrefix + base64.RawURLEncoding.EncodeToString([]byte("acme-key")),
+			"", http.StatusOK, "acme",
+		},
+		{
+			"padded base64url subprotocol", "",
+			wsAuthProtoPrefix + base64.URLEncoding.EncodeToString([]byte("acme-key")),
+			"", http.StatusOK, "acme",
+		},
+		{"query-string token is never a credential", "", "", "?token=acme-key", http.StatusUnauthorized, ""},
+		{"unauthenticated handshake refused", "", "", "", http.StatusUnauthorized, ""},
+		{"unknown key refused", "Bearer nope", "", "", http.StatusUnauthorized, ""},
+		{"malformed subprotocol token refused", "", wsAuthProtoPrefix + "!!not-base64!!", "", http.StatusUnauthorized, ""},
+		{"operator selects a tenant", "Bearer operator-key", "", "?tenant=beta", http.StatusOK, "beta"},
+		{"operator defaults to DEFAULT_TENANT", "Bearer operator-key", "", "", http.StatusOK, "house"},
+		{"operator invalid tenant selection", "Bearer operator-key", "", "?tenant=%20", http.StatusBadRequest, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			var reached bool
+			h := WebSocketGate(WSGateOptions{Auth: auth, DefaultTenant: "house"}, wsScopeEcho(&got, &reached))
+
+			req := httptest.NewRequest(http.MethodGet, "/ws/events"+tc.query, nil)
+			if tc.header != "" {
+				req.Header.Set("Authorization", tc.header)
+			}
+			if tc.subproto != "" {
+				req.Header.Set("Sec-WebSocket-Protocol", tc.subproto)
+			}
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			if w.Code != tc.wantCode {
+				t.Fatalf("code = %d, want %d (body %q)", w.Code, tc.wantCode, w.Body.String())
+			}
+			if tc.wantCode != http.StatusOK {
+				if reached {
+					t.Fatal("rejected handshake still reached the hub")
+				}
+				return
+			}
+			if got != tc.wantTenant {
+				t.Errorf("tenant scope = %q, want %q", got, tc.wantTenant)
+			}
+		})
+	}
+}
+
+// A tenant-key socket is bound: ?tenant= and X-Tenant-ID are ignored and
+// counted, never honoured. No merged all-tenant stream exists.
+func TestWebSocketGate_TenantKeyBindingIsAbsolute(t *testing.T) {
+	auth := wsAuth(t, "", map[string]string{"acme-key": "acme"}, false)
+	for _, tc := range []struct{ name, query, header, wantCarrier string }{
+		{"query", "?tenant=victim", "", "query"},
+		{"header", "", "victim", "header"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var rec conflictRecorder
+			rec.install(t)
+
+			var got string
+			var reached bool
+			h := WebSocketGate(WSGateOptions{Auth: auth, DefaultTenant: "house"}, wsScopeEcho(&got, &reached))
+			req := httptest.NewRequest(http.MethodGet, "/ws/events"+tc.query, nil)
+			req.Header.Set("Authorization", "Bearer acme-key")
+			if tc.header != "" {
+				req.Header.Set(TenantHeader, tc.header)
+			}
+			h.ServeHTTP(httptest.NewRecorder(), req)
+
+			if got != "acme" {
+				t.Fatalf("tenant scope = %q, want acme", got)
+			}
+			if len(rec.calls) != 1 || rec.calls[0] != [2]string{"ws", tc.wantCarrier} {
+				t.Errorf("conflict metric = %v, want one ws/%s record", rec.calls, tc.wantCarrier)
+			}
+		})
+	}
+}
+
+func TestWebSocketGate_OriginPolicy(t *testing.T) {
+	auth := wsAuth(t, "operator-key", nil, false)
+	cases := []struct {
+		name     string
+		origin   string
+		allowed  []string
+		wantCode int
+	}{
+		{"same host allowed by default", "http://example.test", nil, http.StatusOK},
+		{"foreign origin refused", "http://evil.test", nil, http.StatusForbidden},
+		{"allowlisted origin", "https://app.example.com", []string{"https://app.example.com"}, http.StatusOK},
+		{"allowlisted bare host", "https://app.example.com", []string{"app.example.com"}, http.StatusOK},
+		{"non-allowlisted origin", "https://evil.test", []string{"https://app.example.com"}, http.StatusForbidden},
+		{"no origin header (non-browser client)", "", []string{"https://app.example.com"}, http.StatusOK},
+		{"unparseable origin", "::::", []string{"https://app.example.com"}, http.StatusForbidden},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			var reached bool
+			h := WebSocketGate(WSGateOptions{
+				Auth: auth, DefaultTenant: "house",
+				AllowedOrigins: tc.allowed, EnforceOrigin: true,
+			}, wsScopeEcho(&got, &reached))
+
+			req := httptest.NewRequest(http.MethodGet, "http://example.test/ws/events", nil)
+			req.Host = "example.test"
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			req.Header.Set("Authorization", "Bearer operator-key")
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			if w.Code != tc.wantCode {
+				t.Fatalf("code = %d, want %d", w.Code, tc.wantCode)
+			}
+		})
+	}
+}
+
+// Origin enforcement applies before authentication so a cross-origin browser
+// cannot even probe for credentials, and it applies even when no credential
+// source is configured (production without auth).
+func TestWebSocketGate_OriginEnforcedWithoutAuth(t *testing.T) {
+	var got string
+	var reached bool
+	h := WebSocketGate(WSGateOptions{
+		Auth: authn.NewAuthenticator("", nil, false), EnforceOrigin: true,
+	}, wsScopeEcho(&got, &reached))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.test/ws/events", nil)
+	req.Host = "example.test"
+	req.Header.Set("Origin", "http://evil.test")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("cross-origin: want 403, got %d", w.Code)
+	}
+	if reached {
+		t.Fatal("cross-origin handshake reached the hub")
+	}
+}
+
+// Dev default: no credentials configured and no origin policy → /ws* is
+// untouched, exactly as before this gate existed.
+func TestWebSocketGate_DisabledIsPassthrough(t *testing.T) {
+	var got string
+	var reached bool
+	h := WebSocketGate(WSGateOptions{Auth: authn.NewAuthenticator("", nil, false)}, wsScopeEcho(&got, &reached))
+	req := httptest.NewRequest(http.MethodGet, "/ws/events", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK || !reached {
+		t.Fatalf("dev pass-through broken: code=%d reached=%v", w.Code, reached)
+	}
+	if got != "" {
+		t.Errorf("unscoped socket pinned tenant %q", got)
+	}
+}
+
+// Non-/ws paths are none of this gate's business.
+func TestWebSocketGate_IgnoresNonWSPaths(t *testing.T) {
+	var got string
+	var reached bool
+	h := WebSocketGate(WSGateOptions{Auth: wsAuth(t, "operator-key", nil, false), EnforceOrigin: true}, wsScopeEcho(&got, &reached))
+	req := httptest.NewRequest(http.MethodGet, "/api/logs", nil)
+	req.Header.Set("Origin", "http://evil.test")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK || !reached {
+		t.Fatalf("non-ws path was gated: code=%d reached=%v", w.Code, reached)
+	}
+}
+
+func TestWSAllowedOriginHosts(t *testing.T) {
+	got := WSAllowedOriginHosts([]string{"https://app.example.com", " dash.example.com ", ""})
+	want := []string{"app.example.com", "dash.example.com"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/authn/authenticator.go
+++ b/internal/authn/authenticator.go
@@ -1,0 +1,136 @@
+package authn
+
+import (
+	"crypto/subtle"
+	"strings"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+// BearerPrefix is the only credential scheme accepted on every surface.
+const BearerPrefix = "Bearer "
+
+// Failure reasons reported to the auth-failure metric. They are stable
+// strings: "missing_header", "bad_scheme", and "bad_key" predate this package
+// and are kept byte-identical so existing dashboards keep working.
+const (
+	ReasonMissingCredential = "missing_header"
+	ReasonBadScheme         = "bad_scheme"
+	ReasonBadKey            = "bad_key"
+	ReasonBadOrigin         = "bad_origin"
+	ReasonBadTenant         = "bad_tenant"
+)
+
+// Authenticator resolves a bearer token into a Principal. It is shared by the
+// HTTP, WebSocket, and gRPC adapters so all three surfaces agree on what a
+// credential means; only credential extraction differs per transport.
+//
+// A zero-value / disabled Authenticator authenticates nothing and reports
+// Enabled() == false, which is how a development deployment with no API_KEY,
+// no tenant keys file, and no external trust keeps today's open behaviour.
+type Authenticator struct {
+	operatorKey []byte
+	store       *KeyStore
+	trust       bool
+}
+
+// NewAuthenticator wires the operator key (API_KEY), the per-tenant key store
+// (API_TENANT_KEYS_FILE), and the AUTH_TRUST_EXTERNAL switch.
+func NewAuthenticator(operatorKey string, store *KeyStore, trustExternal bool) *Authenticator {
+	a := &Authenticator{store: store, trust: trustExternal}
+	if operatorKey != "" {
+		a.operatorKey = []byte(operatorKey)
+	}
+	return a
+}
+
+// Enabled reports whether any credential source is configured. When false the
+// caller must not gate anything: authentication arrives with configuration,
+// never by surprise.
+func (a *Authenticator) Enabled() bool {
+	if a == nil {
+		return false
+	}
+	return len(a.operatorKey) > 0 || a.store.Enabled() || a.trust
+}
+
+// TrustExternal reports whether a proxy-injected identity header is honoured.
+func (a *Authenticator) TrustExternal() bool { return a != nil && a.trust }
+
+// HasTenantKeys reports whether per-tenant keys are configured.
+func (a *Authenticator) HasTenantKeys() bool { return a != nil && a.store.Enabled() }
+
+// TenantKeyCount is the number of configured tenant keys (never their values).
+func (a *Authenticator) TenantKeyCount() int {
+	if a == nil {
+		return 0
+	}
+	return a.store.Len()
+}
+
+// Tenants lists the tenants covered by the key store.
+func (a *Authenticator) Tenants() []string {
+	if a == nil {
+		return nil
+	}
+	return a.store.Tenants()
+}
+
+// AuthenticateToken resolves a raw bearer token. The operator key is checked
+// first with a constant-time compare, then the tenant key store. A miss
+// returns ReasonBadKey; an empty token returns ReasonMissingCredential.
+func (a *Authenticator) AuthenticateToken(token string) (Principal, string, bool) {
+	if !a.Enabled() {
+		return Principal{}, "", false
+	}
+	if token == "" {
+		return Principal{}, ReasonMissingCredential, false
+	}
+	if len(a.operatorKey) > 0 {
+		got := []byte(token)
+		if len(got) == len(a.operatorKey) && subtle.ConstantTimeCompare(got, a.operatorKey) == 1 {
+			return Principal{Kind: KindOperator}, "", true
+		}
+	}
+	if tenant, ok := a.store.Lookup(token); ok {
+		return Principal{Kind: KindTenant, Tenant: tenant}, "", true
+	}
+	return Principal{}, ReasonBadKey, false
+}
+
+// ExternalPrincipal converts a proxy-injected tenant value into a bound
+// principal. It returns false unless AUTH_TRUST_EXTERNAL is on and the value
+// survives the shared tenant sanitizer.
+//
+// The injected header is trusted ONLY because the operator asserted that a
+// front proxy authenticates the caller, strips inbound copies of this header,
+// and makes the application ports unreachable except through it. Without those
+// conditions this is an authentication bypass — see CLAUDE.md.
+func (a *Authenticator) ExternalPrincipal(raw string) (Principal, bool) {
+	if !a.TrustExternal() {
+		return Principal{}, false
+	}
+	tenant := storage.SanitizeTenantID(raw)
+	if tenant == "" {
+		return Principal{}, false
+	}
+	return Principal{Kind: KindExternal, Tenant: tenant}, true
+}
+
+// TokenFromAuthorization extracts the bearer token from an Authorization
+// header value. The second result is a failure reason when no usable token is
+// present; callers that have a second credential carrier (WebSocket
+// subprotocol, gRPC metadata) may ignore it and try that instead.
+func TokenFromAuthorization(header string) (string, string) {
+	if header == "" {
+		return "", ReasonMissingCredential
+	}
+	if !strings.HasPrefix(header, BearerPrefix) {
+		return "", ReasonBadScheme
+	}
+	token := strings.TrimPrefix(header, BearerPrefix)
+	if token == "" {
+		return "", ReasonMissingCredential
+	}
+	return token, ""
+}

--- a/internal/authn/authenticator_test.go
+++ b/internal/authn/authenticator_test.go
@@ -1,0 +1,123 @@
+package authn
+
+import (
+	"strings"
+	"testing"
+)
+
+func testStore(t *testing.T) *KeyStore {
+	t.Helper()
+	s, err := NewKeyStoreFromMap(map[string]string{"tenant-key": "acme"})
+	if err != nil {
+		t.Fatalf("NewKeyStoreFromMap: %v", err)
+	}
+	return s
+}
+
+func TestAuthenticator_Disabled(t *testing.T) {
+	var nilAuth *Authenticator
+	if nilAuth.Enabled() {
+		t.Error("nil authenticator must be disabled")
+	}
+	a := NewAuthenticator("", nil, false)
+	if a.Enabled() {
+		t.Error("no credential source configured must be disabled")
+	}
+	// A disabled authenticator authenticates nothing, so a caller cannot
+	// accidentally gate traffic with it.
+	if _, _, ok := a.AuthenticateToken("anything"); ok {
+		t.Error("disabled authenticator must not authenticate")
+	}
+}
+
+func TestAuthenticator_OperatorAndTenantKinds(t *testing.T) {
+	a := NewAuthenticator("operator-key", testStore(t), false)
+	if !a.Enabled() || !a.HasTenantKeys() || a.TenantKeyCount() != 1 {
+		t.Fatalf("unexpected state: enabled=%v tenantKeys=%v count=%d", a.Enabled(), a.HasTenantKeys(), a.TenantKeyCount())
+	}
+
+	p, _, ok := a.AuthenticateToken("operator-key")
+	if !ok || p.Kind != KindOperator || p.Bound() {
+		t.Fatalf("operator key: got (%+v, %v), want unbound operator", p, ok)
+	}
+	p, _, ok = a.AuthenticateToken("tenant-key")
+	if !ok || p.Kind != KindTenant || p.Tenant != "acme" || !p.Bound() {
+		t.Fatalf("tenant key: got (%+v, %v), want bound acme", p, ok)
+	}
+	if _, reason, ok := a.AuthenticateToken("nope"); ok || reason != ReasonBadKey {
+		t.Fatalf("unknown key: got (%q,%v), want (bad_key,false)", reason, ok)
+	}
+	if _, reason, ok := a.AuthenticateToken(""); ok || reason != ReasonMissingCredential {
+		t.Fatalf("empty token: got (%q,%v), want (missing_header,false)", reason, ok)
+	}
+}
+
+func TestAuthenticator_ExternalIdentityRequiresFlag(t *testing.T) {
+	off := NewAuthenticator("operator-key", nil, false)
+	if _, ok := off.ExternalPrincipal("acme"); ok {
+		t.Fatal("external identity must be refused unless AUTH_TRUST_EXTERNAL is set")
+	}
+	on := NewAuthenticator("", nil, true)
+	if !on.Enabled() {
+		t.Fatal("trust-external alone enables the gate")
+	}
+	p, ok := on.ExternalPrincipal("acme")
+	if !ok || p.Kind != KindExternal || p.Tenant != "acme" || !p.Bound() {
+		t.Fatalf("external principal: got (%+v,%v)", p, ok)
+	}
+	// The injected value still goes through the shared tenant sanitizer.
+	for _, bad := range []string{"", "   ", "ac\nme", strings.Repeat("t", 200)} {
+		if _, ok := on.ExternalPrincipal(bad); ok {
+			t.Errorf("sanitizer accepted %q", bad)
+		}
+	}
+}
+
+func TestTokenFromAuthorization(t *testing.T) {
+	cases := []struct {
+		header string
+		token  string
+		reason string
+	}{
+		{"", "", ReasonMissingCredential},
+		{"Bearer ", "", ReasonMissingCredential},
+		{"Basic abc", "", ReasonBadScheme},
+		{"bearer abc", "", ReasonBadScheme}, // scheme is case-sensitive, as before
+		{"Bearer abc", "abc", ""},
+	}
+	for _, tc := range cases {
+		token, reason := TokenFromAuthorization(tc.header)
+		if token != tc.token || reason != tc.reason {
+			t.Errorf("TokenFromAuthorization(%q) = (%q,%q), want (%q,%q)", tc.header, token, reason, tc.token, tc.reason)
+		}
+	}
+}
+
+func TestPrincipalContext(t *testing.T) {
+	if _, ok := PrincipalFromContext(nil); ok { //nolint:staticcheck // nil context is the case under test
+		t.Error("nil context must carry no principal")
+	}
+	ctx := WithPrincipal(nil, Principal{Kind: KindTenant, Tenant: "acme"}) //nolint:staticcheck // ditto
+	if tenant, ok := BoundTenantFromContext(ctx); !ok || tenant != "acme" {
+		t.Fatalf("BoundTenantFromContext = (%q,%v), want (acme,true)", tenant, ok)
+	}
+	// Operator principals never bind: tenant precedence stays with the caller.
+	ctx = WithPrincipal(ctx, Principal{Kind: KindOperator})
+	if _, ok := BoundTenantFromContext(ctx); ok {
+		t.Error("operator principal must not bind a tenant")
+	}
+}
+
+func TestRecordConflict_NilHookIsSafe(t *testing.T) {
+	prev := ConflictHook
+	t.Cleanup(func() { ConflictHook = prev })
+	ConflictHook = nil
+	RecordConflict("http", "header") // must not panic
+
+	var got [2]string
+	ConflictHook = func(surface, reason string) { got = [2]string{surface, reason} }
+	RecordConflict("grpc", "metadata")
+	if got != [2]string{"grpc", "metadata"} {
+		t.Fatalf("hook got %v", got)
+	}
+}

--- a/internal/authn/keystore.go
+++ b/internal/authn/keystore.go
@@ -1,0 +1,299 @@
+package authn
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"gopkg.in/yaml.v3"
+)
+
+// MaxKeyFileBytes bounds how much of an operator-supplied key file is read.
+// 1 MiB is ~20k entries; anything larger is a misconfiguration, not a
+// deployment.
+const MaxKeyFileBytes = 1 << 20
+
+// keyEntry is one loaded credential. The key material itself is never stored:
+// only its SHA-256 digest, so a heap dump or a stray %+v cannot leak a usable
+// bearer token.
+type keyEntry struct {
+	digest [sha256.Size]byte
+	tenant string
+}
+
+// KeyStore maps bearer keys to tenants using digest-only storage and
+// constant-time comparison. A nil or empty store is disabled and every Lookup
+// misses, which is what keeps the default (no keys file) deployment on the
+// legacy shared-API_KEY path.
+type KeyStore struct {
+	entries []keyEntry
+	tenants []string // sorted, unique — for logging counts only
+}
+
+// LoadKeyStore reads API_TENANT_KEYS_FILE. Format is chosen by extension:
+// `.json` for JSON, `.yaml`/`.yml` for YAML. Both carry the same shape — an
+// object mapping bearer key to tenant ID:
+//
+//	{"3f7c…": "acme", "9b21…": "acme", "c40d…": "beta"}
+//
+// Multiple keys may map to the same tenant (rotation, per-agent keys).
+// The load is startup-only; there is no reload path by design, so a key file
+// swap is an explicit restart.
+//
+// Refused: unreadable files, files readable or writable by group/other,
+// unknown extensions, empty files, empty keys, keys carrying whitespace or
+// control characters, tenant IDs the storage sanitizer rejects, and duplicate
+// keys. Errors never quote key material.
+func LoadKeyStore(path string) (*KeyStore, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, nil
+	}
+	raw, err := readKeyFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var pairs []pair
+	switch ext := strings.ToLower(filepath.Ext(path)); ext {
+	case ".json":
+		pairs, err = decodeJSONPairs(raw)
+	case ".yaml", ".yml":
+		pairs, err = decodeYAMLPairs(raw)
+	default:
+		return nil, fmt.Errorf("tenant keys file %q: unsupported extension %q (want .json, .yaml, or .yml)", path, ext)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("tenant keys file %q: %w", path, err)
+	}
+	store, err := newKeyStore(pairs)
+	if err != nil {
+		return nil, fmt.Errorf("tenant keys file %q: %w", path, err)
+	}
+	return store, nil
+}
+
+// pair is one key→tenant definition carrying its source position so errors can
+// point at a line without quoting the credential.
+type pair struct {
+	key    string
+	tenant string
+	where  string // "entry 3" or "line 7"
+}
+
+// readKeyFile enforces the file-permission contract before reading a byte.
+// Anything group- or world-accessible is refused with the actual mode so the
+// operator can see what to chmod.
+func readKeyFile(path string) ([]byte, error) {
+	f, err := os.Open(path) // #nosec G304 -- operator-supplied config path
+	if err != nil {
+		return nil, fmt.Errorf("tenant keys file %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	st, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("tenant keys file %q: %w", path, err)
+	}
+	if st.IsDir() {
+		return nil, fmt.Errorf("tenant keys file %q: is a directory", path)
+	}
+	if mode := st.Mode().Perm(); mode&0o077 != 0 {
+		return nil, fmt.Errorf("tenant keys file %q: permissions %04o are too permissive — group/other access must be removed (chmod 600)", path, mode)
+	}
+	raw, err := io.ReadAll(io.LimitReader(f, MaxKeyFileBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("tenant keys file %q: %w", path, err)
+	}
+	if len(raw) > MaxKeyFileBytes {
+		return nil, fmt.Errorf("tenant keys file %q: larger than %d bytes", path, MaxKeyFileBytes)
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, fmt.Errorf("tenant keys file %q: file is empty", path)
+	}
+	return raw, nil
+}
+
+// decodeJSONPairs streams the object so duplicate keys are caught rather than
+// silently last-write-wins as encoding/json would otherwise do.
+func decodeJSONPairs(raw []byte) ([]pair, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return nil, fmt.Errorf("invalid JSON: want an object of \"key\": \"tenant\" pairs")
+	}
+	var out []pair
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, fmt.Errorf("invalid JSON: %w", err)
+		}
+		k, ok := keyTok.(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid JSON: non-string key")
+		}
+		var v any
+		if err := dec.Decode(&v); err != nil {
+			return nil, fmt.Errorf("invalid JSON at entry %d: %w", len(out)+1, err)
+		}
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("entry %d: tenant must be a string", len(out)+1)
+		}
+		out = append(out, pair{key: k, tenant: s, where: fmt.Sprintf("entry %d", len(out)+1)})
+	}
+	if _, err := dec.Token(); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	return out, nil
+}
+
+// decodeYAMLPairs walks the document node-by-node for the same reason:
+// yaml.v3 rejects duplicate keys only in strict mode on some shapes, and the
+// node walk also gives line numbers for free.
+func decodeYAMLPairs(raw []byte) ([]pair, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("invalid YAML: %w", err)
+	}
+	if len(doc.Content) == 0 {
+		return nil, fmt.Errorf("invalid YAML: empty document")
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("invalid YAML: want a mapping of key: tenant pairs")
+	}
+	out := make([]pair, 0, len(root.Content)/2)
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		k, v := root.Content[i], root.Content[i+1]
+		if k.Kind != yaml.ScalarNode || v.Kind != yaml.ScalarNode {
+			return nil, fmt.Errorf("line %d: key and tenant must both be scalars", k.Line)
+		}
+		out = append(out, pair{key: k.Value, tenant: v.Value, where: fmt.Sprintf("line %d", k.Line)})
+	}
+	return out, nil
+}
+
+// newKeyStore validates and digests a set of key→tenant definitions. Unexported
+// because the pair type is internal; callers holding an already-parsed mapping
+// go through NewKeyStoreFromMap and get exactly the same validation.
+func newKeyStore(pairs []pair) (*KeyStore, error) {
+	if len(pairs) == 0 {
+		return nil, fmt.Errorf("no entries found")
+	}
+	s := &KeyStore{entries: make([]keyEntry, 0, len(pairs))}
+	seen := make(map[[sha256.Size]byte]struct{}, len(pairs))
+	tenants := make(map[string]struct{}, len(pairs))
+	for _, p := range pairs {
+		if err := validateKey(p.key); err != nil {
+			return nil, fmt.Errorf("%s: %w", p.where, err)
+		}
+		tenant := storage.SanitizeTenantID(p.tenant)
+		if tenant == "" || tenant != strings.TrimSpace(p.tenant) {
+			return nil, fmt.Errorf("%s: invalid tenant ID (empty, over %d bytes, or contains control characters)", p.where, storage.MaxTenantIDLength)
+		}
+		digest := sha256.Sum256([]byte(p.key))
+		if _, dup := seen[digest]; dup {
+			return nil, fmt.Errorf("%s: duplicate key", p.where)
+		}
+		seen[digest] = struct{}{}
+		tenants[tenant] = struct{}{}
+		s.entries = append(s.entries, keyEntry{digest: digest, tenant: tenant})
+	}
+	s.tenants = make([]string, 0, len(tenants))
+	for t := range tenants {
+		s.tenants = append(s.tenants, t)
+	}
+	sort.Strings(s.tenants)
+	return s, nil
+}
+
+// NewKeyStoreFromMap builds a store from an in-memory mapping. Iteration order
+// of a Go map is random, so entries are sorted by tenant then key digest to
+// keep error messages deterministic.
+func NewKeyStoreFromMap(m map[string]string) (*KeyStore, error) {
+	pairs := make([]pair, 0, len(m))
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for i, k := range keys {
+		pairs = append(pairs, pair{key: k, tenant: m[k], where: fmt.Sprintf("entry %d", i+1)})
+	}
+	return newKeyStore(pairs)
+}
+
+// validateKey rejects credentials that cannot be transported safely or that
+// are obviously unset. Whitespace and control characters are refused because
+// they cannot survive an HTTP header or a gRPC metadata value intact, so they
+// would authenticate in tests and fail in production.
+func validateKey(k string) error {
+	if k == "" {
+		return fmt.Errorf("empty key")
+	}
+	for _, r := range k {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return fmt.Errorf("key contains whitespace or control characters")
+		}
+	}
+	return nil
+}
+
+// Enabled reports whether any tenant key is configured.
+func (s *KeyStore) Enabled() bool { return s != nil && len(s.entries) > 0 }
+
+// Len is the number of configured keys.
+func (s *KeyStore) Len() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.entries)
+}
+
+// Tenants returns the sorted, unique tenants covered by the store. Safe to
+// log: tenant IDs are not credentials.
+func (s *KeyStore) Tenants() []string {
+	if s == nil {
+		return nil
+	}
+	out := make([]string, len(s.tenants))
+	copy(out, s.tenants)
+	return out
+}
+
+// Lookup returns the tenant bound to key. The presented key is digested and
+// compared against every stored digest with subtle.ConstantTimeCompare, and
+// the scan never exits early, so neither the match position nor a partial
+// prefix match is observable through timing.
+func (s *KeyStore) Lookup(key string) (string, bool) {
+	if !s.Enabled() || key == "" {
+		return "", false
+	}
+	digest := sha256.Sum256([]byte(key))
+	var (
+		tenant  string
+		matched int
+	)
+	for i := range s.entries {
+		eq := subtle.ConstantTimeCompare(digest[:], s.entries[i].digest[:])
+		if eq == 1 {
+			tenant = s.entries[i].tenant
+			matched = 1
+		}
+	}
+	if matched != 1 {
+		return "", false
+	}
+	return tenant, true
+}

--- a/internal/authn/keystore_test.go
+++ b/internal/authn/keystore_test.go
@@ -1,0 +1,210 @@
+package authn
+
+import (
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func writeKeyFile(t *testing.T, name, content string, mode os.FileMode) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), mode); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	// WriteFile honours umask, so force the mode the test asked for.
+	if err := os.Chmod(p, mode); err != nil {
+		t.Fatalf("chmod %s: %v", name, err)
+	}
+	return p
+}
+
+func TestLoadKeyStore_JSONAndYAML(t *testing.T) {
+	cases := []struct {
+		name    string
+		file    string
+		content string
+	}{
+		{"json", "keys.json", `{"key-a1":"acme","key-a2":"acme","key-b1":"beta"}`},
+		{"yaml", "keys.yaml", "key-a1: acme\nkey-a2: acme\nkey-b1: beta\n"},
+		{"yml", "keys.yml", "key-a1: acme\nkey-a2: acme\nkey-b1: beta\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store, err := LoadKeyStore(writeKeyFile(t, tc.file, tc.content, 0o600))
+			if err != nil {
+				t.Fatalf("LoadKeyStore: %v", err)
+			}
+			if store.Len() != 3 {
+				t.Fatalf("Len=%d, want 3", store.Len())
+			}
+			// Multiple keys per tenant is the rotation story from #198 Q2.
+			for _, k := range []string{"key-a1", "key-a2"} {
+				if tenant, ok := store.Lookup(k); !ok || tenant != "acme" {
+					t.Errorf("Lookup(%s) = (%q,%v), want (acme,true)", k, tenant, ok)
+				}
+			}
+			if tenant, ok := store.Lookup("key-b1"); !ok || tenant != "beta" {
+				t.Errorf("Lookup(key-b1) = (%q,%v), want (beta,true)", tenant, ok)
+			}
+			if _, ok := store.Lookup("key-a1 "); ok {
+				t.Error("a near-miss key must not authenticate")
+			}
+			if got := store.Tenants(); len(got) != 2 || got[0] != "acme" || got[1] != "beta" {
+				t.Errorf("Tenants() = %v, want [acme beta]", got)
+			}
+		})
+	}
+}
+
+// A key file readable or writable by group/other is refused, and the refusal
+// names the actual mode so the operator knows what to chmod.
+func TestLoadKeyStore_RefusesPermissivePermissions(t *testing.T) {
+	for _, mode := range []os.FileMode{0o640, 0o604, 0o660, 0o666} {
+		path := writeKeyFile(t, "keys.json", `{"k":"acme"}`, mode)
+		_, err := LoadKeyStore(path)
+		if err == nil {
+			t.Fatalf("mode %04o: expected refusal", mode)
+		}
+		if !strings.Contains(err.Error(), "too permissive") {
+			t.Errorf("mode %04o: error %q should explain the permission problem", mode, err)
+		}
+		if !strings.Contains(err.Error(), "0"+strings.TrimPrefix(modeString(mode), "0")) {
+			t.Errorf("mode %04o: error %q should quote the actual mode", mode, err)
+		}
+	}
+}
+
+func modeString(m os.FileMode) string {
+	const digits = "01234567"
+	v := uint32(m.Perm())
+	return string([]byte{'0', digits[(v>>6)&7], digits[(v>>3)&7], digits[v&7]})
+}
+
+func TestLoadKeyStore_Rejects(t *testing.T) {
+	cases := []struct {
+		name    string
+		file    string
+		content string
+		want    string
+	}{
+		{"duplicate json key", "keys.json", `{"qzsecretzq":"acme","qzsecretzq":"beta"}`, "duplicate key"},
+		{"duplicate yaml key", "keys.yaml", "dup: acme\ndup: beta\n", "duplicate key"},
+		{"empty key", "keys.json", `{"":"acme"}`, "empty key"},
+		{"whitespace key", "keys.json", `{"a b":"acme"}`, "whitespace"},
+		{"empty tenant", "keys.json", `{"k":""}`, "invalid tenant"},
+		{"blank tenant", "keys.json", `{"k":"   "}`, "invalid tenant"},
+		{"control char tenant", "keys.json", "{\"k\":\"ac\\u0000me\"}", "invalid tenant"},
+		{"oversize tenant", "keys.json", `{"k":"` + strings.Repeat("t", 200) + `"}`, "invalid tenant"},
+		{"non-string tenant", "keys.json", `{"k":7}`, "must be a string"},
+		{"not an object", "keys.json", `["k"]`, "object"},
+		{"empty file", "keys.json", "  \n", "empty"},
+		{"unknown extension", "keys.txt", `{"k":"acme"}`, "unsupported extension"},
+		{"malformed json", "keys.json", `{"k":`, "invalid JSON"},
+		{"yaml sequence", "keys.yaml", "- a\n- b\n", "mapping"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := LoadKeyStore(writeKeyFile(t, tc.file, tc.content, 0o600))
+			if err == nil {
+				t.Fatalf("expected refusal for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q should mention %q", err, tc.want)
+			}
+			// The key itself must never be echoed back — the position is
+			// enough to find it.
+			if strings.Contains(err.Error(), "qzsecretzq") {
+				t.Errorf("error %q leaks key material", err)
+			}
+		})
+	}
+}
+
+func TestLoadKeyStore_MissingFileAndEmptyPath(t *testing.T) {
+	if store, err := LoadKeyStore(""); err != nil || store != nil {
+		t.Fatalf("empty path: got (%v, %v), want (nil, nil)", store, err)
+	}
+	if _, err := LoadKeyStore(filepath.Join(t.TempDir(), "absent.json")); err == nil {
+		t.Fatal("missing file must be refused")
+	}
+	if store, _ := LoadKeyStore(""); store.Enabled() {
+		t.Error("nil store must report Enabled() == false")
+	}
+}
+
+// TestKeyStore_DigestOnlyMemory walks the loaded store with reflection and
+// asserts the raw key string appears nowhere in it. Digests only — a heap dump
+// or a stray %+v must not yield a usable bearer token.
+func TestKeyStore_DigestOnlyMemory(t *testing.T) {
+	const secret = "super-secret-key-value"
+	store, err := LoadKeyStore(writeKeyFile(t, "keys.json", `{"`+secret+`":"acme"}`, 0o600))
+	if err != nil {
+		t.Fatalf("LoadKeyStore: %v", err)
+	}
+	if tenant, ok := store.Lookup(secret); !ok || tenant != "acme" {
+		t.Fatalf("Lookup = (%q,%v), want (acme,true)", tenant, ok)
+	}
+	forEachString(t, reflect.ValueOf(store), func(path, s string) {
+		if strings.Contains(s, secret) {
+			t.Fatalf("raw key retained at %s", path)
+		}
+	})
+	// The digest IS retained — otherwise the walk above proves nothing.
+	want := sha256.Sum256([]byte(secret))
+	if store.entries[0].digest != want {
+		t.Fatal("store does not hold the key digest")
+	}
+}
+
+// forEachString visits every string reachable from v.
+func forEachString(t *testing.T, v reflect.Value, fn func(path, s string)) {
+	t.Helper()
+	var walk func(reflect.Value, string)
+	walk = func(v reflect.Value, path string) {
+		if !v.IsValid() {
+			return
+		}
+		switch v.Kind() {
+		case reflect.String:
+			fn(path, v.String())
+		case reflect.Ptr, reflect.Interface:
+			if !v.IsNil() {
+				walk(v.Elem(), path+".*")
+			}
+		case reflect.Slice, reflect.Array:
+			for i := range v.Len() {
+				walk(v.Index(i), path+"[]")
+			}
+		case reflect.Map:
+			for _, k := range v.MapKeys() {
+				walk(k, path+".key")
+				walk(v.MapIndex(k), path+".value")
+			}
+		case reflect.Struct:
+			for i := range v.NumField() {
+				walk(v.Field(i), path+"."+v.Type().Field(i).Name)
+			}
+		}
+	}
+	walk(v, "store")
+}
+
+func TestNewKeyStoreFromMap_SameValidation(t *testing.T) {
+	if _, err := NewKeyStoreFromMap(map[string]string{"k": ""}); err == nil {
+		t.Error("empty tenant must be refused")
+	}
+	if _, err := NewKeyStoreFromMap(nil); err == nil {
+		t.Error("empty map must be refused")
+	}
+	store, err := NewKeyStoreFromMap(map[string]string{"k": "acme"})
+	if err != nil {
+		t.Fatalf("NewKeyStoreFromMap: %v", err)
+	}
+	if tenant, ok := store.Lookup("k"); !ok || tenant != "acme" {
+		t.Fatalf("Lookup = (%q,%v)", tenant, ok)
+	}
+}

--- a/internal/authn/principal.go
+++ b/internal/authn/principal.go
@@ -1,0 +1,103 @@
+// Package authn holds the transport-independent authentication primitives
+// shared by the HTTP, WebSocket, and gRPC surfaces: the tenant key store and
+// the authenticated principal that travels on a request context.
+//
+// The package deliberately knows nothing about net/http or gRPC — each
+// transport adapts its own credential carrier (Authorization header,
+// Sec-WebSocket-Protocol entry, gRPC metadata) into the same Principal.
+package authn
+
+import "context"
+
+const (
+	// WSSubprotocol is the only WebSocket subprotocol the server echoes. A
+	// browser that must carry a credential offers it alongside an
+	// `auth.<base64url-token>` entry; the server selects this one, so the token
+	// never appears in the negotiated protocol or in a log line.
+	WSSubprotocol = "otelcontext.v1"
+
+	// WSAuthProtoPrefix marks the credential-bearing subprotocol entry.
+	WSAuthProtoPrefix = "auth."
+)
+
+// Kind classifies an authenticated credential.
+type Kind string
+
+const (
+	// KindOperator is the shared API_KEY. It is authorized for every tenant,
+	// so tenant selection keeps its historical precedence (explicit header or
+	// metadata → trusted resource attribute → DEFAULT_TENANT).
+	KindOperator Kind = "operator"
+
+	// KindTenant is a key from API_TENANT_KEYS_FILE. Its tenant binding is
+	// absolute: client-asserted tenant headers, gRPC metadata, and OTLP
+	// `tenant.id` resource attributes are ignored (and counted) for the
+	// lifetime of the request or connection.
+	KindTenant Kind = "tenant"
+
+	// KindExternal is an identity injected by a front proxy and trusted only
+	// because AUTH_TRUST_EXTERNAL=true. It binds like KindTenant.
+	KindExternal Kind = "external"
+)
+
+// Principal is the authenticated identity of a request or connection.
+// The zero value means "unauthenticated" — which is the normal state of a
+// development deployment with no API_KEY and no tenant keys file.
+type Principal struct {
+	Kind   Kind
+	Tenant string
+}
+
+// Bound reports whether the principal pins the tenant irrevocably. Operator
+// principals are never bound: they may address any tenant.
+func (p Principal) Bound() bool {
+	return (p.Kind == KindTenant || p.Kind == KindExternal) && p.Tenant != ""
+}
+
+// Authenticated reports whether a credential was presented and accepted.
+func (p Principal) Authenticated() bool { return p.Kind != "" }
+
+type principalCtxKey struct{}
+
+// WithPrincipal returns a copy of ctx carrying the authenticated principal.
+func WithPrincipal(ctx context.Context, p Principal) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, principalCtxKey{}, p)
+}
+
+// PrincipalFromContext returns the principal stashed by WithPrincipal.
+// The second result is false when the request was never authenticated.
+func PrincipalFromContext(ctx context.Context) (Principal, bool) {
+	if ctx == nil {
+		return Principal{}, false
+	}
+	p, ok := ctx.Value(principalCtxKey{}).(Principal)
+	return p, ok
+}
+
+// BoundTenantFromContext returns the tenant a bound principal pinned onto ctx.
+// Operator and unauthenticated contexts return ("", false), which leaves the
+// caller's existing tenant precedence untouched.
+func BoundTenantFromContext(ctx context.Context) (string, bool) {
+	p, ok := PrincipalFromContext(ctx)
+	if !ok || !p.Bound() {
+		return "", false
+	}
+	return p.Tenant, true
+}
+
+// ConflictHook is called when a bound principal ignores a client-asserted
+// tenant. surface is "http", "ws", or "grpc"; reason names the ignored
+// carrier ("header", "metadata", "resource_attribute"). Wired by main.go to a
+// Prometheus counter; safe to leave nil. Never called with credential
+// material — only the surface and the carrier name.
+var ConflictHook func(surface, reason string)
+
+// RecordConflict reports an ignored tenant assertion. No-op when unset.
+func RecordConflict(surface, reason string) {
+	if ConflictHook != nil {
+		ConflictHook(surface, reason)
+	}
+}

--- a/internal/config/authn_config_test.go
+++ b/internal/config/authn_config_test.go
@@ -1,0 +1,233 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// productionConfig returns a Config that is valid apart from the
+// production-hardening axis each test drives.
+func productionConfig(t *testing.T) *Config {
+	t.Helper()
+	c := baseValid()
+	c.Env = "production"
+	c.DBDriver = "postgres"
+	return c
+}
+
+// The production startup matrix from the #198 resolution: plaintext OR
+// unauthenticated gRPC is refused, and each waiver flag admits it with a
+// message that names the flag.
+func TestValidate_ProductionRequiresTransportAndAuth(t *testing.T) {
+	certFile, keyFile := writeTLSPair(t)
+
+	cases := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{
+			name:    "plaintext and unauthenticated refused",
+			mutate:  func(*Config) {},
+			wantErr: "transport protection",
+		},
+		{
+			name:    "TLS without authentication refused",
+			mutate:  func(c *Config) { c.TLSCertFile, c.TLSKeyFile = certFile, keyFile },
+			wantErr: "requires authentication",
+		},
+		{
+			name:    "self-signed TLS counts as transport protection",
+			mutate:  func(c *Config) { c.TLSAutoSelfsigned = true },
+			wantErr: "requires authentication",
+		},
+		{
+			name: "TLS plus API_KEY admitted",
+			mutate: func(c *Config) {
+				c.TLSCertFile, c.TLSKeyFile = certFile, keyFile
+				c.APIKey = "secret"
+			},
+		},
+		{
+			name: "TLS plus tenant keys admitted",
+			mutate: func(c *Config) {
+				c.TLSCertFile, c.TLSKeyFile = certFile, keyFile
+				c.APITenantKeysFile = "/etc/otelcontext/keys.json"
+			},
+		},
+		{
+			name:   "AUTH_TRUST_EXTERNAL waives both",
+			mutate: func(c *Config) { c.AuthTrustExternal = true; c.AuthExternalTenantHeader = "X-OtelContext-Tenant" },
+		},
+		{
+			name:   "OTELCONTEXT_ALLOW_INSECURE_GRPC waives both",
+			mutate: func(c *Config) { c.AllowInsecureGRPC = true },
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := productionConfig(t)
+			tc.mutate(c)
+			err := c.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("want admitted, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("want refusal, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q should mention %q", err, tc.wantErr)
+			}
+			// Every refusal names both waivers so the operator can see the
+			// acknowledgement they would be making.
+			for _, flag := range []string{"AUTH_TRUST_EXTERNAL", "OTELCONTEXT_ALLOW_INSECURE_GRPC"} {
+				if !strings.Contains(err.Error(), flag) {
+					t.Errorf("refusal %q does not name %s", err, flag)
+				}
+			}
+		})
+	}
+}
+
+// Development is untouched: plaintext, unauthenticated, no keys file — the
+// configuration that every existing deployment runs today still validates.
+func TestValidate_DevelopmentUnchanged(t *testing.T) {
+	c := baseValid()
+	if err := c.Validate(); err != nil {
+		t.Fatalf("default development config refused: %v", err)
+	}
+	if c.AuthEnabled() {
+		t.Error("AuthEnabled() must be false with no credential source")
+	}
+	if c.EnforceWSOrigin() {
+		t.Error("WebSocket origin policy must be off in an unauthenticated development deployment")
+	}
+	if c.IsProduction() {
+		t.Error("IsProduction() must be false for the default env")
+	}
+}
+
+// The origin policy switches on with authentication, and always in production.
+func TestEnforceWSOrigin(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Config)
+		want   bool
+	}{
+		{"unauthenticated dev", func(*Config) {}, false},
+		{"API_KEY set", func(c *Config) { c.APIKey = "secret" }, true},
+		{"tenant keys set", func(c *Config) { c.APITenantKeysFile = "keys.json" }, true},
+		{"trust external", func(c *Config) { c.AuthTrustExternal = true }, true},
+		{"production without auth", func(c *Config) { c.Env = "production" }, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := baseValid()
+			tc.mutate(c)
+			if got := c.EnforceWSOrigin(); got != tc.want {
+				t.Fatalf("EnforceWSOrigin() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidate_ExternalTenantHeader(t *testing.T) {
+	cases := []struct {
+		name    string
+		header  string
+		wantErr string
+	}{
+		{"default accepted", "X-OtelContext-Tenant", ""},
+		{"empty refused", "", "must not be empty"},
+		{"space refused", "X Tenant", "invalid character"},
+		{"newline refused", "X-Tenant\n", "whitespace"},
+		{"embedded colon refused", "X:Tenant", "invalid character"},
+		{"client header refused", "X-Tenant-ID", "must not be X-Tenant-ID"},
+		{"client header refused case-insensitively", "x-tenant-id", "must not be X-Tenant-ID"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := baseValid()
+			c.AuthTrustExternal = true
+			c.AuthExternalTenantHeader = tc.header
+			err := c.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("want accepted, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %v should mention %q", err, tc.wantErr)
+			}
+		})
+	}
+
+	// The header is only validated when it is actually trusted.
+	c := baseValid()
+	c.AuthExternalTenantHeader = "not a header"
+	if err := c.Validate(); err != nil {
+		t.Fatalf("unused header validated: %v", err)
+	}
+}
+
+// Defaults: reflection follows APP_ENV, everything else is off.
+func TestLoad_AuthenticationDefaults(t *testing.T) {
+	t.Setenv("APP_ENV", "development")
+	c, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.AuthTrustExternal || c.AllowInsecureGRPC || c.APITenantKeysFile != "" || len(c.WSAllowedOrigins) != 0 {
+		t.Fatalf("development defaults are not inert: %+v", struct {
+			Trust    bool
+			Insecure bool
+			Keys     string
+			Origins  []string
+		}{c.AuthTrustExternal, c.AllowInsecureGRPC, c.APITenantKeysFile, c.WSAllowedOrigins})
+	}
+	if !c.GRPCReflectionEnabled() {
+		t.Error("reflection should stay on outside production")
+	}
+	if c.AuthExternalTenantHeader != "X-OtelContext-Tenant" {
+		t.Errorf("AuthExternalTenantHeader = %q", c.AuthExternalTenantHeader)
+	}
+
+	t.Setenv("APP_ENV", "production")
+	c, err = Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.GRPCReflectionEnabled() {
+		t.Error("reflection must default to off in production")
+	}
+
+	t.Setenv("GRPC_REFLECTION", "true")
+	c, err = Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !c.GRPCReflectionEnabled() {
+		t.Error("GRPC_REFLECTION=true must re-enable reflection in production")
+	}
+}
+
+func TestLoad_WSAllowedOrigins(t *testing.T) {
+	t.Setenv("WS_ALLOWED_ORIGINS", " https://app.example.com , , dash.example.com ")
+	c, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := []string{"https://app.example.com", "dash.example.com"}
+	if len(c.WSAllowedOrigins) != len(want) {
+		t.Fatalf("WSAllowedOrigins = %v, want %v", c.WSAllowedOrigins, want)
+	}
+	for i := range want {
+		if c.WSAllowedOrigins[i] != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, c.WSAllowedOrigins[i], want[i])
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -227,11 +227,41 @@ type Config struct {
 	OTLPTrustResourceTenant bool
 
 	// APITenantKeysFile, when non-empty, switches API auth from a single
-	// shared API_KEY into per-tenant bearer tokens. The file contains one
-	// `key=tenant` pair per line; the matched key's tenant OVERRIDES any
-	// X-Tenant-ID header so callers cannot cross tenants. Empty = disabled
-	// (legacy shared-key mode remains available for single-tenant dev).
+	// shared API_KEY into per-tenant bearer tokens. JSON or YAML, chosen by
+	// extension, mapping bearer key to tenant ID (several keys may map to one
+	// tenant). Loaded once at startup; the process holds only SHA-256 digests.
+	// A matched key's tenant BINDS the request — client-supplied X-Tenant-ID,
+	// gRPC metadata, and OTLP `tenant.id` resource attributes are ignored and
+	// counted. Empty = disabled (shared-key mode remains for single-tenant dev).
 	APITenantKeysFile string
+
+	// AuthTrustExternal turns on proxy-injected identity: the value of
+	// AuthExternalTenantHeader is trusted as an authenticated tenant. It is
+	// an authentication BYPASS unless the front proxy authenticates callers,
+	// strips inbound copies of that header, and the application ports are
+	// unreachable except through it — see CLAUDE.md's Authentication section.
+	AuthTrustExternal bool
+
+	// AuthExternalTenantHeader is the dedicated identity header (and gRPC
+	// metadata key, lower-cased) honoured only when AuthTrustExternal is set.
+	// Deliberately distinct from X-Tenant-ID, which stays client-controlled.
+	AuthExternalTenantHeader string
+
+	// WSAllowedOrigins is the WebSocket origin allowlist. Entries may be full
+	// origins ("https://app.example.com") or bare hosts. Empty means
+	// same-host only. Enforced when authentication is enabled or in
+	// production; ignored in an unauthenticated development deployment.
+	WSAllowedOrigins []string
+
+	// GRPCReflection controls gRPC server reflection. Defaults to true outside
+	// production and false in production — reflection enumerates every service
+	// and message type to an unauthenticated peer.
+	GRPCReflection bool
+
+	// AllowInsecureGRPC waives the production requirement for TLS and
+	// authentication on the OTLP gRPC listener. Explicit acknowledgement that
+	// telemetry crosses the network unprotected and unauthenticated.
+	AllowInsecureGRPC bool
 
 	// DevMode disables origin checks for WebSocket and enables dev-friendly defaults.
 	// Derived from APP_ENV == "development".
@@ -484,6 +514,13 @@ func Load(customPath string) (*Config, error) {
 		OTLPTrustResourceTenant: parseTruthy(getEnv("OTLP_TRUST_RESOURCE_TENANT", "")),
 		APITenantKeysFile:       getEnv("API_TENANT_KEYS_FILE", ""),
 
+		// Authenticated tenant identity (HTTP / WebSocket / gRPC)
+		AuthTrustExternal:        parseTruthy(getEnv("AUTH_TRUST_EXTERNAL", "")),
+		AuthExternalTenantHeader: getEnv("AUTH_EXTERNAL_TENANT_HEADER", "X-OtelContext-Tenant"),
+		WSAllowedOrigins:         splitCSV(getEnv("WS_ALLOWED_ORIGINS", "")),
+		GRPCReflection:           getEnvBool("GRPC_REFLECTION", env != "production"),
+		AllowInsecureGRPC:        parseTruthy(getEnv("OTELCONTEXT_ALLOW_INSECURE_GRPC", "")),
+
 		// gRPC server tuning
 		GRPCMaxRecvMB:            getEnvInt("GRPC_MAX_RECV_MB", 16),
 		GRPCMaxConcurrentStreams: getEnvInt("GRPC_MAX_CONCURRENT_STREAMS", 1000),
@@ -645,6 +682,26 @@ func parseTruthy(v string) bool {
 	return false
 }
 
+// splitCSV splits a comma-separated env var into trimmed, non-empty entries.
+// Returns nil (not an empty slice) for an unset or blank value so callers can
+// test the "unset" case with len().
+func splitCSV(v string) []string {
+	if strings.TrimSpace(v) == "" {
+		return nil
+	}
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func getEnvBool(key string, fallback bool) bool {
 	if v, exists := os.LookupEnv(key); exists {
 		if b, err := strconv.ParseBool(v); err == nil {
@@ -772,6 +829,28 @@ func (c *Config) Validate() error {
 	// tenant's data, which is almost never what a multi-tenant install wants.
 	if c.APITenantKeysFile == "" && c.DefaultTenant != "" && c.DefaultTenant != "default" {
 		log.Printf("⚠️  API_TENANT_KEYS_FILE is empty but DEFAULT_TENANT=%q — shared API_KEY permits any holder to read any tenant's data. Set API_TENANT_KEYS_FILE to enforce per-tenant auth.", c.DefaultTenant)
+	}
+
+	// Authenticated tenant identity.
+	if c.AuthTrustExternal {
+		if err := validateHeaderToken(c.AuthExternalTenantHeader); err != nil {
+			return fmt.Errorf("AUTH_EXTERNAL_TENANT_HEADER: %w", err)
+		}
+		if strings.EqualFold(c.AuthExternalTenantHeader, "X-Tenant-ID") {
+			return fmt.Errorf("AUTH_EXTERNAL_TENANT_HEADER must not be X-Tenant-ID — that header stays client-controlled; use a dedicated header your proxy strips and re-injects")
+		}
+	}
+
+	// Production fail-closed: the OTLP gRPC listener must be both protected in
+	// transport and authenticated. Two waivers, each named in the refusal so
+	// the operator knows exactly which acknowledgement they are making.
+	if c.IsProduction() && !c.AuthTrustExternal && !c.AllowInsecureGRPC {
+		if !c.TLSEnabled() {
+			return fmt.Errorf("APP_ENV=production requires transport protection on the OTLP gRPC listener: set TLS_CERT_FILE/TLS_KEY_FILE, or TLS_AUTO_SELFSIGNED=true, or waive with AUTH_TRUST_EXTERNAL=true (proxy-terminated TLS) or OTELCONTEXT_ALLOW_INSECURE_GRPC=true")
+		}
+		if !c.AuthEnabled() {
+			return fmt.Errorf("APP_ENV=production requires authentication on the OTLP gRPC listener: set API_KEY or API_TENANT_KEYS_FILE, or waive with AUTH_TRUST_EXTERNAL=true (proxy-authenticated identity) or OTELCONTEXT_ALLOW_INSECURE_GRPC=true")
+		}
 	}
 
 	// TLS: both paths must be set together, and both files must exist & be readable.
@@ -925,6 +1004,44 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("sum of AGGREGATE_MAX_SERIES_* caps (%d = %d+%d+%d+%d+%d) must be <= AGGREGATE_MAX_SERIES (%d)", sumSubCaps, c.AggregateMaxSeriesMetrics, c.AggregateMaxSeriesTraces, c.AggregateMaxSeriesEdges, c.AggregateMaxSeriesLogs, c.AggregateMaxSeriesSystem, c.AggregateMaxSeries)
 	}
 
+	return nil
+}
+
+// IsProduction reports whether APP_ENV names the production environment.
+func (c *Config) IsProduction() bool { return strings.EqualFold(c.Env, "production") }
+
+// AuthEnabled reports whether any credential source is configured: the shared
+// operator key, a per-tenant key file, or a trusted front proxy.
+func (c *Config) AuthEnabled() bool {
+	return c.APIKey != "" || c.APITenantKeysFile != "" || c.AuthTrustExternal
+}
+
+// EnforceWSOrigin reports whether the WebSocket origin policy applies. It does
+// as soon as authentication is configured, and always in production — an
+// unauthenticated development deployment keeps today's permissive behaviour.
+func (c *Config) EnforceWSOrigin() bool { return c.AuthEnabled() || c.IsProduction() }
+
+// GRPCReflectionEnabled reports whether to register gRPC server reflection.
+// Production defaults to off; GRPC_REFLECTION=true re-enables it explicitly.
+func (c *Config) GRPCReflectionEnabled() bool { return c.GRPCReflection }
+
+// validateHeaderToken checks that a header name is a legal HTTP field name.
+// Anything else would be silently unreachable at runtime.
+func validateHeaderToken(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("must not be empty")
+	}
+	if name != strings.TrimSpace(name) {
+		return fmt.Errorf("must not have leading or trailing whitespace")
+	}
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case strings.ContainsRune("-_.", r):
+		default:
+			return fmt.Errorf("invalid character %q in header name", r)
+		}
+	}
 	return nil
 }
 

--- a/internal/ingest/grpc_auth.go
+++ b/internal/ingest/grpc_auth.go
@@ -1,0 +1,121 @@
+package ingest
+
+import (
+	"context"
+	"strings"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+// authorizationMD is the gRPC metadata key carrying the bearer credential.
+// gRPC lower-cases metadata keys on the wire, so this is the canonical form.
+const authorizationMD = "authorization"
+
+// GRPCAuthOptions configures the OTLP gRPC authentication interceptors.
+type GRPCAuthOptions struct {
+	// Auth resolves credentials. A disabled Authenticator yields nil
+	// interceptors and the server keeps its current unauthenticated behaviour
+	// — which is the development default.
+	Auth *authn.Authenticator
+	// ExternalTenantMetadataKey is the proxy-injected identity key, honoured
+	// only under AUTH_TRUST_EXTERNAL. Compared lower-cased.
+	ExternalTenantMetadataKey string
+	// OnAuthFailure receives the failure reason for metrics. Optional.
+	OnAuthFailure func(reason string)
+}
+
+// NewGRPCAuthInterceptors returns the unary and stream interceptors enforcing
+// bearer authentication on the OTLP gRPC listener.
+//
+// A tenant key binds absolutely: the authenticated tenant is pinned onto the
+// call context, and an `x-tenant-id` metadata value that disagrees is ignored
+// and counted rather than honoured. An operator key authenticates only —
+// tenant precedence stays (metadata → trusted resource attribute →
+// DEFAULT_TENANT), so an existing single-tenant deployment that adds API_KEY
+// sees no change in where its rows land.
+//
+// Both results are nil when authentication is not configured, so the caller
+// installs nothing and pays nothing.
+func NewGRPCAuthInterceptors(o GRPCAuthOptions) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
+	if !o.Auth.Enabled() {
+		return nil, nil
+	}
+	extKey := strings.ToLower(strings.TrimSpace(o.ExternalTenantMetadataKey))
+	authorize := func(ctx context.Context) (context.Context, error) {
+		md, _ := metadata.FromIncomingContext(ctx)
+		principal, reason, ok := authenticateGRPC(o.Auth, md, extKey)
+		if !ok {
+			if o.OnAuthFailure != nil {
+				o.OnAuthFailure(reason)
+			}
+			// The reason is deliberately not returned to the peer: it would
+			// tell a prober whether a key exists. Credentials are never logged.
+			return nil, grpcstatus.Error(codes.Unauthenticated, "unauthenticated")
+		}
+		return bindGRPCPrincipal(ctx, md, principal), nil
+	}
+
+	unary := func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		authCtx, err := authorize(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return handler(authCtx, req)
+	}
+	stream := func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		authCtx, err := authorize(ss.Context())
+		if err != nil {
+			return err
+		}
+		return handler(srv, &authenticatedStream{ServerStream: ss, ctx: authCtx})
+	}
+	return unary, stream
+}
+
+// authenticateGRPC resolves the principal for one call.
+func authenticateGRPC(a *authn.Authenticator, md metadata.MD, extKey string) (authn.Principal, string, bool) {
+	var header string
+	if vals := md.Get(authorizationMD); len(vals) > 0 {
+		header = vals[0]
+	}
+	token, reason := authn.TokenFromAuthorization(header)
+	if token == "" {
+		if reason == authn.ReasonMissingCredential && extKey != "" {
+			if vals := md.Get(extKey); len(vals) > 0 {
+				if p, ok := a.ExternalPrincipal(vals[0]); ok {
+					return p, "", true
+				}
+			}
+		}
+		return authn.Principal{}, reason, false
+	}
+	return a.AuthenticateToken(token)
+}
+
+// bindGRPCPrincipal pins the authenticated identity (and, for a bound
+// principal, its tenant) onto the call context.
+func bindGRPCPrincipal(ctx context.Context, md metadata.MD, p authn.Principal) context.Context {
+	ctx = authn.WithPrincipal(ctx, p)
+	if !p.Bound() {
+		return ctx
+	}
+	if vals := md.Get(tenantHeader); len(vals) > 0 && storage.SanitizeTenantID(vals[0]) != p.Tenant {
+		authn.RecordConflict("grpc", "metadata")
+	}
+	return storage.WithTenantContext(ctx, p.Tenant)
+}
+
+// authenticatedStream carries the authenticated context into a streaming
+// handler. grpc.ServerStream has no setter for its context, so the standard
+// approach is this thin wrapper.
+type authenticatedStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *authenticatedStream) Context() context.Context { return s.ctx }

--- a/internal/ingest/grpc_auth_test.go
+++ b/internal/ingest/grpc_auth_test.go
@@ -1,0 +1,302 @@
+package ingest
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	grpcstatus "google.golang.org/grpc/status"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+func grpcAuthenticator(t *testing.T, operatorKey string, entries map[string]string, trustExternal bool) *authn.Authenticator {
+	t.Helper()
+	var store *authn.KeyStore
+	if len(entries) > 0 {
+		var err error
+		store, err = authn.NewKeyStoreFromMap(entries)
+		if err != nil {
+			t.Fatalf("NewKeyStoreFromMap: %v", err)
+		}
+	}
+	return authn.NewAuthenticator(operatorKey, store, trustExternal)
+}
+
+// conflicts installs the tenant-conflict hook for one test.
+func conflicts(t *testing.T) *[][2]string {
+	t.Helper()
+	prev := authn.ConflictHook
+	t.Cleanup(func() { authn.ConflictHook = prev })
+	var got [][2]string
+	authn.ConflictHook = func(surface, reason string) { got = append(got, [2]string{surface, reason}) }
+	return &got
+}
+
+func mdCtx(pairs ...string) context.Context {
+	return metadata.NewIncomingContext(context.Background(), metadata.Pairs(pairs...))
+}
+
+// A tenant key binds absolutely: a contradicting x-tenant-id is ignored and
+// counted, and the batch the pipeline receives carries the key's tenant —
+// which is the tenant the rows are written under.
+func TestGRPCAuth_TenantKeyOverridesMetadataOnExport(t *testing.T) {
+	got := conflicts(t)
+	unary, _ := NewGRPCAuthInterceptors(GRPCAuthOptions{
+		Auth: grpcAuthenticator(t, "operator-key", map[string]string{"acme-key": "acme"}, false),
+	})
+	if unary == nil {
+		t.Fatal("interceptors must be installed when authentication is configured")
+	}
+
+	h := newAdmissionHarness(t, 8, 0, false)
+	ctx := mdCtx("authorization", "Bearer acme-key", tenantHeader, "victim")
+
+	_, err := unary(ctx, nil, &grpc.UnaryServerInfo{}, func(authCtx context.Context, _ any) (any, error) {
+		return h.traces.Export(authCtx, buildTracesRequest("svc-a", 2))
+	})
+	if err != nil {
+		t.Fatalf("authenticated export: %v", err)
+	}
+
+	select {
+	case b := <-h.pipeline.queue:
+		if b.Tenant != "acme" {
+			t.Fatalf("batch Tenant=%q, want acme (the key's tenant, not the metadata)", b.Tenant)
+		}
+	default:
+		t.Fatal("no batch reached the pipeline")
+	}
+	if len(*got) != 1 || (*got)[0] != [2]string{"grpc", "metadata"} {
+		t.Fatalf("conflict metric = %v, want one grpc/metadata record", *got)
+	}
+}
+
+// A contradicting tenant.id resource attribute is ignored and counted too,
+// even when OTLP_TRUST_RESOURCE_TENANT is on.
+func TestGRPCAuth_TenantKeyOverridesResourceAttribute(t *testing.T) {
+	got := conflicts(t)
+	unary, _ := NewGRPCAuthInterceptors(GRPCAuthOptions{
+		Auth: grpcAuthenticator(t, "", map[string]string{"acme-key": "acme"}, false),
+	})
+
+	h := newAdmissionHarness(t, 8, 0, true) // trustResourceTenant = true
+	ctx := mdCtx("authorization", "Bearer acme-key")
+	req := buildTracesRequest("svc-a", 1)
+	req.ResourceSpans[0].Resource.Attributes = append(req.ResourceSpans[0].Resource.Attributes, strAttr("tenant.id", "victim"))
+
+	if _, err := unary(ctx, nil, &grpc.UnaryServerInfo{}, func(authCtx context.Context, _ any) (any, error) {
+		return h.traces.Export(authCtx, req)
+	}); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	select {
+	case b := <-h.pipeline.queue:
+		if b.Tenant != "acme" {
+			t.Fatalf("batch Tenant=%q, want acme", b.Tenant)
+		}
+	default:
+		t.Fatal("no batch reached the pipeline")
+	}
+	if len(*got) != 1 || (*got)[0] != [2]string{"grpc", "resource_attribute"} {
+		t.Fatalf("conflict metric = %v, want one grpc/resource_attribute record", *got)
+	}
+}
+
+// The operator key authenticates only: explicit metadata still selects the
+// tenant, so an existing deployment that adds API_KEY keeps its routing.
+func TestGRPCAuth_OperatorKeyHonoursMetadataTenant(t *testing.T) {
+	got := conflicts(t)
+	unary, _ := NewGRPCAuthInterceptors(GRPCAuthOptions{
+		Auth: grpcAuthenticator(t, "operator-key", map[string]string{"acme-key": "acme"}, false),
+	})
+
+	h := newAdmissionHarness(t, 8, 0, false)
+	ctx := mdCtx("authorization", "Bearer operator-key", tenantHeader, "beta")
+	if _, err := unary(ctx, nil, &grpc.UnaryServerInfo{}, func(authCtx context.Context, _ any) (any, error) {
+		return h.traces.Export(authCtx, buildTracesRequest("svc-a", 1))
+	}); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	select {
+	case b := <-h.pipeline.queue:
+		if b.Tenant != "beta" {
+			t.Fatalf("batch Tenant=%q, want beta (operator keys do not bind)", b.Tenant)
+		}
+	default:
+		t.Fatal("no batch reached the pipeline")
+	}
+	if len(*got) != 0 {
+		t.Errorf("operator call counted a conflict: %v", *got)
+	}
+}
+
+func TestGRPCAuth_RejectsBadCredentials(t *testing.T) {
+	var reasons []string
+	unary, stream := NewGRPCAuthInterceptors(GRPCAuthOptions{
+		Auth:          grpcAuthenticator(t, "operator-key", map[string]string{"acme-key": "acme"}, false),
+		OnAuthFailure: func(reason string) { reasons = append(reasons, reason) },
+	})
+
+	cases := []struct {
+		name   string
+		ctx    context.Context
+		reason string
+	}{
+		{"no metadata", context.Background(), authn.ReasonMissingCredential},
+		{"no authorization", mdCtx(tenantHeader, "acme"), authn.ReasonMissingCredential},
+		{"bad scheme", mdCtx("authorization", "Basic acme-key"), authn.ReasonBadScheme},
+		{"unknown key", mdCtx("authorization", "Bearer nope"), authn.ReasonBadKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			_, err := unary(tc.ctx, nil, &grpc.UnaryServerInfo{}, func(context.Context, any) (any, error) {
+				called = true
+				return nil, nil
+			})
+			if called {
+				t.Fatal("handler ran despite failed authentication")
+			}
+			if grpcstatus.Code(err) != codes.Unauthenticated {
+				t.Fatalf("code = %v, want Unauthenticated", grpcstatus.Code(err))
+			}
+			// The refusal must not tell a prober which part was wrong.
+			if msg := grpcstatus.Convert(err).Message(); msg != "unauthenticated" {
+				t.Errorf("message = %q, want a non-specific refusal", msg)
+			}
+		})
+	}
+
+	// The stream interceptor enforces exactly the same contract.
+	err := stream(nil, &fakeServerStream{ctx: mdCtx("authorization", "Bearer nope")}, &grpc.StreamServerInfo{},
+		func(any, grpc.ServerStream) error {
+			t.Fatal("stream handler ran despite failed authentication")
+			return nil
+		})
+	if grpcstatus.Code(err) != codes.Unauthenticated {
+		t.Fatalf("stream code = %v, want Unauthenticated", grpcstatus.Code(err))
+	}
+
+	want := []string{
+		authn.ReasonMissingCredential, authn.ReasonMissingCredential,
+		authn.ReasonBadScheme, authn.ReasonBadKey, authn.ReasonBadKey,
+	}
+	if len(reasons) != len(want) {
+		t.Fatalf("failure reasons = %v, want %v", reasons, want)
+	}
+	for i := range want {
+		if reasons[i] != want[i] {
+			t.Errorf("reason[%d] = %q, want %q", i, reasons[i], want[i])
+		}
+	}
+}
+
+// The stream interceptor carries the bound identity into the handler's
+// context, which is what makes a streaming RPC tenant-safe.
+func TestGRPCAuth_StreamCarriesBoundTenant(t *testing.T) {
+	got := conflicts(t)
+	_, stream := NewGRPCAuthInterceptors(GRPCAuthOptions{
+		Auth: grpcAuthenticator(t, "", map[string]string{"acme-key": "acme"}, false),
+	})
+
+	var seen string
+	err := stream(nil, &fakeServerStream{ctx: mdCtx("authorization", "Bearer acme-key", tenantHeader, "victim")},
+		&grpc.StreamServerInfo{}, func(_ any, ss grpc.ServerStream) error {
+			seen = storage.TenantFromContext(ss.Context())
+			if bound, ok := authn.BoundTenantFromContext(ss.Context()); !ok || bound != "acme" {
+				t.Errorf("stream context principal = (%q,%v), want (acme,true)", bound, ok)
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if seen != "acme" {
+		t.Fatalf("stream tenant = %q, want acme", seen)
+	}
+	if len(*got) != 1 || (*got)[0] != [2]string{"grpc", "metadata"} {
+		t.Fatalf("conflict metric = %v, want one grpc/metadata record", *got)
+	}
+}
+
+// AUTH_TRUST_EXTERNAL: the dedicated metadata key is an identity; x-tenant-id
+// still is not.
+func TestGRPCAuth_ExternalIdentityMetadata(t *testing.T) {
+	unary, _ := NewGRPCAuthInterceptors(GRPCAuthOptions{
+		Auth:                      grpcAuthenticator(t, "", nil, true),
+		ExternalTenantMetadataKey: "X-OtelContext-Tenant",
+	})
+	if unary == nil {
+		t.Fatal("trust-external alone must install the interceptors")
+	}
+
+	var seen string
+	if _, err := unary(mdCtx("x-otelcontext-tenant", "acme", tenantHeader, "victim"), nil, &grpc.UnaryServerInfo{},
+		func(ctx context.Context, _ any) (any, error) {
+			seen = storage.TenantFromContext(ctx)
+			return nil, nil
+		}); err != nil {
+		t.Fatalf("injected identity: %v", err)
+	}
+	if seen != "acme" {
+		t.Fatalf("tenant = %q, want acme", seen)
+	}
+
+	// Without the injected key the call is unauthenticated: the client-
+	// controlled tenant metadata is never an identity.
+	if _, err := unary(mdCtx(tenantHeader, "acme"), nil, &grpc.UnaryServerInfo{},
+		func(context.Context, any) (any, error) { return nil, nil }); grpcstatus.Code(err) != codes.Unauthenticated {
+		t.Fatalf("x-tenant-id alone: code = %v, want Unauthenticated", grpcstatus.Code(err))
+	}
+}
+
+// No credential source configured → no interceptors, so a development
+// deployment keeps today's behaviour with zero added cost.
+func TestGRPCAuth_DisabledInstallsNothing(t *testing.T) {
+	unary, stream := NewGRPCAuthInterceptors(GRPCAuthOptions{Auth: authn.NewAuthenticator("", nil, false)})
+	if unary != nil || stream != nil {
+		t.Fatal("interceptors installed without a credential source")
+	}
+}
+
+// fakeServerStream is the minimal grpc.ServerStream a stream interceptor test
+// needs: it only has to carry a context.
+type fakeServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *fakeServerStream) Context() context.Context { return s.ctx }
+
+// The OTLP HTTP path honours the same binding: X-Tenant-ID cannot move an
+// authenticated tenant key's data into another tenant.
+func TestHTTPIngest_BoundTenantIgnoresClientHeader(t *testing.T) {
+	got := conflicts(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/traces", nil)
+	req.Header.Set("X-Tenant-ID", "victim")
+	bound := authn.WithPrincipal(req.Context(), authn.Principal{Kind: authn.KindTenant, Tenant: "acme"})
+	bound = storage.WithTenantContext(bound, "acme")
+
+	ctx := withTenantFromHTTP(req.WithContext(bound))
+	if tenant := storage.TenantFromContext(ctx); tenant != "acme" {
+		t.Fatalf("tenant = %q, want acme", tenant)
+	}
+	if len(*got) != 1 || (*got)[0] != [2]string{"http", "header"} {
+		t.Fatalf("conflict metric = %v, want one http/header record", *got)
+	}
+
+	// Unbound (operator or unauthenticated) requests keep header precedence.
+	plain := httptest.NewRequest(http.MethodPost, "/v1/traces", nil)
+	plain.Header.Set("X-Tenant-ID", "beta")
+	if tenant := storage.TenantFromContext(withTenantFromHTTP(plain)); tenant != "beta" {
+		t.Fatalf("unbound tenant = %q, want beta", tenant)
+	}
+}

--- a/internal/ingest/otlp.go
+++ b/internal/ingest/otlp.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
 	"github.com/RandomCodeSpace/otelcontext/internal/config"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"github.com/RandomCodeSpace/otelcontext/internal/telemetry"
@@ -74,6 +75,16 @@ func hasStorageTenant(ctx context.Context) bool {
 // "tenant.id" path is gated behind cfg.TrustResourceTenant — disabled by
 // default so a compromised SDK cannot forge another tenant's data.
 func resolveTenant(ctx context.Context, resourceAttrs []*commonpb.KeyValue, fallback string, trustResourceAttr bool) string {
+	// An authenticated tenant key binds absolutely. It outranks metadata, the
+	// resource attribute, and the configured default; a disagreeing
+	// `tenant.id` is counted so operators can see clients asserting a tenancy
+	// they do not hold.
+	if bound, ok := authn.BoundTenantFromContext(ctx); ok {
+		if t := tenantFromResource(resourceAttrs); t != "" && t != bound {
+			authn.RecordConflict("grpc", "resource_attribute")
+		}
+		return bound
+	}
 	if t := tenantFromContext(ctx); t != "" {
 		return t
 	}

--- a/internal/ingest/otlp_http.go
+++ b/internal/ingest/otlp_http.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
@@ -43,6 +44,14 @@ const headerContentType = "Content-Type" //nolint:goconst // single literal; Son
 // control characters, oversized strings, and empty values are rejected
 // identically regardless of transport.
 func withTenantFromHTTP(r *http.Request) context.Context {
+	// An authenticated tenant key already pinned the tenant. The header is
+	// then a client assertion about someone else's tenancy: ignore and count.
+	if bound, ok := authn.BoundTenantFromContext(r.Context()); ok {
+		if v := r.Header.Get("X-Tenant-ID"); v != "" && storage.SanitizeTenantID(v) != bound {
+			authn.RecordConflict("http", "header")
+		}
+		return r.Context()
+	}
 	if v := r.Header.Get("X-Tenant-ID"); v != "" {
 		if sanitized := storage.SanitizeTenantID(v); sanitized != "" {
 			return storage.WithTenantContext(r.Context(), sanitized)

--- a/internal/realtime/aggregate_publisher.go
+++ b/internal/realtime/aggregate_publisher.go
@@ -22,8 +22,9 @@ type EnginePublisher struct {
 	// edges supplies caller/callee topology, which is not aggregate data.
 	// nil is allowed and yields a node-only topology.
 	edges func(ctx context.Context) []storage.ServiceMapEdge
-	// tenant scopes the queries. The WebSocket protocol carries no tenant, so
-	// this is the default tenant, exactly as the legacy snapshot path assumed.
+	// tenant scopes the queries when the caller's context carries none. Since
+	// the handshake gate pins one tenant per socket, ctx normally decides; this
+	// stays the fallback for an unauthenticated (development) deployment.
 	tenant string
 }
 
@@ -75,7 +76,14 @@ func (p *EnginePublisher) Snapshot(ctx context.Context, service string) *LiveSna
 	if service != "" {
 		services = []string{service}
 	}
-	q := aggregate.Query{Tenant: p.tenant, Start: start, End: now, Services: services}
+	// The socket's authenticated tenant travels on ctx and outranks the
+	// configured fallback — otherwise every tenant's dashboard would be served
+	// the same tenant's numbers.
+	tenant := p.tenant
+	if storage.HasTenantContext(ctx) {
+		tenant = storage.TenantFromContext(ctx)
+	}
+	q := aggregate.Query{Tenant: tenant, Start: start, End: now, Services: services}
 
 	snap := &LiveSnapshot{
 		Type:     "live_snapshot",

--- a/internal/realtime/events_ws.go
+++ b/internal/realtime/events_ws.go
@@ -6,8 +6,10 @@ import (
 	"log/slog"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"github.com/coder/websocket"
 	"golang.org/x/sync/errgroup"
@@ -54,9 +56,55 @@ type AggregatePublisher interface {
 // engine cannot turn every commit into a broadcast.
 const DefaultPublishFloor = 2 * time.Second
 
-// clientFilter tracks a client's active service filter.
-// Empty string = all services (no filter).
+// eventClientQueue bounds how many undelivered messages a single event-WS
+// client may hold. Overflow disconnects the client rather than dropping
+// messages silently: the log/metric batches are incremental, so a gap is
+// indistinguishable from "nothing happened" and would quietly lie to the
+// dashboard. A reconnect re-seeds with a full snapshot.
+const eventClientQueue = 256
+
+// clientFilter tracks a client's active service filter and its immutable
+// tenant scope.
+//
+// service is client-selectable (empty = all services). tenant is NOT: it is
+// fixed at handshake time from the authenticated principal and there is no
+// protocol message that can change it. Empty tenant means authentication is
+// not configured (development), in which case the socket sees everything —
+// exactly as it did before per-tenant scoping existed.
 type clientFilter struct {
+	conn    *websocket.Conn
+	send    chan []byte
+	service string
+	tenant  string
+	closed  atomic.Bool
+}
+
+// matches reports whether an entry belongs to this client's scope.
+func (cf *clientFilter) matches(tenant, service string) bool {
+	if cf.tenant != "" && cf.tenant != tenant {
+		return false
+	}
+	return cf.service == "" || cf.service == service
+}
+
+// enqueue hands a message to the client's writer goroutine. It reports false
+// when the queue is full — the caller then disconnects the client.
+func (cf *clientFilter) enqueue(msg []byte) bool {
+	if cf.closed.Load() {
+		return false
+	}
+	select {
+	case cf.send <- msg:
+		return true
+	default:
+		return false
+	}
+}
+
+// scopeKey identifies one snapshot audience: a tenant plus a service filter.
+// Snapshots are computed once per key, not once per client.
+type scopeKey struct {
+	tenant  string
 	service string
 }
 
@@ -71,6 +119,20 @@ type EventHub struct {
 	mu      sync.Mutex
 	clients map[*websocket.Conn]*clientFilter
 	pending bool
+
+	// maxClients caps simultaneous event-WS connections (WS_MAX_CLIENTS).
+	// 0 = unlimited (legacy default). Past the cap the handshake is refused
+	// with 503 before the upgrade, so a connection flood cannot exhaust file
+	// descriptors or per-client queue memory.
+	maxClients  int
+	clientCount atomic.Int64
+
+	// Origin policy, mirroring Hub. Enforcement is on when authentication is
+	// enabled or APP_ENV=production.
+	enforceOrigin bool
+	originHosts   []string
+
+	writerWg sync.WaitGroup
 
 	// Real-time batching
 	logsCh       chan LogEntry
@@ -203,27 +265,95 @@ func (h *EventHub) BroadcastMetric(m MetricEntry) {
 	}
 }
 
+// SetMaxClients caps simultaneous event-WS connections. 0 disables the cap.
+// Call once at startup, before the hub takes traffic.
+func (h *EventHub) SetMaxClients(n int) {
+	if n < 0 {
+		n = 0
+	}
+	h.maxClients = n
+}
+
+// SetOriginPolicy configures WebSocket origin enforcement — see
+// Hub.SetOriginPolicy. Call once at startup.
+func (h *EventHub) SetOriginPolicy(enforce bool, allowedHosts []string) {
+	h.enforceOrigin = enforce
+	h.originHosts = append([]string(nil), allowedHosts...)
+}
+
+// ActiveClients reports currently-connected event-WS clients.
+func (h *EventHub) ActiveClients() int64 { return h.clientCount.Load() }
+
 // HandleWebSocket upgrades an HTTP request to a WebSocket connection,
 // registers it as an event client, and listens for filter messages.
+//
+// The connection is scoped to exactly one tenant, taken from the principal the
+// handshake gate authenticated. Writes are serialized through one bounded
+// queue and one writer goroutine per client, so a stalled reader can neither
+// block the snapshot loop nor grow without bound.
 func (h *EventHub) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
+	if h.maxClients > 0 {
+		if n := h.clientCount.Add(1); n > int64(h.maxClients) {
+			h.clientCount.Add(-1)
+			slog.Warn("Event WS connection rejected: max-clients cap reached",
+				"max_clients", h.maxClients, "current", n-1)
+			http.Error(w, "WebSocket connections at capacity, retry later", http.StatusServiceUnavailable)
+			return
+		}
+	} else {
+		h.clientCount.Add(1)
+	}
+	counted := true
+	releaseSlot := func() {
+		if counted {
+			counted = false
+			h.clientCount.Add(-1)
+		}
+	}
+
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		InsecureSkipVerify: true,
+		// Origin verification is skipped only while the policy is off, which
+		// is the unauthenticated development default. Production and every
+		// authenticated deployment enforce WS_ALLOWED_ORIGINS (empty list =
+		// same host).
+		InsecureSkipVerify: !h.enforceOrigin,
+		OriginPatterns:     h.originHosts,
+		Subprotocols:       []string{authn.WSSubprotocol},
 	})
 	if err != nil {
+		releaseSlot()
 		slog.Error("Event WS accept failed", "error", err)
 		return
 	}
 
 	// Check for initial service filter from query params
 	initialService := r.URL.Query().Get("service")
-	h.addClient(conn, initialService)
+	cf := h.addClient(conn, initialService, connTenantScope(r))
+
+	h.writerWg.Add(1)
+	go func() { // #nosec G118 -- long-lived WS writer goroutine outlives the HTTP request intentionally
+		defer h.writerWg.Done()
+		defer releaseSlot()
+		for msg := range cf.send {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			err := conn.Write(ctx, websocket.MessageText, msg)
+			cancel()
+			if err != nil {
+				slog.Debug("Event WS send failed", "error", err)
+				h.removeClient(conn)
+				_ = conn.Close(websocket.StatusGoingAway, "write error")
+				return
+			}
+		}
+	}()
 
 	// Send immediate FULL snapshot so the client has data right away. In
 	// aggregate mode it carries {epoch, revision} and reset=true: a fresh
 	// client has nothing to merge into and must adopt the snapshot whole.
-	h.sendSnapshotTo(conn, initialService)
+	h.sendSnapshotTo(cf)
 
-	// Read loop: client can send {"service":"xxx"} to change filter
+	// Read loop: client can send {"service":"xxx"} to change filter. The
+	// tenant scope is not negotiable and is deliberately absent here.
 	for {
 		_, msg, readErr := conn.Read(r.Context())
 		if readErr != nil {
@@ -241,22 +371,48 @@ func (h *EventHub) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 	_ = conn.Close(websocket.StatusNormalClosure, "bye")
 }
 
-func (h *EventHub) addClient(c *websocket.Conn, service string) {
+func (h *EventHub) addClient(c *websocket.Conn, service, tenant string) *clientFilter {
+	cf := &clientFilter{
+		conn:    c,
+		send:    make(chan []byte, eventClientQueue),
+		service: service,
+		tenant:  tenant,
+	}
 	h.mu.Lock()
-	h.clients[c] = &clientFilter{service: service}
+	h.clients[c] = cf
 	h.mu.Unlock()
 	if h.onConn != nil {
 		h.onConn()
 	}
+	return cf
 }
 
 func (h *EventHub) removeClient(c *websocket.Conn) {
 	h.mu.Lock()
+	cf, ok := h.clients[c]
 	delete(h.clients, c)
 	h.mu.Unlock()
+	if !ok {
+		return
+	}
+	// Closing the queue is what stops the writer goroutine; the CAS guard
+	// makes every removal path idempotent.
+	if cf.closed.CompareAndSwap(false, true) {
+		close(cf.send)
+	}
 	if h.onDisc != nil {
 		h.onDisc()
 	}
+}
+
+// deliver enqueues one message, disconnecting a client whose queue is full.
+func (h *EventHub) deliver(cf *clientFilter, msg []byte) {
+	if cf.enqueue(msg) {
+		return
+	}
+	slog.Warn("Event WS client removed: write queue full", "queue", eventClientQueue)
+	h.removeClient(cf.conn)
+	_ = cf.conn.Close(websocket.StatusPolicyViolation, "client too slow")
 }
 
 func (h *EventHub) updateClientFilter(c *websocket.Conn, service string) {
@@ -267,7 +423,10 @@ func (h *EventHub) updateClientFilter(c *websocket.Conn, service string) {
 	h.mu.Unlock()
 }
 
-// flushSnapshots computes per-service snapshots in parallel and pushes to matching clients.
+// flushSnapshots computes per-scope snapshots in parallel and pushes them to
+// matching clients. A scope is (tenant, service filter): two clients on
+// different tenants never share a computed snapshot, so a snapshot cannot
+// carry another tenant's rows.
 func (h *EventHub) flushSnapshots() {
 	h.mu.Lock()
 	if !h.pending {
@@ -280,26 +439,20 @@ func (h *EventHub) flushSnapshots() {
 		h.mu.Unlock()
 		return
 	}
-
-	// Group clients by service filter
-	groups := make(map[string][]*websocket.Conn)
-	for c, cf := range h.clients {
-		groups[cf.service] = append(groups[cf.service], c)
-	}
+	groups := h.groupByScopeLocked()
 	h.mu.Unlock()
 
 	// Compute snapshots in parallel using errgroup
-	g, ctx := errgroup.WithContext(context.Background())
-	snapshotMap := make(map[string]*LiveSnapshot)
+	g, _ := errgroup.WithContext(context.Background())
+	snapshotMap := make(map[scopeKey]*LiveSnapshot)
 	var snapMu sync.Mutex
 
-	for service := range groups {
-		// Capture
+	for scope := range groups {
 		g.Go(func() error {
-			snap := h.snapshotFor(service)
+			snap := h.snapshotFor(scope)
 			if snap != nil {
 				snapMu.Lock()
-				snapshotMap[service] = snap
+				snapshotMap[scope] = snap
 				snapMu.Unlock()
 			}
 			return nil
@@ -311,40 +464,44 @@ func (h *EventHub) flushSnapshots() {
 	}
 
 	// Broadcast memoized snapshots to matching clients
-	for service, clients := range groups {
-		snap, ok := snapshotMap[service]
+	for scope, clients := range groups {
+		snap, ok := snapshotMap[scope]
 		if !ok {
 			continue
 		}
-
 		msg, err := json.Marshal(snap)
 		if err != nil {
 			slog.Error("Event WS marshal failed", "error", err)
 			continue
 		}
-
-		for _, conn := range clients {
-			writeCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-			if err := conn.Write(writeCtx, websocket.MessageText, msg); err != nil {
-				slog.Debug("Event WS send failed, removing client", "error", err)
-				h.removeClient(conn)
-				_ = conn.Close(websocket.StatusGoingAway, "write error")
-			}
-			cancel()
+		for _, cf := range clients {
+			h.deliver(cf, msg)
 		}
 	}
 }
 
-// flushBatches flushes buffered logs and metrics to clients, respecting filters.
+// groupByScopeLocked buckets connected clients by (tenant, service). Callers
+// must hold h.mu.
+func (h *EventHub) groupByScopeLocked() map[scopeKey][]*clientFilter {
+	groups := make(map[scopeKey][]*clientFilter, len(h.clients))
+	for _, cf := range h.clients {
+		k := scopeKey{tenant: cf.tenant, service: cf.service}
+		groups[k] = append(groups[k], cf)
+	}
+	return groups
+}
+
+// flushBatches flushes buffered logs and metrics to clients, respecting each
+// client's tenant scope first and its service filter second.
 func (h *EventHub) flushBatches() {
 	h.mu.Lock()
 	logs := h.logBuffer
 	h.logBuffer = make([]LogEntry, 0, 100)
 	metrics := h.metricBuffer
 	h.metricBuffer = make([]MetricEntry, 0, 100)
-	clients := make(map[*websocket.Conn]*clientFilter)
-	for c, cf := range h.clients {
-		clients[c] = cf
+	clients := make([]*clientFilter, 0, len(h.clients))
+	for _, cf := range h.clients {
+		clients = append(clients, cf)
 	}
 	h.mu.Unlock()
 
@@ -352,11 +509,11 @@ func (h *EventHub) flushBatches() {
 		return
 	}
 
-	for conn, filter := range clients {
+	for _, cf := range clients {
 		// 1. Filter Logs
 		clientLogs := make([]LogEntry, 0)
 		for _, l := range logs {
-			if filter.service == "" || filter.service == l.ServiceName {
+			if cf.matches(l.Tenant, l.ServiceName) {
 				clientLogs = append(clientLogs, l)
 			}
 		}
@@ -364,34 +521,33 @@ func (h *EventHub) flushBatches() {
 		// 2. Filter Metrics
 		clientMetrics := make([]MetricEntry, 0)
 		for _, m := range metrics {
-			if filter.service == "" || filter.service == m.ServiceName {
+			if cf.matches(m.Tenant, m.ServiceName) {
 				clientMetrics = append(clientMetrics, m)
 			}
 		}
 
 		// 3. Send Batches
 		if len(clientLogs) > 0 {
-			h.sendBatch(conn, "logs", clientLogs)
+			h.sendBatch(cf, "logs", clientLogs)
 		}
 		if len(clientMetrics) > 0 {
-			h.sendBatch(conn, "metrics", clientMetrics)
+			h.sendBatch(cf, "metrics", clientMetrics)
 		}
 	}
 }
 
-func (h *EventHub) sendBatch(conn *websocket.Conn, batchType string, data any) {
-	msg, _ := json.Marshal(HubBatch{Type: batchType, Data: data})
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if err := conn.Write(ctx, websocket.MessageText, msg); err != nil {
-		h.removeClient(conn)
-		_ = conn.Close(websocket.StatusGoingAway, "write error")
+func (h *EventHub) sendBatch(cf *clientFilter, batchType string, data any) {
+	msg, err := json.Marshal(HubBatch{Type: batchType, Data: data})
+	if err != nil {
+		slog.Error("Event WS marshal failed", "error", err, "type", batchType)
+		return
 	}
+	h.deliver(cf, msg)
 }
 
 // sendSnapshotTo sends a snapshot to a single client.
-func (h *EventHub) sendSnapshotTo(conn *websocket.Conn, service string) {
-	snapshot := h.snapshotFor(service)
+func (h *EventHub) sendSnapshotTo(cf *clientFilter) {
+	snapshot := h.snapshotFor(scopeKey{tenant: cf.tenant, service: cf.service})
 	if snapshot == nil {
 		return
 	}
@@ -402,18 +558,21 @@ func (h *EventHub) sendSnapshotTo(conn *websocket.Conn, service string) {
 	if err != nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	_ = conn.Write(ctx, websocket.MessageText, msg)
+	h.deliver(cf, msg)
 }
 
-// snapshotFor produces the payload for one service filter from whichever
-// source owns the numbers in this mode.
-func (h *EventHub) snapshotFor(service string) *LiveSnapshot {
-	if pub := h.aggregatePublisher(); pub != nil {
-		return pub.Snapshot(context.Background(), service)
+// snapshotFor produces the payload for one scope from whichever source owns
+// the numbers in this mode. The tenant travels on the context, which is what
+// scopes both the repository queries and the aggregate publisher.
+func (h *EventHub) snapshotFor(scope scopeKey) *LiveSnapshot {
+	ctx := context.Background()
+	if scope.tenant != "" {
+		ctx = storage.WithTenantContext(ctx, scope.tenant)
 	}
-	return h.computeSnapshot(service)
+	if pub := h.aggregatePublisher(); pub != nil {
+		return pub.Snapshot(ctx, scope.service)
+	}
+	return h.computeSnapshot(ctx, scope.service)
 }
 
 // runAggregate is the revision-driven publication loop.
@@ -469,14 +628,11 @@ func (h *EventHub) publishIfChanged() {
 		h.mu.Unlock()
 		return
 	}
-	groups := make(map[string][]*websocket.Conn)
-	for c, cf := range h.clients {
-		groups[cf.service] = append(groups[cf.service], c)
-	}
+	groups := h.groupByScopeLocked()
 	h.mu.Unlock()
 
-	for service, clients := range groups {
-		snap := pub.Snapshot(context.Background(), service)
+	for scope, clients := range groups {
+		snap := h.snapshotFor(scope)
 		if snap == nil {
 			continue
 		}
@@ -486,21 +642,21 @@ func (h *EventHub) publishIfChanged() {
 			slog.Error("Event WS marshal failed", "error", err)
 			continue
 		}
-		for _, conn := range clients {
-			writeCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-			if err := conn.Write(writeCtx, websocket.MessageText, msg); err != nil {
-				slog.Debug("Event WS send failed, removing client", "error", err)
-				h.removeClient(conn)
-				_ = conn.Close(websocket.StatusGoingAway, "write error")
-			}
-			cancel()
+		for _, cf := range clients {
+			h.deliver(cf, msg)
 		}
 	}
 }
 
 // computeSnapshot queries the DB for the last 15 minutes of data,
 // optionally filtered by a single service name.
-func (h *EventHub) computeSnapshot(service string) *LiveSnapshot {
+func (h *EventHub) computeSnapshot(ctx context.Context, service string) *LiveSnapshot {
+	if h.repo == nil {
+		// No relational source wired (aggregate-only wiring, or a socket-layer
+		// test): there is nothing to snapshot, and every query below would
+		// dereference a nil repository.
+		return nil
+	}
 	now := time.Now()
 	start := now.Add(-15 * time.Minute)
 
@@ -510,11 +666,6 @@ func (h *EventHub) computeSnapshot(service string) *LiveSnapshot {
 	}
 
 	snapshot := &LiveSnapshot{Type: "live_snapshot"}
-
-	// WebSocket snapshots are not tenant-scoped in the current protocol;
-	// use the default-tenant context so repo query helpers behave the same as
-	// a single-tenant install.
-	ctx := context.Background()
 
 	if stats, err := h.repo.GetDashboardStats(ctx, start, now, serviceNames); err == nil {
 		snapshot.Dashboard = stats
@@ -538,5 +689,16 @@ func (h *EventHub) computeSnapshot(service string) *LiveSnapshot {
 func (h *EventHub) Stop() {
 	h.stopOnce.Do(func() {
 		close(h.stopCh)
+		// Close every client queue so the writer goroutines exit; without
+		// this an idle client keeps one goroutine parked on its channel.
+		h.mu.Lock()
+		for c, cf := range h.clients {
+			delete(h.clients, c)
+			if cf.closed.CompareAndSwap(false, true) {
+				close(cf.send)
+			}
+		}
+		h.mu.Unlock()
+		h.writerWg.Wait()
 	})
 }

--- a/internal/realtime/hub.go
+++ b/internal/realtime/hub.go
@@ -9,11 +9,18 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"github.com/coder/websocket"
 )
 
 // LogEntry is a lightweight struct for WebSocket broadcast payloads.
+//
+// Tenant is transport-only: it decides which sockets may see the entry and is
+// never serialized, so the wire payload is unchanged from before per-tenant
+// scoping existed.
 type LogEntry struct {
+	Tenant         string    `json:"-"`
 	ID             uint      `json:"id"`
 	TraceID        string    `json:"trace_id"`
 	SpanID         string    `json:"span_id"`
@@ -26,13 +33,25 @@ type LogEntry struct {
 }
 
 // MetricEntry represents a raw metric point for real-time visualization.
+// Tenant is transport-only — see LogEntry.
 type MetricEntry struct {
+	Tenant      string         `json:"-"`
 	Name        string         `json:"name"`
 	ServiceName string         `json:"service_name"`
 	Value       float64        `json:"value"`
 	Timestamp   time.Time      `json:"timestamp"`
 	Attributes  map[string]any `json:"attributes"`
 }
+
+// tenantTagged is implemented by every entry type that can be delivered to a
+// tenant-scoped socket. It exists so log and metric fan-out share one
+// filtering implementation instead of two that can drift apart.
+type tenantTagged interface {
+	tenantID() string
+}
+
+func (l LogEntry) tenantID() string    { return l.Tenant }
+func (m MetricEntry) tenantID() string { return m.Tenant }
 
 // HubBatch is a unified payload for WebSocket broadcasts.
 type HubBatch struct {
@@ -78,6 +97,12 @@ type Hub struct {
 	writerWg sync.WaitGroup // tracks writer goroutines
 	devMode  bool
 
+	// enforceOrigin and originHosts implement WS_ALLOWED_ORIGINS. Enforcement
+	// is on whenever authentication is enabled or APP_ENV=production; the
+	// empty host list then means same-host only.
+	enforceOrigin bool
+	originHosts   []string
+
 	// onConnectionChange is called when the number of active connections changes.
 	onConnectionChange func(count int)
 
@@ -91,8 +116,13 @@ type Hub struct {
 
 // client represents a single WebSocket connection.
 type client struct {
-	conn   *websocket.Conn
-	send   chan []byte
+	conn *websocket.Conn
+	send chan []byte
+	// tenant is the single tenant this socket is scoped to, resolved from the
+	// authenticated principal at handshake time. Empty means unscoped, which
+	// only happens when authentication is not configured (development) — a
+	// scoped socket never receives another tenant's entries.
+	tenant string
 	closed atomic.Bool // guards against double-close of send channel
 }
 
@@ -210,7 +240,7 @@ func (h *Hub) flush() {
 
 	// Broadcast Logs if any
 	if len(logBatch) > 0 {
-		h.broadcastBatch(HubBatch{Type: "logs", Data: logBatch})
+		broadcastTagged(h, "logs", logBatch)
 		// Recycle logBatch
 		logBatch = logBatch[:0]
 		h.logPool.Put(logBatch) //nolint:staticcheck // SA6002: []T pool; pointer wrap would require broader refactor
@@ -218,25 +248,35 @@ func (h *Hub) flush() {
 
 	// Broadcast Metrics if any
 	if len(metricBatch) > 0 {
-		h.broadcastBatch(HubBatch{Type: "metrics", Data: metricBatch})
+		broadcastTagged(h, "metrics", metricBatch)
 		// Recycle metricBatch
 		metricBatch = metricBatch[:0]
 		h.metricPool.Put(metricBatch) //nolint:staticcheck // SA6002: []T pool; pointer wrap would require broader refactor
 	}
 }
 
-func (h *Hub) broadcastBatch(batch HubBatch) {
-	data, err := json.Marshal(batch)
-	if err != nil {
-		slog.Error("Hub: failed to marshal batch", "error", err, "type", batch.Type)
-		return
-	}
-
+// broadcastTagged fans a batch out to every connected client, filtered by the
+// client's tenant scope. One marshal per distinct scope, not per client: the
+// unscoped payload is built once and each tenant's filtered payload at most
+// once, so a hundred dashboards on one tenant still cost one encode.
+//
+// A client with an empty scope (authentication not configured) keeps the
+// pre-existing behaviour of receiving the whole batch.
+func broadcastTagged[T tenantTagged](h *Hub, batchType string, entries []T) {
+	cache := make(map[string][]byte, 4)
 	sent := 0
 	var slow []*client
 	for c := range h.clients {
+		msg, cached := cache[c.tenant]
+		if !cached {
+			msg = encodeForScope(batchType, c.tenant, entries)
+			cache[c.tenant] = msg
+		}
+		if msg == nil {
+			continue // nothing in this batch belongs to the client's tenant
+		}
 		select {
-		case c.send <- data:
+		case c.send <- msg:
 			sent++
 		default:
 			slow = append(slow, c)
@@ -256,14 +296,47 @@ func (h *Hub) broadcastBatch(batch HubBatch) {
 		}
 	}
 	if sent > 0 && h.onMessageSent != nil {
-		h.onMessageSent(batch.Type)
+		h.onMessageSent(batchType)
 	}
+}
+
+// encodeForScope marshals the batch a single tenant scope may see. It returns
+// nil when the scope has nothing to receive — entries carrying no tenant are
+// invisible to a scoped socket (fail closed).
+func encodeForScope[T tenantTagged](batchType, tenant string, entries []T) []byte {
+	payload := entries
+	if tenant != "" {
+		filtered := make([]T, 0, len(entries))
+		for _, e := range entries {
+			if e.tenantID() == tenant {
+				filtered = append(filtered, e)
+			}
+		}
+		if len(filtered) == 0 {
+			return nil
+		}
+		payload = filtered
+	}
+	data, err := json.Marshal(HubBatch{Type: batchType, Data: payload})
+	if err != nil {
+		slog.Error("Hub: failed to marshal batch", "error", err, "type", batchType)
+		return nil
+	}
+	return data
 }
 
 // SetDevMode controls whether cross-origin WebSocket connections are accepted.
 // Should be true only in development environments.
 func (h *Hub) SetDevMode(devMode bool) {
 	h.devMode = devMode
+}
+
+// SetOriginPolicy configures WebSocket origin enforcement. When enforce is
+// true the browser Origin header must match one of allowedHosts, or the
+// request host when the list is empty. Call once at startup.
+func (h *Hub) SetOriginPolicy(enforce bool, allowedHosts []string) {
+	h.enforceOrigin = enforce
+	h.originHosts = append([]string(nil), allowedHosts...)
 }
 
 // SetMaxClients caps simultaneous WebSocket connections. 0 disables the cap
@@ -354,7 +427,14 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		InsecureSkipVerify: h.devMode, // Allow cross-origin in dev mode only
+		// Cross-origin is allowed in dev mode only, and never once the origin
+		// policy is enforced (authenticated or production deployments).
+		InsecureSkipVerify: h.devMode && !h.enforceOrigin,
+		OriginPatterns:     h.originHosts,
+		// Echo ONLY otelcontext.v1. A browser carrying a credential offers
+		// `otelcontext.v1, auth.<base64url>`; selecting the first entry keeps
+		// the token out of the negotiated protocol and out of every log line.
+		Subprotocols: []string{authn.WSSubprotocol},
 	})
 	if err != nil {
 		releaseSlot()
@@ -363,8 +443,9 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	c := &client{
-		conn: conn,
-		send: make(chan []byte, 256),
+		conn:   conn,
+		send:   make(chan []byte, 256),
+		tenant: connTenantScope(r),
 	}
 
 	h.register <- c
@@ -414,4 +495,14 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 	if c.closed.CompareAndSwap(false, true) {
 		close(c.send)
 	}
+}
+
+// connTenantScope reads the tenant the handshake gate pinned onto the request
+// context. Empty means the socket is unscoped, which happens only when
+// authentication is not configured — the gate always pins exactly one tenant.
+func connTenantScope(r *http.Request) string {
+	if r == nil || !storage.HasTenantContext(r.Context()) {
+		return ""
+	}
+	return storage.TenantFromContext(r.Context())
 }

--- a/internal/realtime/ws_tenant_test.go
+++ b/internal/realtime/ws_tenant_test.go
@@ -1,0 +1,320 @@
+package realtime_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/api"
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
+	"github.com/RandomCodeSpace/otelcontext/internal/realtime"
+	"github.com/coder/websocket"
+)
+
+// The tests live in package realtime_test because they compose the WebSocket
+// handshake gate (internal/api) with the hubs, and internal/api already
+// imports internal/realtime.
+
+func keyAuth(t *testing.T, entries map[string]string) *authn.Authenticator {
+	t.Helper()
+	store, err := authn.NewKeyStoreFromMap(entries)
+	if err != nil {
+		t.Fatalf("NewKeyStoreFromMap: %v", err)
+	}
+	return authn.NewAuthenticator("operator-key", store, false)
+}
+
+// gatedServer serves one WebSocket handler behind the handshake gate.
+func gatedServer(t *testing.T, opts api.WSGateOptions, h http.HandlerFunc) string {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.Handle("/ws/events", h)
+	srv := httptest.NewServer(api.WebSocketGate(opts, mux))
+	t.Cleanup(srv.Close)
+	return "ws" + srv.URL[len("http"):] + "/ws/events"
+}
+
+// dialKey opens a socket authenticated with a bearer key. It returns the
+// handshake status code rather than the response so the body is closed exactly
+// once, here.
+func dialKey(t *testing.T, url, key string) (*websocket.Conn, int, error) {
+	t.Helper()
+	hdr := http.Header{}
+	if key != "" {
+		hdr.Set("Authorization", "Bearer "+key)
+	}
+	return dialWith(t, url, hdr)
+}
+
+// dialWith dials with arbitrary handshake headers.
+func dialWith(t *testing.T, url string, hdr http.Header) (*websocket.Conn, int, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, resp, err := websocket.Dial(ctx, url, &websocket.DialOptions{
+		HTTPHeader:   hdr,
+		Subprotocols: hdrSubprotocols(hdr),
+	})
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode
+		if resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+	}
+	if err == nil {
+		t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "test") })
+	}
+	return conn, status, err
+}
+
+// hdrSubprotocols lets a caller pass subprotocols through the same helper.
+func hdrSubprotocols(hdr http.Header) []string {
+	if v := hdr.Values("X-Test-Subprotocols"); len(v) > 0 {
+		hdr.Del("X-Test-Subprotocols")
+		return v
+	}
+	return nil
+}
+
+// readBatch waits for one hub batch and decodes the log bodies it carries.
+func readBatch(t *testing.T, conn *websocket.Conn, within time.Duration) (string, []string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), within)
+	defer cancel()
+	_, msg, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var batch struct {
+		Type string `json:"type"`
+		Data []struct {
+			Body   string `json:"body"`
+			Tenant string `json:"tenant"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(msg, &batch); err != nil {
+		t.Fatalf("decode batch: %v (%s)", err, msg)
+	}
+	bodies := make([]string, 0, len(batch.Data))
+	for _, d := range batch.Data {
+		if d.Tenant != "" {
+			t.Errorf("tenant leaked into the wire payload: %s", msg)
+		}
+		bodies = append(bodies, d.Body)
+	}
+	return batch.Type, bodies
+}
+
+// TestHub_CrossTenantIsolation is the #194 blocker-7 acceptance test: a
+// tenant-A key can never receive tenant-B events.
+func TestHub_CrossTenantIsolation(t *testing.T) {
+	hub := realtime.NewHub(nil)
+	go hub.Run()
+	t.Cleanup(hub.Stop)
+
+	auth := keyAuth(t, map[string]string{"acme-key": "acme", "beta-key": "beta"})
+	url := gatedServer(t, api.WSGateOptions{Auth: auth, DefaultTenant: "default"}, hub.HandleWebSocket)
+
+	acme, _, err := dialKey(t, url, "acme-key")
+	if err != nil {
+		t.Fatalf("acme dial: %v", err)
+	}
+	beta, _, err := dialKey(t, url, "beta-key")
+	if err != nil {
+		t.Fatalf("beta dial: %v", err)
+	}
+	// Let both registrations land before broadcasting.
+	waitFor(t, func() bool { return hub.ActiveClients() == 2 })
+
+	hub.Broadcast(realtime.LogEntry{Tenant: "acme", Body: "acme-only", ServiceName: "svc"})
+	hub.Broadcast(realtime.LogEntry{Tenant: "beta", Body: "beta-only", ServiceName: "svc"})
+
+	typ, bodies := readBatch(t, acme, 3*time.Second)
+	if typ != "logs" || len(bodies) != 1 || bodies[0] != "acme-only" {
+		t.Fatalf("acme socket received %v (type %q), want [acme-only]", bodies, typ)
+	}
+	_, bodies = readBatch(t, beta, 3*time.Second)
+	if len(bodies) != 1 || bodies[0] != "beta-only" {
+		t.Fatalf("beta socket received %v, want [beta-only]", bodies)
+	}
+}
+
+// An entry with no tenant is invisible to a scoped socket: fail closed.
+func TestHub_UntaggedEntryNeverReachesScopedSocket(t *testing.T) {
+	hub := realtime.NewHub(nil)
+	go hub.Run()
+	t.Cleanup(hub.Stop)
+
+	auth := keyAuth(t, map[string]string{"acme-key": "acme"})
+	url := gatedServer(t, api.WSGateOptions{Auth: auth, DefaultTenant: "default"}, hub.HandleWebSocket)
+	acme, _, err := dialKey(t, url, "acme-key")
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	waitFor(t, func() bool { return hub.ActiveClients() == 1 })
+
+	hub.Broadcast(realtime.LogEntry{Body: "untagged", ServiceName: "svc"})
+	hub.Broadcast(realtime.LogEntry{Tenant: "acme", Body: "tagged", ServiceName: "svc"})
+
+	_, bodies := readBatch(t, acme, 3*time.Second)
+	for _, b := range bodies {
+		if b == "untagged" {
+			t.Fatalf("untagged entry reached a scoped socket: %v", bodies)
+		}
+	}
+}
+
+// The handshake is refused outright once authentication is configured.
+func TestHub_UnauthenticatedHandshakeRefused(t *testing.T) {
+	// The hub loop is deliberately NOT started: no handshake gets far enough
+	// to register a client, and starting it would race Run's WaitGroup.Add
+	// against Stop's Wait for no benefit.
+	hub := realtime.NewHub(nil)
+
+	auth := keyAuth(t, map[string]string{"acme-key": "acme"})
+	url := gatedServer(t, api.WSGateOptions{Auth: auth, DefaultTenant: "default"}, hub.HandleWebSocket)
+
+	if _, status, err := dialKey(t, url, ""); err == nil {
+		t.Fatal("unauthenticated handshake succeeded")
+	} else if status != http.StatusUnauthorized {
+		t.Fatalf("want 401, got status=%d err=%v", status, err)
+	}
+	if _, status, err := dialKey(t, url, "wrong-key"); err == nil {
+		t.Fatal("bad-key handshake succeeded")
+	} else if status != http.StatusUnauthorized {
+		t.Fatalf("want 401, got status=%d err=%v", status, err)
+	}
+	if hub.ActiveClients() != 0 {
+		t.Fatalf("refused handshakes still occupy %d admission slots", hub.ActiveClients())
+	}
+}
+
+// Production origin policy: a cross-origin browser handshake is refused.
+func TestHub_OriginViolationRefusedInProduction(t *testing.T) {
+	hub := realtime.NewHub(nil) // no client ever registers — see the test above
+
+	auth := keyAuth(t, map[string]string{"acme-key": "acme"})
+	url := gatedServer(t, api.WSGateOptions{
+		Auth: auth, DefaultTenant: "default",
+		AllowedOrigins: []string{"https://app.example.com"}, EnforceOrigin: true,
+	}, hub.HandleWebSocket)
+
+	hdr := http.Header{}
+	hdr.Set("Authorization", "Bearer acme-key")
+	hdr.Set("Origin", "https://evil.example.com")
+	conn, status, err := dialWith(t, url, hdr)
+	if err == nil {
+		_ = conn.Close(websocket.StatusNormalClosure, "test")
+		t.Fatal("cross-origin handshake succeeded")
+	}
+	if status != http.StatusForbidden {
+		t.Fatalf("want 403, got status=%d err=%v", status, err)
+	}
+}
+
+// The browser carrier: the credential travels as a subprotocol entry and the
+// server echoes ONLY otelcontext.v1 — never the token-bearing entry.
+func TestHub_SubprotocolEchoesOnlyOtelcontextV1(t *testing.T) {
+	hub := realtime.NewHub(nil)
+	go hub.Run()
+	t.Cleanup(hub.Stop)
+
+	auth := keyAuth(t, map[string]string{"acme-key": "acme"})
+	url := gatedServer(t, api.WSGateOptions{Auth: auth, DefaultTenant: "default"}, hub.HandleWebSocket)
+
+	authEntry := "auth." + base64.RawURLEncoding.EncodeToString([]byte("acme-key"))
+	hdr := http.Header{}
+	hdr.Add("X-Test-Subprotocols", authn.WSSubprotocol)
+	hdr.Add("X-Test-Subprotocols", authEntry)
+	conn, _, err := dialWith(t, url, hdr)
+	if err != nil {
+		t.Fatalf("subprotocol dial: %v", err)
+	}
+
+	if got := conn.Subprotocol(); got != authn.WSSubprotocol {
+		t.Fatalf("negotiated subprotocol = %q, want %q", got, authn.WSSubprotocol)
+	}
+	waitFor(t, func() bool { return hub.ActiveClients() == 1 })
+	hub.Broadcast(realtime.LogEntry{Tenant: "acme", Body: "scoped", ServiceName: "svc"})
+	hub.Broadcast(realtime.LogEntry{Tenant: "beta", Body: "other", ServiceName: "svc"})
+	_, bodies := readBatch(t, conn, 3*time.Second)
+	if len(bodies) != 1 || bodies[0] != "scoped" {
+		t.Fatalf("subprotocol-authenticated socket received %v, want [scoped]", bodies)
+	}
+}
+
+// EventHub carries the same guarantee on the snapshot/batch stream.
+func TestEventHub_CrossTenantIsolation(t *testing.T) {
+	hub := realtime.NewEventHub(nil, nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	go hub.Start(ctx, time.Hour, 25*time.Millisecond)
+	t.Cleanup(func() { cancel(); hub.Stop() })
+
+	auth := keyAuth(t, map[string]string{"acme-key": "acme", "beta-key": "beta"})
+	url := gatedServer(t, api.WSGateOptions{Auth: auth, DefaultTenant: "default"}, hub.HandleWebSocket)
+
+	acme, _, err := dialKey(t, url, "acme-key")
+	if err != nil {
+		t.Fatalf("acme dial: %v", err)
+	}
+	beta, _, err := dialKey(t, url, "beta-key")
+	if err != nil {
+		t.Fatalf("beta dial: %v", err)
+	}
+	waitFor(t, func() bool { return hub.ActiveClients() == 2 })
+
+	hub.BroadcastLog(realtime.LogEntry{Tenant: "acme", Body: "acme-only", ServiceName: "svc"})
+	hub.BroadcastLog(realtime.LogEntry{Tenant: "beta", Body: "beta-only", ServiceName: "svc"})
+
+	_, bodies := readBatch(t, acme, 3*time.Second)
+	if len(bodies) != 1 || bodies[0] != "acme-only" {
+		t.Fatalf("acme socket received %v, want [acme-only]", bodies)
+	}
+	_, bodies = readBatch(t, beta, 3*time.Second)
+	if len(bodies) != 1 || bodies[0] != "beta-only" {
+		t.Fatalf("beta socket received %v, want [beta-only]", bodies)
+	}
+}
+
+// EventHub gained the admission cap the realtime Hub already had.
+func TestEventHub_MaxClientsCap(t *testing.T) {
+	hub := realtime.NewEventHub(nil, nil, nil)
+	hub.SetMaxClients(1)
+	ctx, cancel := context.WithCancel(context.Background())
+	go hub.Start(ctx, time.Hour, time.Hour)
+	t.Cleanup(func() { cancel(); hub.Stop() })
+
+	url := gatedServer(t, api.WSGateOptions{Auth: authn.NewAuthenticator("", nil, false)}, hub.HandleWebSocket)
+
+	if _, _, err := dialKey(t, url, ""); err != nil {
+		t.Fatalf("first dial: %v", err)
+	}
+	waitFor(t, func() bool { return hub.ActiveClients() == 1 })
+
+	_, status, err := dialKey(t, url, "")
+	if err == nil {
+		t.Fatal("second dial succeeded past the cap")
+	}
+	if status != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got status=%d err=%v", status, err)
+	}
+}
+
+// waitFor polls a condition for up to 3s; test helpers elsewhere in this
+// package use the same shape.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met within 3s")
+}

--- a/internal/telemetry/authn_metrics.go
+++ b/internal/telemetry/authn_metrics.go
@@ -1,0 +1,49 @@
+package telemetry
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// AuthnMetrics covers the authenticated-tenant-identity surfaces (HTTP,
+// WebSocket, gRPC). It lives apart from Metrics because it is wired from
+// package-level hooks in authn/api/ingest rather than passed down the call
+// graph, and because a duplicate registration must be impossible even when a
+// test constructs the platform twice.
+type AuthnMetrics struct {
+	// TenantConflictsTotal counts client-asserted tenants that an
+	// authenticated binding overrode. Labels: surface (http|ws|grpc), reason
+	// (header|query|metadata|resource_attribute). A non-zero rate means a
+	// client is sending a tenant it is not entitled to — misconfiguration at
+	// best, a probe at worst.
+	TenantConflictsTotal *prometheus.CounterVec
+
+	// GRPCAuthFailuresTotal counts rejected gRPC calls by reason
+	// (missing_header|bad_scheme|bad_key).
+	GRPCAuthFailuresTotal *prometheus.CounterVec
+}
+
+var (
+	authnMetricsOnce sync.Once
+	authnMetrics     *AuthnMetrics
+)
+
+// NewAuthnMetrics returns the process-wide authn metric set, registering the
+// collectors on first call.
+func NewAuthnMetrics() *AuthnMetrics {
+	authnMetricsOnce.Do(func() {
+		authnMetrics = &AuthnMetrics{
+			TenantConflictsTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "OtelContext_auth_tenant_conflicts_total",
+				Help: "Client-asserted tenants ignored because an authenticated key binds the request, by surface (http|ws|grpc) and carrier (header|query|metadata|resource_attribute).",
+			}, []string{"surface", "reason"}),
+			GRPCAuthFailuresTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "OtelContext_grpc_auth_failures_total",
+				Help: "gRPC authentication failures by reason (missing_header|bad_scheme|bad_key).",
+			}, []string{"reason"}),
+		}
+	})
+	return authnMetrics
+}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/ai"
 	"github.com/RandomCodeSpace/otelcontext/internal/api"
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
 	"github.com/RandomCodeSpace/otelcontext/internal/config"
 	"github.com/RandomCodeSpace/otelcontext/internal/graph"
 	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
@@ -151,6 +152,18 @@ func main() {
 	cfg.GuardSelfInstrumentation()
 	if err := cfg.ValidateDBForEnv(); err != nil {
 		fatal("DB/Env validation", err)
+	}
+	// Authenticated tenant identity (#194 blockers 7 + 8). Loaded once, at
+	// startup: swapping the key file is an explicit restart, never a live
+	// reload, and the process keeps only SHA-256 digests of the keys.
+	tenantKeys, err := authn.LoadKeyStore(cfg.APITenantKeysFile)
+	if err != nil {
+		fatal("load tenant keys file", err, "path", cfg.APITenantKeysFile)
+	}
+	authenticator := authn.NewAuthenticator(cfg.APIKey, tenantKeys, cfg.AuthTrustExternal)
+	authnMetrics := telemetry.NewAuthnMetrics()
+	authn.ConflictHook = func(surface, reason string) {
+		authnMetrics.TenantConflictsTotal.WithLabelValues(surface, reason).Inc()
 	}
 	if strings.EqualFold(cfg.DBDriver, "sqlite") {
 		slog.Warn("SQLite driver in use. Auto-tuned defaults survive ~50-120 services " +
@@ -331,6 +344,7 @@ func main() {
 	})
 	hub.SetDevMode(cfg.DevMode)
 	hub.SetMaxClients(cfg.WSMaxClients)
+	hub.SetOriginPolicy(cfg.EnforceWSOrigin(), api.WSAllowedOriginHosts(cfg.WSAllowedOrigins))
 	hub.SetWSMetrics(
 		func(msgType string) { metrics.WSMessagesSent.WithLabelValues(msgType).Inc() },
 		func() { metrics.WSSlowClientsRemoved.Inc() },
@@ -344,6 +358,8 @@ func main() {
 		metrics.IncrementActiveConns,
 		metrics.DecrementActiveConns,
 	)
+	eventHub.SetMaxClients(cfg.WSMaxClients)
+	eventHub.SetOriginPolicy(cfg.EnforceWSOrigin(), api.WSAllowedOriginHosts(cfg.WSAllowedOrigins))
 	// The hub is STARTED further down, after the aggregate engine exists: in
 	// AGGREGATE_MODE=aggregate its publication loop is revision-driven and
 	// needs the publisher wired before the first tick.
@@ -781,6 +797,7 @@ func main() {
 	logHandler := func(l storage.Log) {
 		start := time.Now()
 		eventHub.BroadcastLog(realtime.LogEntry{
+			Tenant:         l.TenantID,
 			ID:             l.ID,
 			TraceID:        l.TraceID,
 			SpanID:         l.SpanID,
@@ -824,6 +841,7 @@ func main() {
 
 	metricsServer.SetMetricCallback(func(m tsdb.RawMetric) {
 		eventHub.BroadcastMetric(realtime.MetricEntry{
+			Tenant:      m.TenantID,
 			Name:        m.Name,
 			ServiceName: m.ServiceName,
 			Value:       m.Value,
@@ -912,6 +930,28 @@ func main() {
 			metricsUnaryInterceptor(metrics),
 		),
 	}
+	// OTLP gRPC authentication. Installed only when a credential source is
+	// configured, so an unauthenticated development deployment is untouched.
+	// Auth runs AFTER the metrics interceptor so rejected calls still show up
+	// in the request counters.
+	if authUnary, authStream := ingest.NewGRPCAuthInterceptors(ingest.GRPCAuthOptions{
+		Auth:                      authenticator,
+		ExternalTenantMetadataKey: cfg.AuthExternalTenantHeader,
+		OnAuthFailure: func(reason string) {
+			authnMetrics.GRPCAuthFailuresTotal.WithLabelValues(reason).Inc()
+		},
+	}); authUnary != nil {
+		grpcOpts = append(grpcOpts,
+			grpc.ChainUnaryInterceptor(authUnary),
+			grpc.ChainStreamInterceptor(authStream),
+		)
+		slog.Info("🔑 gRPC OTLP authentication enabled",
+			"tenant_keys", authenticator.TenantKeyCount(),
+			"operator_key", cfg.APIKey != "",
+			"trust_external", cfg.AuthTrustExternal)
+	} else {
+		slog.Warn("🔓 gRPC OTLP unauthenticated — tenant identity is client-controlled; set API_KEY or API_TENANT_KEYS_FILE")
+	}
 	slog.Info("📡 gRPC server tuned",
 		"max_recv_mb", recvBytes,
 		"max_concurrent_streams", streams,
@@ -938,7 +978,14 @@ func main() {
 	coltracepb.RegisterTraceServiceServer(grpcServer, traceServer)
 	collogspb.RegisterLogsServiceServer(grpcServer, logsServer)
 	colmetricspb.RegisterMetricsServiceServer(grpcServer, metricsServer)
-	reflection.Register(grpcServer)
+	// Reflection enumerates every service and message type to an
+	// unauthenticated peer, so production defaults to off. GRPC_REFLECTION=true
+	// re-enables it explicitly.
+	if cfg.GRPCReflectionEnabled() {
+		reflection.Register(grpcServer)
+	} else {
+		slog.Info("🔒 gRPC reflection disabled (APP_ENV=production) — set GRPC_REFLECTION=true to re-enable")
+	}
 
 	go func() {
 		slog.Info("📡 gRPC OTLP receiver started", "port", cfg.GRPCPort)
@@ -999,23 +1046,39 @@ func main() {
 		metrics.APIAuthFailuresTotal.WithLabelValues(reason).Inc()
 	}
 
-	// Authentication. Per-tenant keys (if configured) take precedence over the
-	// shared API key — they enforce tenant boundaries at the auth layer rather
-	// than trusting a client-supplied X-Tenant-ID header.
+	// Authentication (HTTP + WebSocket). One authenticator serves every
+	// surface: the operator key authenticates, a tenant key authenticates AND
+	// binds the tenant, and a proxy-injected identity binds it too when the
+	// operator has accepted the AUTH_TRUST_EXTERNAL deployment contract.
+	httpHandler = api.WebSocketGate(api.WSGateOptions{
+		Auth:                 authenticator,
+		DefaultTenant:        cfg.DefaultTenant,
+		AllowedOrigins:       cfg.WSAllowedOrigins,
+		EnforceOrigin:        cfg.EnforceWSOrigin(),
+		ExternalTenantHeader: cfg.AuthExternalTenantHeader,
+	}, httpHandler)
+	httpHandler = api.AuthGate(api.AuthGateOptions{
+		Auth:                 authenticator,
+		MCPPath:              cfg.MCPPath,
+		ExternalTenantHeader: cfg.AuthExternalTenantHeader,
+	}, httpHandler)
 	switch {
-	case cfg.APITenantKeysFile != "":
-		entries, err := api.LoadTenantKeys(cfg.APITenantKeysFile)
-		if err != nil {
-			fatal("load tenant keys file", err, "path", cfg.APITenantKeysFile)
-		}
-		tka := api.NewTenantKeyAuth(entries)
-		httpHandler = tka.Middleware(cfg.MCPPath, httpHandler)
-		slog.Info("🔑 Per-tenant API key authentication enabled", "tenants", len(entries))
+	case authenticator.HasTenantKeys():
+		slog.Info("🔑 Per-tenant bearer authentication enabled",
+			"keys", authenticator.TenantKeyCount(),
+			"tenants", len(authenticator.Tenants()),
+			"operator_key", cfg.APIKey != "")
 	case cfg.APIKey != "":
-		httpHandler = api.APIKeyGate(cfg.APIKey, cfg.MCPPath, httpHandler)
 		slog.Info("🔑 API key authentication enabled (shared key)")
+	case cfg.AuthTrustExternal:
+		slog.Warn("🔑 Authentication delegated to the front proxy (AUTH_TRUST_EXTERNAL=true) — the deployment contract in CLAUDE.md is mandatory",
+			"identity_header", cfg.AuthExternalTenantHeader)
 	default:
 		slog.Warn("API authentication disabled — set API_KEY or API_TENANT_KEYS_FILE for production")
+	}
+	if cfg.EnforceWSOrigin() {
+		slog.Info("🔒 WebSocket origin policy enforced",
+			"allowed_origins", cfg.WSAllowedOrigins, "same_host_only", len(cfg.WSAllowedOrigins) == 0)
 	}
 
 	httpHandler = api.MetricsMiddleware(metrics, httpHandler)


### PR DESCRIPTION
Part of #194 (blockers 7, 8) — implements the #198 frozen contract; map #195