### PR TITLE
feat(metrics): OTLP histogram completeness for aggregate mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,74 @@ resolved tenant is stamped on every async-pipeline `Batch`, so
 When `OTLP_TRUST_RESOURCE_TENANT=true` and one Export carries resources for
 several tenants, the Export is split into one batch per tenant. Every row in the relational DB carries a `tenant_id` column; every read method in `internal/storage/` scopes by the tenant in the request context (`Where("tenant_id = ?", tenant)`). Retention (`RetentionScheduler`) is **cross-tenant** — it purges by age, not by tenant.
 
+### OTLP Metric Points in Aggregate Mode
+
+`MetricsServer.Export` (`internal/ingest/otlp.go`) accounts four OTLP point
+types. Folding lives in `internal/aggregate/histogram.go`; the platform sketch
+is positive-only at scale 4.
+
+| Point type | Aggregate handling |
+|---|---|
+| `NumberDataPoint` (Gauge, Sum) | Gauge-like or baseline-converted per the temporality model. Also feeds the TSDB ring and the real-time bypass. |
+| `HistogramDataPoint` (delta) | Bucket counts folded as **weighted** synthetic observations at each finite positive bucket's geometric midpoint — one sketch add per bucket, never one per count. |
+| `ExponentialHistogramDataPoint` (delta) | Exact index transfer. Scale > 4 downscales by shifting indexes; scale 0–3 downscales the accumulating sketch to the source scale; `zero_count` folds into the zero bucket. |
+| `SummaryDataPoint` | **Wholly unsupported.** Producer-chosen quantiles cannot be merged across series or windows. |
+
+**Delta temporality only.** GA aggregates delta-temporality Histogram and
+ExponentialHistogram points. A cumulative (or unspecified-temporality)
+histogram point is refused **completely** — no count, no scalar, no bin — and
+counted on `otelcontext_ingest_metrics_unsupported_total{type,reason}`.
+Convert upstream with the OpenTelemetry Collector's
+[`cumulativetodeltaprocessor`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor),
+which handles cumulative Sum, Histogram and ExponentialHistogram streams.
+⚠️ That processor is **stateful**: it keeps the previous cumulative value per
+series in memory, so the collector fleet must route each series to **one**
+instance (a single collector, or a `loadbalancing` exporter keyed by the
+resource/attribute set). Round-robin across replicas produces wrong deltas and
+spurious resets, not an error.
+
+**Percentile honesty.** Scalars (count/sum/min/max) are kept even when the
+distribution cannot enter the sketch; percentiles are then marked unavailable
+and `otelcontext_ingest_metrics_sketch_dropped_total{reason}` is incremented:
+- `negative_observations` — negative exponential buckets held counts, or an
+  explicit bucket admits negative values and no reported `min >= 0` proves the
+  population non-negative. Publishing the positive side's p99 as the global p99
+  is a lie, so no quantile is published at all.
+- `scale_out_of_range` — an ExponentialHistogram below scale 0. Valid OTLP,
+  not representable by the unsigned sketch scale.
+- `no_finite_boundaries` — an explicit-bounds Histogram with observations and
+  no boundary.
+
+The `+Inf` bucket is tracked separately (`HistogramTailCount` /
+`HistogramTailBound`) and never folded. `AggregateDelta.HistogramQuantile`
+returns `(value, lowerBound, ok)`: a quantile landing in the tail is answered
+as `p99 >= last_finite_boundary`, never as an ordinary estimate.
+`AccuracyMetadata` carries `source_bucket_error` and `unbounded_tail`
+alongside the sketch's own bound — a bare `degraded=true` does not describe an
+unbounded bucket.
+
+**Dimensions.** Configured `AGGREGATE_METRIC_DIMS` keys are extracted from each
+point's attributes into the SeriesKey `DimsID`, identically for all three point
+types. Missing any configured key yields `DimsID=0` (all-or-nothing). String,
+int, bool and double attribute values are supported; array and kvlist values
+are refused from identity and counted on
+`otelcontext_ingest_metrics_dims_rejected_total{reason="unsupported_value_type"}`.
+Extraction runs against a request-local scratch — no per-point map allocation.
+
+**Response honesty.** Every refused point lands in
+`ExportMetricsPartialSuccess.rejected_data_points` with an exact count and a
+bounded message naming the types and reasons. The Export still returns success
+for the accepted points, and **clients must not retry a populated
+partial-success response**. Late and future points are *not* counted there:
+they are excluded from aggregates and reported on the lateness counters, but a
+retry would not change their fate. Legacy mode (`AGGREGATE_MODE=legacy`) has no
+aggregate accounting to be honest about and leaves the response unchanged.
+
+Aggregate store schema is **v4**: eight `hist_*` columns carry the population
+statistics and accuracy metadata. A v3 file cannot be migrated (the columns
+have no derivable values) — start an older binary or set
+`AGGREGATE_ALLOW_REBUILD=true`.
+
 ## Storage Architecture
 
 | Layer | Package | Purpose |

--- a/internal/aggregate/delta.go
+++ b/internal/aggregate/delta.go
@@ -1,6 +1,9 @@
 package aggregate
 
-import "time"
+import (
+	"math"
+	"time"
+)
 
 // AggregateDelta is the compact aggregate contribution of one Export request to
 // one series in one window (CONTEXT.md, "Delta"). It is what request-local
@@ -87,6 +90,40 @@ type AggregateDelta struct {
 	// ResetCount is the number of counter resets observed in this window
 	// (start-time change or value regression, per #166).
 	ResetCount uint64
+
+	// --- histogram metrics (#199) ---
+	//
+	// Populated by OTLP Histogram and ExponentialHistogram data points. The
+	// distribution itself rides in Sketch, which no metric series uses for
+	// anything else (Duration* is trace-only, gauges and counters carry no
+	// sketch), so a metric delta holds at most one distribution.
+
+	// HistogramCount is the population count reported by the folded points.
+	// It counts OBSERVATIONS, unlike Count which counts data points.
+	HistogramCount uint64
+	// HistogramSum is the authoritative sum reported by the producer. It is
+	// never derived from the sketch: bucket folding only knows bucket
+	// midpoints, and a sum of midpoints is an estimate.
+	HistogramSum float64
+	// HistogramMin and HistogramMax are the producer-reported extremes, valid
+	// only when HistHasMin / HistHasMax are set in HistogramFlags.
+	HistogramMin float64
+	HistogramMax float64
+	// HistogramFlags is the bit set defined in histogram.go:
+	// HistPercentilesUnavailable, HistUnboundedTail, HistHasMin, HistHasMax,
+	// plus a SketchDropReason in its high byte.
+	HistogramFlags uint32
+	// HistogramSourceError is the worst-case relative error imported from the
+	// SOURCE histogram's bucket widths, as a fraction. Zero for exponential
+	// histograms; an explicit-bounds histogram with decade-wide buckets can
+	// put this an order of magnitude above the sketch's own bound.
+	HistogramSourceError float64
+	// HistogramTailBound is the last finite boundary below the +Inf bucket,
+	// and HistogramTailCount how many observations landed above it. They are
+	// NOT in the sketch: a quantile that falls in the tail is answerable only
+	// as "at least HistogramTailBound".
+	HistogramTailBound float64
+	HistogramTailCount uint64
 
 	// --- logs ---
 
@@ -182,6 +219,109 @@ func (d *AggregateDelta) ObserveCounter(delta float64, reset bool) {
 	}
 }
 
+// ObserveHistogram records one folded OTLP histogram data point.
+//
+// Count counts the DATA POINT; HistogramCount counts the observations it
+// summarizes. Both are needed: the first is the reduction denominator, the
+// second is the population the percentiles describe.
+//
+// A fold with percentiles unavailable contributes its scalars and poisons the
+// series' percentile availability for the window. That is deliberate: once one
+// point in a window could not be represented, no quantile computed from the
+// rest describes the window's distribution.
+func (d *AggregateDelta) ObserveHistogram(f HistogramFold) {
+	d.Count++
+	d.HistogramCount += f.Count
+	d.HistogramSum += f.Sum
+	if f.HasMin && (d.HistogramFlags&HistHasMin == 0 || f.Min < d.HistogramMin) {
+		d.HistogramMin = f.Min
+	}
+	if f.HasMax && (d.HistogramFlags&HistHasMax == 0 || f.Max > d.HistogramMax) {
+		d.HistogramMax = f.Max
+	}
+	if f.SourceBucketError > d.HistogramSourceError {
+		d.HistogramSourceError = f.SourceBucketError
+	}
+	if f.UnboundedTail {
+		// The sound lower bound for a union of tails is the LOWEST of their
+		// boundaries: an observation from the other tail is only known to
+		// exceed its own.
+		if d.HistogramFlags&HistUnboundedTail == 0 || f.UnboundedTailBound < d.HistogramTailBound {
+			d.HistogramTailBound = f.UnboundedTailBound
+		}
+		d.HistogramTailCount += f.UnboundedTailCount
+	}
+	d.HistogramFlags = mergeHistFlags(d.HistogramFlags, f.flags())
+	if f.Sketch != nil {
+		if d.Sketch == nil {
+			d.Sketch = NewSketch()
+		}
+		d.Sketch.Merge(f.Sketch)
+	}
+}
+
+// mergeHistFlags ORs two histogram flag words. The drop reason is the LOWEST
+// non-zero code of the two, which makes the merge order-independent without
+// needing a per-reason counter.
+func mergeHistFlags(a, b uint32) uint32 {
+	reasonA, reasonB := histReason(a), histReason(b)
+	reason := reasonA
+	switch {
+	case reasonA == SketchDropNone:
+		reason = reasonB
+	case reasonB != SketchDropNone && reasonB < reasonA:
+		reason = reasonB
+	}
+	return withHistReason((a|b)&^histReasonMask, reason)
+}
+
+// HistogramPercentilesAvailable reports whether a quantile may be published
+// for this delta's histogram distribution.
+func (d *AggregateDelta) HistogramPercentilesAvailable() bool {
+	return d.HistogramCount > 0 && d.HistogramFlags&HistPercentilesUnavailable == 0
+}
+
+// HistogramQuantile estimates the q-quantile of the folded histogram
+// distribution.
+//
+// The three-way return is the whole point (#199 Q2). lowerBound=true means the
+// quantile falls inside the source histogram's +Inf bucket: the answer is
+// "at least value", not "approximately value", and a caller that renders it as
+// an ordinary number is fabricating a tail it was never given. ok=false means
+// no quantile may be published at all -- an empty window, or a point whose
+// percentiles were suppressed.
+func (d *AggregateDelta) HistogramQuantile(q float64) (value float64, lowerBound, ok bool) {
+	if !d.HistogramPercentilesAvailable() || math.IsNaN(q) || q < 0 || q > 1 {
+		return 0, false, false
+	}
+	var sketched uint64
+	if d.Sketch != nil {
+		sketched = d.Sketch.Count()
+	}
+	total := sketched + d.HistogramTailCount
+	if total == 0 {
+		return 0, false, false
+	}
+	// Same rank convention as Sketch.Quantile: the element at rank
+	// q*(n-1), with the tail occupying the top HistogramTailCount ranks.
+	if rank := q * float64(total-1); rank >= float64(sketched) {
+		return d.HistogramTailBound, true, true
+	}
+	if d.Sketch == nil {
+		return 0, false, false
+	}
+	// Rescale q onto the sketched population so the sketch answers the same
+	// rank it would have answered inside the full distribution.
+	sq := 0.0
+	if sketched > 1 {
+		sq = q * float64(total-1) / float64(sketched-1)
+	}
+	if sq > 1 {
+		sq = 1
+	}
+	return d.Sketch.Quantile(sq), false, true
+}
+
 // Merge folds other into d. Every field is additive or order-independent, so
 // merging is associative and commutative: the result depends only on the
 // multiset of observations, never on the order they arrived in.
@@ -228,6 +368,28 @@ func (d *AggregateDelta) Merge(other *AggregateDelta) {
 
 	d.CounterDelta += other.CounterDelta
 	d.ResetCount += other.ResetCount
+
+	if other.HistogramCount > 0 || other.HistogramFlags != 0 {
+		if other.HistogramFlags&HistHasMin != 0 &&
+			(d.HistogramFlags&HistHasMin == 0 || other.HistogramMin < d.HistogramMin) {
+			d.HistogramMin = other.HistogramMin
+		}
+		if other.HistogramFlags&HistHasMax != 0 &&
+			(d.HistogramFlags&HistHasMax == 0 || other.HistogramMax > d.HistogramMax) {
+			d.HistogramMax = other.HistogramMax
+		}
+		if other.HistogramFlags&HistUnboundedTail != 0 &&
+			(d.HistogramFlags&HistUnboundedTail == 0 || other.HistogramTailBound < d.HistogramTailBound) {
+			d.HistogramTailBound = other.HistogramTailBound
+		}
+		d.HistogramCount += other.HistogramCount
+		d.HistogramSum += other.HistogramSum
+		d.HistogramTailCount += other.HistogramTailCount
+		if other.HistogramSourceError > d.HistogramSourceError {
+			d.HistogramSourceError = other.HistogramSourceError
+		}
+		d.HistogramFlags = mergeHistFlags(d.HistogramFlags, other.HistogramFlags)
+	}
 
 	d.LogCount += other.LogCount
 	if !other.FirstTimestamp.IsZero() && (d.FirstTimestamp.IsZero() || other.FirstTimestamp.Before(d.FirstTimestamp)) {

--- a/internal/aggregate/dims_config.go
+++ b/internal/aggregate/dims_config.go
@@ -1,6 +1,8 @@
 package aggregate
 
 import (
+	"strconv"
+
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 )
 
@@ -70,4 +72,110 @@ func InternDimValues(c *Cache, tenantID uint32, keys, values []string) uint32 {
 		}
 	}
 	return c.InternDims(tenantID, pairs)
+}
+
+// --- hot-path dimension extraction (#199 Q4) ---------------------------------
+//
+// ExtractDimensionValues above allocates a map[string]string per call. That is
+// fine for the config-time helper it was written as and unacceptable per metric
+// data point: configured dimensions are BOUNDED (an operator lists a handful of
+// keys per metric), so a point's tuple resolves against a request-local scratch
+// with no map, no per-point slice and one string allocation only for a non-string
+// attribute value that has to be rendered.
+
+// MaxDimensionKeys bounds one metric's configured dimension tuple. A tuple
+// longer than this is refused from identity rather than silently truncated.
+const MaxDimensionKeys = 16
+
+// DimsRejectUnsupportedValue is the metric label for an attribute value that
+// has no canonical scalar rendering (array, kvlist, bytes). The point is still
+// aggregated -- under DimsID 0, the "no configured dims" sentinel.
+const DimsRejectUnsupportedValue = "unsupported_value_type"
+
+// dimScratch is one Export request's reusable dimension-extraction workspace.
+// It is owned by a Reducer, which is request-local and single-goroutine, so no
+// synchronization is needed and no allocation survives the request.
+type dimScratch struct {
+	vals  [MaxDimensionKeys]string
+	found [MaxDimensionKeys]bool
+	buf   []byte
+}
+
+// resolve extracts the configured tuple for keys out of attrs.
+//
+// It returns ok=false when any configured key is absent or carries an empty
+// value -- the all-or-nothing contract, which exists because a partial tuple is
+// a different series wearing the same name. rejected=true additionally reports
+// that a key WAS present but its value had no scalar rendering, which is worth
+// a counter: the operator configured a dimension that can never bind.
+func (s *dimScratch) resolve(keys []string, attrs []*commonpb.KeyValue) (vals []string, rejected, ok bool) {
+	n := len(keys)
+	if n == 0 || n > MaxDimensionKeys {
+		return nil, false, false
+	}
+	for i := 0; i < n; i++ {
+		s.vals[i] = ""
+		s.found[i] = false
+	}
+	remaining := n
+	for _, kv := range attrs {
+		if kv == nil || kv.Value == nil || remaining == 0 {
+			continue
+		}
+		idx := -1
+		for i := 0; i < n; i++ {
+			if !s.found[i] && keys[i] == kv.Key {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			continue
+		}
+		v, scalar := s.scalarValue(kv.Value)
+		if !scalar {
+			return nil, true, false
+		}
+		if v == "" {
+			// An empty value cannot be interned: the dictionary refuses a
+			// zero-length identity, and every empty value in a namespace would
+			// collide. Treat it as absent.
+			continue
+		}
+		s.vals[idx] = v
+		s.found[idx] = true
+		remaining--
+	}
+	if remaining != 0 {
+		return nil, false, false
+	}
+	return s.vals[:n], false, true
+}
+
+// scalarValue renders an OTLP attribute value as its canonical dimension
+// string. String, int, bool and double values are supported; array, kvlist and
+// bytes values are not -- they have no stable canonical rendering, and hashing
+// one into identity would make the series depend on element order.
+func (s *dimScratch) scalarValue(v *commonpb.AnyValue) (string, bool) {
+	switch tv := v.Value.(type) {
+	case *commonpb.AnyValue_StringValue:
+		return tv.StringValue, true
+	case *commonpb.AnyValue_IntValue:
+		s.buf = strconv.AppendInt(s.buf[:0], tv.IntValue, 10)
+		return string(s.buf), true
+	case *commonpb.AnyValue_BoolValue:
+		if tv.BoolValue {
+			return "true", true
+		}
+		return "false", true
+	case *commonpb.AnyValue_DoubleValue:
+		s.buf = strconv.AppendFloat(s.buf[:0], tv.DoubleValue, 'g', -1, 64)
+		return string(s.buf), true
+	case nil:
+		// An AnyValue with no value set is an absent attribute, not a
+		// rejection.
+		return "", true
+	default:
+		return "", false
+	}
 }

--- a/internal/aggregate/histogram.go
+++ b/internal/aggregate/histogram.go
@@ -1,0 +1,509 @@
+package aggregate
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+)
+
+// OTLP histogram folding (#199).
+//
+// The platform sketch is positive-only and fixed at scale 4. Every OTLP
+// distribution point that reaches aggregate accounting has to be expressed in
+// that mapping or be honestly refused, and the two source shapes fail in
+// different ways:
+//
+//   - ExponentialHistogram shares the sketch's own mapping, so a scale change
+//     is an exact integer index shift ("perfect subsetting"). Folding one is
+//     lossless at the bucket-count level; only the NEGATIVE range and scales
+//     below 0 have no representation.
+//   - Histogram (explicit bounds) has arbitrary boundaries. Its counts can only
+//     be folded as weighted synthetic observations placed inside each bucket,
+//     which imports the SOURCE histogram's bucket width as error on top of the
+//     sketch's own. That error is carried out on the fold, not hidden.
+//
+// Nothing here expands a bucket count into individual observations: a bucket
+// holding a million counts costs one bin add.
+
+// ErrHistogramMalformed marks a data point that violates the OTLP data model.
+// A malformed point is refused entirely -- it never contributes a count, a sum
+// or a bin -- and is reported in ExportMetricsPartialSuccess.
+var ErrHistogramMalformed = errors.New("aggregate: malformed histogram point")
+
+// Exponential-histogram scale bounds from the OTLP data model. Scales outside
+// this range are malformed, not merely unrepresentable.
+const (
+	ExpHistogramMinScale int32 = -10
+	ExpHistogramMaxScale int32 = 20
+)
+
+// SketchDropReason names why a histogram point's percentiles are unavailable
+// while its scalar statistics were still accepted. It is persisted with the
+// delta so a read can say WHY it has no percentile rather than implying the
+// window was empty.
+type SketchDropReason uint8
+
+// SketchDropReason values. The numbering is durable: it is stored in the
+// delta's histogram flags word.
+const (
+	// SketchDropNone means the sketch describes the whole distribution.
+	SketchDropNone SketchDropReason = 0
+	// SketchDropNegativeObservations means the point recorded values below
+	// zero. The positive-only sketch cannot hold them, and reporting the
+	// positive side's p99 as the distribution's p99 would be a lie.
+	SketchDropNegativeObservations SketchDropReason = 1
+	// SketchDropScaleOutOfRange means an ExponentialHistogram arrived at a
+	// scale below 0. Downscaling the sketch to a negative scale is not
+	// representable, and upscaling the point's buckets would not be exact.
+	SketchDropScaleOutOfRange SketchDropReason = 2
+	// SketchDropNoFiniteBoundaries means an explicit-bounds Histogram carried
+	// observations but no finite boundary to place them between.
+	SketchDropNoFiniteBoundaries SketchDropReason = 3
+)
+
+// String renders the reason as the metric label value.
+func (r SketchDropReason) String() string {
+	switch r {
+	case SketchDropNegativeObservations:
+		return "negative_observations"
+	case SketchDropScaleOutOfRange:
+		return "scale_out_of_range"
+	case SketchDropNoFiniteBoundaries:
+		return "no_finite_boundaries"
+	default:
+		return "none"
+	}
+}
+
+// Histogram delta flag bits. They live in AggregateDelta.HistogramFlags; the
+// low byte is a bit set and the high byte carries the SketchDropReason.
+const (
+	// HistPercentilesUnavailable marks that the sketch does NOT describe the
+	// whole distribution, so no quantile may be published from it.
+	HistPercentilesUnavailable uint32 = 1 << 0
+	// HistUnboundedTail marks that observations landed in a +Inf bucket.
+	HistUnboundedTail uint32 = 1 << 1
+	// HistHasMin marks that the producer reported the minimum.
+	HistHasMin uint32 = 1 << 2
+	// HistHasMax marks that the producer reported the maximum.
+	HistHasMax uint32 = 1 << 3
+
+	histReasonShift = 8
+	histReasonMask  = uint32(0xff) << histReasonShift
+)
+
+// histReason extracts the SketchDropReason from a flags word.
+func histReason(flags uint32) SketchDropReason {
+	return SketchDropReason((flags & histReasonMask) >> histReasonShift) // #nosec G115 -- masked to one byte
+}
+
+// withHistReason returns flags carrying reason.
+func withHistReason(flags uint32, reason SketchDropReason) uint32 {
+	return (flags &^ histReasonMask) | (uint32(reason) << histReasonShift)
+}
+
+// ExpBuckets is one side (positive or negative) of an OTLP exponential
+// histogram: Counts[i] belongs to bucket index Offset+i.
+type ExpBuckets struct {
+	Offset int32
+	Counts []uint64
+}
+
+// total sums the bucket counts, reporting overflow rather than wrapping.
+func (b ExpBuckets) total() (uint64, bool) {
+	var sum uint64
+	for _, c := range b.Counts {
+		next := sum + c
+		if next < sum {
+			return 0, false
+		}
+		sum = next
+	}
+	return sum, true
+}
+
+// HistogramCommon is the identity and scalar payload shared by both histogram
+// point shapes. Attributes are the RAW OTLP point attributes: dimension
+// extraction happens in the reducer, against a request-local scratch, so no
+// per-point map is allocated (#199 Q4).
+type HistogramCommon struct {
+	Tenant   string
+	Service  string
+	Name     string
+	Resource ResourceIdentity
+
+	Timestamp time.Time
+	StartTime time.Time
+
+	Temporality Temporality
+	Attributes  []*commonpb.KeyValue
+
+	Count  uint64
+	Sum    float64
+	HasSum bool
+	Min    float64
+	HasMin bool
+	Max    float64
+	HasMax bool
+}
+
+// HistogramInput is one OTLP explicit-bounds HistogramDataPoint.
+//
+// Bounds are the explicit_bounds array and BucketCounts the bucket_counts
+// array; the OTLP data model requires len(BucketCounts) == len(Bounds)+1, with
+// the last bucket unbounded above.
+type HistogramInput struct {
+	HistogramCommon
+	Bounds       []float64
+	BucketCounts []uint64
+}
+
+// ExponentialHistogramInput is one OTLP ExponentialHistogramDataPoint.
+type ExponentialHistogramInput struct {
+	HistogramCommon
+	Scale     int32
+	ZeroCount uint64
+	Positive  ExpBuckets
+	Negative  ExpBuckets
+}
+
+// HistogramFold is the result of folding one histogram data point.
+//
+// Scalars are always populated for an accepted point. Sketch is nil exactly
+// when PercentilesUnavailable is set: the two never disagree, because a caller
+// that saw a non-nil sketch and an "unavailable" flag would eventually publish
+// the sketch.
+type HistogramFold struct {
+	Sketch *Sketch
+	Count  uint64
+	Sum    float64
+	HasSum bool
+	Min    float64
+	HasMin bool
+	Max    float64
+	HasMax bool
+
+	// PercentilesUnavailable suppresses every quantile derived from this
+	// point, and DropReason says why.
+	PercentilesUnavailable bool
+	DropReason             SketchDropReason
+
+	// SourceBucketError is the worst-case relative error contributed by the
+	// SOURCE histogram's own bucket widths, as a fraction. It is 0 for an
+	// exponential histogram (index transfer is exact) and can dwarf the
+	// scale-4 sketch's 2.17% for a coarse explicit-bounds histogram.
+	SourceBucketError float64
+
+	// UnboundedTail reports that observations landed in the +Inf bucket.
+	// Those observations are deliberately NOT folded into the sketch: their
+	// only known property is "greater than UnboundedTailBound", and placing
+	// them at any finite value would turn a lower bound into a fabricated
+	// estimate. UnboundedTailCount is how many.
+	UnboundedTail      bool
+	UnboundedTailBound float64
+	UnboundedTailCount uint64
+}
+
+// flags renders the fold's metadata as the delta's histogram flags word.
+func (f HistogramFold) flags() uint32 {
+	var flags uint32
+	if f.PercentilesUnavailable {
+		flags |= HistPercentilesUnavailable
+	}
+	if f.UnboundedTail {
+		flags |= HistUnboundedTail
+	}
+	if f.HasMin {
+		flags |= HistHasMin
+	}
+	if f.HasMax {
+		flags |= HistHasMax
+	}
+	return withHistReason(flags, f.DropReason)
+}
+
+// scalarsOnly marks the fold as accepted-without-percentiles.
+func (f *HistogramFold) scalarsOnly(reason SketchDropReason) {
+	f.Sketch = nil
+	f.PercentilesUnavailable = true
+	f.DropReason = reason
+}
+
+// foldScalars copies the point's scalar statistics onto a fold.
+func foldScalars(c HistogramCommon) HistogramFold {
+	return HistogramFold{
+		Count:  c.Count,
+		Sum:    c.Sum,
+		HasSum: c.HasSum,
+		Min:    c.Min,
+		HasMin: c.HasMin,
+		Max:    c.Max,
+		HasMax: c.HasMax,
+	}
+}
+
+// validateScalars rejects scalar statistics that cannot describe any
+// population. A non-finite sum or an inverted min/max is a producer bug, and
+// letting it into an additive delta poisons every merge downstream.
+func validateScalars(c HistogramCommon) error {
+	if c.HasSum && (math.IsNaN(c.Sum) || math.IsInf(c.Sum, 0)) {
+		return fmt.Errorf("%w: non-finite sum", ErrHistogramMalformed)
+	}
+	if c.HasMin && (math.IsNaN(c.Min) || math.IsInf(c.Min, 0)) {
+		return fmt.Errorf("%w: non-finite min", ErrHistogramMalformed)
+	}
+	if c.HasMax && (math.IsNaN(c.Max) || math.IsInf(c.Max, 0)) {
+		return fmt.Errorf("%w: non-finite max", ErrHistogramMalformed)
+	}
+	if c.HasMin && c.HasMax && c.Min > c.Max {
+		return fmt.Errorf("%w: min %g above max %g", ErrHistogramMalformed, c.Min, c.Max)
+	}
+	return nil
+}
+
+// maxExpBuckets bounds one side of an exponential histogram. A conforming
+// producer needs a few thousand buckets in practice; anything past this cap is
+// a corrupt or hostile payload and is refused before it is walked.
+const maxExpBuckets = 1 << 16
+
+// validateExpBuckets rejects an index range that cannot exist.
+func validateExpBuckets(side string, b ExpBuckets) error {
+	if len(b.Counts) > maxExpBuckets {
+		return fmt.Errorf("%w: %s buckets %d above cap %d",
+			ErrHistogramMalformed, side, len(b.Counts), maxExpBuckets)
+	}
+	if int64(b.Offset)+int64(len(b.Counts)) > math.MaxInt32 {
+		return fmt.Errorf("%w: %s bucket index overflows int32", ErrHistogramMalformed, side)
+	}
+	return nil
+}
+
+// FoldExponentialHistogram converts one OTLP ExponentialHistogramDataPoint
+// into the platform sketch (#199 Q1).
+//
+// Scale handling:
+//   - s > 4: downscale exactly to 4 by an arithmetic right shift of each
+//     bucket index, merging the counts that collapse together. OTel's
+//     perfect-subsetting property makes this exact at the bucket-count level.
+//   - s == 4: direct index transfer.
+//   - 0 <= s < 4: the ACCUMULATED sketch is explicitly downscaled to s before
+//     any bucket lands, so the result carries the source's coarser mapping
+//     honestly. Relying on the sketch's incidental bin-collapse instead would
+//     leave the advertised relative error a lie.
+//   - s < 0: not representable by the sketch (its scale is unsigned). Scalars
+//     are kept, percentiles are marked unavailable.
+//
+// zero_count folds into the sketch's zero bucket; count, sum, min and max fold
+// normally. Negative buckets holding observations suppress percentiles for the
+// WHOLE point: publishing the positive side's p99 as the distribution's p99
+// would be a lie, and dropping the point entirely would lose a legitimate
+// count.
+func FoldExponentialHistogram(in ExponentialHistogramInput) (HistogramFold, error) {
+	if err := validateScalars(in.HistogramCommon); err != nil {
+		return HistogramFold{}, err
+	}
+	if in.Scale < ExpHistogramMinScale || in.Scale > ExpHistogramMaxScale {
+		return HistogramFold{}, fmt.Errorf("%w: scale %d outside [%d,%d]",
+			ErrHistogramMalformed, in.Scale, ExpHistogramMinScale, ExpHistogramMaxScale)
+	}
+	if err := validateExpBuckets("positive", in.Positive); err != nil {
+		return HistogramFold{}, err
+	}
+	if err := validateExpBuckets("negative", in.Negative); err != nil {
+		return HistogramFold{}, err
+	}
+	posTotal, ok := in.Positive.total()
+	if !ok {
+		return HistogramFold{}, fmt.Errorf("%w: positive bucket counts overflow", ErrHistogramMalformed)
+	}
+	negTotal, ok := in.Negative.total()
+	if !ok {
+		return HistogramFold{}, fmt.Errorf("%w: negative bucket counts overflow", ErrHistogramMalformed)
+	}
+	// The data model REQUIRES count == zero_count + sum(positive) +
+	// sum(negative). A point that disagrees is describing a population it did
+	// not measure, and there is no defensible way to guess which half is true.
+	observed := in.ZeroCount + posTotal + negTotal
+	if observed < posTotal || in.Count != observed {
+		return HistogramFold{}, fmt.Errorf("%w: count %d disagrees with bucket total %d",
+			ErrHistogramMalformed, in.Count, observed)
+	}
+
+	fold := foldScalars(in.HistogramCommon)
+	if negTotal > 0 {
+		fold.scalarsOnly(SketchDropNegativeObservations)
+		return fold, nil
+	}
+	if in.Scale < 0 {
+		fold.scalarsOnly(SketchDropScaleOutOfRange)
+		return fold, nil
+	}
+
+	sk := NewSketch()
+	scale := uint8(in.Scale) // #nosec G115 -- guarded to [0, ExpHistogramMaxScale] above
+	var shift uint8
+	switch {
+	case scale > SketchDefaultScale:
+		shift = scale - SketchDefaultScale
+	case scale < SketchDefaultScale:
+		// Explicit downscale of the accumulation target, per #199 Q1.
+		sk.downscale(scale)
+	}
+	for i, c := range in.Positive.Counts {
+		if c == 0 {
+			continue
+		}
+		idx := in.Positive.Offset + int32(i) // #nosec G115 -- length capped at maxExpBuckets
+		if shift > 0 {
+			idx >>= shift
+		}
+		sk.ObserveBucket(idx, c)
+	}
+	sk.ObserveZero(in.ZeroCount)
+	fold.Sketch = sk
+	return fold, nil
+}
+
+// FoldHistogram converts one OTLP explicit-bounds HistogramDataPoint into the
+// platform sketch (#199 Q2).
+//
+// Each finite bucket's count enters the sketch ONCE, as a weighted synthetic
+// observation at the bucket's geometric midpoint. The geometric midpoint is
+// only defined for a strictly positive bucket, so:
+//
+//   - A bucket whose lower boundary is below zero can only be folded when the
+//     point's own min proves the population is non-negative; the effective
+//     lower boundary then becomes max(0, boundary, min). Without that proof
+//     the point keeps its scalars and loses its percentiles.
+//   - A bucket whose effective lower boundary is exactly 0 has no geometric
+//     midpoint. Its observations are placed at upper/2 and the bucket
+//     contributes 100% source error, which is the truth: the observation could
+//     have been anywhere in (0, upper].
+//
+// The +Inf bucket is never folded. Its count and the last finite boundary are
+// carried out separately so a quantile that lands in the tail can be answered
+// as a LOWER BOUND (p99 >= boundary) instead of an invented number.
+func FoldHistogram(in HistogramInput) (HistogramFold, error) {
+	if err := validateScalars(in.HistogramCommon); err != nil {
+		return HistogramFold{}, err
+	}
+	if err := validateBounds(in); err != nil {
+		return HistogramFold{}, err
+	}
+
+	fold := foldScalars(in.HistogramCommon)
+	if in.Count == 0 || len(in.BucketCounts) == 0 {
+		// Nothing observed: an empty sketch is an honest answer, and its
+		// relative error is still the scale-4 bound.
+		fold.Sketch = NewSketch()
+		return fold, nil
+	}
+	if len(in.Bounds) == 0 {
+		// One bucket spanning (-Inf, +Inf]. Every observation is in the
+		// unbounded tail with no finite boundary to bound it by.
+		fold.scalarsOnly(SketchDropNoFiniteBoundaries)
+		return fold, nil
+	}
+
+	nonNegative := in.HasMin && in.Min >= 0
+	lastIdx := len(in.BucketCounts) - 1
+	sk := NewSketch()
+
+	for i, c := range in.BucketCounts {
+		if c == 0 {
+			continue
+		}
+		if i == lastIdx {
+			fold.UnboundedTail = true
+			fold.UnboundedTailBound = in.Bounds[len(in.Bounds)-1]
+			fold.UnboundedTailCount += c
+			continue
+		}
+		upper := in.Bounds[i]
+		lower := math.Inf(-1)
+		if i > 0 {
+			lower = in.Bounds[i-1]
+		}
+		if in.HasMin && in.Min > lower {
+			lower = in.Min
+		}
+		if lower < 0 || upper <= 0 {
+			// The bucket admits negative values. Only a reported min at or
+			// above zero proves none were observed there; an upper boundary
+			// at or below zero with a non-zero count contradicts such a min
+			// outright.
+			if !nonNegative || upper <= 0 {
+				fold.scalarsOnly(SketchDropNegativeObservations)
+				fold.UnboundedTail = false
+				fold.UnboundedTailBound = 0
+				fold.UnboundedTailCount = 0
+				return fold, nil
+			}
+			lower = 0
+		}
+		mid, relErr := bucketMidpoint(lower, upper)
+		if relErr > fold.SourceBucketError {
+			fold.SourceBucketError = relErr
+		}
+		sk.ObserveN(mid, c)
+	}
+	fold.Sketch = sk
+	return fold, nil
+}
+
+// bucketMidpoint returns the representative value of the finite bucket
+// (lower, upper] and the worst-case relative error of placing every one of its
+// observations there. lower is at or above zero and below upper.
+func bucketMidpoint(lower, upper float64) (mid, relErr float64) {
+	if lower <= 0 {
+		// (0, upper]: no geometric midpoint exists. The true value can be
+		// arbitrarily close to zero, so the arithmetic midpoint carries 100%
+		// worst-case relative error.
+		return upper / 2, 1
+	}
+	mid = math.Sqrt(lower * upper)
+	// Placing an observation at the geometric midpoint of a bucket whose
+	// boundary ratio is gamma is wrong by at most sqrt(gamma)-1 either way.
+	return mid, math.Sqrt(upper/lower) - 1
+}
+
+// validateBounds enforces the explicit-bounds data model: bucket_counts is one
+// longer than explicit_bounds, boundaries are finite and strictly ascending,
+// and the bucket counts add up to count.
+func validateBounds(in HistogramInput) error {
+	switch {
+	case len(in.BucketCounts) == 0 && len(in.Bounds) == 0:
+		if in.Count != 0 {
+			return fmt.Errorf("%w: count %d with no buckets", ErrHistogramMalformed, in.Count)
+		}
+		return nil
+	case len(in.BucketCounts) != len(in.Bounds)+1:
+		return fmt.Errorf("%w: %d bucket counts for %d bounds",
+			ErrHistogramMalformed, len(in.BucketCounts), len(in.Bounds))
+	}
+	prev := math.Inf(-1)
+	for i, b := range in.Bounds {
+		if math.IsNaN(b) || math.IsInf(b, 0) {
+			return fmt.Errorf("%w: bound %d is not finite", ErrHistogramMalformed, i)
+		}
+		if b <= prev {
+			return fmt.Errorf("%w: bound %d (%g) does not exceed its predecessor", ErrHistogramMalformed, i, b)
+		}
+		prev = b
+	}
+	var total uint64
+	for _, c := range in.BucketCounts {
+		next := total + c
+		if next < total {
+			return fmt.Errorf("%w: bucket counts overflow", ErrHistogramMalformed)
+		}
+		total = next
+	}
+	if total != in.Count {
+		return fmt.Errorf("%w: count %d disagrees with bucket total %d", ErrHistogramMalformed, in.Count, total)
+	}
+	return nil
+}

--- a/internal/aggregate/histogram_test.go
+++ b/internal/aggregate/histogram_test.go
@@ -1,0 +1,652 @@
+package aggregate
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+)
+
+// #199: OTLP histogram completeness for aggregate mode.
+//
+// The shared builders below exist because every case here needs the same
+// identity/scalar preamble and only differs in its buckets. Copy-pasting the
+// preamble per test would trip the CI duplication gate and, worse, let two
+// cases drift apart on the fields they are not testing.
+
+const histTestMetric = "http.server.duration"
+
+// histCommon returns the identity and scalar payload every case shares.
+func histCommon(count uint64, sum float64) HistogramCommon {
+	return HistogramCommon{
+		Tenant:      "acme",
+		Service:     "checkout",
+		Name:        histTestMetric,
+		Timestamp:   time.Unix(1_700_000_000, 0),
+		StartTime:   time.Unix(1_699_999_700, 0),
+		Temporality: TemporalityDelta,
+		Count:       count,
+		Sum:         sum,
+		HasSum:      true,
+	}
+}
+
+// withExtremes stamps the producer-reported min/max onto a payload.
+func withExtremes(c HistogramCommon, minV, maxV float64) HistogramCommon {
+	c.Min, c.HasMin = minV, true
+	c.Max, c.HasMax = maxV, true
+	return c
+}
+
+// expPointFromValues builds an exponential histogram at scale whose positive
+// buckets hold exactly the given values, using the platform's own index
+// mapping. Building the source this way is what makes the downscale assertion
+// meaningful: the reference sketch observes the SAME values directly.
+func expPointFromValues(scale uint8, values []float64) ExponentialHistogramInput {
+	minIdx, maxIdx := int32(math.MaxInt32), int32(math.MinInt32)
+	for _, v := range values {
+		idx := sketchIndex(v, scale)
+		if idx < minIdx {
+			minIdx = idx
+		}
+		if idx > maxIdx {
+			maxIdx = idx
+		}
+	}
+	counts := make([]uint64, maxIdx-minIdx+1)
+	var sum float64
+	for _, v := range values {
+		counts[sketchIndex(v, scale)-minIdx]++
+		sum += v
+	}
+	return ExponentialHistogramInput{
+		HistogramCommon: histCommon(uint64(len(values)), sum),
+		Scale:           int32(scale),
+		Positive:        ExpBuckets{Offset: minIdx, Counts: counts},
+	}
+}
+
+// referenceSketch observes values directly at scale — the answer the fold has
+// to reproduce.
+func referenceSketch(t *testing.T, scale uint8, values []float64) *Sketch {
+	t.Helper()
+	sk, err := NewSketchAtScale(scale)
+	if err != nil {
+		t.Fatalf("NewSketchAtScale(%d): %v", scale, err)
+	}
+	for _, v := range values {
+		sk.Observe(v)
+	}
+	return sk
+}
+
+// assertSameQuantiles fails when two sketches disagree on any quantile of
+// interest. Equality is EXACT: both sides answer with a bucket representative,
+// so an approximate comparison would hide a one-bin error.
+func assertSameQuantiles(t *testing.T, got, want *Sketch) {
+	t.Helper()
+	for _, q := range []float64{0, 0.25, 0.5, 0.9, 0.99, 1} {
+		g, w := got.Quantile(q), want.Quantile(q)
+		if g != w {
+			t.Errorf("quantile(%g) = %v, want %v", q, g, w)
+		}
+	}
+}
+
+var histTestValues = []float64{1.5, 3.7, 12.25, 99.9, 512.5, 1024, 4096.75}
+
+// TestFoldExponentialHistogramDownscalesAboveScaleFour pins #199 Q1's main
+// claim: an s > 4 point is folded by shifting indexes, and the result is
+// bit-identical to observing the same values at scale 4. Perfect subsetting is
+// either exact or it is not a property worth relying on.
+func TestFoldExponentialHistogramDownscalesAboveScaleFour(t *testing.T) {
+	for _, scale := range []uint8{5, 6, 10} {
+		in := expPointFromValues(scale, histTestValues)
+		fold, err := FoldExponentialHistogram(in)
+		if err != nil {
+			t.Fatalf("scale %d: FoldExponentialHistogram: %v", scale, err)
+		}
+		if fold.PercentilesUnavailable {
+			t.Fatalf("scale %d: percentiles unavailable on a clean positive point", scale)
+		}
+		if fold.Sketch.Scale() != SketchDefaultScale {
+			t.Errorf("scale %d: folded sketch scale = %d, want %d", scale, fold.Sketch.Scale(), SketchDefaultScale)
+		}
+		if fold.Sketch.Count() != uint64(len(histTestValues)) {
+			t.Errorf("scale %d: sketch count = %d, want %d", scale, fold.Sketch.Count(), len(histTestValues))
+		}
+		if fold.SourceBucketError != 0 {
+			t.Errorf("scale %d: source bucket error = %v, want 0 (index transfer is exact)", scale, fold.SourceBucketError)
+		}
+		assertSameQuantiles(t, fold.Sketch, referenceSketch(t, SketchDefaultScale, histTestValues))
+	}
+}
+
+// TestFoldExponentialHistogramDownscalesSketchBelowScaleFour pins the other
+// half of Q1: a coarser source downscales the ACCUMULATOR, so the sketch
+// advertises the source's real resolution instead of a scale-4 bound it cannot
+// honour.
+func TestFoldExponentialHistogramDownscalesSketchBelowScaleFour(t *testing.T) {
+	for _, scale := range []uint8{0, 1, 2, 3} {
+		in := expPointFromValues(scale, histTestValues)
+		fold, err := FoldExponentialHistogram(in)
+		if err != nil {
+			t.Fatalf("scale %d: FoldExponentialHistogram: %v", scale, err)
+		}
+		if fold.Sketch.Scale() != scale {
+			t.Errorf("scale %d: folded sketch scale = %d, want %d", scale, fold.Sketch.Scale(), scale)
+		}
+		want := referenceSketch(t, scale, histTestValues)
+		if fold.Sketch.RelativeError() != want.RelativeError() {
+			t.Errorf("scale %d: relative error = %v, want %v",
+				scale, fold.Sketch.RelativeError(), want.RelativeError())
+		}
+		assertSameQuantiles(t, fold.Sketch, want)
+	}
+}
+
+// TestFoldExponentialHistogramFoldsZeroCount pins that zero_count is folded
+// normally rather than dropped: those are real observations, just not
+// representable in the log mapping.
+func TestFoldExponentialHistogramFoldsZeroCount(t *testing.T) {
+	in := expPointFromValues(SketchDefaultScale, histTestValues)
+	in.ZeroCount = 3
+	in.Count += 3
+	fold, err := FoldExponentialHistogram(in)
+	if err != nil {
+		t.Fatalf("FoldExponentialHistogram: %v", err)
+	}
+	if fold.Sketch.ZeroCount() != 3 {
+		t.Errorf("zero count = %d, want 3", fold.Sketch.ZeroCount())
+	}
+	if fold.Sketch.Count() != in.Count {
+		t.Errorf("sketch count = %d, want %d", fold.Sketch.Count(), in.Count)
+	}
+	if fold.Sketch.Quantile(0) != 0 {
+		t.Errorf("q0 = %v, want 0 (the zero bucket is the smallest)", fold.Sketch.Quantile(0))
+	}
+}
+
+// TestFoldExponentialHistogramNegativeBucketsSuppressPercentiles is the
+// non-negotiable half of Q1: the count and the scalars survive, the percentiles
+// do not. Publishing the positive side's p99 as the distribution's p99 is the
+// specific lie this test exists to prevent.
+func TestFoldExponentialHistogramNegativeBucketsSuppressPercentiles(t *testing.T) {
+	in := expPointFromValues(SketchDefaultScale, histTestValues)
+	in.Negative = ExpBuckets{Offset: 0, Counts: []uint64{2, 1}}
+	in.Count += 3
+	in.Min, in.HasMin = -8, true
+	fold, err := FoldExponentialHistogram(in)
+	if err != nil {
+		t.Fatalf("FoldExponentialHistogram: %v", err)
+	}
+	if fold.Sketch != nil {
+		t.Error("sketch retained despite negative observations")
+	}
+	if !fold.PercentilesUnavailable || fold.DropReason != SketchDropNegativeObservations {
+		t.Errorf("unavailable=%v reason=%v, want true/negative_observations",
+			fold.PercentilesUnavailable, fold.DropReason)
+	}
+	if fold.DropReason.String() != "negative_observations" {
+		t.Errorf("reason label = %q", fold.DropReason.String())
+	}
+	if fold.Count != in.Count || fold.Sum != in.Sum || fold.Min != -8 {
+		t.Errorf("scalars lost: count=%d sum=%v min=%v", fold.Count, fold.Sum, fold.Min)
+	}
+}
+
+// TestFoldExponentialHistogramNegativeScaleKeepsScalars covers the one valid
+// OTLP scale range the unsigned sketch scale cannot express.
+func TestFoldExponentialHistogramNegativeScaleKeepsScalars(t *testing.T) {
+	in := ExponentialHistogramInput{
+		HistogramCommon: histCommon(9, 900),
+		Scale:           -3,
+		Positive:        ExpBuckets{Offset: 1, Counts: []uint64{4, 5}},
+	}
+	fold, err := FoldExponentialHistogram(in)
+	if err != nil {
+		t.Fatalf("FoldExponentialHistogram: %v", err)
+	}
+	if fold.Sketch != nil || fold.DropReason != SketchDropScaleOutOfRange {
+		t.Fatalf("sketch=%v reason=%v, want nil/scale_out_of_range", fold.Sketch, fold.DropReason)
+	}
+	if fold.Count != 9 || fold.Sum != 900 {
+		t.Errorf("scalars lost: count=%d sum=%v", fold.Count, fold.Sum)
+	}
+}
+
+// TestFoldExponentialHistogramRejectsMalformed pins that a point violating the
+// data model is refused ENTIRELY, not silently repaired.
+func TestFoldExponentialHistogramRejectsMalformed(t *testing.T) {
+	cases := map[string]ExponentialHistogramInput{
+		"scale above max": {HistogramCommon: histCommon(1, 1), Scale: 21,
+			Positive: ExpBuckets{Counts: []uint64{1}}},
+		"scale below min": {HistogramCommon: histCommon(1, 1), Scale: -11,
+			Positive: ExpBuckets{Counts: []uint64{1}}},
+		"count disagrees with buckets": {HistogramCommon: histCommon(5, 1), Scale: 4,
+			Positive: ExpBuckets{Counts: []uint64{1, 1}}},
+		"bucket cap exceeded": {HistogramCommon: histCommon(0, 0), Scale: 4,
+			Positive: ExpBuckets{Counts: make([]uint64, maxExpBuckets+1)}},
+		"index overflows int32": {HistogramCommon: histCommon(1, 1), Scale: 4,
+			Positive: ExpBuckets{Offset: math.MaxInt32, Counts: []uint64{1}}},
+		"non-finite sum": {HistogramCommon: HistogramCommon{Sum: math.Inf(1), HasSum: true}, Scale: 4},
+		"min above max":  {HistogramCommon: withExtremes(histCommon(0, 0), 9, 1), Scale: 4},
+	}
+	for name, in := range cases {
+		if _, err := FoldExponentialHistogram(in); !errors.Is(err, ErrHistogramMalformed) {
+			t.Errorf("%s: err = %v, want ErrHistogramMalformed", name, err)
+		}
+	}
+}
+
+// histPoint builds an explicit-bounds point with the given bounds and counts.
+func histPoint(bounds []float64, counts []uint64) HistogramInput {
+	var total uint64
+	for _, c := range counts {
+		total += c
+	}
+	return HistogramInput{
+		HistogramCommon: histCommon(total, 1234),
+		Bounds:          bounds,
+		BucketCounts:    counts,
+	}
+}
+
+var histTestBounds = []float64{1, 2, 4}
+
+// TestFoldHistogramFoldsBucketsAsWeightedObservations pins #199 Q2's folding
+// rule: one weighted add per bucket at the geometric midpoint, with the
+// source's own bucket error carried out on the fold.
+func TestFoldHistogramFoldsBucketsAsWeightedObservations(t *testing.T) {
+	in := histPoint(histTestBounds, []uint64{0, 5, 7, 0})
+	fold, err := FoldHistogram(in)
+	if err != nil {
+		t.Fatalf("FoldHistogram: %v", err)
+	}
+	if fold.Sketch.Count() != 12 {
+		t.Fatalf("sketch count = %d, want 12", fold.Sketch.Count())
+	}
+	if fold.UnboundedTail {
+		t.Error("unbounded tail reported for an empty +Inf bucket")
+	}
+	// Both folded buckets have a boundary ratio of 2, so the worst-case error
+	// of a geometric midpoint is sqrt(2)-1 for each.
+	if want := math.Sqrt(2) - 1; math.Abs(fold.SourceBucketError-want) > 1e-12 {
+		t.Errorf("source bucket error = %v, want %v", fold.SourceBucketError, want)
+	}
+	// The (1,2] bucket's five observations must all sit at sqrt(2).
+	if got, want := fold.Sketch.Quantile(0), sketchValue(sketchIndex(math.Sqrt2, SketchDefaultScale), SketchDefaultScale); got != want {
+		t.Errorf("q0 = %v, want the sqrt(2) bucket representative %v", got, want)
+	}
+}
+
+// TestFoldHistogramDoesNotExpandCounts pins the "never expand count
+// observations in a loop" requirement. A billion-count bucket that folded per
+// observation would not return inside this test's lifetime.
+func TestFoldHistogramDoesNotExpandCounts(t *testing.T) {
+	const huge = uint64(1_000_000_000)
+	in := histPoint(histTestBounds, []uint64{0, huge, huge, 0})
+	start := time.Now()
+	fold, err := FoldHistogram(in)
+	if err != nil {
+		t.Fatalf("FoldHistogram: %v", err)
+	}
+	if fold.Sketch.Count() != 2*huge {
+		t.Fatalf("sketch count = %d, want %d", fold.Sketch.Count(), 2*huge)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("folding two buckets took %s; counts are being expanded", elapsed)
+	}
+}
+
+// TestFoldHistogramUnboundedTail pins that +Inf observations are tracked
+// separately and never folded: their only known property is a lower bound.
+func TestFoldHistogramUnboundedTail(t *testing.T) {
+	in := histPoint(histTestBounds, []uint64{0, 5, 7, 2})
+	fold, err := FoldHistogram(in)
+	if err != nil {
+		t.Fatalf("FoldHistogram: %v", err)
+	}
+	if !fold.UnboundedTail || fold.UnboundedTailCount != 2 || fold.UnboundedTailBound != 4 {
+		t.Fatalf("tail = %v/%d/%v, want true/2/4",
+			fold.UnboundedTail, fold.UnboundedTailCount, fold.UnboundedTailBound)
+	}
+	if fold.Sketch.Count() != 12 {
+		t.Errorf("sketch count = %d, want 12 — tail observations must stay out", fold.Sketch.Count())
+	}
+	if fold.PercentilesUnavailable {
+		t.Error("an unbounded tail suppresses the tail quantiles, not the whole distribution")
+	}
+}
+
+// TestFoldHistogramNegativeBucketNeedsAProvingMin pins Q2's negative rule from
+// both sides: without a min at or above zero the percentiles go, with one the
+// bucket folds against an effective lower boundary.
+func TestFoldHistogramNegativeBucketNeedsAProvingMin(t *testing.T) {
+	unproven := histPoint(histTestBounds, []uint64{3, 5, 7, 0})
+	fold, err := FoldHistogram(unproven)
+	if err != nil {
+		t.Fatalf("FoldHistogram: %v", err)
+	}
+	if fold.Sketch != nil || fold.DropReason != SketchDropNegativeObservations {
+		t.Fatalf("unproven: sketch=%v reason=%v, want nil/negative_observations", fold.Sketch, fold.DropReason)
+	}
+	if fold.Count != 15 {
+		t.Errorf("unproven: count = %d, want 15 — scalars must survive", fold.Count)
+	}
+
+	proven := unproven
+	proven.HistogramCommon = withExtremes(proven.HistogramCommon, 0.5, 3.9)
+	fold, err = FoldHistogram(proven)
+	if err != nil {
+		t.Fatalf("FoldHistogram (proven): %v", err)
+	}
+	if fold.PercentilesUnavailable {
+		t.Fatalf("proven: percentiles suppressed despite min=0.5")
+	}
+	if fold.Sketch.Count() != 15 {
+		t.Errorf("proven: sketch count = %d, want 15", fold.Sketch.Count())
+	}
+}
+
+// TestFoldHistogramZeroLowerBoundCarriesFullError pins that a bucket whose
+// effective lower boundary is exactly zero admits 100% source error rather
+// than pretending a geometric midpoint exists.
+func TestFoldHistogramZeroLowerBoundCarriesFullError(t *testing.T) {
+	in := histPoint(histTestBounds, []uint64{4, 0, 0, 0})
+	in.HistogramCommon = withExtremes(in.HistogramCommon, 0, 0.9)
+	fold, err := FoldHistogram(in)
+	if err != nil {
+		t.Fatalf("FoldHistogram: %v", err)
+	}
+	if fold.SourceBucketError != 1 {
+		t.Errorf("source bucket error = %v, want 1", fold.SourceBucketError)
+	}
+	if fold.Sketch.Count() != 4 {
+		t.Errorf("sketch count = %d, want 4", fold.Sketch.Count())
+	}
+}
+
+// TestFoldHistogramRejectsMalformed pins the explicit-bounds data model.
+func TestFoldHistogramRejectsMalformed(t *testing.T) {
+	cases := map[string]HistogramInput{
+		"bucket/bound arity": {HistogramCommon: histCommon(1, 1), Bounds: histTestBounds, BucketCounts: []uint64{1, 0}},
+		"count disagrees":    {HistogramCommon: histCommon(99, 1), Bounds: histTestBounds, BucketCounts: []uint64{1, 0, 0, 0}},
+		"bounds not ascending": {HistogramCommon: histCommon(1, 1), Bounds: []float64{4, 2},
+			BucketCounts: []uint64{1, 0, 0}},
+		"non-finite bound": {HistogramCommon: histCommon(1, 1), Bounds: []float64{math.Inf(1)},
+			BucketCounts: []uint64{1, 0}},
+		"count with no buckets": {HistogramCommon: histCommon(7, 1)},
+	}
+	for name, in := range cases {
+		if _, err := FoldHistogram(in); !errors.Is(err, ErrHistogramMalformed) {
+			t.Errorf("%s: err = %v, want ErrHistogramMalformed", name, err)
+		}
+	}
+}
+
+// TestFoldHistogramWithoutFiniteBoundsSuppressesPercentiles covers the single
+// (-Inf, +Inf] bucket: there is no boundary to place anything against.
+func TestFoldHistogramWithoutFiniteBoundsSuppressesPercentiles(t *testing.T) {
+	fold, err := FoldHistogram(histPoint(nil, []uint64{6}))
+	if err != nil {
+		t.Fatalf("FoldHistogram: %v", err)
+	}
+	if fold.Sketch != nil || fold.DropReason != SketchDropNoFiniteBoundaries {
+		t.Fatalf("sketch=%v reason=%v, want nil/no_finite_boundaries", fold.Sketch, fold.DropReason)
+	}
+}
+
+// TestHistogramQuantileAnswersTailAsALowerBound pins the three-way contract on
+// the read helper: a quantile inside the +Inf bucket is "at least the last
+// finite boundary", never an ordinary estimate.
+func TestHistogramQuantileAnswersTailAsALowerBound(t *testing.T) {
+	fold, err := FoldHistogram(histPoint(histTestBounds, []uint64{0, 5, 7, 2}))
+	if err != nil {
+		t.Fatalf("FoldHistogram: %v", err)
+	}
+	var d AggregateDelta
+	d.ObserveHistogram(fold)
+
+	value, lower, ok := d.HistogramQuantile(0.99)
+	if !ok || !lower || value != 4 {
+		t.Errorf("p99 = %v lower=%v ok=%v, want 4/true/true", value, lower, ok)
+	}
+	value, lower, ok = d.HistogramQuantile(0.5)
+	if !ok || lower || value <= 0 {
+		t.Errorf("p50 = %v lower=%v ok=%v, want a positive estimate", value, lower, ok)
+	}
+
+	suppressed, err := FoldHistogram(histPoint(histTestBounds, []uint64{3, 5, 7, 0}))
+	if err != nil {
+		t.Fatalf("FoldHistogram: %v", err)
+	}
+	var sd AggregateDelta
+	sd.ObserveHistogram(suppressed)
+	if _, _, ok := sd.HistogramQuantile(0.99); ok {
+		t.Error("a suppressed distribution published a quantile")
+	}
+	acc := AccuracyFromHistogramDelta(&sd)
+	if !acc.PercentilesUnavailable || acc.PercentilesUnavailableReason != "negative_observations" {
+		t.Errorf("accuracy = %+v, want percentiles_unavailable/negative_observations", acc)
+	}
+}
+
+// TestAccuracyFromHistogramDeltaNamesTheSourceApproximation pins that a bare
+// degraded=true is not what an unbounded tail or a coarse source reports.
+func TestAccuracyFromHistogramDeltaNamesTheSourceApproximation(t *testing.T) {
+	fold, err := FoldHistogram(histPoint(histTestBounds, []uint64{0, 5, 7, 2}))
+	if err != nil {
+		t.Fatalf("FoldHistogram: %v", err)
+	}
+	var d AggregateDelta
+	d.ObserveHistogram(fold)
+	acc := AccuracyFromHistogramDelta(&d)
+	if !acc.UnboundedTail || acc.UnboundedTailBound != 4 {
+		t.Errorf("accuracy tail = %v/%v, want true/4", acc.UnboundedTail, acc.UnboundedTailBound)
+	}
+	if acc.SourceBucketError <= acc.RelativeErrorBound {
+		t.Errorf("source error %v must dominate the sketch bound %v for decade-ish buckets",
+			acc.SourceBucketError, acc.RelativeErrorBound)
+	}
+}
+
+// TestHistogramDeltaMergeIsOrderIndependent pins the additive contract for the
+// new fields, including the tail bound, whose sound merge is the LOWEST of the
+// two boundaries.
+func TestHistogramDeltaMergeIsOrderIndependent(t *testing.T) {
+	foldA, err := FoldHistogram(histPoint(histTestBounds, []uint64{0, 5, 0, 2}))
+	if err != nil {
+		t.Fatalf("FoldHistogram A: %v", err)
+	}
+	foldB, err := FoldHistogram(histPoint([]float64{1, 2, 8}, []uint64{0, 0, 3, 1}))
+	if err != nil {
+		t.Fatalf("FoldHistogram B: %v", err)
+	}
+	var ab, ba AggregateDelta
+	ab.ObserveHistogram(foldA)
+	ab.ObserveHistogram(foldB)
+	ba.ObserveHistogram(foldB)
+	ba.ObserveHistogram(foldA)
+
+	if ab.HistogramCount != ba.HistogramCount || ab.HistogramTailCount != ba.HistogramTailCount {
+		t.Fatalf("counts differ by order: %+v vs %+v", ab, ba)
+	}
+	if ab.HistogramTailBound != 4 || ba.HistogramTailBound != 4 {
+		t.Errorf("tail bound = %v/%v, want the lower of 4 and 8 both ways",
+			ab.HistogramTailBound, ba.HistogramTailBound)
+	}
+	if ab.HistogramFlags != ba.HistogramFlags {
+		t.Errorf("flags differ by order: %d vs %d", ab.HistogramFlags, ba.HistogramFlags)
+	}
+}
+
+// --- Q3: temporality ---------------------------------------------------------
+
+// TestReducerRejectsNonDeltaHistograms pins #199 Q3: GA aggregates
+// delta-temporality histograms only, and a refusal contributes NOTHING.
+func TestReducerRejectsNonDeltaHistograms(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	cases := []struct {
+		temporality Temporality
+		reason      string
+	}{
+		{TemporalityCumulative, ReasonCumulativeTemporality},
+		{TemporalityUnspecified, ReasonUnspecifiedTemporality},
+	}
+	for _, c := range cases {
+		e := testEngine(t, now)
+		r := e.NewReducer(now)
+
+		hist := histPoint(histTestBounds, []uint64{0, 5, 7, 0})
+		hist.Timestamp, hist.Temporality = now, c.temporality
+		res := r.ReduceHistogramPoint(hist)
+		if !res.Rejected() || res.Reason != c.reason {
+			t.Errorf("histogram %v: rejected=%v reason=%q, want true/%s",
+				c.temporality, res.Rejected(), res.Reason, c.reason)
+		}
+
+		exp := expPointFromValues(SketchDefaultScale, histTestValues)
+		exp.Timestamp, exp.Temporality = now, c.temporality
+		res = r.ReduceExponentialHistogramPoint(exp)
+		if !res.Rejected() || res.Reason != c.reason {
+			t.Errorf("exponential %v: rejected=%v reason=%q, want true/%s",
+				c.temporality, res.Rejected(), res.Reason, c.reason)
+		}
+
+		if r.Len() != 0 {
+			t.Errorf("%v: %d deltas emitted; a rejected point must contribute nothing", c.temporality, r.Len())
+		}
+		if got := r.Stats().InputPoints[SignalMetric]; got != 0 {
+			t.Errorf("%v: %d input points counted for rejected histograms", c.temporality, got)
+		}
+	}
+}
+
+// --- Q4: dimensions ----------------------------------------------------------
+
+// dimsEngine builds an engine that aggregates histTestMetric by two dimensions.
+func dimsEngine(t *testing.T, now time.Time) *Engine {
+	t.Helper()
+	e, err := NewEngine(EngineConfig{
+		Mode:       ModeShadow,
+		Now:        func() time.Time { return now },
+		MetricDims: DimsConfig{histTestMetric: {"http.method", "http.status"}},
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	return e
+}
+
+// attr builds one OTLP attribute with a string value.
+func attr(k, v string) *commonpb.KeyValue {
+	return &commonpb.KeyValue{Key: k, Value: &commonpb.AnyValue{
+		Value: &commonpb.AnyValue_StringValue{StringValue: v}}}
+}
+
+// intAttr builds one OTLP attribute with an int value.
+func intAttr(k string, v int64) *commonpb.KeyValue {
+	return &commonpb.KeyValue{Key: k, Value: &commonpb.AnyValue{
+		Value: &commonpb.AnyValue_IntValue{IntValue: v}}}
+}
+
+// dimsIDs reduces one point of each shape with the given attributes and
+// returns the DimsID each landed on.
+func dimsIDs(t *testing.T, r *Reducer, now time.Time, attrs []*commonpb.KeyValue) map[Signal][]uint32 {
+	t.Helper()
+
+	num := MetricInput{Tenant: "acme", Service: "checkout", Name: histTestMetric,
+		Value: 1, Timestamp: now, Temporality: TemporalityDelta, Attributes: attrs}
+	r.ReduceMetricPoint(num)
+
+	hist := histPoint(histTestBounds, []uint64{0, 5, 7, 0})
+	hist.Timestamp, hist.Attributes = now, attrs
+	if res := r.ReduceHistogramPoint(hist); res.Rejected() {
+		t.Fatalf("histogram rejected: %v", res.Err)
+	}
+
+	exp := expPointFromValues(SketchDefaultScale, histTestValues)
+	exp.Timestamp, exp.Attributes = now, attrs
+	if res := r.ReduceExponentialHistogramPoint(exp); res.Rejected() {
+		t.Fatalf("exponential rejected: %v", res.Err)
+	}
+
+	ids := make([]uint32, 0, len(r.Deltas()))
+	for swk := range r.Deltas() {
+		ids = append(ids, swk.Key.DimsID)
+	}
+	return map[Signal][]uint32{SignalMetric: ids}
+}
+
+// TestDimsInternedIdenticallyAcrossPointTypes pins #199 Q4: the configured
+// tuple resolves to ONE series identity whatever shape the point arrived in.
+// Three shapes landing on three DimsIDs would silently triple the cardinality
+// of every histogram-backed metric.
+func TestDimsInternedIdenticallyAcrossPointTypes(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := dimsEngine(t, now)
+	r := e.NewReducer(now)
+	attrs := []*commonpb.KeyValue{attr("http.method", "GET"), intAttr("http.status", 200), attr("noise", "x")}
+
+	ids := dimsIDs(t, r, now, attrs)[SignalMetric]
+	if len(ids) != 1 {
+		t.Fatalf("three points produced %d series, want 1 (%v)", len(ids), ids)
+	}
+	if ids[0] == 0 {
+		t.Fatal("configured dimensions resolved to DimsID 0")
+	}
+	if r.Stats().DimsRejected != 0 {
+		t.Errorf("dims rejected = %d, want 0", r.Stats().DimsRejected)
+	}
+}
+
+// TestDimsMissingKeyFallsBackToZero pins the all-or-nothing contract, and
+// TestDimsRejectsNonScalarValues the reasoned counter for values with no
+// canonical rendering.
+func TestDimsMissingKeyFallsBackToZero(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := dimsEngine(t, now)
+	r := e.NewReducer(now)
+
+	ids := dimsIDs(t, r, now, []*commonpb.KeyValue{attr("http.method", "GET")})[SignalMetric]
+	if len(ids) != 1 || ids[0] != 0 {
+		t.Fatalf("partial tuple produced %v, want a single DimsID 0", ids)
+	}
+}
+
+func TestDimsRejectsNonScalarValues(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := dimsEngine(t, now)
+	r := e.NewReducer(now)
+
+	arrayAttr := &commonpb.KeyValue{Key: "http.status", Value: &commonpb.AnyValue{
+		Value: &commonpb.AnyValue_ArrayValue{ArrayValue: &commonpb.ArrayValue{}}}}
+	ids := dimsIDs(t, r, now, []*commonpb.KeyValue{attr("http.method", "GET"), arrayAttr})[SignalMetric]
+	if len(ids) != 1 || ids[0] != 0 {
+		t.Fatalf("array dimension produced %v, want a single DimsID 0", ids)
+	}
+	if got := r.Stats().DimsRejected; got != 3 {
+		t.Errorf("dims rejected = %d, want 3 (one per point shape)", got)
+	}
+}
+
+// TestDimsExtractionDoesNotAllocatePerPoint pins the hot-path requirement:
+// resolving a bounded tuple must not allocate a map per point.
+func TestDimsExtractionDoesNotAllocatePerPoint(t *testing.T) {
+	keys := []string{"http.method", "http.status"}
+	attrs := []*commonpb.KeyValue{attr("http.method", "GET"), attr("http.status", "200"), attr("noise", "x")}
+	var s dimScratch
+	// Warm the scratch buffer so its one-time growth is not counted.
+	s.resolve(keys, attrs)
+	allocs := testing.AllocsPerRun(100, func() {
+		if _, _, ok := s.resolve(keys, attrs); !ok {
+			t.Fatal("resolve failed")
+		}
+	})
+	if allocs != 0 {
+		t.Errorf("resolve allocated %v times per point, want 0", allocs)
+	}
+}

--- a/internal/aggregate/metrics.go
+++ b/internal/aggregate/metrics.go
@@ -91,6 +91,7 @@ func (r promRecorder) RecordReduction(stats ReducerStats, deltas map[Signal]uint
 			r.m.AggregateShadowErrorsTotal.WithLabelValues(service).Add(float64(n))
 		}
 	}
+	r.m.RecordMetricDimsRejected(DimsRejectUnsupportedValue, stats.DimsRejected)
 }
 
 // RecordOverflow implements MetricsRecorder.

--- a/internal/aggregate/query.go
+++ b/internal/aggregate/query.go
@@ -80,6 +80,50 @@ type AccuracyMetadata struct {
 	// Degraded reports that the merged sketch collapsed or saturated, which
 	// puts estimates in the affected range OUTSIDE RelativeErrorBound.
 	Degraded bool `json:"degraded,omitempty"`
+
+	// --- OTLP histogram provenance (#199) ---
+	//
+	// A bare Degraded=true does not describe a folded source histogram: an
+	// explicit-bounds histogram imports its own bucket width as error, and an
+	// unbounded +Inf bucket is not an error bound at all but a missing tail.
+	// Both are named here rather than collapsed into one boolean.
+
+	// SourceBucketError is the worst-case relative error imported from the
+	// SOURCE histogram's bucket widths, as a fraction. Zero for a native
+	// sketch and for exponential histograms, whose index transfer is exact.
+	// When non-zero it, not RelativeErrorBound, is the number that dominates.
+	SourceBucketError float64 `json:"source_bucket_error,omitempty"`
+	// UnboundedTail reports that observations landed in the source
+	// histogram's +Inf bucket. A quantile that falls there is a LOWER BOUND
+	// (>= UnboundedTailBound), never an estimate.
+	UnboundedTail      bool    `json:"unbounded_tail,omitempty"`
+	UnboundedTailBound float64 `json:"unbounded_tail_bound,omitempty"`
+	// PercentilesUnavailable suppresses every quantile: the sketch does not
+	// describe the whole distribution. PercentilesUnavailableReason names why
+	// (negative_observations, scale_out_of_range, no_finite_boundaries).
+	PercentilesUnavailable       bool   `json:"percentiles_unavailable,omitempty"`
+	PercentilesUnavailableReason string `json:"percentiles_unavailable_reason,omitempty"`
+}
+
+// AccuracyFromHistogramDelta derives the accuracy metadata of a folded OTLP
+// histogram distribution. It layers the source histogram's provenance on top
+// of the merged sketch's own bound, so a caller cannot read a 2.17% error
+// bound off a distribution whose source buckets were a decade wide.
+func AccuracyFromHistogramDelta(d *AggregateDelta) AccuracyMetadata {
+	if d == nil {
+		return AccuracyFromSketch(nil)
+	}
+	acc := AccuracyFromSketch(d.Sketch)
+	acc.SourceBucketError = d.HistogramSourceError
+	if d.HistogramFlags&HistUnboundedTail != 0 {
+		acc.UnboundedTail = true
+		acc.UnboundedTailBound = d.HistogramTailBound
+	}
+	if d.HistogramFlags&HistPercentilesUnavailable != 0 {
+		acc.PercentilesUnavailable = true
+		acc.PercentilesUnavailableReason = histReason(d.HistogramFlags).String()
+	}
+	return acc
 }
 
 // AccuracyFromSketch derives the accuracy metadata of a merged sketch. A nil

--- a/internal/aggregate/read_contract_test.go
+++ b/internal/aggregate/read_contract_test.go
@@ -639,7 +639,9 @@ func TestRequestErrorRateReflectsEntryPointStatusOnly(t *testing.T) {
 
 // TestStoreRefusesAV2FileAndRebuildsOnDemand is #197 Q5's fail-closed policy at
 // the v2 -> v3 bump: request_count cannot be derived from a v2 file, so the only
-// two answers are "run the old binary" and "destroy and recreate".
+// two answers are "run the old binary" and "destroy and recreate". The wanted
+// version is read from StoreSchemaVersion, not spelled out: the policy is what
+// this test pins, and it does not change when a later bump adds columns.
 func TestStoreRefusesAV2FileAndRebuildsOnDemand(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "aggregate.db")
 	store := newTestStoreAt(t, path, StoreConfig{})
@@ -655,8 +657,9 @@ func TestStoreRefusesAV2FileAndRebuildsOnDemand(t *testing.T) {
 	if !errors.As(err, &schemaErr) {
 		t.Fatalf("open of a v2 file = %v, want *SchemaError", err)
 	}
-	if schemaErr.Got != "2" || schemaErr.Want != "3" {
-		t.Fatalf("mismatch reported %s -> %s, want 2 -> 3", schemaErr.Got, schemaErr.Want)
+	want := fmt.Sprint(StoreSchemaVersion)
+	if schemaErr.Got != "2" || schemaErr.Want != want {
+		t.Fatalf("mismatch reported %s -> %s, want 2 -> %s", schemaErr.Got, schemaErr.Want, want)
 	}
 
 	rebuilt, err := OpenSQLiteStore(StoreConfig{Path: path, AllowRebuild: true})
@@ -667,7 +670,7 @@ func TestStoreRefusesAV2FileAndRebuildsOnDemand(t *testing.T) {
 	if rebuilt.UUID() == original {
 		t.Fatal("rebuild kept the old store uuid; it must mint a new identity")
 	}
-	// The rebuilt schema must actually carry the v3 columns.
+	// The rebuilt schema must actually carry the current columns.
 	if err := rebuilt.CommitGroup(&GroupBatch{
 		Series: []SeriesRow{{ID: 1, Key: storeKey(1)}},
 		Deltas: []DeltaRow{{SeriesID: 1, WindowStart: 600, Delta: &AggregateDelta{Count: 3, RequestCount: 2, ErrorRequestCount: 1}}},

--- a/internal/aggregate/reducer.go
+++ b/internal/aggregate/reducer.go
@@ -3,6 +3,8 @@ package aggregate
 import (
 	"strings"
 	"time"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 )
 
 // Request-local reduction.
@@ -49,6 +51,10 @@ type ReducerStats struct {
 	// StaleCumulative counts cumulative points ignored as stale or duplicate
 	// against their baseline (#166 case 1).
 	StaleCumulative uint64
+	// DimsRejected counts metric points whose configured dimension tuple was
+	// refused from series identity because an attribute value had no scalar
+	// rendering (#199 Q4). The point is still aggregated, under DimsID 0.
+	DimsRejected uint64
 	// ErrorsByService counts errors per service — the cheap invariant #165
 	// asks for on the aggregate side, and nothing more expensive.
 	ErrorsByService map[string]uint64
@@ -63,6 +69,7 @@ func (s *ReducerStats) merge(other *ReducerStats) {
 		s.Accepted[i] += other.Accepted[i]
 	}
 	s.StaleCumulative += other.StaleCumulative
+	s.DimsRejected += other.DimsRejected
 	for svc, n := range other.ErrorsByService {
 		if s.ErrorsByService == nil {
 			s.ErrorsByService = make(map[string]uint64, len(other.ErrorsByService))
@@ -129,6 +136,10 @@ type MetricInput struct {
 	Monotonic   bool
 	// Resource carries the stable identity used to derive the ProducerID.
 	Resource ResourceIdentity
+	// Attributes are the RAW OTLP point attributes. The configured dimension
+	// tuple is extracted from them here, against a request-local scratch, so
+	// the hot path never allocates a per-point map (#199 Q4).
+	Attributes []*commonpb.KeyValue
 }
 
 // Reducer collapses one Export request into deltas.
@@ -143,6 +154,10 @@ type Reducer struct {
 	// a restart the durable dictionary is warm but the intern cache is empty,
 	// so a reverse lookup would silently render an unnamed topology.
 	ids map[SeriesWindowKey]topoIdentity
+	// dims is the request-local dimension-extraction scratch (#199 Q4). It is
+	// allocated on the first configured metric point and reused for every
+	// point in the request.
+	dims *dimScratch
 }
 
 // NewReducer returns a reducer for one Export request. arrival is the single
@@ -380,6 +395,156 @@ func (r *Reducer) ReduceLog(in LogInput) {
 	}
 }
 
+// dimsIDFor resolves the DimsID of one metric point from its attributes.
+//
+// Missing any configured key yields 0, the "no configured dims" sentinel and
+// the existing all-or-nothing contract. The scan allocates no per-point map:
+// the configured tuple is bounded, so a request-local scratch holds it.
+func (r *Reducer) dimsIDFor(tenantID uint32, metricName string, attrs []*commonpb.KeyValue) uint32 {
+	keys := r.eng.dims.Get(metricName)
+	if len(keys) == 0 {
+		return 0
+	}
+	if r.dims == nil {
+		r.dims = &dimScratch{}
+	}
+	values, rejected, ok := r.dims.resolve(keys, attrs)
+	if rejected {
+		r.stats.DimsRejected++
+	}
+	if !ok {
+		return 0
+	}
+	return InternDimValues(r.eng.cache, tenantID, keys, values)
+}
+
+// metricSeriesKey builds the metric SeriesKey for one point, including its
+// configured dimension tuple. It is shared by every metric point shape so the
+// three of them cannot drift apart on identity (#199 Q4).
+func (r *Reducer) metricSeriesKey(tenantID uint32, service, name string, attrs []*commonpb.KeyValue) SeriesKey {
+	return SeriesKey{
+		TenantID:  tenantID,
+		ServiceID: r.eng.cache.Intern(tenantID, KindService, service),
+		NameID:    r.eng.cache.Intern(tenantID, KindMetricName, name),
+		DimsID:    r.dimsIDFor(tenantID, name, attrs),
+		Signal:    SignalMetric,
+	}
+}
+
+// MetricPointOutcome is the reducer's verdict on one metric data point.
+type MetricPointOutcome uint8
+
+// MetricPointOutcome values.
+const (
+	// MetricPointAccepted means the point contributed to a delta.
+	MetricPointAccepted MetricPointOutcome = iota
+	// MetricPointExcluded means the point fell outside the mutable-window horizon.
+	// It is counted as late or future, NOT as an OTLP rejection: the client
+	// sent well-formed telemetry and retrying would not help.
+	MetricPointExcluded
+	// MetricPointRejectedTemporality means a histogram point arrived with a
+	// temporality the GA engine does not support (#199 Q3).
+	MetricPointRejectedTemporality
+	// MetricPointRejectedMalformed means the point violates the OTLP data model.
+	MetricPointRejectedMalformed
+)
+
+// MetricPointResult reports what the reducer did with one metric data point,
+// so the OTLP Export path can build an honest partial-success response.
+type MetricPointResult struct {
+	Outcome MetricPointOutcome
+	// Reason is the metric label for a rejection, "" when accepted.
+	Reason string
+	// Err carries the validation failure behind PointRejectedMalformed.
+	Err error
+	// SketchDropped reports that the point's scalars were accepted but its
+	// percentiles suppressed, and DropReason says why. This is NOT a
+	// rejection: the point still contributes count, sum, min and max.
+	SketchDropped bool
+	DropReason    SketchDropReason
+}
+
+// Rejected reports whether the point must be counted in
+// ExportMetricsPartialSuccess.rejected_data_points.
+func (r MetricPointResult) Rejected() bool {
+	return r.Outcome == MetricPointRejectedTemporality || r.Outcome == MetricPointRejectedMalformed
+}
+
+// Rejection reasons reported to OTLP clients.
+const (
+	// ReasonCumulativeTemporality — GA aggregates delta-temporality
+	// histograms only; see CLAUDE.md for the collector-side conversion.
+	ReasonCumulativeTemporality = "cumulative_temporality"
+	// ReasonUnspecifiedTemporality — a histogram with no temporality set is
+	// not interpretable either way.
+	ReasonUnspecifiedTemporality = "unspecified_temporality"
+	// ReasonMalformedPoint — the point violates the OTLP data model.
+	ReasonMalformedPoint = "malformed_point"
+	// ReasonUnsupportedType — the point type has no aggregate model at all
+	// (Summary).
+	ReasonUnsupportedType = "unsupported_type"
+)
+
+// checkHistogramTemporality enforces the #199 Q3 contract: GA aggregates
+// delta-temporality histogram points only. A cumulative histogram is refused
+// COMPLETELY -- it does not contribute a count, and it is reported to the
+// client as a rejected data point so nobody builds a dashboard on a number
+// that silently is not there.
+func checkHistogramTemporality(t Temporality) (MetricPointResult, bool) {
+	switch t {
+	case TemporalityDelta:
+		return MetricPointResult{}, true
+	case TemporalityCumulative:
+		return MetricPointResult{Outcome: MetricPointRejectedTemporality, Reason: ReasonCumulativeTemporality}, false
+	default:
+		return MetricPointResult{Outcome: MetricPointRejectedTemporality, Reason: ReasonUnspecifiedTemporality}, false
+	}
+}
+
+// reduceFold folds an already-validated histogram fold into its series.
+func (r *Reducer) reduceFold(c HistogramCommon, fold HistogramFold) MetricPointResult {
+	window, ok := r.admitPoint(SignalMetric, c.Timestamp)
+	if !ok {
+		return MetricPointResult{Outcome: MetricPointExcluded}
+	}
+	tenantID := r.eng.cache.InternTenant(c.Tenant)
+	key := r.metricSeriesKey(tenantID, c.Service, c.Name, c.Attributes)
+	r.delta(key, window).ObserveHistogram(fold)
+	r.identify(key, window, topoIdentity{Kind: topoMetric, Tenant: c.Tenant, A: c.Service, B: c.Name})
+	r.stats.Accepted[SignalMetric]++
+	return MetricPointResult{
+		Outcome:       MetricPointAccepted,
+		SketchDropped: fold.PercentilesUnavailable,
+		DropReason:    fold.DropReason,
+	}
+}
+
+// ReduceHistogramPoint folds one OTLP explicit-bounds Histogram data point
+// (#199 Q2).
+func (r *Reducer) ReduceHistogramPoint(in HistogramInput) MetricPointResult {
+	if res, ok := checkHistogramTemporality(in.Temporality); !ok {
+		return res
+	}
+	fold, err := FoldHistogram(in)
+	if err != nil {
+		return MetricPointResult{Outcome: MetricPointRejectedMalformed, Reason: ReasonMalformedPoint, Err: err}
+	}
+	return r.reduceFold(in.HistogramCommon, fold)
+}
+
+// ReduceExponentialHistogramPoint folds one OTLP ExponentialHistogram data
+// point (#199 Q1).
+func (r *Reducer) ReduceExponentialHistogramPoint(in ExponentialHistogramInput) MetricPointResult {
+	if res, ok := checkHistogramTemporality(in.Temporality); !ok {
+		return res
+	}
+	fold, err := FoldExponentialHistogram(in)
+	if err != nil {
+		return MetricPointResult{Outcome: MetricPointRejectedMalformed, Reason: ReasonMalformedPoint, Err: err}
+	}
+	return r.reduceFold(in.HistogramCommon, fold)
+}
+
 // ReduceMetricPoint folds one metric data point into its metric series,
 // applying the #166 aggregation model for its temporality and monotonicity.
 func (r *Reducer) ReduceMetricPoint(in MetricInput) {
@@ -388,12 +553,7 @@ func (r *Reducer) ReduceMetricPoint(in MetricInput) {
 		return
 	}
 	tenantID := r.eng.cache.InternTenant(in.Tenant)
-	key := SeriesKey{
-		TenantID:  tenantID,
-		ServiceID: r.eng.cache.Intern(tenantID, KindService, in.Service),
-		NameID:    r.eng.cache.Intern(tenantID, KindMetricName, in.Name),
-		Signal:    SignalMetric,
-	}
+	key := r.metricSeriesKey(tenantID, in.Service, in.Name, in.Attributes)
 
 	switch {
 	// Gauges and cumulative non-monotonic sums (UpDownCounter): gauge-like,

--- a/internal/aggregate/sketch.go
+++ b/internal/aggregate/sketch.go
@@ -156,6 +156,55 @@ func (s *Sketch) Observe(value float64) {
 	s.add(sketchIndex(value, s.scale), 1)
 }
 
+// ObserveN records n observations of the same value. It is the weighted form
+// of Observe and exists for histogram folding (#199): a source bucket holding
+// a million counts must cost one bin add, never a million calls to Observe.
+//
+// ObserveN never allocates.
+func (s *Sketch) ObserveN(value float64, n uint64) {
+	if n == 0 || math.IsNaN(value) || math.IsInf(value, 0) {
+		return
+	}
+	s.count += n
+	s.sum += value * float64(n)
+	if value <= 0 {
+		s.zeroCount += n
+		return
+	}
+	s.add(sketchIndex(value, s.scale), n)
+}
+
+// ObserveZero records n observations that belong in the zero bucket. It is the
+// landing slot for an OTLP exponential histogram's zero_count, which by
+// definition holds values at (or within zero_threshold of) zero and has no
+// representation in the log mapping.
+func (s *Sketch) ObserveZero(n uint64) {
+	if n == 0 {
+		return
+	}
+	s.count += n
+	s.zeroCount += n
+}
+
+// ObserveBucket records n observations already resolved to a bucket index in
+// THIS sketch's mapping. It is the exact-transfer primitive for OTLP
+// exponential histograms, whose bucket indexes use the identical
+// (base^i, base^(i+1)] convention: no value is reconstructed, so no mapping
+// error is introduced beyond the source histogram's own bucket width.
+//
+// The sketch's running sum is advanced by the bucket's representative value
+// times n. That makes Sum() an ESTIMATE for bucket-folded observations; the
+// authoritative sum of a histogram point is carried separately on the delta
+// (AggregateDelta.HistogramSum) and never derived from here.
+func (s *Sketch) ObserveBucket(index int32, n uint64) {
+	if n == 0 {
+		return
+	}
+	s.count += n
+	s.sum += sketchValue(index, s.scale) * float64(n)
+	s.add(index, n)
+}
+
 // Quantile returns the estimated q-quantile of the observed values, for q in
 // [0,1]. An empty sketch returns 0; an out-of-range or NaN q returns NaN.
 //

--- a/internal/aggregate/store.go
+++ b/internal/aggregate/store.go
@@ -40,7 +40,12 @@ import (
 // kind of every span it summarised are long gone. Backfilling zeros would make
 // every historical window read "0 requests, N spans", which is worse than an
 // operator-acknowledged rebuild, so the fail-closed policy stands unchanged.
-const StoreSchemaVersion = 3
+//
+// v4 added the eight hist_* columns that carry an OTLP histogram point's
+// population statistics and its accuracy metadata (#199). A v3 file has no
+// column to put them in and no way to reconstruct them, so the same
+// rebuild-or-downgrade choice applies.
+const StoreSchemaVersion = 4
 
 // Store errors.
 var (

--- a/internal/aggregate/store_sqlite.go
+++ b/internal/aggregate/store_sqlite.go
@@ -294,7 +294,9 @@ func (s *SQLiteStore) Close() error {
 const deltaColumnList = `point_count, error_count, duration_count, duration_sum, duration_min, duration_max,
 	gauge_count, gauge_sum, gauge_min, gauge_max, gauge_last, gauge_last_ts,
 	counter_delta, reset_count, log_count, first_ts, last_ts, sketch,
-	request_count, error_request_count`
+	request_count, error_request_count,
+	hist_count, hist_sum, hist_min, hist_max, hist_flags, hist_source_error,
+	hist_tail_bound, hist_tail_count`
 
 // deltaColumnDDL is deltaColumnList with types, shared by both tables.
 const deltaColumnDDL = `point_count INTEGER NOT NULL,
@@ -316,10 +318,18 @@ const deltaColumnDDL = `point_count INTEGER NOT NULL,
 	last_ts INTEGER NOT NULL,
 	sketch BLOB,
 	request_count INTEGER NOT NULL,
-	error_request_count INTEGER NOT NULL`
+	error_request_count INTEGER NOT NULL,
+	hist_count INTEGER NOT NULL,
+	hist_sum REAL NOT NULL,
+	hist_min REAL NOT NULL,
+	hist_max REAL NOT NULL,
+	hist_flags INTEGER NOT NULL,
+	hist_source_error REAL NOT NULL,
+	hist_tail_bound REAL NOT NULL,
+	hist_tail_count INTEGER NOT NULL`
 
 // deltaValuePlaceholders matches deltaColumnList's arity.
-const deltaValuePlaceholders = `?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?`
+const deltaValuePlaceholders = `?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?`
 
 // schemaDDL is the complete aggregate schema (#162).
 func schemaDDL() []string {
@@ -1520,19 +1530,24 @@ type scanFunc func(dst ...any) error
 // that also wants the series id).
 func scanDelta(scan scanFunc, id *int64) (*AggregateDelta, error) {
 	var (
-		d                   AggregateDelta
-		gaugeLastTS         int64
-		firstTS, lastTS     int64
-		sketch              []byte
-		dst                 []any
-		pointCount, errCnt  int64
-		durCount, gaugeCnt  int64
-		resetCount, logCnt  int64
-		reqCount, errReqCnt int64
-		durSum, durMin      float64
-		durMax, gaugeSum    float64
-		gaugeMin, gaugeMax  float64
-		gaugeLast, counterD float64
+		d                    AggregateDelta
+		gaugeLastTS          int64
+		firstTS, lastTS      int64
+		sketch               []byte
+		dst                  []any
+		pointCount, errCnt   int64
+		durCount, gaugeCnt   int64
+		resetCount, logCnt   int64
+		reqCount, errReqCnt  int64
+		durSum, durMin       float64
+		durMax, gaugeSum     float64
+		gaugeMin, gaugeMax   float64
+		gaugeLast, counterD  float64
+		histCount, histFlags int64
+		histTailCount        int64
+		histSum, histMin     float64
+		histMax, histSrcErr  float64
+		histTailBound        float64
 	)
 	if id != nil {
 		dst = append(dst, id)
@@ -1542,6 +1557,8 @@ func scanDelta(scan scanFunc, id *int64) (*AggregateDelta, error) {
 		&gaugeCnt, &gaugeSum, &gaugeMin, &gaugeMax, &gaugeLast, &gaugeLastTS,
 		&counterD, &resetCount, &logCnt, &firstTS, &lastTS, &sketch,
 		&reqCount, &errReqCnt,
+		&histCount, &histSum, &histMin, &histMax, &histFlags, &histSrcErr,
+		&histTailBound, &histTailCount,
 	)
 	if err := scan(dst...); err != nil {
 		return nil, err
@@ -1558,6 +1575,11 @@ func scanDelta(scan scanFunc, id *int64) (*AggregateDelta, error) {
 	d.GaugeSum, d.GaugeMin, d.GaugeMax, d.GaugeLast = gaugeSum, gaugeMin, gaugeMax, gaugeLast
 	d.CounterDelta = counterD
 	d.GaugeLastTime = timeFromNanos(gaugeLastTS)
+	d.HistogramCount = uint64(histCount)         // #nosec G115 -- counters are written from uint64
+	d.HistogramTailCount = uint64(histTailCount) // #nosec G115 -- counters are written from uint64
+	d.HistogramFlags = uint32(histFlags)         // #nosec G115 -- flags are written from uint32
+	d.HistogramSum, d.HistogramMin, d.HistogramMax = histSum, histMin, histMax
+	d.HistogramSourceError, d.HistogramTailBound = histSrcErr, histTailBound
 	d.FirstTimestamp = timeFromNanos(firstTS)
 	d.LastTimestamp = timeFromNanos(lastTS)
 	if len(sketch) > 0 {
@@ -1586,6 +1608,9 @@ func deltaArgs(d *AggregateDelta, sketch []byte) []any {
 		d.CounterDelta, int64(d.ResetCount), int64(d.LogCount), // #nosec G115
 		nanosOf(d.FirstTimestamp), nanosOf(d.LastTimestamp), blob,
 		int64(d.RequestCount), int64(d.ErrorRequestCount), // #nosec G115 -- counters are bounded by ingest volume
+		int64(d.HistogramCount), d.HistogramSum, d.HistogramMin, d.HistogramMax, // #nosec G115 -- counters are bounded by ingest volume
+		int64(d.HistogramFlags), d.HistogramSourceError, // #nosec G115 -- a uint32 flags word always fits int64
+		d.HistogramTailBound, int64(d.HistogramTailCount), // #nosec G115 -- counters are bounded by ingest volume
 	}
 }
 

--- a/internal/ingest/aggregate_bridge.go
+++ b/internal/ingest/aggregate_bridge.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
@@ -330,4 +332,185 @@ func aggregateTemporality(m *metricspb.Metric) (aggregate.Temporality, bool) {
 		}
 	}
 	return aggregate.TemporalityUnspecified, false
+}
+
+// --- OTLP metric completeness (#199) -----------------------------------------
+
+// otlpDataPointNoRecordedValue is DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK. A
+// point carrying it asserts that no value was recorded in the interval; it is
+// neither accepted nor rejected, because there is nothing to account for.
+const otlpDataPointNoRecordedValue uint32 = 1
+
+// OTLP point-type labels for the unsupported/rejection counters.
+const (
+	pointTypeHistogram    = "histogram"
+	pointTypeExpHistogram = "exponential_histogram"
+	pointTypeSummary      = "summary"
+)
+
+// otlpTemporality maps an OTLP AggregationTemporality onto the engine's enum.
+// Unlike aggregateTemporality it is not Sum-specific: histogram points carry
+// their temporality on the enclosing Histogram/ExponentialHistogram message.
+func otlpTemporality(t metricspb.AggregationTemporality) aggregate.Temporality {
+	switch t {
+	case metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA:
+		return aggregate.TemporalityDelta
+	case metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE:
+		return aggregate.TemporalityCumulative
+	default:
+		return aggregate.TemporalityUnspecified
+	}
+}
+
+// histogramCommonFields builds the identity and scalar payload shared by both
+// histogram point shapes. Optional sum/min/max arrive as proto pointers and
+// their presence is carried explicitly: a missing min is not a min of zero,
+// and treating it as one would claim the population is non-negative.
+func histogramCommonFields(
+	tenant, service, name string,
+	res aggregate.ResourceIdentity,
+	temporality aggregate.Temporality,
+	attrs []*commonpb.KeyValue,
+	timeNanos, startNanos uint64,
+	count uint64,
+	sum, minV, maxV *float64,
+) aggregate.HistogramCommon {
+	c := aggregate.HistogramCommon{
+		Tenant:      tenant,
+		Service:     service,
+		Name:        name,
+		Resource:    res,
+		Timestamp:   time.Unix(0, int64(timeNanos)),  // #nosec G115 -- OTLP nanos fit int64 until year 2262
+		StartTime:   time.Unix(0, int64(startNanos)), // #nosec G115 -- OTLP nanos fit int64 until year 2262
+		Temporality: temporality,
+		Attributes:  attrs,
+		Count:       count,
+	}
+	if sum != nil {
+		c.Sum, c.HasSum = *sum, true
+	}
+	if minV != nil {
+		c.Min, c.HasMin = *minV, true
+	}
+	if maxV != nil {
+		c.Max, c.HasMax = *maxV, true
+	}
+	return c
+}
+
+// aggregateHistogramInput converts one OTLP HistogramDataPoint.
+func aggregateHistogramInput(
+	tenant, service, name string,
+	res aggregate.ResourceIdentity,
+	temporality aggregate.Temporality,
+	p *metricspb.HistogramDataPoint,
+) aggregate.HistogramInput {
+	return aggregate.HistogramInput{
+		HistogramCommon: histogramCommonFields(tenant, service, name, res, temporality,
+			p.Attributes, p.TimeUnixNano, p.StartTimeUnixNano, p.Count, p.Sum, p.Min, p.Max),
+		Bounds:       p.ExplicitBounds,
+		BucketCounts: p.BucketCounts,
+	}
+}
+
+// aggregateExpHistogramInput converts one OTLP ExponentialHistogramDataPoint.
+func aggregateExpHistogramInput(
+	tenant, service, name string,
+	res aggregate.ResourceIdentity,
+	temporality aggregate.Temporality,
+	p *metricspb.ExponentialHistogramDataPoint,
+) aggregate.ExponentialHistogramInput {
+	return aggregate.ExponentialHistogramInput{
+		HistogramCommon: histogramCommonFields(tenant, service, name, res, temporality,
+			p.Attributes, p.TimeUnixNano, p.StartTimeUnixNano, p.Count, p.Sum, p.Min, p.Max),
+		Scale:     p.Scale,
+		ZeroCount: p.ZeroCount,
+		Positive:  expBuckets(p.Positive),
+		Negative:  expBuckets(p.Negative),
+	}
+}
+
+// expBuckets converts one side of an exponential histogram.
+func expBuckets(b *metricspb.ExponentialHistogramDataPoint_Buckets) aggregate.ExpBuckets {
+	if b == nil {
+		return aggregate.ExpBuckets{}
+	}
+	return aggregate.ExpBuckets{Offset: b.Offset, Counts: b.BucketCounts}
+}
+
+// metricRejectKey identifies one (point type, reason) pair in the partial
+// success accounting.
+type metricRejectKey struct{ kind, reason string }
+
+// metricRejections accumulates the metric data points one Export refused, so
+// the response can report an exact rejected_data_points count with a bounded
+// message naming the types and reasons (#199 Q5).
+//
+// Late and future points are deliberately NOT counted here. They are excluded
+// from aggregates and reported on the lateness counters, but the client sent
+// well-formed telemetry and a retry would not change the outcome; calling that
+// a rejection would train operators to ignore the field that matters.
+type metricRejections struct {
+	total  uint64
+	counts map[metricRejectKey]uint64
+}
+
+// add records n rejected points of one type and reason.
+func (m *metricRejections) add(kind, reason string, n uint64) {
+	if n == 0 {
+		return
+	}
+	if m.counts == nil {
+		m.counts = make(map[metricRejectKey]uint64, 4)
+	}
+	m.counts[metricRejectKey{kind: kind, reason: reason}] += n
+	m.total += n
+}
+
+// maxRejectionReasons bounds how many distinct (type, reason) pairs the
+// response message names. The COUNT is always exact; only the prose is capped,
+// because an error message is not a log sink.
+const maxRejectionReasons = 6
+
+// message renders the bounded human-readable summary.
+func (m *metricRejections) message() string {
+	if m.total == 0 {
+		return ""
+	}
+	keys := make([]metricRejectKey, 0, len(m.counts))
+	for k := range m.counts {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if m.counts[keys[i]] != m.counts[keys[j]] {
+			return m.counts[keys[i]] > m.counts[keys[j]]
+		}
+		if keys[i].kind != keys[j].kind {
+			return keys[i].kind < keys[j].kind
+		}
+		return keys[i].reason < keys[j].reason
+	})
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d metric data points were not aggregated and must not be retried:", m.total)
+	for i, k := range keys {
+		if i == maxRejectionReasons {
+			fmt.Fprintf(&sb, " (+%d more reasons)", len(keys)-i)
+			break
+		}
+		fmt.Fprintf(&sb, " %s/%s=%d", k.kind, k.reason, m.counts[k])
+	}
+	return sb.String()
+}
+
+// record folds one reducer verdict into the rejection accounting and the
+// telemetry counters.
+func (m *metricRejections) record(metrics *telemetry.Metrics, kind string, res aggregate.MetricPointResult) {
+	if res.Rejected() {
+		m.add(kind, res.Reason, 1)
+		metrics.RecordMetricUnsupported(kind, res.Reason, 1)
+		return
+	}
+	if res.SketchDropped {
+		metrics.RecordMetricSketchDropped(res.DropReason.String())
+	}
 }

--- a/internal/ingest/otlp.go
+++ b/internal/ingest/otlp.go
@@ -302,6 +302,9 @@ func (s *MetricsServer) Export(ctx context.Context, req *colmetricspb.ExportMetr
 	if s.aggregateEngine != nil {
 		reducer = s.aggregateEngine.NewReducer(start)
 	}
+	// rejected accumulates the points aggregate accounting refused, for the
+	// OTLP partial-success response (#199 Q5).
+	var rejected metricRejections
 
 	for _, resourceMetrics := range req.ResourceMetrics {
 		serviceName := getServiceName(resourceMetrics.Resource.Attributes)
@@ -319,66 +322,53 @@ func (s *MetricsServer) Export(ctx context.Context, req *colmetricspb.ExportMetr
 
 		for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
 			for _, m := range scopeMetrics.Metrics {
-				var points []*metricspb.NumberDataPoint
-
-				// Extract points based on metric type
-				switch m.Data.(type) {
+				switch data := m.Data.(type) {
 				case *metricspb.Metric_Gauge:
-					points = m.GetGauge().DataPoints
+					s.exportNumberPoints(reducer, m, data.Gauge.GetDataPoints(), serviceName, tenantID, producerIdentity)
 				case *metricspb.Metric_Sum:
-					points = m.GetSum().DataPoints
-				}
-
-				for _, p := range points {
-					var val float64
-					if p.Value != nil {
-						switch v := p.Value.(type) {
-						case *metricspb.NumberDataPoint_AsDouble:
-							val = v.AsDouble
-						case *metricspb.NumberDataPoint_AsInt:
-							val = float64(v.AsInt)
+					s.exportNumberPoints(reducer, m, data.Sum.GetDataPoints(), serviceName, tenantID, producerIdentity)
+				case *metricspb.Metric_Histogram:
+					// Distribution points have no legacy consumer: the TSDB
+					// ring buffer holds scalars only. They exist for aggregate
+					// accounting, so nothing runs in legacy mode and nothing
+					// is reported rejected there either — the aggregate
+					// contract is what promises to account for them (#199).
+					if reducer == nil {
+						continue
+					}
+					temporality := otlpTemporality(data.Histogram.GetAggregationTemporality())
+					for _, p := range data.Histogram.GetDataPoints() {
+						if p == nil || p.Flags&otlpDataPointNoRecordedValue != 0 {
+							continue
 						}
+						res := reducer.ReduceHistogramPoint(aggregateHistogramInput(
+							tenantID, serviceName, m.Name, producerIdentity, temporality, p))
+						rejected.record(s.metrics, pointTypeHistogram, res)
 					}
-
-					raw := tsdb.RawMetric{
-						Name:        m.Name,
-						ServiceName: serviceName,
-						Value:       val,
-						Timestamp:   time.Unix(0, int64(p.TimeUnixNano)), // #nosec G115 -- OTLP time in nanos: uint64 source fits int64 until year 2262
-						Attributes:  make(map[string]any),
-						TenantID:    tenantID,
+				case *metricspb.Metric_ExponentialHistogram:
+					if reducer == nil {
+						continue
 					}
-
-					// Convert attributes to map for TSDB grouping
-					for _, kv := range p.Attributes {
-						raw.Attributes[kv.Key] = kv.Value.String()
+					temporality := otlpTemporality(data.ExponentialHistogram.GetAggregationTemporality())
+					for _, p := range data.ExponentialHistogram.GetDataPoints() {
+						if p == nil || p.Flags&otlpDataPointNoRecordedValue != 0 {
+							continue
+						}
+						res := reducer.ReduceExponentialHistogramPoint(aggregateExpHistogramInput(
+							tenantID, serviceName, m.Name, producerIdentity, temporality, p))
+						rejected.record(s.metrics, pointTypeExpHistogram, res)
 					}
-
-					// 0. Aggregate accounting, ahead of every other consumer.
-					if reducer != nil {
-						temporality, monotonic := aggregateTemporality(m)
-						reducer.ReduceMetricPoint(aggregate.MetricInput{
-							Tenant:      tenantID,
-							Service:     serviceName,
-							Name:        m.Name,
-							Value:       val,
-							Timestamp:   raw.Timestamp,
-							StartTime:   time.Unix(0, int64(p.StartTimeUnixNano)), // #nosec G115 -- OTLP time in nanos: uint64 source fits int64 until year 2262
-							Temporality: temporality,
-							Monotonic:   monotonic,
-							Resource:    producerIdentity,
-						})
+				case *metricspb.Metric_Summary:
+					// Summary is wholly unsupported (#199 Q5). It carries
+					// producer-chosen quantiles that cannot be merged across
+					// series or windows, so there is no honest way to fold it
+					// into a sketch. Every point is counted and reported.
+					if reducer == nil {
+						continue
 					}
-
-					// 1. Process via TSDB Aggregator (for storage)
-					if s.aggregator != nil {
-						s.aggregator.Ingest(raw)
-					}
-
-					// 2. Real-time bypass (for live charts)
-					if s.metricCallback != nil {
-						s.metricCallback(raw)
-					}
+					n := uint64(len(data.Summary.GetDataPoints()))
+					rejected.add(pointTypeSummary, aggregate.ReasonUnsupportedType, n)
+					s.metrics.RecordMetricUnsupported(pointTypeSummary, aggregate.ReasonUnsupportedType, len(data.Summary.GetDataPoints()))
 				}
 			}
 		}
@@ -395,7 +385,85 @@ func (s *MetricsServer) Export(ctx context.Context, req *colmetricspb.ExportMetr
 		s.metrics.RecordIngestion(1)
 	}
 
-	return &colmetricspb.ExportMetricsServiceResponse{}, nil
+	resp := &colmetricspb.ExportMetricsServiceResponse{}
+	if rejected.total > 0 {
+		// Export SUCCEEDS: every accepted point is committed. The rejected
+		// count is exact and the client must not retry it — a retry replays
+		// the same unsupported points to the same refusal. A zero here is
+		// reserved for warning-only responses where everything was accepted,
+		// so it is never written on this branch (#199 Q5).
+		resp.PartialSuccess = &colmetricspb.ExportMetricsPartialSuccess{
+			RejectedDataPoints: int64(rejected.total), // #nosec G115 -- bounded by the request's point count
+			ErrorMessage:       rejected.message(),
+		}
+	}
+	return resp, nil
+}
+
+// exportNumberPoints handles the Gauge and Sum data points of one metric: the
+// aggregate reduction, the TSDB ring buffer and the real-time bypass, in that
+// order. It is a method rather than a closure so the histogram branches above
+// stay flat and the loop body is not duplicated per instrument type.
+func (s *MetricsServer) exportNumberPoints(
+	reducer *aggregate.Reducer,
+	m *metricspb.Metric,
+	points []*metricspb.NumberDataPoint,
+	serviceName, tenantID string,
+	producerIdentity aggregate.ResourceIdentity,
+) {
+	for _, p := range points {
+		if p == nil {
+			continue
+		}
+		var val float64
+		switch v := p.Value.(type) {
+		case *metricspb.NumberDataPoint_AsDouble:
+			val = v.AsDouble
+		case *metricspb.NumberDataPoint_AsInt:
+			val = float64(v.AsInt)
+		}
+
+		raw := tsdb.RawMetric{
+			Name:        m.Name,
+			ServiceName: serviceName,
+			Value:       val,
+			Timestamp:   time.Unix(0, int64(p.TimeUnixNano)), // #nosec G115 -- OTLP time in nanos: uint64 source fits int64 until year 2262
+			Attributes:  make(map[string]any),
+			TenantID:    tenantID,
+		}
+
+		// Convert attributes to map for TSDB grouping
+		for _, kv := range p.Attributes {
+			raw.Attributes[kv.Key] = kv.Value.String()
+		}
+
+		// 0. Aggregate accounting, ahead of every other consumer.
+		if reducer != nil {
+			temporality, monotonic := aggregateTemporality(m)
+			reducer.ReduceMetricPoint(aggregate.MetricInput{
+				Tenant:      tenantID,
+				Service:     serviceName,
+				Name:        m.Name,
+				Value:       val,
+				Timestamp:   raw.Timestamp,
+				StartTime:   time.Unix(0, int64(p.StartTimeUnixNano)), // #nosec G115 -- OTLP time in nanos: uint64 source fits int64 until year 2262
+				Temporality: temporality,
+				Monotonic:   monotonic,
+				Resource:    producerIdentity,
+				Attributes:  p.Attributes,
+			})
+		}
+
+		// 1. Process via TSDB Aggregator (for storage)
+		if s.aggregator != nil {
+			s.aggregator.Ingest(raw)
+		}
+
+		// 2. Real-time bypass (for live charts)
+		if s.metricCallback != nil {
+			s.metricCallback(raw)
+		}
+	}
 }
 
 // Export handles incoming OTLP trace data.

--- a/internal/ingest/otlp_metrics_completeness_test.go
+++ b/internal/ingest/otlp_metrics_completeness_test.go
@@ -1,0 +1,216 @@
+package ingest
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+)
+
+// #199 Q5: the OTLP metrics Export tells the client exactly how many data
+// points it refused. The shared builders keep every case to its own payload.
+
+// metricsExportServer returns a MetricsServer wired to a shadow-mode aggregate
+// engine and nothing else: these tests are about the aggregate path's response,
+// not about the TSDB or the DB.
+func metricsExportServer(t *testing.T, now time.Time) *MetricsServer {
+	t.Helper()
+	s := NewMetricsServer(nil, nil, nil, aggTestConfig())
+	s.SetAggregateEngine(newAggregateEngine(t, now))
+	return s
+}
+
+// metricsRequest wraps metrics in the one resource these tests use.
+func metricsRequest(metrics ...*metricspb.Metric) *colmetricspb.ExportMetricsServiceRequest {
+	return &colmetricspb.ExportMetricsServiceRequest{
+		ResourceMetrics: []*metricspb.ResourceMetrics{{
+			Resource: &resourcepb.Resource{Attributes: []*commonpb.KeyValue{{
+				Key:   "service.name",
+				Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "checkout"}},
+			}}},
+			ScopeMetrics: []*metricspb.ScopeMetrics{{Metrics: metrics}},
+		}},
+	}
+}
+
+// histogramMetric builds an explicit-bounds Histogram metric with one point.
+func histogramMetric(name string, temporality metricspb.AggregationTemporality, ts time.Time, counts []uint64) *metricspb.Metric {
+	var total uint64
+	for _, c := range counts {
+		total += c
+	}
+	sum := 42.0
+	return &metricspb.Metric{
+		Name: name,
+		Data: &metricspb.Metric_Histogram{Histogram: &metricspb.Histogram{
+			AggregationTemporality: temporality,
+			DataPoints: []*metricspb.HistogramDataPoint{{
+				TimeUnixNano:   uint64(ts.UnixNano()), // #nosec G115 -- test timestamps are positive
+				Count:          total,
+				Sum:            &sum,
+				ExplicitBounds: []float64{1, 2, 4},
+				BucketCounts:   counts,
+			}},
+		}},
+	}
+}
+
+// expHistogramMetric builds an ExponentialHistogram metric with one point.
+func expHistogramMetric(name string, scale int32, ts time.Time, counts []uint64) *metricspb.Metric {
+	var total uint64
+	for _, c := range counts {
+		total += c
+	}
+	return &metricspb.Metric{
+		Name: name,
+		Data: &metricspb.Metric_ExponentialHistogram{ExponentialHistogram: &metricspb.ExponentialHistogram{
+			AggregationTemporality: metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
+			DataPoints: []*metricspb.ExponentialHistogramDataPoint{{
+				TimeUnixNano: uint64(ts.UnixNano()), // #nosec G115 -- test timestamps are positive
+				Count:        total,
+				Scale:        scale,
+				Positive:     &metricspb.ExponentialHistogramDataPoint_Buckets{Offset: 0, BucketCounts: counts},
+			}},
+		}},
+	}
+}
+
+// summaryMetric builds a Summary metric with n points.
+func summaryMetric(name string, ts time.Time, n int) *metricspb.Metric {
+	points := make([]*metricspb.SummaryDataPoint, n)
+	for i := range points {
+		points[i] = &metricspb.SummaryDataPoint{
+			TimeUnixNano: uint64(ts.UnixNano()), // #nosec G115 -- test timestamps are positive
+			Count:        7,
+		}
+	}
+	return &metricspb.Metric{
+		Name: name,
+		Data: &metricspb.Metric_Summary{Summary: &metricspb.Summary{DataPoints: points}},
+	}
+}
+
+// TestExportReportsRejectedDataPoints pins #199 Q5 end to end: Summary,
+// cumulative Histogram and a malformed ExponentialHistogram are counted
+// exactly, named in the message, and reported alongside a SUCCESSFUL export of
+// the accepted points.
+func TestExportReportsRejectedDataPoints(t *testing.T) {
+	now := time.Now().UTC()
+	s := metricsExportServer(t, now)
+
+	// count disagrees with the bucket totals: malformed.
+	malformed := expHistogramMetric("bad.exp", 4, now, []uint64{1, 2})
+	malformed.GetExponentialHistogram().DataPoints[0].Count = 99
+
+	resp, err := s.Export(context.Background(), metricsRequest(
+		histogramMetric("ok.hist", metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, now, []uint64{0, 5, 7, 0}),
+		histogramMetric("cumulative.hist", metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, now, []uint64{0, 5, 7, 0}),
+		malformed,
+		summaryMetric("legacy.summary", now, 2),
+	))
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if resp.PartialSuccess == nil {
+		t.Fatal("no partial success reported; three point types were refused")
+	}
+	if got := resp.PartialSuccess.RejectedDataPoints; got != 4 {
+		t.Errorf("rejected_data_points = %d, want 4 (1 cumulative + 1 malformed + 2 summary)", got)
+	}
+	msg := resp.PartialSuccess.ErrorMessage
+	for _, want := range []string{
+		"summary/" + aggregate.ReasonUnsupportedType,
+		"histogram/" + aggregate.ReasonCumulativeTemporality,
+		"exponential_histogram/" + aggregate.ReasonMalformedPoint,
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message %q does not name %q", msg, want)
+		}
+	}
+}
+
+// TestExportWithoutRejectionsLeavesPartialSuccessUnset pins the other half of
+// Q5: a zero rejected count is reserved for warning-only responses, so a clean
+// metrics export must not fabricate one.
+func TestExportWithoutRejectionsLeavesPartialSuccessUnset(t *testing.T) {
+	now := time.Now().UTC()
+	s := metricsExportServer(t, now)
+
+	resp, err := s.Export(context.Background(), metricsRequest(
+		histogramMetric("ok.hist", metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, now, []uint64{0, 5, 7, 0}),
+		expHistogramMetric("ok.exp", 6, now, []uint64{3, 4, 5}),
+	))
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if resp.PartialSuccess != nil {
+		t.Fatalf("partial success set on a clean export: %+v", resp.PartialSuccess)
+	}
+}
+
+// TestExportSkipsNoRecordedValuePoints pins that a point flagged
+// NO_RECORDED_VALUE is neither aggregated nor reported as a rejection: the
+// producer is stating there was nothing to record.
+func TestExportSkipsNoRecordedValuePoints(t *testing.T) {
+	now := time.Now().UTC()
+	s := metricsExportServer(t, now)
+
+	m := histogramMetric("gap.hist", metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA, now, []uint64{0, 0, 0, 0})
+	m.GetHistogram().DataPoints[0].Flags = otlpDataPointNoRecordedValue
+
+	resp, err := s.Export(context.Background(), metricsRequest(m))
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if resp.PartialSuccess != nil {
+		t.Fatalf("partial success set for a no-recorded-value point: %+v", resp.PartialSuccess)
+	}
+}
+
+// TestExportInLegacyModeIgnoresDistributionPoints pins the mode boundary: with
+// no aggregate engine wired there is no aggregate accounting to be honest
+// about, and the response stays exactly what it was before #199.
+func TestExportInLegacyModeIgnoresDistributionPoints(t *testing.T) {
+	now := time.Now().UTC()
+	s := NewMetricsServer(nil, nil, nil, aggTestConfig())
+
+	resp, err := s.Export(context.Background(), metricsRequest(
+		summaryMetric("legacy.summary", now, 2),
+		histogramMetric("cumulative.hist", metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE, now, []uint64{0, 1, 0, 0}),
+	))
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if resp.PartialSuccess != nil {
+		t.Fatalf("legacy mode reported partial success: %+v", resp.PartialSuccess)
+	}
+}
+
+// TestRejectionMessageIsBounded pins that the message names at most
+// maxRejectionReasons pairs while the COUNT stays exact.
+func TestRejectionMessageIsBounded(t *testing.T) {
+	var m metricRejections
+	for i := 0; i < maxRejectionReasons+3; i++ {
+		m.add(pointTypeHistogram, string(rune('a'+i)), uint64(i+1))
+	}
+	msg := m.message()
+	if !strings.Contains(msg, "more reasons") {
+		t.Errorf("message %q did not truncate", msg)
+	}
+	if strings.Count(msg, pointTypeHistogram+"/") != maxRejectionReasons {
+		t.Errorf("message named %d reasons, want %d", strings.Count(msg, pointTypeHistogram+"/"), maxRejectionReasons)
+	}
+	var want uint64
+	for i := 0; i < maxRejectionReasons+3; i++ {
+		want += uint64(i + 1)
+	}
+	if m.total != want {
+		t.Errorf("total = %d, want %d", m.total, want)
+	}
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -157,6 +157,29 @@ type Metrics struct {
 	// label matcher. reason="dlq_full"|"dlq_error".
 	ExemplarSubmitLostTotal *prometheus.CounterVec
 
+	// --- OTLP metric completeness (#199) ---
+	// IngestMetricsUnsupportedTotal — metric data points the aggregate path
+	// refused outright and reported in ExportMetricsPartialSuccess. Labeled by
+	// the OTLP point type (summary|histogram|exponential_histogram) and the
+	// reason: cumulative_temporality, unspecified_temporality, unsupported_type
+	// or malformed_point. Every increment is a point that did NOT enter
+	// aggregate accounting, and the client must not retry it.
+	IngestMetricsUnsupportedTotal *prometheus.CounterVec
+	// IngestMetricsSketchDroppedTotal — histogram points whose SCALARS were
+	// kept but whose percentiles are unavailable, by reason:
+	// negative_observations (negative buckets or a bucket that spans negative
+	// values without a proving min>=0), scale_out_of_range (an
+	// ExponentialHistogram below scale 0, which the positive-only scale-4
+	// sketch cannot represent) or no_finite_boundaries.
+	// This is NOT a rejection: count/sum/min/max still land in the aggregate.
+	IngestMetricsSketchDroppedTotal *prometheus.CounterVec
+	// IngestMetricsDimsRejectedTotal — metric points whose configured
+	// dimension tuple was refused from series identity, by reason. Today the
+	// only reason is unsupported_value_type: an array or kvlist attribute
+	// value has no canonical scalar rendering, so it cannot be interned.
+	// The point is still aggregated, under DimsID=0.
+	IngestMetricsDimsRejectedTotal *prometheus.CounterVec
+
 	// HTTPOTLPThrottledTotal — count of HTTP 429s issued by the OTLP HTTP
 	// receiver when the async ingest pipeline is full. Mirrors the gRPC
 	// RESOURCE_EXHAUSTED path so operators see a single throttling signal
@@ -557,6 +580,18 @@ func New() *Metrics {
 		Name: "otelcontext_dashboard_p99_row_cap_hits_total",
 		Help: "Number of dashboard p99 computations that hit the SQLite row cap (200k). Indicates the dataset is too large for in-memory p99 — use Postgres for prod.",
 	})
+	m.IngestMetricsUnsupportedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_ingest_metrics_unsupported_total",
+		Help: "OTLP metric data points refused by the aggregate path and reported as rejected_data_points. type=summary|histogram|exponential_histogram, reason=cumulative_temporality|unspecified_temporality|unsupported_type|malformed_point.",
+	}, []string{"type", "reason"})
+	m.IngestMetricsSketchDroppedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_ingest_metrics_sketch_dropped_total",
+		Help: "Histogram points accepted for their scalars but whose percentiles are unavailable. reason=negative_observations|scale_out_of_range|no_finite_boundaries.",
+	}, []string{"reason"})
+	m.IngestMetricsDimsRejectedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_ingest_metrics_dims_rejected_total",
+		Help: "Metric points whose configured dimension tuple was refused from series identity. reason=unsupported_value_type. The point is still aggregated under DimsID=0.",
+	}, []string{"reason"})
 	m.AggregateInputPointsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "otelcontext_aggregate_input_points_total",
 		Help: "Points offered to the aggregate reducer, per signal, counted before sampling and severity gates.",
@@ -675,6 +710,34 @@ func New() *Metrics {
 		Help: "Retained traces forced past max spans/bytes. Persisted with truncated=true plus retained/observed span counts.",
 	})
 	return m
+}
+
+// RecordMetricUnsupported counts one OTLP metric data point refused by the
+// aggregate path. pointType is the OTLP point type, reason names why.
+// A nil *Metrics is a no-op: every ingest unit test passes one.
+func (m *Metrics) RecordMetricUnsupported(pointType, reason string, n int) {
+	if m == nil || n <= 0 {
+		return
+	}
+	m.IngestMetricsUnsupportedTotal.WithLabelValues(pointType, reason).Add(float64(n))
+}
+
+// RecordMetricSketchDropped counts one histogram point kept for its scalars
+// with percentiles suppressed.
+func (m *Metrics) RecordMetricSketchDropped(reason string) {
+	if m == nil {
+		return
+	}
+	m.IngestMetricsSketchDroppedTotal.WithLabelValues(reason).Inc()
+}
+
+// RecordMetricDimsRejected counts metric points whose dimension tuple was
+// refused from series identity.
+func (m *Metrics) RecordMetricDimsRejected(reason string, n uint64) {
+	if m == nil || n == 0 {
+		return
+	}
+	m.IngestMetricsDimsRejectedTotal.WithLabelValues(reason).Add(float64(n))
 }
 
 // RecordExemplarEligible implements ingest.ExemplarMetrics.


### PR DESCRIPTION
Implements the frozen contract from #199 (map #195, parent #194).

## Q1 — ExponentialHistogram scale conversion
- `FoldExponentialHistogram` (`internal/aggregate/histogram.go`). Scale > 4 downscales to 4 by an arithmetic right shift of each bucket index, merging collapsed counts. Scale 0–3 explicitly downscales the **accumulating** sketch to the source scale before any bucket lands — no reliance on incidental bin-collapse. Scale 4 is a direct transfer.
- Scale outside `[-10, 20]`, one-side bucket arrays past a 65,536 cap, an `offset + len` that overflows int32, a non-finite sum/min/max, an inverted min/max, and a `count` that disagrees with `zero_count + sum(positive) + sum(negative)` are all `ErrHistogramMalformed` and refused entirely.
- `zero_count`, `count`, `sum`, `min`, `max` fold normally.
- Negative buckets holding observations: scalars kept, `Sketch` nil, percentiles marked unavailable, `otelcontext_ingest_metrics_sketch_dropped_total{reason="negative_observations"}`.
- Valid-but-unrepresentable negative scales keep scalars with `reason="scale_out_of_range"` (the sketch scale is unsigned).

## Q2 — Fixed-bucket Histogram
- `FoldHistogram`. One weighted `Sketch.ObserveN` per bucket; counts are never expanded in a loop (pinned by a test that folds two 1e9-count buckets).
- Geometric midpoint only for finite positive buckets. A bucket admitting negative values folds only when a reported `min >= 0` proves the population non-negative (effective lower boundary becomes `max(0, boundary, min)`); otherwise scalars are kept and percentiles marked unavailable. An effective lower boundary of exactly 0 carries 100% source error rather than pretending a geometric midpoint exists.
- The `+Inf` bucket is tracked separately (`HistogramTailCount` / `HistogramTailBound`) and never folded. `AggregateDelta.HistogramQuantile` returns `(value, lowerBound, ok)`: a quantile landing in the tail answers `p99 >= last_finite_boundary`.
- `AccuracyMetadata` gained `source_bucket_error`, `unbounded_tail`, `unbounded_tail_bound`, `percentiles_unavailable` and `percentiles_unavailable_reason`. A bare `degraded=true` no longer has to describe an unbounded bucket.

## Q3 — Cumulative histogram temporality
- Cumulative and unspecified-temporality histogram points are refused completely (no count, no scalar, no bin), counted on `otelcontext_ingest_metrics_unsupported_total{type,reason}` and included in the partial-success rejected total.
- CLAUDE.md documents collector-side conversion via `cumulativetodeltaprocessor`, including the warning that it is **stateful** and needs stable routing to one collector instance.

## Q4 — Dimensions from point attributes
- `Reducer.metricSeriesKey` resolves `DimsID` through `InternDimValues` for `NumberDataPoint`, `HistogramDataPoint` and `ExponentialHistogramDataPoint` identically. Missing any configured key → `DimsID=0`.
- Extraction runs against a request-local `dimScratch` with fixed slots — no per-point `map[string]string`. Pinned by an `AllocsPerRun` test asserting 0 allocations.
- String, int, bool and double values supported. Array/kvlist values are refused from identity and counted on `otelcontext_ingest_metrics_dims_rejected_total{reason="unsupported_value_type"}`.

## Q5 — Unsupported types and response honesty
- Summary is wholly unsupported; every point counted.
- `ExportMetricsPartialSuccess.rejected_data_points` carries the exact total with a bounded message naming type/reason pairs (capped at 6 pairs, count always exact). `PartialSuccess` is left nil when nothing was rejected, so a zero count stays reserved for warning-only responses.
- Late/future points are **not** counted as rejections — they are excluded-window accounting, and a retry would not change their fate.
- Legacy mode (`AGGREGATE_MODE=legacy`) has no aggregate accounting to be honest about and leaves the response byte-identical to before.

## Store schema
`StoreSchemaVersion` 3 → 4: eight `hist_*` columns on `aggregate_delta_log` and `aggregate_buckets`. A v3 file cannot be migrated; the existing fail-closed `AGGREGATE_ALLOW_REBUILD` policy applies.

## Files changed
- new: `internal/aggregate/histogram.go`, `internal/aggregate/histogram_test.go`, `internal/ingest/otlp_metrics_completeness_test.go`
- modified: `internal/aggregate/{delta,dims_config,metrics,query,reducer,sketch,store,store_sqlite}.go`, `internal/aggregate/read_contract_test.go`, `internal/ingest/{aggregate_bridge,otlp}.go`, `internal/telemetry/metrics.go`, `CLAUDE.md`

## Test results

```
go build ./...                        Success
go vet ./...                          No issues found
go test -race ./internal/aggregate/... ./internal/ingest/... ./internal/telemetry/...
                                      485 passed, 0 failed
go test ./...                         all packages ok, 0 failures
golangci-lint run (3 packages)        1 issue, pre-existing (prealloc, internal/aggregate/engine.go:786 — untouched by this branch)
```

`read_contract_test.go` was updated in one place: `TestStoreRefusesAV2FileAndRebuildsOnDemand` hard-coded `Want == "3"`; it now reads `StoreSchemaVersion`, so the fail-closed policy it pins survives future column bumps.
