### PR TITLE
fix(ingest): Stats().Processed was a pickup tally, not a completion barrier

### DIFF
--- a/internal/ingest/pipeline.go
+++ b/internal/ingest/pipeline.go
@@ -550,6 +550,13 @@ func (p *Pipeline) Stop() {
 // Stats returns snapshot counters for tests and for telemetry that
 // doesn't already use Prometheus instruments. The values are best-effort
 // and not synchronized across atomics — sufficient for diagnostics.
+//
+// Processed is the one exception and is load-bearing: it is incremented in
+// process()'s outermost defer, so observing Processed >= N guarantees that
+// N batches finished completely — writes attempted, callbacks fired, tenant
+// slots and byte reservations released. That makes it the correct barrier
+// for a caller (a test, a drain check) that wants to read state process()
+// produced. Every other counter is a plain progress tally.
 func (p *Pipeline) Stats() PipelineStats {
 	return PipelineStats{
 		Enqueued:        p.enqueuedTotal.Load(),
@@ -571,7 +578,7 @@ func (p *Pipeline) Stats() PipelineStats {
 // PipelineStats is a snapshot of pipeline counters.
 type PipelineStats struct {
 	Enqueued        int64
-	Processed       int64
+	Processed       int64 // batches whose process() ran to completion (see Stats)
 	DroppedHealthy  int64
 	RejectedFull    int64
 	RejectedBytes   int64 // batches rejected because the byte cap was exceeded
@@ -646,6 +653,14 @@ func (p *Pipeline) process(b *Batch) {
 	if b == nil {
 		return
 	}
+	// processedTotal is the pipeline's completion barrier and must therefore
+	// be the LAST thing process() touches — hence registered as the FIRST
+	// defer (defers run LIFO). By the time it increments, the batch's write
+	// has committed or failed, the callbacks have run, the per-tenant slot is
+	// released and the byte reservation is returned. It used to be a plain
+	// increment at the top of the function, which made Stats().Processed mean
+	// "a worker picked this batch up" — a barrier for nothing.
+	defer p.processedTotal.Add(1)
 	// Release the byte reservation taken at Submit time. Unconditional —
 	// every batch that reached the channel reserved sizeBytes, priority or
 	// not — and deferred so the panic path below releases too. Mirrors the
@@ -674,7 +689,6 @@ func (p *Pipeline) process(b *Batch) {
 			}
 		}
 	}()
-	p.processedTotal.Add(1)
 
 	if len(b.Traces) == 0 && len(b.Spans) == 0 && len(b.Logs) == 0 {
 		return

--- a/internal/ingest/pipeline_test.go
+++ b/internal/ingest/pipeline_test.go
@@ -497,17 +497,21 @@ func TestPipeline_PerTenantCap_ReleasedAfterProcess(t *testing.T) {
 	if _, err := p.Submit(mk()); err != nil {
 		t.Fatalf("submit 1: %v", err)
 	}
-	// Wait for the worker to drain it (and release the slot). The test
-	// passes locally in milliseconds; 30s is for the race detector on
-	// starved shared CI runners, where 5s was observed to expire.
-	if !waitFor(t, 30*time.Second, func() bool { return p.Stats().Processed == 1 }) {
+	// Wait for the worker to finish the batch. Processed is incremented in
+	// process()'s outermost defer, so Processed == 1 happens-after the
+	// per-tenant slot release — which is exactly the postcondition the next
+	// submit depends on. The 30s deadline this wait carried was a symptom
+	// fix: while Processed meant "picked up", the second Submit could land
+	// before the slot was released, get silently soft-dropped (no error) and
+	// leave Processed pinned at 1 for however long the deadline allowed.
+	if !waitFor(t, 5*time.Second, func() bool { return p.Stats().Processed == 1 }) {
 		t.Fatalf("worker did not process first batch")
 	}
 	// Second batch must succeed because the slot was released.
 	if _, err := p.Submit(mk()); err != nil {
 		t.Fatalf("submit 2 after release: %v", err)
 	}
-	if !waitFor(t, 30*time.Second, func() bool { return p.Stats().Processed == 2 }) {
+	if !waitFor(t, 5*time.Second, func() bool { return p.Stats().Processed == 2 }) {
 		t.Fatalf("worker did not process second batch")
 	}
 	if got := p.TenantDropped(); got != 0 {


### PR DESCRIPTION
Fixes the intermittent ingest pipeline test failures (map #195 collateral; supersedes the deadline bump from #193)

## Root cause — production code, `internal/ingest/pipeline.go`

`Pipeline.process()` incremented `processedTotal` **at the top of the function**,
before any of the work the counter claims to have completed:

```go
func (p *Pipeline) process(b *Batch) {
    if b == nil { return }
    defer func() { p.inFlightBytes.Add(-b.sizeBytes); ... }()   // byte release
    if !b.Priority() { defer p.releaseTenantSlot(b.Tenant) }    // tenant slot release
    defer func() { recover() ... }()
    p.processedTotal.Add(1)                                     // <-- HERE
    ...
    p.writer.BatchCreateAll(...)   // the actual write
    ... SpanCallback / LogCallback ...
}
```

So `Stats().Processed` meant *"a worker has picked this batch up"*, not
*"this batch is done"*. Every caller that used it as a completion barrier —
and all three failing tests do — was reading state that `process()` had not
produced yet. The window is the whole body of `process()`; `waitFor` polls
every 2 ms, so any preemption longer than one poll interval between the
increment and `BatchCreateAll` opens it.

### Interleaving 1 — `TestPipeline_StoreMinSeverity_*` ("got 0")

```
worker                                   test goroutine
------                                   --------------
process(b)
  processedTotal.Add(1)   // 0 -> 1
  <preempted>
                                         waitFor: Stats().Processed >= 1  -> true
                                         w.mu.Lock(); read w.logsCalls    -> EMPTY
                                         w.mu.Unlock()
                                         t.Fatalf("...got 0")
  applyStoreSeverity(...)
  writer.BatchCreateAll(...)             // too late
```

Note there is no data race here — `w.mu` is held correctly on both sides — so
`-race` never flagged it. The bug is a missing *logical* happens-before: the
test synchronised on a counter that is not ordered against the state it reads.
That is why the failure is invisible to the race detector and why it only shows
up in full-package runs, where the two `t.Parallel()` severity tests run
concurrently with everything else and preemption is likely.

### Interleaving 2 — `TestPipeline_PerTenantCap_ReleasedAfterProcess`

Worse, because it turns into a permanent stall rather than a fast failure.
`releaseTenantSlot` is a **deferred** call, i.e. it runs at the *end* of
`process()`, while `Processed` was incremented at the *start*:

```
worker                                   test goroutine
------                                   --------------
process(b1)
  processedTotal.Add(1)   // 0 -> 1
  <preempted>
                                         waitFor: Processed == 1 -> true
                                         Submit(b2)
                                           tenantInFlight["single"] == 1 >= cap 1
                                           -> SubmitSoftDropped, nil error
                                           -> b2 NEVER ENQUEUED
                                         waitFor: Processed == 2 ...
  writer.BatchCreateAll(...)
  defer releaseTenantSlot("single")      // slot freed, but b2 is already gone
                                         ... 30 s later: t.Fatalf(
                                             "worker did not process second batch")
```

`Submit` returns `(SubmitSoftDropped, nil)` — a *successful* Export with no
error — so the test's `if err != nil` check passes and the batch silently
vanishes. Once b2 is dropped, `Processed` can never reach 2, which is why
**#193's deadline bump from 5 s to 30 s could not work**: the wait was not slow,
it was unsatisfiable. It only made the failure take 25 s longer.

## Fix

`processedTotal` is now incremented in `process()`'s **outermost defer** —
registered first, so it runs last (defers are LIFO). Observing
`Processed >= N` now happens-after, for those N batches: the `BatchCreateAll`
transaction, the span/log callbacks, the per-tenant slot release and the
byte-reservation release. `Stats()` documents that contract.

Was production code at fault? **Yes.** The counter is named `Processed`,
documented as batches processed, and exported on the public `PipelineStats`
struct; incrementing it at pickup over-reported completed work by the in-flight
depth and made `Enqueued - Processed` useless as a backlog signal. No data is
lost or mis-persisted by the old placement — nothing in `main.go` consumes
`Processed` today — so operator impact was cosmetic, but the defect is in
`pipeline.go`, not in the tests.

The 30 s deadlines that #193 introduced are reverted to 5 s; the comment now
records why a deadline was never the answer.

## Evidence

**Reproduced on `origin/main` first.** Unloaded loops (21 × `GOMAXPROCS=2`,
21 × `GOMAXPROCS=1`, full package, `-race`) stayed green — the natural window is
sub-millisecond on an idle 8-core box. Running six copies of the `-race` test
binary concurrently at `GOMAXPROCS=2` reproduced it twice in 13 rounds
(78 binary runs):

```
--- FAIL: TestPipeline_StoreMinSeverity_DropsBelowThresholdFromPersist (0.00s)
    pipeline_test.go:620: expected 2 logs persisted (WARN+ERROR), got 0: []
```

`(0.00s)` — the assertion fires immediately after `waitFor` succeeds, which is
the signature of a bad barrier, not a slow worker.

**Deterministic proof of mechanism.** Inserting `time.Sleep(50ms)` between the
pickup point and `BatchCreateAll` widens the window to certainty:

| build | probe | result |
|---|---|---|
| `origin/main` | 50 ms | 3/3 fail: `got 0`, `got 0: []`, `worker did not process second batch` |
| this branch | 50 ms | 3/3 pass |

## Verification

- `gofmt` clean, `go vet ./...` clean, `go build ./...` clean.
- 30-run proof on this branch, full `./internal/ingest/` package with `-race`:
  20 runs at default `GOMAXPROCS` + 10 runs at `GOMAXPROCS=2` — **30/30 PASS, 0 failures**.
- The amplifier re-run against the fixed build: 15 rounds × 6 concurrent
  `-race` binaries at `GOMAXPROCS=2` = **90/90 PASS, 0 failures**.
- Full `go test ./... -count=1`: 1141 passed in 28 packages.

## Note on the "worker did not process first batch" line in the CI report

The reachable failure in `TestPipeline_PerTenantCap_ReleasedAfterProcess` is the
**second** wait (`pipeline_test.go:511`), which is what both the probe and the
mechanism above produce. The first wait cannot stall on a fresh pipeline: only
one batch is submitted, nothing can soft-drop it (queue and byte fullness are
both 0, the tenant map is empty) and a started worker will always reach the
increment. Treating the CI transcript's "first batch" as the second-batch
assertion is the only reading the code admits.
