### PR TITLE
feat(aggregate): metadata lifecycle — dictionary GC and miner persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,10 +122,71 @@ they are excluded from aggregates and reported on the lateness counters, but a
 retry would not change their fate. Legacy mode (`AGGREGATE_MODE=legacy`) has no
 aggregate accounting to be honest about and leaves the response unchanged.
 
-Aggregate store schema is **v4**: eight `hist_*` columns carry the population
-statistics and accuracy metadata. A v3 file cannot be migrated (the columns
-have no derivable values) — start an older binary or set
-`AGGREGATE_ALLOW_REBUILD=true`.
+Aggregate store schema is **v5**: v4 added the eight `hist_*` columns carrying
+population statistics and accuracy metadata; v5 added `aggregate_log_template`
+(durable log-template miner state) plus the `dict_id_high_watermark` /
+`series_id_high_watermark` meta keys. An older file cannot be migrated — start
+an older binary or set `AGGREGATE_ALLOW_REBUILD=true`.
+
+### Aggregate identity lifecycle (#200)
+
+The dictionary and series tables were append-only. They are not any more.
+
+**Dictionary/series GC.** A mark-and-sweep pass runs on the **daily**
+maintenance tick (`RetentionScheduler`, wired from `main.go` next to
+`aggStore.Analyze`; `AGGREGATE_GC_ENABLED=false` disables it). The **mark**
+phase reads the reference set (`aggregate_buckets`, `aggregate_delta_log`,
+`aggregate_baseline`) and all three identity tables inside **one deferred read
+transaction** on the read pool — no writer lock, so a daily full scan can never
+become an ACK-latency incident. Marking is transitive: surviving series mark
+their tenant/service/name/dim-tuple IDs, surviving dim tuples mark the dim-key
+and dim-value IDs encoded inside them, and miner templates plus persisted alias
+records mark **both ends** of every alias, followed transitively through
+retired chains. The **sweep** phase runs through the writer's
+identity-maintenance barrier (`Writer.RunBarrier`, executed on the commit
+goroutine): revalidate candidates against durable, active, pending and staged
+references → fence survivors from new lookup → delete series, then dict, then
+template rows in **one** transaction → remove forward and reverse map entries
+only after the commit. A failed delete releases the fence and changes nothing
+in memory. `internal/aggregate/gc.go`.
+
+**High-watermarks, not MAX(id)+1.** `aggregate_meta` carries
+`dict_id_high_watermark` and `series_id_high_watermark`, bumped inside the same
+transaction as the rows they cover and never decreasing. ID allocation reseeds
+from them: once GC can delete the highest ID, `MAX(id)+1` would re-mint a number
+a finalized bucket or an alias row still names.
+
+**Miner persistence.** `aggregate_log_template` holds tenant/service partition,
+stable template ID (which IS the `log_template` dictionary ID and IS the log
+series `NameID`), versioned token pattern, alias target, partition sequence and
+the overflow flag. Identity-critical mutations — new templates, pattern
+generalizations, alias changes — are staged into `GroupBatch.Templates` and
+commit **atomically with the delta that used the identity**; a periodic
+snapshot alone lets acknowledged identity state vanish in a crash. Counters
+(`hit_count`, `first_ts`, `last_ts`) take the cheap periodic dirty write plus a
+best-effort save at shutdown. **Raw log samples are never persisted** —
+credential/PII sink; exemplars already carry the raw line. Reload
+(`aggregate.RestoreMiner`) rebuilds partitions and prefix trees in `main.go`
+**before** recovery and before ingest starts.
+
+**Identity bounds.** Every non-tenant dictionary value carries an encoded-length
+cap (`AGGREGATE_MAX_VALUE_BYTES`, default 512); over-length identities route to
+`__other__` and are **never truncated**. Service, dim-key, dim-value and
+dim-tuple namespaces now carry both per-tenant and instance-wide count caps.
+The tenant namespace is different: an over-length, empty, or over-cap tenant is
+**REJECTED** — the point is refused and counted on
+`otelcontext_aggregate_tenant_rejected_total`, never collapsed into a shared
+`__other__` tenant, because a shared overflow tenant is exactly the cross-tenant
+merge the cap exists to prevent. Startup identity preloads ask for `limit+1` and
+fail with a `*PreloadError` when the table exceeds the supported bound, instead
+of truncating the load in silence.
+
+Observability: `otelcontext_aggregate_gc_runs_total{result}`,
+`otelcontext_aggregate_gc_duration_seconds{phase=mark|barrier}`,
+`otelcontext_aggregate_gc_swept_total{table}`,
+`otelcontext_aggregate_gc_retained{table}`,
+`otelcontext_aggregate_identity_overflow_total{kind,bound}`,
+`otelcontext_aggregate_tenant_rejected_total{signal}`.
 
 ## Storage Architecture
 

--- a/internal/aggregate/dict.go
+++ b/internal/aggregate/dict.go
@@ -69,6 +69,106 @@ const OtherValue = "__other__"
 // never propagates it to the hot path — identity resolution never fails.
 var ErrDictFull = errors.New("aggregate: dictionary full")
 
+// ErrTenantRejected is returned when a tenant identity cannot be admitted: its
+// encoded name is over the tenant length cap, it is empty, or the
+// instance-wide tenant-identity cap is full.
+//
+// Unlike every other namespace, a tenant is NEVER collapsed into __other__
+// (#200 Q3). Merging two tenants into one identity is a data-isolation
+// failure, not a degradation: the point is refused and counted instead.
+var ErrTenantRejected = errors.New("aggregate: tenant identity rejected")
+
+// Identity bound defaults (#200 Q3).
+const (
+	// DefaultMaxValueBytes is the encoded-value length cap applied to every
+	// non-tenant dictionary kind. An over-length value is routed to
+	// __other__ and NEVER truncated: a truncated value is a different
+	// identity wearing the same name, which is worse than an honest
+	// "unnamed" bucket.
+	DefaultMaxValueBytes = 512
+
+	// DefaultMaxTenantBytes is the stricter cap on a tenant name. Tenants are
+	// asserted by clients (header, gRPC metadata, or an OTLP resource
+	// attribute), so the namespace that scopes every other namespace gets the
+	// tightest bound.
+	DefaultMaxTenantBytes = 128
+
+	// DefaultMaxTenants is the instance-wide tenant-identity cap. A shared
+	// API key grants access to every tenant, so an authenticated but hostile
+	// client can still assert tenant names; this is what bounds that.
+	DefaultMaxTenants = 256
+
+	// Instance-wide dictionary backstops for the namespaces that were
+	// uncapped before #200. The per-tenant caps bound one tenant; these bound
+	// the instance when many tenants each stay just under their own cap.
+	DefaultMaxServicesPerTenant  = 500
+	DefaultMaxServices           = 5000
+	DefaultMaxDimKeysPerTenant   = 200
+	DefaultMaxDimKeys            = 2000
+	DefaultMaxDimValuesPerTenant = 5000
+	DefaultMaxDimValues          = 50000
+	DefaultMaxDimTuplesPerTenant = 5000
+	DefaultMaxDimTuples          = 50000
+)
+
+// Bounds is the identity-bound configuration of a Cache and its Registrar
+// (#200 Q3). The zero value takes every default.
+type Bounds struct {
+	// MaxValueBytes caps the encoded length of a non-tenant dictionary value.
+	MaxValueBytes int
+	// MaxTenantBytes caps the encoded length of a tenant name.
+	MaxTenantBytes int
+	// MaxTenants is the instance-wide tenant-identity cap.
+	MaxTenants int
+	// PerTenantKind caps entries per (tenant, kind). A missing or zero entry
+	// means unlimited. __other__ entries are exempt.
+	PerTenantKind map[Kind]int
+	// InstanceKind caps entries per kind across every tenant — the backstop
+	// behind PerTenantKind. A missing or zero entry means unlimited.
+	InstanceKind map[Kind]int
+}
+
+// withDefaults returns b with unset knobs filled in.
+func (b Bounds) withDefaults() Bounds {
+	if b.MaxValueBytes <= 0 {
+		b.MaxValueBytes = DefaultMaxValueBytes
+	}
+	if b.MaxTenantBytes <= 0 {
+		b.MaxTenantBytes = DefaultMaxTenantBytes
+	}
+	if b.MaxTenants <= 0 {
+		b.MaxTenants = DefaultMaxTenants
+	}
+	b.PerTenantKind = cloneKindLimits(b.PerTenantKind)
+	b.InstanceKind = cloneKindLimits(b.InstanceKind)
+	return b
+}
+
+// cloneKindLimits copies a kind-limit map, dropping non-positive entries.
+func cloneKindLimits(in map[Kind]int) map[Kind]int {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[Kind]int, len(in))
+	for k, v := range in {
+		if v > 0 {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// valueCap returns the encoded-length cap for kind.
+func (b Bounds) valueCap(kind Kind) int {
+	if kind == KindTenant {
+		return b.MaxTenantBytes
+	}
+	return b.MaxValueBytes
+}
+
 // Registrar mints dictionary IDs. Phase 1 ships MemRegistrar, whose IDs are
 // provisional and vanish on restart; Phase 2 (#173) plugs in a SQLite-backed
 // registrar that mints durable IDs atomically with the first delta referencing
@@ -121,6 +221,16 @@ type CacheStats struct {
 	// Errors counts misses the Registrar failed for any other reason. These
 	// were also routed to __other__; Phase 2 must surface this as a metric.
 	Errors uint64
+	// OverLength counts values refused for exceeding the encoded-length cap
+	// and routed to __other__ (#200 Q3). Never truncated.
+	OverLength uint64
+	// TenantsRejected counts tenant identities refused outright — over-length,
+	// empty, or past the instance-wide tenant cap. These points are DROPPED,
+	// not collapsed.
+	TenantsRejected uint64
+	// Fenced counts lookups that hit a dictionary ID the identity-maintenance
+	// barrier had fenced, and were therefore served from __other__ (#200 Q2).
+	Fenced uint64
 }
 
 // Cache is the hot-path canonical-value to ID map in front of a Registrar. It
@@ -137,22 +247,64 @@ type CacheStats struct {
 // cached, so a pathological-cardinality tenant cannot grow this map without
 // bound; they pay a Registrar call per point instead.
 type Cache struct {
-	reg Registrar
+	reg    Registrar
+	bounds Bounds
 
 	mu  sync.RWMutex
 	ids map[dictScope]map[string]uint32
+	// fenced holds the dictionary IDs the identity-maintenance barrier has
+	// taken out of service while their rows are being deleted (#200 Q2). It
+	// is read on the hit path under the same RLock as ids, and only when
+	// fenceOn says a barrier is actually in progress, so the steady-state
+	// cost is one atomic load.
+	fenced map[uint32]struct{}
+	// fenceOn mirrors len(fenced) > 0 so the hit path can skip the map probe.
+	fenceOn atomic.Bool
 
-	hits      atomic.Uint64
-	misses    atomic.Uint64
-	overflows atomic.Uint64
-	errors    atomic.Uint64
+	// overflow, when set, publishes an identity routed to __other__ by a #200
+	// Q3 bound. It is a plain function rather than a MetricsRecorder so this
+	// file keeps no dependency on the engine's metric surface.
+	overflow atomic.Pointer[func(Kind, string)]
+
+	hits            atomic.Uint64
+	misses          atomic.Uint64
+	overflows       atomic.Uint64
+	errors          atomic.Uint64
+	overLength      atomic.Uint64
+	tenantsRejected atomic.Uint64
+	fencedHits      atomic.Uint64
 }
 
-// NewCache returns a Cache in front of reg. reg must not be nil.
-func NewCache(reg Registrar) *Cache {
+// NewCache returns a Cache in front of reg with default bounds. reg must not
+// be nil.
+func NewCache(reg Registrar) *Cache { return NewCacheWithBounds(reg, Bounds{}) }
+
+// NewCacheWithBounds returns a Cache in front of reg honouring b (#200 Q3).
+func NewCacheWithBounds(reg Registrar, b Bounds) *Cache {
 	return &Cache{
-		reg: reg,
-		ids: make(map[dictScope]map[string]uint32),
+		reg:    reg,
+		bounds: b.withDefaults(),
+		ids:    make(map[dictScope]map[string]uint32),
+	}
+}
+
+// Bounds returns the identity bounds in force.
+func (c *Cache) Bounds() Bounds { return c.bounds }
+
+// SetOverflowSink installs (or, with nil, removes) the callback that publishes
+// bound-driven __other__ routing. Safe to call while interning is in flight.
+func (c *Cache) SetOverflowSink(fn func(kind Kind, bound string)) {
+	if fn == nil {
+		c.overflow.Store(nil)
+		return
+	}
+	c.overflow.Store(&fn)
+}
+
+// recordOverflow publishes one bound-driven routing, if a sink is installed.
+func (c *Cache) recordOverflow(kind Kind, bound string) {
+	if p := c.overflow.Load(); p != nil {
+		(*p)(kind, bound)
 	}
 }
 
@@ -161,14 +313,38 @@ func NewCache(reg Registrar) *Cache {
 // pre-created __other__ ID for the scope.
 func (c *Cache) Intern(tenantID uint32, kind Kind, value string) uint32 {
 	scope := dictScope{tenant: tenantID, kind: kind}
-	c.mu.RLock()
-	id, ok := c.ids[scope][value]
-	c.mu.RUnlock()
-	if ok {
-		c.hits.Add(1)
+	if id, ok := c.lookupCached(scope, value); ok {
 		return id
 	}
+	if len(value) > c.bounds.valueCap(kind) {
+		// Over-length identities are routed, never truncated (#200 Q3).
+		c.overLength.Add(1)
+		c.recordOverflow(kind, "length")
+		return c.reg.OtherID(tenantID, kind)
+	}
 	return c.register(scope, []byte(value))
+}
+
+// lookupCached is the hit path: one RLock, no allocation, and — only while a
+// maintenance barrier is fencing IDs — one extra map probe.
+func (c *Cache) lookupCached(scope dictScope, value string) (uint32, bool) {
+	c.mu.RLock()
+	id, ok := c.ids[scope][value]
+	blocked := false
+	if ok && c.fenceOn.Load() {
+		_, blocked = c.fenced[id]
+	}
+	c.mu.RUnlock()
+	switch {
+	case blocked:
+		c.fencedHits.Add(1)
+		return 0, false
+	case ok:
+		c.hits.Add(1)
+		return id, true
+	default:
+		return 0, false
+	}
 }
 
 // InternBytes is Intern for a byte-slice value (dimension tuples). The slice is
@@ -176,20 +352,55 @@ func (c *Cache) Intern(tenantID uint32, kind Kind, value string) uint32 {
 // does not allocate.
 func (c *Cache) InternBytes(tenantID uint32, kind Kind, value []byte) uint32 {
 	scope := dictScope{tenant: tenantID, kind: kind}
-	c.mu.RLock()
-	id, ok := c.ids[scope][string(value)]
-	c.mu.RUnlock()
-	if ok {
-		c.hits.Add(1)
+	if id, ok := c.lookupCached(scope, string(value)); ok {
 		return id
+	}
+	if len(value) > c.bounds.valueCap(kind) {
+		c.overLength.Add(1)
+		c.recordOverflow(kind, "length")
+		return c.reg.OtherID(tenantID, kind)
 	}
 	return c.register(scope, value)
 }
 
 // InternTenant returns the ID for a tenant name, which lives in the
 // instance-global tenant namespace.
-func (c *Cache) InternTenant(name string) uint32 {
-	return c.Intern(GlobalTenant, KindTenant, name)
+//
+// It is the ONE namespace that refuses instead of degrading (#200 Q3): an
+// over-length, empty, or over-cap tenant returns ok=false and the caller drops
+// the point. Collapsing two tenants onto one identity would silently merge
+// their telemetry, and no downstream reader could tell.
+//
+// One consequence worth stating plainly: while the identity-maintenance
+// barrier is fencing a tenant ID, this refuses points for that tenant instead
+// of routing them anywhere. That window is single-digit milliseconds, once a
+// day, and it only ever covers a tenant GC had already determined nothing
+// references. A refused point is the honest answer; an __other__ tenant is not.
+func (c *Cache) InternTenant(name string) (uint32, bool) {
+	const scopeTenant = KindTenant
+	scope := dictScope{tenant: GlobalTenant, kind: scopeTenant}
+	if id, ok := c.lookupCached(scope, name); ok {
+		return id, true
+	}
+	if name == "" || len(name) > c.bounds.MaxTenantBytes {
+		c.tenantsRejected.Add(1)
+		return 0, false
+	}
+	c.misses.Add(1)
+	id, err := c.reg.Register(GlobalTenant, scopeTenant, []byte(name))
+	if err != nil || id == 0 {
+		c.tenantsRejected.Add(1)
+		return 0, false
+	}
+	c.mu.Lock()
+	inner := c.ids[scope]
+	if inner == nil {
+		inner = make(map[string]uint32)
+		c.ids[scope] = inner
+	}
+	inner[name] = id
+	c.mu.Unlock()
+	return id, true
 }
 
 // register handles the miss path: one Registrar call, then a cache store on
@@ -200,6 +411,7 @@ func (c *Cache) register(scope dictScope, value []byte) uint32 {
 	if err != nil {
 		if errors.Is(err, ErrDictFull) {
 			c.overflows.Add(1)
+			c.recordOverflow(scope.kind, "count")
 		} else {
 			c.errors.Add(1)
 		}
@@ -248,11 +460,83 @@ func (c *Cache) Len() int {
 // Stats returns a snapshot of the cache counters.
 func (c *Cache) Stats() CacheStats {
 	return CacheStats{
-		Hits:      c.hits.Load(),
-		Misses:    c.misses.Load(),
-		Overflows: c.overflows.Load(),
-		Errors:    c.errors.Load(),
+		Hits:            c.hits.Load(),
+		Misses:          c.misses.Load(),
+		Overflows:       c.overflows.Load(),
+		Errors:          c.errors.Load(),
+		OverLength:      c.overLength.Load(),
+		TenantsRejected: c.tenantsRejected.Load(),
+		Fenced:          c.fencedHits.Load(),
 	}
+}
+
+// --- identity-maintenance barrier hooks (#200 Q2) ---------------------------
+
+// Fence takes ids out of service for the hot path without touching the maps
+// that hold them. A fenced ID is never returned by Intern; the value resolves
+// to __other__ for the duration, which is the same degradation a full
+// namespace already produces.
+//
+// Fencing is deliberately NOT deletion: a sweep whose DELETE fails must be
+// able to release the fence and leave memory exactly as it was.
+func (c *Cache) Fence(ids map[uint32]struct{}) {
+	if len(ids) == 0 {
+		return
+	}
+	c.mu.Lock()
+	if c.fenced == nil {
+		c.fenced = make(map[uint32]struct{}, len(ids))
+	}
+	for id := range ids {
+		c.fenced[id] = struct{}{}
+	}
+	c.fenceOn.Store(true)
+	c.mu.Unlock()
+}
+
+// Unfence releases every fenced ID.
+func (c *Cache) Unfence() {
+	c.mu.Lock()
+	c.fenced = nil
+	c.fenceOn.Store(false)
+	c.mu.Unlock()
+}
+
+// Forget removes cached entries whose ID is in ids. It runs after a sweep has
+// COMMITTED, never before: the forward map and the reverse map must not
+// disagree with the database in the window where the delete could still fail.
+func (c *Cache) Forget(ids map[uint32]struct{}) {
+	if len(ids) == 0 {
+		return
+	}
+	c.mu.Lock()
+	for scope, inner := range c.ids {
+		for value, id := range inner {
+			if _, gone := ids[id]; gone {
+				delete(inner, value)
+			}
+		}
+		if len(inner) == 0 {
+			delete(c.ids, scope)
+		}
+	}
+	c.mu.Unlock()
+}
+
+// Roots returns every dictionary ID this cache can still hand to the hot path.
+// They are GC roots by construction: a cached ID is one map read away from
+// becoming a series identity, and no lock the collector can take would make
+// that read wait.
+func (c *Cache) Roots() map[uint32]struct{} {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make(map[uint32]struct{}, len(c.ids)*4)
+	for _, inner := range c.ids {
+		for _, id := range inner {
+			out[id] = struct{}{}
+		}
+	}
+	return out
 }
 
 // DimPair is one operator-configured dimension, already reduced to dictionary

--- a/internal/aggregate/dict_test.go
+++ b/internal/aggregate/dict_test.go
@@ -79,7 +79,7 @@ func TestCacheInternIsStableAndTenantScoped(t *testing.T) {
 func TestCacheInternTenantUsesGlobalScope(t *testing.T) {
 	reg := NewMemRegistrar(nil)
 	c := NewCache(reg)
-	id := c.InternTenant("acme")
+	id, _ := c.InternTenant("acme")
 	if id != c.Intern(GlobalTenant, KindTenant, "acme") {
 		t.Fatal("InternTenant disagrees with the global tenant scope")
 	}

--- a/internal/aggregate/engine.go
+++ b/internal/aggregate/engine.go
@@ -143,6 +143,11 @@ type EngineConfig struct {
 	// whose IDs are provisional and vanish on restart (#173 replaces it).
 	Registrar Registrar
 
+	// Bounds are the identity bounds of #200 Q3: encoded-value length caps,
+	// per-(tenant, kind) and instance-wide dictionary counts, and the tenant
+	// cap. The zero value takes every default.
+	Bounds Bounds
+
 	// Miner is the ingest-owned template miner (#163). Defaults to one built
 	// from the log-template cap.
 	Miner *TemplateMiner
@@ -301,7 +306,7 @@ func NewEngine(cfg EngineConfig) (*Engine, error) {
 	e := &Engine{
 		mode:    cfg.Mode,
 		now:     cfg.Now,
-		cache:   NewCache(reg),
+		cache:   NewCacheWithBounds(reg, cfg.Bounds),
 		miner:   cfg.Miner,
 		metrics: cfg.Metrics,
 		dims:    cfg.MetricDims,
@@ -316,6 +321,7 @@ func NewEngine(cfg EngineConfig) (*Engine, error) {
 	if e.metrics == nil {
 		e.metrics = noopRecorder{}
 	}
+	e.cache.SetOverflowSink(e.metrics.RecordIdentityOverflow)
 	limCfg.OtherNameID = e.otherNameID
 	e.limiter = NewLimiter(limCfg)
 	e.baselines = NewBaselineTracker(BaselineTrackerConfig{
@@ -425,8 +431,36 @@ func (e *Engine) Store() Store {
 	return *p
 }
 
-// TenantID resolves a tenant name to its dictionary ID for the read path.
-func (e *Engine) TenantID(name string) uint32 { return e.cache.InternTenant(name) }
+// TenantID resolves a tenant name to its dictionary ID for the read path. ok
+// is false when the tenant identity was REJECTED — over-length, empty, or past
+// the instance-wide tenant cap (#200 Q3). A rejected tenant is never collapsed
+// into a shared identity; the caller reads nothing rather than another
+// tenant's data.
+func (e *Engine) TenantID(name string) (uint32, bool) { return e.cache.InternTenant(name) }
+
+// ActiveSeriesKeys returns every series identity the mutable shards currently
+// hold. It is a GC root set (#200 Q1): a series present in memory is live even
+// if the durable tables have not caught up with it yet.
+//
+// Bounded by AGGREGATE_MAX_SERIES plus the overflow reserve, so the map is
+// thousands of entries, not millions.
+func (e *Engine) ActiveSeriesKeys() map[SeriesKey]struct{} {
+	out := make(map[SeriesKey]struct{}, 1024)
+	if e == nil {
+		return out
+	}
+	for i := range e.shards {
+		sh := &e.shards[i]
+		sh.mu.Lock()
+		for _, window := range sh.windows {
+			for key := range window {
+				out[key] = struct{}{}
+			}
+		}
+		sh.mu.Unlock()
+	}
+	return out
+}
 
 // Ownership captures {mutable set, finalized watermark, revision, epoch} in
 // one critical section. Every read path starts here.
@@ -529,7 +563,13 @@ func (e *Engine) otherNameID(tenantID uint32, signal Signal) uint32 {
 // registration time: that pair is the immutable surrogate identity, and the
 // text may evolve under the same ID later without the ID moving (#163).
 func (e *Engine) registerTemplate(r TemplateRegistration) (uint32, error) {
-	tenantID := e.cache.InternTenant(r.Tenant)
+	tenantID, ok := e.cache.InternTenant(r.Tenant)
+	if !ok {
+		// No tenant identity means no template identity. The miner treats a
+		// zero ID as "no identity available" and routes the line to its
+		// partition overflow; the reducer has already refused the point.
+		return 0, ErrTenantRejected
+	}
 	if r.IsOther {
 		return e.cache.OtherID(tenantID, KindLogTemplate), nil
 	}

--- a/internal/aggregate/gc.go
+++ b/internal/aggregate/gc.go
@@ -1,0 +1,473 @@
+package aggregate
+
+// Identity garbage collection (#200 Q1, Q2, Q5).
+//
+// The aggregate dictionary and the series table were append-only: every name a
+// deployment ever emitted stayed on disk forever, long after the last bucket
+// naming it was purged by retention. This is the collector that ends that.
+//
+// The algorithm is mark-and-sweep with transitive marking, run on the daily
+// maintenance tick:
+//
+//	MARK   (no writer lock, consistent reader snapshot)
+//	  1. Every series ID referenced by aggregate_buckets, aggregate_delta_log
+//	     or aggregate_baseline is live.
+//	  2. Every live series marks its tenant, service, name and dim-tuple IDs.
+//	  3. Every live dim tuple marks the dim-key and dim-value IDs inside it.
+//	  4. Every live dictionary row marks its own tenant.
+//	  5. Miner templates, staged template mutations, overflow sentinels and
+//	     persisted alias records mark their template IDs — BOTH ends of every
+//	     alias, followed transitively.
+//	  6. In-memory roots: the hot-path cache, the registrar's staged rows and
+//	     hand-outs, the series registry's staged rows and hand-outs, and the
+//	     engine's live shard keys.
+//
+//	SWEEP  (identity-maintenance barrier, on the writer)
+//	  7. Revalidate every candidate against durable, active, pending and
+//	     staged references one more time.
+//	  8. Fence the survivors of that revalidation from new lookup.
+//	  9. Delete series rows, then dictionary rows, then template rows, in ONE
+//	     transaction.
+//	 10. On success remove the forward and reverse map entries. On failure
+//	     release the fence and change NOTHING.
+//
+// The split is the whole design. Step 1-6 is a full scan of three tables and
+// must never hold the writer lock: a daily maintenance pass that stalls the
+// group commit is an ACK-latency incident, not maintenance. Steps 7-10 are
+// bounded by the candidate count and are the only part that serializes.
+//
+// Why the revalidation in step 7 is not paranoia: the scan ran without a lock,
+// so anything could have referenced a candidate while it was running. The
+// registrar and the series registry each keep a "handed out since the last
+// completed sweep" set precisely so that window is closed — an ID a hot-path
+// goroutine took before it ever reached the cache map is invisible to every
+// other root.
+
+import (
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+)
+
+// GCStats is the outcome of one identity garbage-collection pass.
+type GCStats struct {
+	// SeriesScanned, DictScanned and TemplatesScanned are the row counts the
+	// mark phase examined.
+	SeriesScanned, DictScanned, TemplatesScanned int
+	// SeriesSwept, DictSwept and TemplatesSwept are the rows actually deleted.
+	SeriesSwept, DictSwept, TemplatesSwept int64
+	// SeriesRetained and DictRetained are the rows the mark phase kept.
+	SeriesRetained, DictRetained int
+	// Revalidated counts candidates the barrier rescued after the lock-free
+	// scan — a non-zero value is normal under load, a large one means the scan
+	// is running too long.
+	Revalidated int
+	// MarkDuration is the lock-free scan; BarrierDuration is the part that
+	// serializes with the writer. Only the second belongs in an ACK-latency
+	// budget.
+	MarkDuration, BarrierDuration time.Duration
+	// Duration is the wall time of the whole pass.
+	Duration time.Duration
+}
+
+// Barrier is the identity-maintenance barrier the collector runs its sweep
+// through (#200 Q2). It is implemented by the group-commit writer: running the
+// sweep on the writer goroutine is what makes "no commit interleaves with a
+// delete" structural rather than a convention.
+type Barrier interface {
+	// RunBarrier executes fn with no group commit in flight and no commit
+	// able to start until it returns. fn must be bounded — it is on the ACK
+	// path of every Export parked behind the writer.
+	RunBarrier(fn func()) error
+}
+
+// GCConfig configures one collection pass.
+type GCConfig struct {
+	// Store is the durable aggregate store. Must satisfy GCStore.
+	Store Store
+	// Registrar owns the dictionary identity maps.
+	Registrar *DurableRegistrar
+	// Cache is the hot-path intern cache in front of Registrar.
+	Cache *Cache
+	// Miner is the log-template miner whose templates are GC roots.
+	Miner *TemplateMiner
+	// Engine supplies the live shard keys.
+	Engine *Engine
+	// Series is the writer's series registry.
+	Series *seriesRegistry
+	// Barrier serializes the sweep with the commit path.
+	Barrier Barrier
+	// Metrics records the pass. nil disables recording.
+	Metrics StoreMetrics
+}
+
+// Collect runs one mark-and-sweep pass over the aggregate identity tables.
+//
+// It is safe to call concurrently with ingest. It is NOT safe to call twice
+// concurrently — the writer runs it, and the writer is one goroutine.
+func Collect(cfg GCConfig) (GCStats, error) {
+	var stats GCStats
+	start := time.Now()
+	metrics := cfg.Metrics
+	if metrics == nil {
+		metrics = noopStoreMetrics{}
+	}
+	gcs, ok := cfg.Store.(GCStore)
+	if !ok || cfg.Registrar == nil || cfg.Series == nil || cfg.Barrier == nil {
+		return stats, nil
+	}
+
+	mark, err := markPhase(gcs, cfg, &stats)
+	if err != nil {
+		stats.Duration = time.Since(start)
+		metrics.RecordGC(stats, err)
+		return stats, err
+	}
+	stats.MarkDuration = time.Since(start)
+
+	barrierStart := time.Now()
+	var sweepErr error
+	if err := cfg.Barrier.RunBarrier(func() {
+		sweepErr = sweepPhase(gcs, cfg, mark, &stats)
+	}); err != nil {
+		stats.Duration = time.Since(start)
+		metrics.RecordGC(stats, err)
+		return stats, err
+	}
+	stats.BarrierDuration = time.Since(barrierStart)
+	stats.Duration = time.Since(start)
+	metrics.RecordGC(stats, sweepErr)
+	return stats, sweepErr
+}
+
+// markSet is the output of the lock-free mark phase.
+type markSet struct {
+	// seriesCandidates and dictCandidates are the rows nothing was found to
+	// reference. They are candidates, not conclusions: the barrier revalidates
+	// every one of them.
+	seriesCandidates map[SeriesID]struct{}
+	dictCandidates   map[uint32]struct{}
+	// templateRows is the set of dictionary IDs that also back a durable
+	// miner-state row, so the sweep deletes both together.
+	templateRows map[uint32]struct{}
+	// candidateKeys remembers each series candidate's identity. A candidate
+	// the barrier rescues has to un-mark the dictionary IDs its key names, or
+	// the sweep would delete the name of a series it just decided to keep.
+	candidateKeys map[SeriesID]SeriesKey
+	// dimTuples is the canonical encoding of every live dim tuple, so a
+	// rescued series can re-mark the dim-key/dim-value IDs inside its tuple.
+	dimTuples map[uint32][]byte
+}
+
+// markPhase performs the transitive mark WITHOUT the writer lock.
+func markPhase(gcs GCStore, cfg GCConfig, stats *GCStats) (*markSet, error) {
+	snap, err := gcs.GCSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	referenced := snap.Referenced
+	seriesRows, dictRows, templateRows := snap.Series, snap.Dict, snap.Templates
+	stats.SeriesScanned = len(seriesRows)
+	stats.DictScanned = len(dictRows)
+	stats.TemplatesScanned = len(templateRows)
+
+	// --- series liveness --------------------------------------------------
+	liveSeries := make(map[SeriesID]struct{}, len(referenced))
+	for id := range referenced {
+		liveSeries[id] = struct{}{}
+	}
+	for id := range cfg.Series.Roots() {
+		liveSeries[id] = struct{}{}
+	}
+	activeKeys := cfg.Engine.ActiveSeriesKeys()
+
+	ms := &markSet{
+		seriesCandidates: make(map[SeriesID]struct{}),
+		dictCandidates:   make(map[uint32]struct{}),
+		templateRows:     make(map[uint32]struct{}, len(templateRows)),
+		candidateKeys:    make(map[SeriesID]SeriesKey),
+	}
+	for _, row := range templateRows {
+		ms.templateRows[row.ID] = struct{}{}
+	}
+
+	liveDict := make(map[uint32]struct{}, len(dictRows))
+	dimTuples := make(map[uint32][]byte, 64)
+	dictByID := make(map[uint32]DictRow, len(dictRows))
+	for _, row := range dictRows {
+		dictByID[row.ID] = row
+		if row.Kind == KindDimTuple {
+			dimTuples[row.ID] = row.Value
+		}
+	}
+
+	// A series survives when a durable row references it, when a live shard
+	// still holds its key, or when the registry can still hand its ID out.
+	for _, row := range seriesRows {
+		_, referencedRow := liveSeries[row.ID]
+		_, active := activeKeys[row.Key]
+		if referencedRow || active {
+			stats.SeriesRetained++
+			markSeriesDict(row.Key, liveDict)
+			continue
+		}
+		ms.seriesCandidates[row.ID] = struct{}{}
+		ms.candidateKeys[row.ID] = row.Key
+	}
+
+	// --- transitive dictionary marking ------------------------------------
+	// Dim tuples reached through a surviving series mark the dim-key and
+	// dim-value IDs they contain. Without this the tuple lives and its
+	// components are collected, which is the one failure mode that silently
+	// unnames every dimension on a dashboard.
+	for id := range liveDict {
+		if enc, ok := dimTuples[id]; ok {
+			markDimComponents(enc, liveDict)
+		}
+	}
+
+	// Miner templates, staged mutations, sentinels and alias chains.
+	if cfg.Miner != nil {
+		for id := range cfg.Miner.Roots() {
+			liveDict[id] = struct{}{}
+		}
+	}
+	markAliasClosure(templateRows, liveDict)
+
+	// In-memory roots that no durable row reflects yet.
+	for id := range cfg.Registrar.Roots() {
+		liveDict[id] = struct{}{}
+	}
+	if cfg.Cache != nil {
+		for id := range cfg.Cache.Roots() {
+			liveDict[id] = struct{}{}
+		}
+	}
+
+	// A surviving dictionary row keeps its own tenant alive: a tenant ID that
+	// scopes a live name is not garbage even when no series names it directly.
+	for id := range liveDict {
+		if row, ok := dictByID[id]; ok && row.TenantID != GlobalTenant {
+			liveDict[row.TenantID] = struct{}{}
+		}
+	}
+
+	for _, row := range dictRows {
+		if _, live := liveDict[row.ID]; live {
+			stats.DictRetained++
+			continue
+		}
+		ms.dictCandidates[row.ID] = struct{}{}
+	}
+	ms.dimTuples = dimTuples
+	return ms, nil
+}
+
+// markSeriesDict marks the four dictionary IDs a series key names.
+func markSeriesDict(k SeriesKey, live map[uint32]struct{}) {
+	for _, id := range [...]uint32{k.TenantID, k.ServiceID, k.NameID, k.DimsID} {
+		if id != 0 {
+			live[id] = struct{}{}
+		}
+	}
+}
+
+// markDimComponents decodes a canonical dim-tuple encoding and marks the
+// dim-key and dim-value IDs inside it. A malformed tuple marks whatever it
+// managed to decode and stops: refusing to guess is what keeps a corrupt row
+// from taking live identities down with it.
+func markDimComponents(enc []byte, live map[uint32]struct{}) {
+	for len(enc) > 0 {
+		keyID, n := binary.Uvarint(enc)
+		if n <= 0 {
+			return
+		}
+		enc = enc[n:]
+		valueID, n := binary.Uvarint(enc)
+		if n <= 0 {
+			return
+		}
+		enc = enc[n:]
+		if keyID > 0 && keyID <= uint64(^uint32(0)) {
+			live[uint32(keyID)] = struct{}{}
+		}
+		if valueID > 0 && valueID <= uint64(^uint32(0)) {
+			live[uint32(valueID)] = struct{}{}
+		}
+	}
+}
+
+// markAliasClosure follows persisted alias edges transitively from every
+// already-live template. A retired alias is collectible only when nothing
+// live reaches it, and marking one end of a chain has to mark the rest of it.
+func markAliasClosure(rows []TemplateRow, live map[uint32]struct{}) {
+	aliasOf := make(map[uint32]uint32, len(rows))
+	aliasFrom := make(map[uint32][]uint32, len(rows))
+	for _, row := range rows {
+		if row.AliasOf != 0 {
+			aliasOf[row.ID] = row.AliasOf
+			aliasFrom[row.AliasOf] = append(aliasFrom[row.AliasOf], row.ID)
+		}
+	}
+	queue := make([]uint32, 0, len(live))
+	for id := range live {
+		queue = append(queue, id)
+	}
+	for len(queue) > 0 {
+		id := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
+		// Forward: the survivor a live retired ID forwards to.
+		if to, ok := aliasOf[id]; ok {
+			if _, seen := live[to]; !seen {
+				live[to] = struct{}{}
+				queue = append(queue, to)
+			}
+		}
+		// Backward: every retired ID that forwards INTO a live template. A
+		// historical series still names it, so it and its row stay.
+		for _, from := range aliasFrom[id] {
+			if _, seen := live[from]; !seen {
+				live[from] = struct{}{}
+				queue = append(queue, from)
+			}
+		}
+	}
+}
+
+// sweepPhase runs inside the identity-maintenance barrier.
+func sweepPhase(gcs GCStore, cfg GCConfig, ms *markSet, stats *GCStats) error {
+	// The series registry is the writer's own structure and the barrier runs
+	// on the writer, so it is held across the sweep rather than fenced. The
+	// dictionary registrar is on the ingest hot path and gets the fence
+	// instead: no ingest goroutine may block on a DELETE.
+	cfg.Series.Lock()
+	defer cfg.Series.Unlock()
+
+	before := len(ms.seriesCandidates) + len(ms.dictCandidates)
+	rescued := make([]SeriesID, 0, 8)
+	for id := range ms.candidateKeys {
+		if _, still := ms.seriesCandidates[id]; !still {
+			continue
+		}
+		rescued = append(rescued, id)
+	}
+	cfg.Series.revalidateLocked(ms.seriesCandidates)
+	cfg.Registrar.Revalidate(ms.dictCandidates)
+
+	// A series the barrier rescued keeps its NAME alive too. Re-mark the four
+	// dictionary IDs its key holds — plus the components of its dim tuple —
+	// and drop them from the dictionary candidate set. Sweeping the name of a
+	// series we just decided to keep is the exact shape of the bug this whole
+	// phase exists to prevent.
+	remark := make(map[uint32]struct{}, 8)
+	for _, id := range rescued {
+		if _, gone := ms.seriesCandidates[id]; gone {
+			continue
+		}
+		markSeriesDict(ms.candidateKeys[id], remark)
+	}
+	for id := range remark {
+		if enc, ok := ms.dimTuples[id]; ok {
+			markDimComponents(enc, remark)
+		}
+	}
+	for id := range remark {
+		delete(ms.dictCandidates, id)
+	}
+	stats.Revalidated = before - (len(ms.seriesCandidates) + len(ms.dictCandidates))
+	stats.SeriesRetained += len(rescued) - len(ms.seriesCandidates)
+
+	if len(ms.seriesCandidates) == 0 && len(ms.dictCandidates) == 0 {
+		cfg.Registrar.ClearTouched()
+		cfg.Series.clearTouchedLocked()
+		return nil
+	}
+
+	cfg.Registrar.Fence(ms.dictCandidates)
+	if cfg.Cache != nil {
+		cfg.Cache.Fence(ms.dictCandidates)
+	}
+
+	seriesIDs := sortedSeriesIDs(ms.seriesCandidates)
+	dictIDs := sortedDictIDs(ms.dictCandidates)
+	templateIDs := make([]uint32, 0, len(dictIDs))
+	for _, id := range dictIDs {
+		if _, ok := ms.templateRows[id]; ok {
+			templateIDs = append(templateIDs, id)
+		}
+	}
+
+	sweep, err := gcs.SweepIdentities(seriesIDs, dictIDs, templateIDs)
+	if err != nil {
+		// Nothing was deleted, so nothing in memory may change. Release the
+		// fence and leave every map exactly as it was.
+		cfg.Registrar.Unfence()
+		if cfg.Cache != nil {
+			cfg.Cache.Unfence()
+		}
+		return fmt.Errorf("aggregate gc: sweep failed: %w", err)
+	}
+	stats.SeriesSwept = sweep.Series
+	stats.DictSwept = sweep.Dict
+	stats.TemplatesSwept = sweep.Templates
+
+	// Committed. Only now do the forward and reverse maps lose their entries;
+	// Forget also drops the fence, so a swept value's next appearance mints a
+	// fresh ID instead of resurrecting a deleted one.
+	cfg.Series.forgetLocked(ms.seriesCandidates)
+	if cfg.Cache != nil {
+		cfg.Cache.Forget(ms.dictCandidates)
+		cfg.Cache.Unfence()
+	}
+	cfg.Registrar.Forget(ms.dictCandidates)
+	return nil
+}
+
+// sortedSeriesIDs renders a candidate set as an ordered slice; deletion order
+// is deterministic so a failure is reproducible.
+func sortedSeriesIDs(set map[SeriesID]struct{}) []SeriesID {
+	out := make([]SeriesID, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// sortedDictIDs is sortedSeriesIDs for dictionary IDs.
+func sortedDictIDs(set map[uint32]struct{}) []uint32 {
+	out := make([]uint32, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// LogGC prints one collection pass at info level.
+func LogGC(stats GCStats, err error) {
+	if err != nil {
+		slog.Error("aggregate: identity gc failed", "error", err,
+			"mark_duration", stats.MarkDuration, "barrier_duration", stats.BarrierDuration)
+		return
+	}
+	if stats.SeriesSwept == 0 && stats.DictSwept == 0 && stats.TemplatesSwept == 0 {
+		slog.Debug("aggregate: identity gc found nothing to collect",
+			"series_scanned", stats.SeriesScanned, "dict_scanned", stats.DictScanned,
+			"duration", stats.Duration)
+		return
+	}
+	slog.Info("🧹 Aggregate identity gc complete",
+		"series_swept", stats.SeriesSwept,
+		"dict_swept", stats.DictSwept,
+		"templates_swept", stats.TemplatesSwept,
+		"series_retained", stats.SeriesRetained,
+		"dict_retained", stats.DictRetained,
+		"revalidated", stats.Revalidated,
+		"mark_duration", stats.MarkDuration,
+		"barrier_duration", stats.BarrierDuration,
+		"duration", stats.Duration,
+	)
+}

--- a/internal/aggregate/lifecycle_test.go
+++ b/internal/aggregate/lifecycle_test.go
@@ -1,0 +1,639 @@
+package aggregate
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Shared scaffolding for the #200 identity-lifecycle tests. Every test in this
+// file builds on these four helpers rather than re-declaring a store/engine/
+// writer stack — the duplication gate is set at 3% and a per-test stack is
+// forty lines of identical wiring.
+
+// lifecycleFixture is a store plus the identity stack that sits on it.
+type lifecycleFixture struct {
+	t      *testing.T
+	path   string
+	clock  *fixedClock
+	store  Store
+	sqlite *SQLiteStore
+	reg    *DurableRegistrar
+	eng    *Engine
+	writer *Writer
+}
+
+// newLifecycleFixture opens a fresh store at a fresh path and wires a cold
+// identity stack over it.
+func newLifecycleFixture(t *testing.T, b Bounds) *lifecycleFixture {
+	t.Helper()
+	return openLifecycleFixture(t, filepath.Join(t.TempDir(), "aggregate.db"), b, nil)
+}
+
+// openLifecycleFixture wires a cold identity stack over the store at path,
+// which is what a restart looks like: durable rows are there, every in-memory
+// map starts empty. wrap, when set, decorates the store the writer sees.
+func openLifecycleFixture(t *testing.T, path string, b Bounds, wrap func(*SQLiteStore) Store) *lifecycleFixture {
+	t.Helper()
+	sqlite := newTestStoreAt(t, path, StoreConfig{})
+	var store Store = sqlite
+	if wrap != nil {
+		store = wrap(sqlite)
+	}
+	reg, err := NewDurableRegistrarWithBounds(store, b)
+	if err != nil {
+		t.Fatalf("NewDurableRegistrarWithBounds: %v", err)
+	}
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	eng, err := NewEngine(EngineConfig{
+		Mode:      ModeAggregate,
+		Registrar: reg,
+		Bounds:    b,
+		Now:       clock.Now,
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	f := &lifecycleFixture{t: t, path: path, clock: clock, store: store, sqlite: sqlite, reg: reg, eng: eng}
+	f.writer = newTestWriter(t, store, eng, clock, WriterConfig{Registrar: reg})
+	return f
+}
+
+// restart stops the writer, closes the store, and reopens a cold stack on the
+// same file. This is the only way to observe what durable identity actually
+// survives — a warm cache is a root and keeps everything alive by definition.
+func (f *lifecycleFixture) restart(b Bounds) *lifecycleFixture {
+	f.t.Helper()
+	f.writer.Stop()
+	if err := f.sqlite.Close(); err != nil {
+		f.t.Fatalf("close store: %v", err)
+	}
+	return openLifecycleFixture(f.t, f.path, b, nil)
+}
+
+// collect runs one GC pass through the fixture's writer barrier.
+func (f *lifecycleFixture) collect() GCStats {
+	f.t.Helper()
+	stats, err := f.writer.CollectIdentities()
+	if err != nil {
+		f.t.Fatalf("CollectIdentities: %v", err)
+	}
+	return stats
+}
+
+// countRows returns the row count of one aggregate table.
+func countRows(t *testing.T, s *SQLiteStore, table string) int {
+	t.Helper()
+	var n int
+	if err := s.reader.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+// dictExists reports whether a dictionary row survived.
+func dictExists(t *testing.T, s *SQLiteStore, id uint32) bool {
+	t.Helper()
+	var n int
+	if err := s.reader.QueryRow(`SELECT COUNT(*) FROM aggregate_dict WHERE id = ?`, id).Scan(&n); err != nil {
+		t.Fatalf("probe dict %d: %v", id, err)
+	}
+	return n > 0
+}
+
+// seed commits one batch straight to the store, bypassing the reducer. The
+// identity tests care about exactly which rows exist, not about how a span
+// became one.
+func seed(t *testing.T, store Store, b *GroupBatch) {
+	t.Helper()
+	if err := store.CommitGroup(b); err != nil {
+		t.Fatalf("CommitGroup: %v", err)
+	}
+}
+
+// dictRow is a terse DictRow builder.
+func dictRow(id, tenant uint32, kind Kind, value string) DictRow {
+	return DictRow{ID: id, TenantID: tenant, Kind: kind, Value: []byte(value)}
+}
+
+// lifecycleTraceKey builds a trace-operation key from its dictionary IDs.
+func lifecycleTraceKey(tenant, service, name, dims uint32) SeriesKey {
+	return SeriesKey{
+		TenantID:    tenant,
+		ServiceID:   service,
+		NameID:      name,
+		DimsID:      dims,
+		Signal:      SignalTraceOp,
+		StatusClass: StatusOK,
+	}
+}
+
+// --- Q3: bounds --------------------------------------------------------------
+
+func TestBoundsOverLengthRoutesToOtherNeverTruncates(t *testing.T) {
+	reg := NewMemRegistrar(nil)
+	c := NewCacheWithBounds(reg, Bounds{MaxValueBytes: 16})
+
+	long := strings.Repeat("s", 17)
+	id := c.Intern(1, KindService, long)
+	other := c.OtherID(1, KindService)
+	if id != other {
+		t.Fatalf("over-length service id = %d, want the __other__ id %d", id, other)
+	}
+	if entry, ok := reg.Lookup(id); !ok || string(entry.Value) != OtherValue {
+		t.Fatalf("over-length value was registered as %q; it must never be truncated into the dictionary", entry.Value)
+	}
+	if stats := c.Stats(); stats.OverLength != 1 {
+		t.Fatalf("OverLength = %d, want 1", stats.OverLength)
+	}
+
+	// Exactly at the cap is admitted: the bound is a maximum, not a margin.
+	exact := c.Intern(1, KindService, strings.Repeat("s", 16))
+	if exact == other || exact == 0 {
+		t.Fatalf("value exactly at the cap was refused (id %d, other %d)", exact, other)
+	}
+}
+
+func TestBoundsTenantIsRejectedNeverCollapsed(t *testing.T) {
+	f := newLifecycleFixture(t, Bounds{MaxTenantBytes: 8, MaxTenants: 2})
+	c := f.eng.Cache()
+
+	for _, name := range []string{"", strings.Repeat("t", 9)} {
+		if id, ok := c.InternTenant(name); ok {
+			t.Fatalf("tenant %q admitted as %d; over-length and empty tenants must be refused", name, id)
+		}
+	}
+	first, ok := c.InternTenant("alpha")
+	if !ok {
+		t.Fatal("first tenant refused")
+	}
+	if _, ok := c.InternTenant("beta"); !ok {
+		t.Fatal("second tenant refused below the cap")
+	}
+	third, ok := c.InternTenant("gamma")
+	if ok {
+		t.Fatalf("third tenant admitted as %d past a cap of 2", third)
+	}
+	// The rejected tenant must NOT have been folded onto an existing one.
+	if third == first {
+		t.Fatal("a refused tenant collapsed onto an admitted tenant's identity")
+	}
+	if got := c.OtherID(GlobalTenant, KindTenant); got != 0 {
+		t.Fatalf("tenant namespace minted an __other__ entry (%d); a shared overflow tenant is the merge the cap prevents", got)
+	}
+	if stats := c.Stats(); stats.TenantsRejected != 3 {
+		t.Fatalf("TenantsRejected = %d, want 3", stats.TenantsRejected)
+	}
+}
+
+func TestBoundsRejectedTenantDropsThePoint(t *testing.T) {
+	f := newLifecycleFixture(t, Bounds{MaxTenantBytes: 4})
+	r := f.eng.NewReducer(f.clock.Now())
+	r.ReduceSpan(SpanInput{
+		Tenant: strings.Repeat("t", 5), Service: "svc", SpanName: "op",
+		Timestamp: f.clock.Now(), DurationMicros: 100,
+	})
+	if r.Len() != 0 {
+		t.Fatalf("reducer emitted %d deltas for a rejected tenant, want 0", r.Len())
+	}
+	stats := r.Stats()
+	if stats.TenantsRejected != 1 {
+		t.Fatalf("TenantsRejected = %d, want 1", stats.TenantsRejected)
+	}
+	if stats.Accepted[SignalTraceOp] != 0 {
+		t.Fatalf("a dropped point was counted as accepted (%d)", stats.Accepted[SignalTraceOp])
+	}
+	if stats.InputPoints[SignalTraceOp] != 1 {
+		t.Fatalf("InputPoints = %d, want 1 — a dropped point is still offered telemetry", stats.InputPoints[SignalTraceOp])
+	}
+}
+
+func TestBoundsPerTenantAndInstanceCaps(t *testing.T) {
+	reg, err := NewDurableRegistrarWithBounds(nil, Bounds{
+		PerTenantKind: map[Kind]int{KindService: 2},
+		InstanceKind:  map[Kind]int{KindService: 3},
+	})
+	if err != nil {
+		t.Fatalf("NewDurableRegistrarWithBounds: %v", err)
+	}
+	admit := func(tenant uint32, value string) bool {
+		_, err := reg.Register(tenant, KindService, []byte(value))
+		return err == nil
+	}
+	if !admit(1, "a") || !admit(1, "b") {
+		t.Fatal("per-tenant cap bound below its limit")
+	}
+	if admit(1, "c") {
+		t.Fatal("per-tenant cap of 2 admitted a third service")
+	}
+	// A second tenant has its own per-tenant budget but shares the instance
+	// backstop, which is the whole point of having both.
+	if !admit(2, "a") {
+		t.Fatal("second tenant refused its first service")
+	}
+	if admit(2, "b") {
+		t.Fatal("instance-wide backstop of 3 admitted a fourth service")
+	}
+}
+
+func TestPreloadFailsFastAboveTheSupportedBound(t *testing.T) {
+	prevDict, prevSeries := MaxDictRows, MaxSeriesRows
+	MaxDictRows, MaxSeriesRows = 2, 2
+	t.Cleanup(func() { MaxDictRows, MaxSeriesRows = prevDict, prevSeries })
+
+	store := newTestStore(t)
+	seed(t, store, &GroupBatch{Dicts: []DictRow{
+		dictRow(1, GlobalTenant, KindTenant, "acme"),
+		dictRow(2, 1, KindService, "svc"),
+		dictRow(3, 1, KindOperation, "GET /a"),
+	}})
+
+	_, err := NewDurableRegistrarWithBounds(store, Bounds{})
+	var preload *PreloadError
+	if !errors.As(err, &preload) {
+		t.Fatalf("registrar preload over the bound: got %v, want *PreloadError", err)
+	}
+	if preload.Table != "aggregate_dict" || preload.Max != 2 {
+		t.Fatalf("PreloadError = %+v, want aggregate_dict at max 2", preload)
+	}
+	if !strings.Contains(preload.Error(), "aggregate_dict") {
+		t.Fatalf("PreloadError message does not name the table: %s", preload.Error())
+	}
+}
+
+// --- Q1/Q2: mark, sweep, watermarks, barrier ---------------------------------
+
+func TestGCSweepsOnlyUnreferencedIdentities(t *testing.T) {
+	f := newLifecycleFixture(t, Bounds{})
+	seed(t, f.store, &GroupBatch{
+		Dicts: []DictRow{
+			dictRow(1, GlobalTenant, KindTenant, "acme"),
+			dictRow(2, 1, KindService, "svc"),
+			dictRow(3, 1, KindOperation, "GET /live"),
+			dictRow(4, 1, KindOperation, "GET /orphan"),
+		},
+		Series: []SeriesRow{{ID: 1, Key: lifecycleTraceKey(1, 2, 3, 0)}},
+		Deltas: []DeltaRow{{SeriesID: 1, WindowStart: WindowStart(f.clock.Now()), Delta: spanDelta(2, 100)}},
+	})
+
+	cold := f.restart(Bounds{})
+	stats := cold.collect()
+
+	if stats.DictSwept != 1 {
+		t.Fatalf("DictSwept = %d, want 1 (the orphan operation only)", stats.DictSwept)
+	}
+	if stats.SeriesSwept != 0 {
+		t.Fatalf("SeriesSwept = %d, want 0 — the series has a delta row", stats.SeriesSwept)
+	}
+	for _, id := range []uint32{1, 2, 3} {
+		if !dictExists(t, cold.sqlite, id) {
+			t.Fatalf("dictionary id %d was swept while a live series names it", id)
+		}
+	}
+	if dictExists(t, cold.sqlite, 4) {
+		t.Fatal("the orphan operation survived collection")
+	}
+}
+
+func TestGCMarksDimTupleComponentsTransitively(t *testing.T) {
+	f := newLifecycleFixture(t, Bounds{})
+	// keyID 5, valueID 6 encoded canonically into tuple 7.
+	tuple := AppendCanonicalDims(nil, []DimPair{{KeyID: 5, ValueID: 6}})
+	seed(t, f.store, &GroupBatch{
+		Dicts: []DictRow{
+			dictRow(1, GlobalTenant, KindTenant, "acme"),
+			dictRow(2, 1, KindService, "svc"),
+			dictRow(3, 1, KindMetricName, "http.server.duration"),
+			dictRow(5, 1, KindDimKey, "http.route"),
+			dictRow(6, 1, KindDimValue, "/checkout"),
+			{ID: 7, TenantID: 1, Kind: KindDimTuple, Value: tuple},
+			dictRow(8, 1, KindDimKey, "orphan.key"),
+		},
+		Series: []SeriesRow{{ID: 1, Key: SeriesKey{TenantID: 1, ServiceID: 2, NameID: 3, DimsID: 7, Signal: SignalMetric}}},
+		Deltas: []DeltaRow{{SeriesID: 1, WindowStart: WindowStart(f.clock.Now()), Delta: spanDelta(1, 10)}},
+	})
+
+	cold := f.restart(Bounds{})
+	cold.collect()
+
+	for _, id := range []uint32{5, 6, 7} {
+		if !dictExists(t, cold.sqlite, id) {
+			t.Fatalf("dictionary id %d was swept; a live dim tuple must mark the key and value inside it", id)
+		}
+	}
+	if dictExists(t, cold.sqlite, 8) {
+		t.Fatal("a dim key no tuple contains survived collection")
+	}
+}
+
+func TestGCFollowsRetiredTemplateAliasChains(t *testing.T) {
+	f := newLifecycleFixture(t, Bounds{})
+	now := f.clock.Now().UnixNano()
+	// 10 -> 11 -> 12: two retirements deep. Only 10 is named by a series, so
+	// nothing but the transitive alias closure keeps 11 and 12 alive.
+	seed(t, f.store, &GroupBatch{
+		Dicts: []DictRow{
+			dictRow(1, GlobalTenant, KindTenant, "acme"),
+			dictRow(2, 1, KindService, "svc"),
+			dictRow(10, 1, KindLogTemplate, "svc\x00retired one"),
+			dictRow(11, 1, KindLogTemplate, "svc\x00retired two"),
+			dictRow(12, 1, KindLogTemplate, "svc\x00survivor"),
+			dictRow(13, 1, KindLogTemplate, "svc\x00unreachable"),
+		},
+		Templates: []TemplateRow{
+			{ID: 10, Tenant: "acme", Service: "svc", Tokens: "retired\x00one", AliasOf: 11, LastSeen: now},
+			{ID: 11, Tenant: "acme", Service: "svc", Tokens: "retired\x00two", AliasOf: 12, LastSeen: now},
+			{ID: 12, Tenant: "acme", Service: "svc", Tokens: "survivor", LastSeen: now},
+			{ID: 13, Tenant: "acme", Service: "svc", Tokens: "unreachable", LastSeen: now},
+		},
+		Series: []SeriesRow{{ID: 1, Key: SeriesKey{TenantID: 1, ServiceID: 2, NameID: 10, Signal: SignalLog, StatusClass: SeverityTierInfo}}},
+		Deltas: []DeltaRow{{SeriesID: 1, WindowStart: WindowStart(f.clock.Now()), Delta: spanDelta(1, 10)}},
+	})
+
+	cold := f.restart(Bounds{})
+	cold.collect()
+
+	for _, id := range []uint32{10, 11, 12} {
+		if !dictExists(t, cold.sqlite, id) {
+			t.Fatalf("template %d was swept; every hop of a live alias chain stays", id)
+		}
+	}
+	if dictExists(t, cold.sqlite, 13) {
+		t.Fatal("a template no series and no alias reaches survived collection")
+	}
+	if countRows(t, cold.sqlite, "aggregate_log_template") != 3 {
+		t.Fatalf("template rows = %d, want 3 — the swept dict id must take its miner row with it",
+			countRows(t, cold.sqlite, "aggregate_log_template"))
+	}
+}
+
+func TestGCHighWatermarkSurvivesSweepOfHighestID(t *testing.T) {
+	f := newLifecycleFixture(t, Bounds{})
+	seed(t, f.store, &GroupBatch{
+		Dicts: []DictRow{
+			dictRow(1, GlobalTenant, KindTenant, "acme"),
+			dictRow(2, 1, KindService, "svc"),
+			dictRow(900, 1, KindOperation, "GET /orphan"),
+		},
+		Series: []SeriesRow{{ID: 700, Key: lifecycleTraceKey(1, 2, 900, 0)}},
+	})
+	// The series row exists but nothing references it, so both the highest
+	// dictionary ID and the highest series ID are collectible.
+	cold := f.restart(Bounds{})
+	stats := cold.collect()
+	if stats.DictSwept == 0 || stats.SeriesSwept == 0 {
+		t.Fatalf("expected the highest ids to be collected, got %+v", stats)
+	}
+	if dictExists(t, cold.sqlite, 900) {
+		t.Fatal("the highest dictionary id survived collection")
+	}
+
+	// MAX(id)+1 would now reseed at 3 and 1. The watermarks must not.
+	after := cold.restart(Bounds{})
+	if next := after.reg.Next(); next <= 900 {
+		t.Fatalf("dictionary reseeded at %d after sweeping id 900; a watermark must never decrease", next)
+	}
+	if next := after.writer.series.Next(); next <= 700 {
+		t.Fatalf("series reseeded at %d after sweeping id 700; a watermark must never decrease", next)
+	}
+}
+
+func TestBarrierFencedIDsAreNotHandedOut(t *testing.T) {
+	reg, err := NewDurableRegistrarWithBounds(nil, Bounds{})
+	if err != nil {
+		t.Fatalf("NewDurableRegistrarWithBounds: %v", err)
+	}
+	c := NewCacheWithBounds(reg, Bounds{})
+	id := c.Intern(1, KindService, "svc")
+	if id == 0 {
+		t.Fatal("service was not interned")
+	}
+
+	fence := map[uint32]struct{}{id: {}}
+	reg.Fence(fence)
+	c.Fence(fence)
+
+	if got := c.Intern(1, KindService, "svc"); got == id {
+		t.Fatal("a fenced dictionary id was handed to the hot path")
+	} else if got != c.OtherID(1, KindService) {
+		t.Fatalf("fenced lookup resolved to %d, want the __other__ id %d", got, c.OtherID(1, KindService))
+	}
+	if _, ok := reg.Lookup(id); ok {
+		t.Fatal("a fenced dictionary id still reverses through the resolver")
+	}
+
+	// Releasing the fence restores the identity byte-for-byte.
+	reg.Unfence()
+	c.Unfence()
+	if got := c.Intern(1, KindService, "svc"); got != id {
+		t.Fatalf("after Unfence the value resolved to %d, want the original %d", got, id)
+	}
+}
+
+func TestSweepFailureLeavesMemoryUntouched(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aggregate.db")
+	boom := errors.New("sweep refused")
+	seedStore := newTestStoreAt(t, path, StoreConfig{})
+	seed(t, seedStore, &GroupBatch{Dicts: []DictRow{
+		dictRow(1, GlobalTenant, KindTenant, "acme"),
+		dictRow(2, 1, KindService, "orphan"),
+	}})
+	if err := seedStore.Close(); err != nil {
+		t.Fatalf("close seed store: %v", err)
+	}
+
+	var failing *failingSweepStore
+	f := openLifecycleFixture(t, path, Bounds{}, func(s *SQLiteStore) Store {
+		failing = &failingSweepStore{SQLiteStore: s, err: boom}
+		return failing
+	})
+
+	_, err := f.writer.CollectIdentities()
+	if !errors.Is(err, boom) {
+		t.Fatalf("CollectIdentities: got %v, want the sweep error", err)
+	}
+	if !dictExists(t, f.sqlite, 2) {
+		t.Fatal("a failed sweep deleted rows anyway")
+	}
+	// The fence must be released and the identity must resolve exactly as it
+	// did before the attempt.
+	if _, ok := f.reg.Lookup(2); !ok {
+		t.Fatal("a failed sweep left the reverse index fenced")
+	}
+	if got := f.eng.Cache().Intern(1, KindService, "orphan"); got != 2 {
+		t.Fatalf("after a failed sweep the value resolved to %d, want the untouched id 2", got)
+	}
+}
+
+// failingSweepStore is a store whose identity sweep always refuses.
+type failingSweepStore struct {
+	*SQLiteStore
+	err error
+}
+
+func (s *failingSweepStore) SweepIdentities([]SeriesID, []uint32, []uint32) (SweepStats, error) {
+	return SweepStats{}, s.err
+}
+
+// --- Q4/Q5: miner persistence ------------------------------------------------
+
+func TestMinerIdentityRidesTheGroupCommit(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	inner := newTestStore(t)
+	var seen []*GroupBatch
+	hooked := &hookStore{Store: inner, beforeCommit: func(b *GroupBatch) {
+		copyBatch := *b
+		seen = append(seen, &copyBatch)
+	}}
+	reg, err := NewDurableRegistrarWithBounds(inner, Bounds{})
+	if err != nil {
+		t.Fatalf("registrar: %v", err)
+	}
+	eng, err := NewEngine(EngineConfig{Mode: ModeAggregate, Registrar: reg, Now: clock.Now})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	w := newTestWriter(t, hooked, eng, clock, WriterConfig{Registrar: reg})
+
+	r := eng.NewReducer(clock.Now())
+	r.ReduceLog(LogInput{
+		Tenant: "acme", Service: "svc", Severity: "ERROR",
+		Body: "connection refused to 10.0.0.1", Timestamp: clock.Now(),
+	})
+	if _, err := eng.ApplyReducerErr(r); err != nil {
+		t.Fatalf("ApplyReducerErr: %v", err)
+	}
+	_ = w
+
+	if len(seen) == 0 {
+		t.Fatal("no group commit was observed")
+	}
+	batch := seen[len(seen)-1]
+	if len(batch.Templates) == 0 {
+		t.Fatal("the template identity did not ride the commit that used it")
+	}
+	if len(batch.Deltas) == 0 {
+		t.Fatal("the batch carrying the template identity carried no delta")
+	}
+	if eng.Miner().PendingCount() != 0 {
+		t.Fatalf("PendingCount = %d after a successful commit, want 0", eng.Miner().PendingCount())
+	}
+	if countRows(t, inner, "aggregate_log_template") == 0 {
+		t.Fatal("no template row became durable")
+	}
+}
+
+func TestMinerSurvivesCrashBetweenCommitAndSnapshot(t *testing.T) {
+	f := newLifecycleFixture(t, Bounds{})
+	r := f.eng.NewReducer(f.clock.Now())
+	r.ReduceLog(LogInput{
+		Tenant: "acme", Service: "svc", Severity: "ERROR",
+		Body: "payment gateway timeout after 30s", Timestamp: f.clock.Now(),
+	})
+	if _, err := f.eng.ApplyReducerErr(r); err != nil {
+		t.Fatalf("ApplyReducerErr: %v", err)
+	}
+	before, _ := f.eng.Miner().Mine("acme", "svc", "ERROR", "payment gateway timeout after 30s")
+	if before == 0 {
+		t.Fatal("template id is zero")
+	}
+
+	// A crash here: no periodic statistics write ever runs. The identity is
+	// durable regardless, because it rode the group commit.
+	f.writer.Stop()
+	if err := f.sqlite.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	cold := openLifecycleFixture(t, f.path, Bounds{}, nil)
+	restored, err := RestoreMiner(cold.store, cold.eng.Miner())
+	if err != nil {
+		t.Fatalf("RestoreMiner: %v", err)
+	}
+	if restored == 0 {
+		t.Fatal("no template state survived the crash")
+	}
+	after, isOther := cold.eng.Miner().Mine("acme", "svc", "ERROR", "payment gateway timeout after 30s")
+	if isOther {
+		t.Fatal("the reloaded miner routed a known pattern to overflow")
+	}
+	if after != before {
+		t.Fatalf("template id changed across restart: %d -> %d", before, after)
+	}
+}
+
+func TestMinerReloadRebuildsEquivalentState(t *testing.T) {
+	f := newLifecycleFixture(t, Bounds{})
+	bodies := []string{
+		"GET /api/users/42 took 13ms",
+		"GET /api/users/1337 took 91ms",
+		"cache miss for key ab12cd34ef56ab78",
+		"worker 3 finished batch",
+	}
+	want := make([]uint32, len(bodies))
+	for i, body := range bodies {
+		r := f.eng.NewReducer(f.clock.Now())
+		r.ReduceLog(LogInput{Tenant: "acme", Service: "svc", Severity: "INFO", Body: body, Timestamp: f.clock.Now()})
+		if _, err := f.eng.ApplyReducerErr(r); err != nil {
+			t.Fatalf("ApplyReducerErr: %v", err)
+		}
+		want[i], _ = f.eng.Miner().Mine("acme", "svc", "INFO", body)
+	}
+	f.writer.SaveTemplateStats()
+
+	cold := f.restart(Bounds{})
+	if _, err := RestoreMiner(cold.store, cold.eng.Miner()); err != nil {
+		t.Fatalf("RestoreMiner: %v", err)
+	}
+	rowsBefore := countRows(t, cold.sqlite, "aggregate_log_template")
+	for i, body := range bodies {
+		got, _ := cold.eng.Miner().Mine("acme", "svc", "INFO", body)
+		if got != want[i] {
+			t.Fatalf("body %q: template id %d after reload, want %d", body, got, want[i])
+		}
+	}
+	if rowsAfter := countRows(t, cold.sqlite, "aggregate_log_template"); rowsAfter != rowsBefore {
+		t.Fatalf("replaying known bodies minted new template rows: %d -> %d", rowsBefore, rowsAfter)
+	}
+}
+
+// --- schema policy -----------------------------------------------------------
+
+func TestStoreV4FileIsRefusedThenRebuilt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aggregate.db")
+	store := newTestStoreAt(t, path, StoreConfig{})
+	seed(t, store, &GroupBatch{Dicts: []DictRow{dictRow(1, GlobalTenant, KindTenant, "acme")}})
+	if _, err := store.writer.Exec(
+		`UPDATE aggregate_meta SET value = '4' WHERE key = 'schema_version'`); err != nil {
+		t.Fatalf("stamp v4: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	_, err := OpenSQLiteStore(StoreConfig{Path: path})
+	var schemaErr *SchemaError
+	if !errors.As(err, &schemaErr) {
+		t.Fatalf("opening a v4 file: got %v, want *SchemaError", err)
+	}
+	if schemaErr.Got != "4" || schemaErr.Want != "5" {
+		t.Fatalf("SchemaError = %+v, want a 4 -> 5 mismatch", schemaErr)
+	}
+
+	rebuilt := newTestStoreAt(t, path, StoreConfig{AllowRebuild: true})
+	if n := countRows(t, rebuilt, "aggregate_dict"); n != 0 {
+		t.Fatalf("rebuild kept %d dictionary rows; the rebuild path destroys aggregate data by design", n)
+	}
+	if n := countRows(t, rebuilt, "aggregate_log_template"); n != 0 {
+		t.Fatalf("rebuilt store has %d template rows, want 0", n)
+	}
+	dictWM, seriesWM, err := rebuilt.Watermarks()
+	if err != nil {
+		t.Fatalf("Watermarks: %v", err)
+	}
+	if dictWM != 1 || seriesWM != 1 {
+		t.Fatalf("fresh watermarks = (%d, %d), want (1, 1)", dictWM, seriesWM)
+	}
+}

--- a/internal/aggregate/metrics.go
+++ b/internal/aggregate/metrics.go
@@ -36,6 +36,15 @@ type MetricsRecorder interface {
 	// RecordClosedWindowEvicted counts one closed window the cap forced out of
 	// memory before it was finalized. Every one is lost data.
 	RecordClosedWindowEvicted()
+	// RecordTenantRejected counts one point dropped because its tenant
+	// identity was refused (#200 Q3). Unlike every other identity cap this is
+	// a DROP, so it deserves its own counter rather than a reason label on
+	// the overflow one.
+	RecordTenantRejected(signal Signal)
+	// RecordIdentityOverflow counts one identity routed to __other__ by a
+	// #200 Q3 bound, labeled by dictionary kind and the bound that tripped
+	// ("length" or "count").
+	RecordIdentityOverflow(kind Kind, bound string)
 }
 
 // noopRecorder is the default when no metrics are wired.
@@ -46,6 +55,8 @@ func (noopRecorder) RecordOverflow(Signal, OverflowReason)           {}
 func (noopRecorder) SetActiveSeries(_, _ map[Signal]int)             {}
 func (noopRecorder) SetClosedWindows(int)                            {}
 func (noopRecorder) RecordClosedWindowEvicted()                      {}
+func (noopRecorder) RecordTenantRejected(Signal)                     {}
+func (noopRecorder) RecordIdentityOverflow(Kind, string)             {}
 
 // promRecorder bridges the engine onto the platform's Prometheus metrics.
 type promRecorder struct{ m *telemetry.Metrics }
@@ -116,6 +127,16 @@ func (r promRecorder) SetClosedWindows(held int) {
 // RecordClosedWindowEvicted implements MetricsRecorder.
 func (r promRecorder) RecordClosedWindowEvicted() {
 	r.m.AggregateClosedWindowsEvictedTotal.Inc()
+}
+
+// RecordTenantRejected implements MetricsRecorder.
+func (r promRecorder) RecordTenantRejected(signal Signal) {
+	r.m.AggregateTenantRejectedTotal.WithLabelValues(signal.String()).Inc()
+}
+
+// RecordIdentityOverflow implements MetricsRecorder.
+func (r promRecorder) RecordIdentityOverflow(kind Kind, bound string) {
+	r.m.AggregateIdentityOverflowTotal.WithLabelValues(kind.String(), bound).Inc()
 }
 
 // promStoreRecorder bridges the durable store and the group-commit writer onto
@@ -191,6 +212,27 @@ func (r promStoreRecorder) RecordPurge(stats PurgeStats, err error) {
 func (r promStoreRecorder) SetBacklog(rows int64, ageSeconds float64) {
 	r.m.AggregateDeltaLogRows.Set(float64(rows))
 	r.m.AggregateDeltaLogAgeSeconds.Set(ageSeconds)
+}
+
+// RecordGC implements StoreMetrics.
+func (r promStoreRecorder) RecordGC(stats GCStats, err error) {
+	r.m.AggregateGCDurationSeconds.WithLabelValues("mark").Observe(stats.MarkDuration.Seconds())
+	r.m.AggregateGCDurationSeconds.WithLabelValues("barrier").Observe(stats.BarrierDuration.Seconds())
+	r.m.AggregateGCRunsTotal.WithLabelValues(result(err)).Inc()
+	if err != nil {
+		return
+	}
+	for table, n := range map[string]int64{
+		"aggregate_series":       stats.SeriesSwept,
+		"aggregate_dict":         stats.DictSwept,
+		"aggregate_log_template": stats.TemplatesSwept,
+	} {
+		if n > 0 {
+			r.m.AggregateGCSweptTotal.WithLabelValues(table).Add(float64(n))
+		}
+	}
+	r.m.AggregateGCRetained.WithLabelValues("aggregate_series").Set(float64(stats.SeriesRetained))
+	r.m.AggregateGCRetained.WithLabelValues("aggregate_dict").Set(float64(stats.DictRetained))
 }
 
 // RecordRecovery implements StoreMetrics.

--- a/internal/aggregate/query.go
+++ b/internal/aggregate/query.go
@@ -287,7 +287,13 @@ func (e *Engine) plan(q Query, visit visitFunc) (Ownership, Selector, bool, erro
 		return own, sel, false, fmt.Errorf("%w: [%s,%s) is not a bounded forward range",
 			ErrSelectorUnbounded, q.Start.Format(time.RFC3339), q.End.Format(time.RFC3339))
 	}
-	tenantID := e.cache.InternTenant(q.Tenant)
+	tenantID, tenantOK := e.cache.InternTenant(q.Tenant)
+	if !tenantOK {
+		// A tenant name the write path would refuse cannot own data. Minting
+		// an ID for it here would also let an unbounded stream of junk tenant
+		// names in a query string grow the dictionary (#200 Q3).
+		return own, sel, false, fmt.Errorf("%w: tenant identity rejected", ErrSelectorUnbounded)
+	}
 	start := WindowStart(q.Start)
 	end := WindowStart(q.End.Add(WindowSize - time.Second))
 	if end <= start {

--- a/internal/aggregate/query_test.go
+++ b/internal/aggregate/query_test.go
@@ -162,7 +162,8 @@ func newQueryFixture(t *testing.T) *queryFixture {
 	t.Helper()
 	now := mustTime(t, "2026-08-21T12:02:00Z")
 	e := testEngine(t, now)
-	return &queryFixture{engine: e, now: now, tenantID: e.TenantID("default")}
+	tenantID, _ := e.TenantID("default")
+	return &queryFixture{engine: e, now: now, tenantID: tenantID}
 }
 
 // traceKey builds a trace-operation series key for a named service.

--- a/internal/aggregate/read_contract_test.go
+++ b/internal/aggregate/read_contract_test.go
@@ -168,7 +168,7 @@ func newSeedFixture(t *testing.T) *seedFixture {
 	store := newTestStoreAt(t, filepath.Join(t.TempDir(), "aggregate.db"), StoreConfig{})
 	e.SetStore(store)
 
-	tenantID := e.TenantID("default")
+	tenantID, _ := e.TenantID("default")
 	windowSecs := int64(WindowSize / time.Second)
 	base := WindowStart(now) - int64(seedWindows+2)*windowSecs
 
@@ -262,7 +262,7 @@ func (f *seedFixture) query(services ...string) Query {
 // selector is the store-level equivalent of query.
 func (f *seedFixture) selector() Selector {
 	return Selector{
-		TenantID: f.engine.TenantID("default"),
+		TenantID: mustTenantID(f.engine, "default"),
 		Start:    f.base,
 		End:      f.base + int64(seedWindows)*int64(WindowSize/time.Second),
 	}
@@ -449,7 +449,7 @@ func TestPercentilePathReadsEverySketchBearingRow(t *testing.T) {
 	store := newTestStoreAt(t, filepath.Join(t.TempDir(), "aggregate.db"), StoreConfig{})
 	e.SetStore(store)
 
-	tenantID := e.TenantID("default")
+	tenantID, _ := e.TenantID("default")
 	windowSecs := int64(WindowSize / time.Second)
 	base := WindowStart(now) - 4*windowSecs
 
@@ -684,4 +684,14 @@ func TestStoreRefusesAV2FileAndRebuildsOnDemand(t *testing.T) {
 	if len(sums) != 1 || sums[0].RequestCount != 2 || sums[0].ErrorRequestCount != 1 {
 		t.Fatalf("rebuilt store summed %+v, want 2 requests / 1 error request", sums)
 	}
+}
+
+// mustTenantID resolves a tenant identity in tests, failing loudly on the
+// rejection path rather than silently building a zero-tenant key.
+func mustTenantID(e *Engine, name string) uint32 {
+	id, ok := e.TenantID(name)
+	if !ok {
+		panic("aggregate test: tenant identity rejected: " + name)
+	}
+	return id
 }

--- a/internal/aggregate/reducer.go
+++ b/internal/aggregate/reducer.go
@@ -55,6 +55,12 @@ type ReducerStats struct {
 	// refused from series identity because an attribute value had no scalar
 	// rendering (#199 Q4). The point is still aggregated, under DimsID 0.
 	DimsRejected uint64
+	// TenantsRejected counts points DROPPED because their tenant identity was
+	// refused — over-length, empty, or past the instance-wide tenant cap
+	// (#200 Q3). Every other namespace degrades into __other__; the tenant
+	// namespace refuses instead, because a shared overflow tenant is exactly
+	// the cross-tenant merge the cap exists to prevent.
+	TenantsRejected uint64
 	// ErrorsByService counts errors per service — the cheap invariant #165
 	// asks for on the aggregate side, and nothing more expensive.
 	ErrorsByService map[string]uint64
@@ -70,6 +76,7 @@ func (s *ReducerStats) merge(other *ReducerStats) {
 	}
 	s.StaleCumulative += other.StaleCumulative
 	s.DimsRejected += other.DimsRejected
+	s.TenantsRejected += other.TenantsRejected
 	for svc, n := range other.ErrorsByService {
 		if s.ErrorsByService == nil {
 			s.ErrorsByService = make(map[string]uint64, len(other.ErrorsByService))
@@ -268,6 +275,14 @@ func (r *Reducer) countError(service string) {
 	r.stats.ErrorsByService[service]++
 }
 
+// rejectTenant records one point dropped for an unusable tenant identity. The
+// point was already counted as input by admitPoint; it is NOT counted as
+// accepted, so the shadow-comparison numerator stays honest.
+func (r *Reducer) rejectTenant(signal Signal) {
+	r.stats.TenantsRejected++
+	r.eng.metrics.RecordTenantRejected(signal)
+}
+
 // IsRequestSpan reports whether a span is a request entry point and therefore
 // contributes to AggregateDelta.RequestCount.
 //
@@ -286,7 +301,11 @@ func (r *Reducer) ReduceSpan(in SpanInput) {
 	if !ok {
 		return
 	}
-	tenantID := r.eng.cache.InternTenant(in.Tenant)
+	tenantID, tenantOK := r.eng.cache.InternTenant(in.Tenant)
+	if !tenantOK {
+		r.rejectTenant(SignalTraceOp)
+		return
+	}
 	operation := NormalizeOperation(in.HTTPRoute, in.URLPath, in.SpanName)
 	key := SeriesKey{
 		TenantID:    tenantID,
@@ -349,7 +368,11 @@ func (r *Reducer) ReduceEdge(in EdgeInput) {
 	if !ok {
 		return
 	}
-	tenantID := r.eng.cache.InternTenant(in.Tenant)
+	tenantID, tenantOK := r.eng.cache.InternTenant(in.Tenant)
+	if !tenantOK {
+		r.rejectTenant(SignalServiceEdge)
+		return
+	}
 	key := SeriesKey{
 		TenantID:  tenantID,
 		ServiceID: r.eng.cache.Intern(tenantID, KindService, in.Caller),
@@ -377,7 +400,11 @@ func (r *Reducer) ReduceLog(in LogInput) {
 	if !ok {
 		return
 	}
-	tenantID := r.eng.cache.InternTenant(in.Tenant)
+	tenantID, tenantOK := r.eng.cache.InternTenant(in.Tenant)
+	if !tenantOK {
+		r.rejectTenant(SignalLog)
+		return
+	}
 	templateID, _ := r.eng.miner.MineAt(in.Tenant, in.Service, in.Severity, in.Body, r.arrival)
 	tier := SeverityTier(in.Severity, in.SeverityNumber)
 	key := SeriesKey{
@@ -507,7 +534,11 @@ func (r *Reducer) reduceFold(c HistogramCommon, fold HistogramFold) MetricPointR
 	if !ok {
 		return MetricPointResult{Outcome: MetricPointExcluded}
 	}
-	tenantID := r.eng.cache.InternTenant(c.Tenant)
+	tenantID, tenantOK := r.eng.cache.InternTenant(c.Tenant)
+	if !tenantOK {
+		r.rejectTenant(SignalMetric)
+		return MetricPointResult{Outcome: MetricPointExcluded}
+	}
 	key := r.metricSeriesKey(tenantID, c.Service, c.Name, c.Attributes)
 	r.delta(key, window).ObserveHistogram(fold)
 	r.identify(key, window, topoIdentity{Kind: topoMetric, Tenant: c.Tenant, A: c.Service, B: c.Name})
@@ -552,7 +583,11 @@ func (r *Reducer) ReduceMetricPoint(in MetricInput) {
 	if !ok {
 		return
 	}
-	tenantID := r.eng.cache.InternTenant(in.Tenant)
+	tenantID, tenantOK := r.eng.cache.InternTenant(in.Tenant)
+	if !tenantOK {
+		r.rejectTenant(SignalMetric)
+		return
+	}
 	key := r.metricSeriesKey(tenantID, in.Service, in.Name, in.Attributes)
 
 	switch {

--- a/internal/aggregate/registrar.go
+++ b/internal/aggregate/registrar.go
@@ -31,38 +31,66 @@ type DurableRegistrar struct {
 	ids     map[dictScope]map[string]uint32
 	other   map[dictScope]uint32
 	pending map[uint32]DictRow
-	limits  map[Kind]int
+	bounds  Bounds
 	counts  map[dictScope]int
+	// kindCounts is the instance-wide census behind bounds.InstanceKind: it
+	// is what stops a thousand tenants, each just under its own per-tenant
+	// cap, from adding up to an unbounded dictionary (#200 Q3).
+	kindCounts map[Kind]int
+	// tenants counts admitted tenant identities against Bounds.MaxTenants.
+	tenants int
 	// byID is the reverse index used by the read path (Resolver). IDs are
 	// minted from one process-wide counter, so a single flat map is enough:
 	// an ID is unique across every (tenant, kind) scope.
 	byID map[uint32]DictEntry
+	// touched records every ID handed out since the last completed sweep. It
+	// is the race-closer for GC (#200 Q2): an ID returned to a hot-path
+	// goroutine that has not yet reached the Cache map is invisible to every
+	// other root, and collecting it would strand a live identity.
+	touched map[uint32]struct{}
+	// fenced holds IDs the maintenance barrier has taken out of service.
+	// Register refuses them (the Cache routes to __other__) until the sweep
+	// either commits — and the entries are removed — or fails and the fence
+	// is released with memory untouched.
+	fenced map[uint32]struct{}
 }
 
 // NewDurableRegistrar builds a registrar warmed from the store's dictionary so
 // IDs survive restart. limits caps entries per (tenant, kind); a missing or
 // zero entry means unlimited, and __other__ entries are always exempt.
 func NewDurableRegistrar(store Store, limits map[Kind]int) (*DurableRegistrar, error) {
+	return NewDurableRegistrarWithBounds(store, Bounds{PerTenantKind: limits})
+}
+
+// NewDurableRegistrarWithBounds is NewDurableRegistrar with the full #200 Q3
+// bound set: encoded-value length caps, per-(tenant, kind) counts, and the
+// instance-wide backstops behind them.
+//
+// The preload is exact, not truncated. LoadDict is asked for one row more than
+// the supported bound and a full page fails startup: a silent LIMIT is how a
+// registrar comes up believing a value is unregistered, mints a second ID for
+// it, and splits one series into two that no query can reunite.
+func NewDurableRegistrarWithBounds(store Store, b Bounds) (*DurableRegistrar, error) {
 	r := &DurableRegistrar{
-		next:    1, // 0 is the "none" sentinel and is never minted.
-		ids:     make(map[dictScope]map[string]uint32),
-		other:   make(map[dictScope]uint32),
-		pending: make(map[uint32]DictRow),
-		counts:  make(map[dictScope]int),
-		byID:    make(map[uint32]DictEntry),
-	}
-	if len(limits) > 0 {
-		r.limits = make(map[Kind]int, len(limits))
-		for k, v := range limits {
-			r.limits[k] = v
-		}
+		next:       1, // 0 is the "none" sentinel and is never minted.
+		ids:        make(map[dictScope]map[string]uint32),
+		other:      make(map[dictScope]uint32),
+		pending:    make(map[uint32]DictRow),
+		bounds:     b.withDefaults(),
+		counts:     make(map[dictScope]int),
+		kindCounts: make(map[Kind]int),
+		byID:       make(map[uint32]DictEntry),
+		touched:    make(map[uint32]struct{}),
 	}
 	if store == nil {
 		return r, nil
 	}
-	rows, err := store.LoadDict(0)
+	rows, err := store.LoadDict(MaxDictRows + 1)
 	if err != nil {
 		return nil, err
+	}
+	if len(rows) > MaxDictRows {
+		return nil, &PreloadError{Table: "aggregate_dict", Rows: len(rows), Max: MaxDictRows}
 	}
 	for _, row := range rows {
 		scope := dictScope{tenant: row.TenantID, kind: row.Kind}
@@ -78,12 +106,52 @@ func NewDurableRegistrar(store Store, limits map[Kind]int) (*DurableRegistrar, e
 			r.other[scope] = row.ID
 		} else {
 			r.counts[scope]++
+			r.kindCounts[row.Kind]++
+			if row.Kind == KindTenant {
+				r.tenants++
+			}
 		}
 		if row.ID >= r.next {
 			r.next = row.ID + 1
 		}
 	}
+	// Reseed from the durable high-watermark, never below it. MAX(id)+1 alone
+	// stops being safe the moment GC can delete the highest ID: the next boot
+	// would re-mint a number that finalized buckets, alias rows or an
+	// operator's saved query may still name (#200 Q1).
+	if wm, ok := store.(WatermarkStore); ok {
+		dictWM, _, err := wm.Watermarks()
+		if err != nil {
+			return nil, err
+		}
+		if dictWM > r.next {
+			r.next = dictWM
+		}
+	}
 	return r, nil
+}
+
+// PreloadError reports a warm-up load whose retained row count exceeds the
+// bound this build supports. It is fatal at startup by design: the alternative
+// is a silently truncated identity map.
+type PreloadError struct {
+	Table string
+	Rows  int
+	Max   int
+}
+
+func (e *PreloadError) Error() string {
+	return fmt.Sprintf("aggregate store: %s holds more than %d retained rows (%d+); "+
+		"this build cannot warm an identity map that large — raise the bound in a build that supports it "+
+		"or let the dictionary GC reduce it with an older binary", e.Table, e.Max, e.Rows)
+}
+
+// Next reports the ID the registrar would mint next. It is the value persisted
+// as the dictionary high-watermark.
+func (r *DurableRegistrar) Next() uint32 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.next
 }
 
 // Register implements Registrar.
@@ -98,30 +166,66 @@ func (r *DurableRegistrar) Register(tenantID uint32, kind Kind, value []byte) (u
 		// correct home for an identity we cannot name.
 		return 0, ErrDictFull
 	}
+	if len(value) > r.bounds.valueCap(kind) {
+		// Defensive: the Cache already routes over-length values. A registrar
+		// that accepted one would put a value in the dictionary that the hot
+		// path can never look up again.
+		return 0, ErrDictFull
+	}
 	scope := dictScope{tenant: tenantID, kind: kind}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if id, ok := r.ids[scope][string(value)]; ok {
+		if _, blocked := r.fenced[id]; blocked {
+			return 0, ErrDictFull
+		}
+		r.touched[id] = struct{}{}
 		return id, nil
 	}
-	if limit, ok := r.limits[kind]; ok && limit > 0 && r.counts[scope] >= limit {
-		return 0, ErrDictFull
+	if err := r.capsLocked(scope, kind); err != nil {
+		return 0, err
 	}
 	id, err := r.mintLocked(scope, value)
 	if err != nil {
 		return 0, err
 	}
 	r.counts[scope]++
+	r.kindCounts[kind]++
+	if kind == KindTenant {
+		r.tenants++
+	}
 	return id, nil
+}
+
+// capsLocked applies the per-(tenant, kind), instance-wide and tenant-identity
+// caps. r.mu must be held.
+func (r *DurableRegistrar) capsLocked(scope dictScope, kind Kind) error {
+	if kind == KindTenant && r.tenants >= r.bounds.MaxTenants {
+		return ErrDictFull
+	}
+	if limit, ok := r.bounds.PerTenantKind[kind]; ok && r.counts[scope] >= limit {
+		return ErrDictFull
+	}
+	if limit, ok := r.bounds.InstanceKind[kind]; ok && r.kindCounts[kind] >= limit {
+		return ErrDictFull
+	}
+	return nil
 }
 
 // OtherID implements Registrar. The overflow entry bypasses the capacity cap:
 // a quota must never block creation of the entry that absorbs quota violations.
 func (r *DurableRegistrar) OtherID(tenantID uint32, kind Kind) uint32 {
+	if kind == KindTenant {
+		// There is no __other__ tenant, by decision (#200 Q3): a shared
+		// overflow tenant is exactly the cross-tenant merge the cap exists to
+		// prevent. Callers get 0 and must refuse the point.
+		return 0
+	}
 	scope := dictScope{tenant: tenantID, kind: kind}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if id, ok := r.other[scope]; ok {
+		r.touched[id] = struct{}{}
 		return id
 	}
 	id, err := r.mintLocked(scope, []byte(OtherValue))
@@ -148,6 +252,7 @@ func (r *DurableRegistrar) mintLocked(scope dictScope, value []byte) (uint32, er
 	row := DictRow{ID: id, TenantID: scope.tenant, Kind: scope.kind, Value: slices.Clone(value)}
 	r.pending[id] = row
 	r.byID[id] = DictEntry(row)
+	r.touched[id] = struct{}{}
 	return id, nil
 }
 
@@ -157,6 +262,9 @@ func (r *DurableRegistrar) mintLocked(scope dictScope, value []byte) (uint32, er
 func (r *DurableRegistrar) Lookup(id uint32) (DictEntry, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if _, blocked := r.fenced[id]; blocked {
+		return DictEntry{}, false
+	}
 	e, ok := r.byID[id]
 	return e, ok
 }
@@ -210,6 +318,9 @@ type seriesRegistry struct {
 	ids     map[SeriesKey]SeriesID
 	keys    map[SeriesID]SeriesKey
 	pending map[SeriesID]SeriesRow
+	// touched records IDs handed out since the last completed sweep, for the
+	// same reason the registrar keeps one (#200 Q2).
+	touched map[SeriesID]struct{}
 }
 
 // newSeriesRegistry warms a registry from the store.
@@ -219,19 +330,32 @@ func newSeriesRegistry(store Store) (*seriesRegistry, error) {
 		ids:     make(map[SeriesKey]SeriesID),
 		keys:    make(map[SeriesID]SeriesKey),
 		pending: make(map[SeriesID]SeriesRow),
+		touched: make(map[SeriesID]struct{}),
 	}
 	if store == nil {
 		return r, nil
 	}
-	rows, err := store.LoadSeries(0)
+	rows, err := store.LoadSeries(MaxSeriesRows + 1)
 	if err != nil {
 		return nil, err
+	}
+	if len(rows) > MaxSeriesRows {
+		return nil, &PreloadError{Table: "aggregate_series", Rows: len(rows), Max: MaxSeriesRows}
 	}
 	for _, row := range rows {
 		r.ids[row.Key] = row.ID
 		r.keys[row.ID] = row.Key
 		if row.ID >= r.next {
 			r.next = row.ID + 1
+		}
+	}
+	if wm, ok := store.(WatermarkStore); ok {
+		_, seriesWM, err := wm.Watermarks()
+		if err != nil {
+			return nil, err
+		}
+		if seriesWM > r.next {
+			r.next = seriesWM
 		}
 	}
 	return r, nil
@@ -242,6 +366,7 @@ func (r *seriesRegistry) Resolve(key SeriesKey) SeriesID {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if id, ok := r.ids[key]; ok {
+		r.touched[id] = struct{}{}
 		return id
 	}
 	id := r.next
@@ -249,7 +374,16 @@ func (r *seriesRegistry) Resolve(key SeriesKey) SeriesID {
 	r.ids[key] = id
 	r.keys[id] = key
 	r.pending[id] = SeriesRow{ID: id, Key: key}
+	r.touched[id] = struct{}{}
 	return id
+}
+
+// Next reports the ID the registry would mint next — the value persisted as
+// the series high-watermark.
+func (r *seriesRegistry) Next() SeriesID {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.next
 }
 
 // Key resolves an ID back to its identity from the in-memory map.
@@ -294,3 +428,175 @@ var (
 	_ Resolver  = (*DurableRegistrar)(nil)
 	_ Resolver  = (*MemRegistrar)(nil)
 )
+
+// --- GC hooks (#200 Q1, Q2) -------------------------------------------------
+
+// Roots returns the dictionary IDs the registrar itself keeps alive: every
+// staged (not yet durable) registration, every pre-created __other__ sentinel,
+// and every ID handed out since the last completed sweep.
+//
+// The __other__ entries are unconditional roots. They absorb quota violations,
+// so a sweep that collected one because nothing referenced it this hour would
+// force the next overflow to mint a second sentinel for the same namespace.
+func (r *DurableRegistrar) Roots() map[uint32]struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[uint32]struct{}, len(r.pending)+len(r.other)+len(r.touched))
+	for id := range r.pending {
+		out[id] = struct{}{}
+	}
+	for _, id := range r.other {
+		out[id] = struct{}{}
+	}
+	for id := range r.touched {
+		out[id] = struct{}{}
+	}
+	return out
+}
+
+// Fence takes candidate IDs out of service. Register refuses a fenced ID (the
+// Cache routes the value to __other__) and Lookup reports it unknown, but no
+// map entry moves: a failed DELETE must be able to release the fence and leave
+// memory byte-for-byte as it was.
+func (r *DurableRegistrar) Fence(ids map[uint32]struct{}) {
+	if len(ids) == 0 {
+		return
+	}
+	r.mu.Lock()
+	if r.fenced == nil {
+		r.fenced = make(map[uint32]struct{}, len(ids))
+	}
+	for id := range ids {
+		r.fenced[id] = struct{}{}
+	}
+	r.mu.Unlock()
+}
+
+// Unfence releases every fenced ID without changing anything else.
+func (r *DurableRegistrar) Unfence() {
+	r.mu.Lock()
+	r.fenced = nil
+	r.mu.Unlock()
+}
+
+// Revalidate drops from candidates every ID the registrar can still hand out.
+// It runs INSIDE the maintenance barrier, under the registrar mutex, so an ID
+// a concurrent Register returned either lands in touched before this runs (and
+// survives) or blocks until the sweep has decided (and gets re-minted).
+func (r *DurableRegistrar) Revalidate(candidates map[uint32]struct{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id := range candidates {
+		_, staged := r.pending[id]
+		_, used := r.touched[id]
+		if staged || used {
+			delete(candidates, id)
+		}
+	}
+	for _, id := range r.other {
+		delete(candidates, id)
+	}
+}
+
+// Forget removes swept IDs from the forward, reverse and count maps and clears
+// the fence. It runs only after the DELETE has committed.
+func (r *DurableRegistrar) Forget(ids map[uint32]struct{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id := range ids {
+		entry, ok := r.byID[id]
+		if !ok {
+			continue
+		}
+		scope := dictScope{tenant: entry.TenantID, kind: entry.Kind}
+		if inner := r.ids[scope]; inner != nil {
+			delete(inner, string(entry.Value))
+			if len(inner) == 0 {
+				delete(r.ids, scope)
+			}
+		}
+		delete(r.byID, id)
+		if r.counts[scope] > 0 {
+			r.counts[scope]--
+			if r.counts[scope] == 0 {
+				delete(r.counts, scope)
+			}
+		}
+		if r.kindCounts[entry.Kind] > 0 {
+			r.kindCounts[entry.Kind]--
+		}
+		if entry.Kind == KindTenant && r.tenants > 0 {
+			r.tenants--
+		}
+	}
+	r.fenced = nil
+	r.touched = make(map[uint32]struct{})
+}
+
+// ClearTouched resets the "handed out since the last sweep" set without
+// deleting anything. A sweep that collected nothing still has to clear it, or
+// the set grows for the life of the process.
+func (r *DurableRegistrar) ClearTouched() {
+	r.mu.Lock()
+	r.touched = make(map[uint32]struct{})
+	r.mu.Unlock()
+}
+
+// Lock and Unlock expose the registry mutex to the maintenance barrier. The
+// series registry is the writer's own structure — the barrier already runs on
+// the writer goroutine — so it is held across the sweep rather than fenced.
+func (r *seriesRegistry) Lock()   { r.mu.Lock() }
+func (r *seriesRegistry) Unlock() { r.mu.Unlock() }
+
+// rootsLocked returns the series IDs the registry keeps alive. r.mu must be
+// held.
+func (r *seriesRegistry) rootsLocked() map[SeriesID]struct{} {
+	out := make(map[SeriesID]struct{}, len(r.pending)+len(r.touched))
+	for id := range r.pending {
+		out[id] = struct{}{}
+	}
+	for id := range r.touched {
+		out[id] = struct{}{}
+	}
+	return out
+}
+
+// Roots returns the series IDs the registry keeps alive.
+func (r *seriesRegistry) Roots() map[SeriesID]struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.rootsLocked()
+}
+
+// revalidateLocked drops from candidates every series the registry can still
+// resolve to. r.mu must be held.
+func (r *seriesRegistry) revalidateLocked(candidates map[SeriesID]struct{}) {
+	for id := range candidates {
+		_, staged := r.pending[id]
+		_, used := r.touched[id]
+		if staged || used {
+			delete(candidates, id)
+		}
+	}
+}
+
+// forgetLocked removes swept series from both directions of the map. r.mu must
+// be held, and the DELETE must already have committed.
+func (r *seriesRegistry) forgetLocked(ids map[SeriesID]struct{}) {
+	for id := range ids {
+		key, ok := r.keys[id]
+		if !ok {
+			continue
+		}
+		delete(r.keys, id)
+		if cur, ok := r.ids[key]; ok && cur == id {
+			delete(r.ids, key)
+		}
+	}
+	r.touched = make(map[SeriesID]struct{})
+}
+
+// clearTouchedLocked resets the touched set. r.mu must be held.
+func (r *seriesRegistry) clearTouchedLocked() {
+	r.touched = make(map[SeriesID]struct{})
+}

--- a/internal/aggregate/store.go
+++ b/internal/aggregate/store.go
@@ -45,7 +45,34 @@ import (
 // population statistics and its accuracy metadata (#199). A v3 file has no
 // column to put them in and no way to reconstruct them, so the same
 // rebuild-or-downgrade choice applies.
-const StoreSchemaVersion = 4
+//
+// v5 added aggregate_log_template — the durable log-template miner state —
+// plus the dict_id/series_id high-watermark meta keys that dictionary GC
+// requires (#200). A v4 file has neither, and a binary that started GC against
+// a MAX(id)+1 reseed could re-mint an ID a finalized bucket still names, so the
+// fail-closed policy stands: run an older binary or accept the rebuild.
+const StoreSchemaVersion = 5
+
+// Meta keys that carry monotonically increasing identity high-watermarks
+// (#200 Q1). MAX(id)+1 stopped being a safe reseed the moment GC could delete
+// the highest ID, so allocation comes from these instead.
+const (
+	MetaDictWatermark   = "dict_id_high_watermark"
+	MetaSeriesWatermark = "series_id_high_watermark"
+)
+
+// MaxDictRows and MaxSeriesRows bound the startup identity warm-up. They are
+// far above the #158 caps; they exist so a corrupted or hostile file cannot
+// make startup allocate without bound. Exceeding one fails startup with a
+// *PreloadError rather than truncating the load in silence (#200 Q3).
+//
+// Declared as var (not const) for the same reason MaxReadRows is: a test has
+// to exercise the fail-fast path without seeding two million rows through a
+// race-instrumented SQLite. Nothing outside a test may assign them.
+var (
+	MaxDictRows   = 2_000_000
+	MaxSeriesRows = 500_000
+)
 
 // Store errors.
 var (
@@ -173,11 +200,124 @@ type GroupBatch struct {
 	Series    []SeriesRow
 	Deltas    []DeltaRow
 	Baselines []BaselineRow
+	// Templates are identity-critical log-template mutations: a new template,
+	// a pattern generalization, or an alias change (#200 Q4). They ride the
+	// same transaction as the delta that used the resulting identity, because
+	// a 15-minute snapshot alone lets acknowledged identity state vanish in a
+	// crash — the bucket would survive naming a template ID that the reloaded
+	// miner has never heard of.
+	Templates []TemplateRow
 }
 
 // Empty reports whether the batch would commit nothing.
 func (b *GroupBatch) Empty() bool {
-	return len(b.Dicts) == 0 && len(b.Series) == 0 && len(b.Deltas) == 0 && len(b.Baselines) == 0
+	return len(b.Dicts) == 0 && len(b.Series) == 0 && len(b.Deltas) == 0 &&
+		len(b.Baselines) == 0 && len(b.Templates) == 0
+}
+
+// TemplateRow is one durable log-template record (#200 Q4).
+//
+// It carries exactly what a reload needs to rebuild the prefix tree, resolve a
+// historical template ID, and re-enforce the per-partition cap. It carries NO
+// raw log sample: the miner keeps one in memory for diagnostics, and persisting
+// it would turn the aggregate file into a credential and PII sink for the sake
+// of a field exemplars already provide.
+type TemplateRow struct {
+	// ID is the immutable surrogate template identity — the same uint32 the
+	// log_template dictionary minted, and the NameID of every log series that
+	// used it.
+	ID uint32
+	// Tenant and Service name the partition. They are the strings, not
+	// dictionary IDs: the miner is keyed by them and a reload must rebuild
+	// its partitions before any dictionary lookup is warm.
+	Tenant, Service string
+	// PatternVersion increments on every generalization of Tokens. It makes a
+	// stale periodic stats write unable to overwrite a newer pattern.
+	PatternVersion uint32
+	// Tokens is the token pattern, NUL-joined. Tokens never contain
+	// whitespace (the tokenizer splits on it) and never contain NUL.
+	Tokens string
+	// Seq is the partition-local creation ordinal. Convergence keeps the
+	// lower one, so it has to survive a restart or two restarts could pick
+	// different survivors for the same pair.
+	Seq uint64
+	// IsOther marks the partition's pre-created overflow identity.
+	IsOther bool
+	// AliasOf is the surviving template this ID forwards to, or 0.
+	AliasOf uint32
+	// Count, FirstSeen and LastSeen are the non-identity statistics. They are
+	// refreshed by the periodic dirty-partition write, not by the identity
+	// commit path.
+	Count               uint64
+	FirstSeen, LastSeen int64
+}
+
+// TemplateStatRow is the non-identity half of a template: the counters a
+// periodic dirty-partition write refreshes. Losing one costs a count, not an
+// identity, so it does not need to ride a group commit.
+type TemplateStatRow struct {
+	ID                  uint32
+	Count               uint64
+	FirstSeen, LastSeen int64
+}
+
+// SweepStats is the outcome of one identity sweep.
+type SweepStats struct {
+	// Series, Dict and Templates count deleted rows per table.
+	Series, Dict, Templates int64
+	// Duration is the wall time of the delete transaction.
+	Duration time.Duration
+}
+
+// WatermarkStore is the optional Store capability that carries the identity
+// high-watermarks. It is separate from Store so an implementation predating
+// #200 still satisfies Store; the registrars degrade to MAX(id)+1 without it,
+// which is correct exactly as long as nothing collects.
+type WatermarkStore interface {
+	// Watermarks returns the persisted dictionary and series high-watermarks:
+	// the next ID each allocator may mint. Zero means "not yet stamped".
+	Watermarks() (uint32, SeriesID, error)
+}
+
+// GCSnapshot is one consistent read of every identity table, taken inside a
+// single read transaction (#200 Q1).
+//
+// One transaction, not four queries: a series marked live from the bucket scan
+// and a dictionary row read a moment later have to describe the same instant.
+// Read them separately and a commit landing in between makes a brand-new
+// series invisible to the reference set while its brand-new name is visible to
+// the candidate set — and GC deletes the name of a series that exists.
+type GCSnapshot struct {
+	// Referenced is every series ID named by aggregate_buckets,
+	// aggregate_delta_log or aggregate_baseline.
+	Referenced map[SeriesID]struct{}
+	// Series, Dict and Templates are the identity tables themselves.
+	Series    []SeriesRow
+	Dict      []DictRow
+	Templates []TemplateRow
+}
+
+// GCStore is the Store capability the dictionary/series collector needs. It is
+// separate from Store for the same reason WatermarkStore is.
+type GCStore interface {
+	// GCSnapshot reads the reference set and all three identity tables inside
+	// ONE read transaction. It runs on the READ pool, without the writer
+	// lock: the full scan is the part of GC that must never become an
+	// ACK-latency incident.
+	GCSnapshot() (*GCSnapshot, error)
+
+	// LoadTemplates returns every durable log-template row, capped at max.
+	LoadTemplates(max int) ([]TemplateRow, error)
+
+	// SweepIdentities deletes the given series, dictionary and template rows
+	// in ONE transaction, series first. It runs under the writer lock. A
+	// partial sweep is never observable: either every row named here is gone
+	// or none of them are.
+	SweepIdentities(series []SeriesID, dict []uint32, templates []uint32) (SweepStats, error)
+
+	// SaveTemplateStats refreshes the non-identity template counters. Rows
+	// whose template no longer exists are ignored, not created.
+	SaveTemplateStats(rows []TemplateStatRow) error
 }
 
 // SeriesInfo is a series' durable identity, resolved back from its ID.
@@ -462,6 +602,8 @@ type StoreMetrics interface {
 	// RecordRecovery publishes the startup recovery duration and how many
 	// delta rows were replayed.
 	RecordRecovery(d time.Duration, replayed int, finalized int)
+	// RecordGC publishes one identity garbage-collection pass.
+	RecordGC(stats GCStats, err error)
 }
 
 // noopStoreMetrics is the default when no metrics are wired.
@@ -473,6 +615,7 @@ func (noopStoreMetrics) RecordFinalize(FinalizeStats, error)           {}
 func (noopStoreMetrics) RecordPurge(PurgeStats, error)                 {}
 func (noopStoreMetrics) SetBacklog(int64, float64)                     {}
 func (noopStoreMetrics) RecordRecovery(time.Duration, int, int)        {}
+func (noopStoreMetrics) RecordGC(GCStats, error)                       {}
 
 // MutableSince returns the oldest window start still inside the mutable set at
 // now: the current window minus the lateness horizon. Everything strictly older

--- a/internal/aggregate/store_sqlite.go
+++ b/internal/aggregate/store_sqlite.go
@@ -8,9 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -46,11 +48,14 @@ const (
 	// defaultBusyTimeoutMs bounds how long a statement waits on the writer
 	// lock before erroring, matching the main DB's stanza.
 	defaultBusyTimeoutMs = 5000
-	// maxDictRows and maxSeriesRows bound the startup warm-up loads. Both are
-	// far above the #158 caps; they exist so a corrupted or hostile file
-	// cannot make startup allocate without bound.
-	maxDictRows   = 2_000_000
-	maxSeriesRows = 500_000
+	// maxTemplateRows bounds the startup log-template warm-up. The
+	// per-partition cap times a sane partition count sits orders of magnitude
+	// below it; it exists so a corrupted file cannot make startup allocate
+	// without bound.
+	maxTemplateRows = 200_000
+	// sweepChunk bounds how many IDs go into one DELETE ... IN (...) so a
+	// sweep never compiles a statement with a hundred thousand parameters.
+	sweepChunk = 500
 	// purgeWindowsPerPass bounds how many windows one PurgeBefore call
 	// deletes, so retention never opens an unbounded transaction.
 	purgeWindowsPerPass = 4096
@@ -64,6 +69,7 @@ var aggregateTables = []string{
 	"aggregate_baseline",
 	"aggregate_buckets",
 	"aggregate_delta_log",
+	"aggregate_log_template",
 	"aggregate_series",
 	"aggregate_dict",
 	"aggregate_meta",
@@ -413,6 +419,30 @@ func schemaDDL() []string {
 			value REAL NOT NULL,
 			PRIMARY KEY (series_id, producer_id)
 		) WITHOUT ROWID`,
+
+		// Durable log-template miner state (#200 Q4). The primary key IS the
+		// dictionary ID minted for the template, which is also the NameID of
+		// every log series that used it: one identity, three tables, no
+		// second ID space to keep in step.
+		//
+		// There is no sample column, deliberately. Raw log bodies are a
+		// credential and PII sink; exemplars already carry the raw line for
+		// the cases that need one.
+		`CREATE TABLE IF NOT EXISTS aggregate_log_template (
+			template_id INTEGER PRIMARY KEY,
+			tenant TEXT NOT NULL,
+			service TEXT NOT NULL,
+			pattern_version INTEGER NOT NULL,
+			tokens TEXT NOT NULL,
+			seq INTEGER NOT NULL,
+			is_other INTEGER NOT NULL,
+			alias_of INTEGER NOT NULL,
+			hit_count INTEGER NOT NULL,
+			first_ts INTEGER NOT NULL,
+			last_ts INTEGER NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_aggregate_log_template_partition
+			ON aggregate_log_template (tenant, service)`,
 	}
 }
 
@@ -523,6 +553,10 @@ func (s *SQLiteStore) createSchema() error {
 		{"sketch_codec_version", fmt.Sprint(SketchEncodingVersion)},
 		{"store_uuid", uuid},
 		{"created_at", time.Now().UTC().Format(time.RFC3339)},
+		// The watermarks start at 1 — the first ID either allocator may mint,
+		// since 0 is the "none" sentinel. They only ever increase (#200 Q1).
+		{MetaDictWatermark, "1"},
+		{MetaSeriesWatermark, "1"},
 	}
 	for _, kv := range meta {
 		if _, err := tx.Exec(`INSERT OR REPLACE INTO aggregate_meta (key, value) VALUES (?, ?)`, kv[0], kv[1]); err != nil {
@@ -654,6 +688,15 @@ func (s *SQLiteStore) commitGroup(b *GroupBatch) (int64, error) {
 		return 0, err
 	}
 	if err := upsertBaselines(tx, b.Baselines); err != nil {
+		return 0, err
+	}
+	if err := upsertTemplates(tx, b.Templates); err != nil {
+		return 0, err
+	}
+	// The high-watermarks ride the same transaction as the rows whose IDs
+	// they cover. Stamping them afterwards would leave a window in which a
+	// committed row names an ID the next boot is free to mint again (#200 Q1).
+	if err := bumpWatermarks(tx, b); err != nil {
 		return 0, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -1451,10 +1494,40 @@ func (s *SQLiteStore) ResolveSeries(ids []SeriesID) ([]SeriesInfo, error) {
 
 // LoadDict implements Store.
 func (s *SQLiteStore) LoadDict(max int) ([]DictRow, error) {
-	if max <= 0 || max > maxDictRows {
-		max = maxDictRows
+	return scanDictRows(s.reader, dictLimit(max))
+}
+
+// LoadSeries implements Store.
+func (s *SQLiteStore) LoadSeries(max int) ([]SeriesRow, error) {
+	return scanSeriesRows(s.reader, seriesLimit(max))
+}
+
+// dictLimit and seriesLimit clamp a caller's row limit to one row past the
+// supported bound. The extra row is what lets a caller distinguish "the whole
+// table" from "as much of it as fit", which a bare LIMIT cannot (#200 Q3).
+func dictLimit(max int) int {
+	if max <= 0 || max > MaxDictRows+1 {
+		return MaxDictRows + 1
 	}
-	rows, err := s.reader.Query(`SELECT id, tenant_id, kind, value FROM aggregate_dict LIMIT ?`, max)
+	return max
+}
+
+func seriesLimit(max int) int {
+	if max <= 0 || max > MaxSeriesRows+1 {
+		return MaxSeriesRows + 1
+	}
+	return max
+}
+
+// queryer is the read surface shared by the pool and a read transaction, so
+// the identity scans can run either standalone or inside one snapshot.
+type queryer interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+}
+
+// scanDictRows reads the dictionary table through q.
+func scanDictRows(q queryer, limit int) ([]DictRow, error) {
+	rows, err := q.Query(`SELECT id, tenant_id, kind, value FROM aggregate_dict ORDER BY id LIMIT ?`, limit)
 	if err != nil {
 		return nil, fmt.Errorf("aggregate store: load dict: %w", err)
 	}
@@ -1480,14 +1553,11 @@ func (s *SQLiteStore) LoadDict(max int) ([]DictRow, error) {
 	return out, rows.Err()
 }
 
-// LoadSeries implements Store.
-func (s *SQLiteStore) LoadSeries(max int) ([]SeriesRow, error) {
-	if max <= 0 || max > maxSeriesRows {
-		max = maxSeriesRows
-	}
-	rows, err := s.reader.Query(
+// scanSeriesRows reads the series table through q.
+func scanSeriesRows(q queryer, limit int) ([]SeriesRow, error) {
+	rows, err := q.Query(
 		`SELECT id, tenant_id, service_id, name_id, dims_id, signal, status_class, http_class, method, span_kind, severity
-		 FROM aggregate_series LIMIT ?`, max)
+		 FROM aggregate_series ORDER BY id LIMIT ?`, limit)
 	if err != nil {
 		return nil, fmt.Errorf("aggregate store: load series: %w", err)
 	}
@@ -1687,5 +1757,366 @@ func producerFromBytes(b []byte) ProducerID {
 	return ProducerID(v)
 }
 
-// compile-time assertion that the SQLite store satisfies the interface.
-var _ Store = (*SQLiteStore)(nil)
+// compile-time assertion that the SQLite store satisfies the contract.
+var (
+	_ Store          = (*SQLiteStore)(nil)
+	_ WatermarkStore = (*SQLiteStore)(nil)
+	_ GCStore        = (*SQLiteStore)(nil)
+)
+
+// --- identity persistence and GC (#200) -------------------------------------
+
+// upsertTemplates writes the identity-critical half of the log-template miner
+// state. It rides the same transaction as the delta that used the identity.
+//
+// The pattern is written only when this row's pattern_version is at least the
+// stored one, so a re-offered row from a failed commit can never roll a newer
+// generalization backwards.
+func upsertTemplates(tx *sql.Tx, rows []TemplateRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	stmt, err := tx.Prepare(`INSERT INTO aggregate_log_template
+		(template_id, tenant, service, pattern_version, tokens, seq, is_other, alias_of, hit_count, first_ts, last_ts)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?)
+		ON CONFLICT(template_id) DO UPDATE SET
+			pattern_version = excluded.pattern_version,
+			tokens          = excluded.tokens,
+			alias_of        = excluded.alias_of,
+			hit_count       = MAX(hit_count, excluded.hit_count),
+			last_ts         = MAX(last_ts, excluded.last_ts)
+		WHERE excluded.pattern_version >= aggregate_log_template.pattern_version`)
+	if err != nil {
+		return fmt.Errorf("aggregate store: prepare template upsert: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+	for _, r := range rows {
+		if _, err := stmt.Exec(
+			int64(r.ID), r.Tenant, r.Service, int64(r.PatternVersion), r.Tokens,
+			// #nosec G115 -- partition-local ordinal, bounded by the per-service cap
+			int64(r.Seq), boolToInt(r.IsOther), int64(r.AliasOf),
+			// #nosec G115 -- a hit count large enough to wrap int64 is not reachable
+			int64(r.Count), r.FirstSeen, r.LastSeen,
+		); err != nil {
+			return fmt.Errorf("aggregate store: upsert template %d: %w", r.ID, err)
+		}
+	}
+	return nil
+}
+
+// clampUint64 reads a counter column that this package only ever writes as a
+// uint64. A negative value means the file was hand-edited or corrupted; zero
+// is the honest reading, and it costs a count rather than an identity.
+func clampUint64(n int64) uint64 {
+	if n < 0 {
+		return 0
+	}
+	return uint64(n)
+}
+
+// boolToInt renders a bool as SQLite's 0/1.
+func boolToInt(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// bumpWatermarks raises the persisted identity high-watermarks to cover every
+// ID this batch made durable. They never decrease.
+func bumpWatermarks(tx *sql.Tx, b *GroupBatch) error {
+	var dictWM, seriesWM int64
+	for _, r := range b.Dicts {
+		if int64(r.ID)+1 > dictWM {
+			dictWM = int64(r.ID) + 1
+		}
+	}
+	for _, r := range b.Templates {
+		if int64(r.ID)+1 > dictWM {
+			dictWM = int64(r.ID) + 1
+		}
+	}
+	for _, r := range b.Series {
+		if int64(r.ID)+1 > seriesWM {
+			seriesWM = int64(r.ID) + 1
+		}
+	}
+	for _, kv := range []struct {
+		key   string
+		value int64
+	}{{MetaDictWatermark, dictWM}, {MetaSeriesWatermark, seriesWM}} {
+		if kv.value <= 0 {
+			continue
+		}
+		if _, err := tx.Exec(`INSERT INTO aggregate_meta (key, value) VALUES (?, ?)
+			ON CONFLICT(key) DO UPDATE SET value = excluded.value
+			WHERE CAST(excluded.value AS INTEGER) > CAST(aggregate_meta.value AS INTEGER)`,
+			kv.key, strconv.FormatInt(kv.value, 10)); err != nil {
+			return fmt.Errorf("aggregate store: bump %s: %w", kv.key, err)
+		}
+	}
+	return nil
+}
+
+// Watermarks implements WatermarkStore.
+func (s *SQLiteStore) Watermarks() (uint32, SeriesID, error) {
+	var dictWM, seriesWM int64
+	for _, spec := range []struct {
+		key string
+		dst *int64
+	}{{MetaDictWatermark, &dictWM}, {MetaSeriesWatermark, &seriesWM}} {
+		var raw sql.NullString
+		err := s.reader.QueryRow(`SELECT value FROM aggregate_meta WHERE key = ?`, spec.key).Scan(&raw)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			continue
+		case err != nil:
+			return 0, 0, fmt.Errorf("aggregate store: read %s: %w", spec.key, err)
+		}
+		if !raw.Valid {
+			continue
+		}
+		n, convErr := strconv.ParseInt(strings.TrimSpace(raw.String), 10, 64)
+		if convErr != nil || n < 0 {
+			return 0, 0, &SchemaError{Reason: "missing_meta", Detail: spec.key + " is not a non-negative integer"}
+		}
+		*spec.dst = n
+	}
+	if dictWM > int64(math.MaxUint32) {
+		return 0, 0, &SchemaError{Reason: "missing_meta", Detail: MetaDictWatermark + " exceeds the uint32 dictionary ID space"}
+	}
+	// #nosec G115 -- bounded by the MaxUint32 check directly above
+	return uint32(dictWM), SeriesID(seriesWM), nil
+}
+
+// GCSnapshot implements GCStore. Every scan runs inside ONE deferred read
+// transaction, which in WAL mode pins a single snapshot of the file for its
+// whole life — the reference set and the identity tables therefore describe
+// the same instant. No writer lock is taken: a commit may land during the
+// scan, and the barrier's revalidation is what accounts for it.
+func (s *SQLiteStore) GCSnapshot() (*GCSnapshot, error) {
+	tx, err := s.reader.BeginTx(context.Background(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate store: begin gc snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	snap := &GCSnapshot{Referenced: make(map[SeriesID]struct{}, 1024)}
+	for _, q := range []string{
+		`SELECT DISTINCT series_id FROM aggregate_buckets`,
+		`SELECT DISTINCT series_id FROM aggregate_delta_log`,
+		`SELECT DISTINCT series_id FROM aggregate_baseline`,
+	} {
+		if err := collectSeriesIDs(tx, q, snap.Referenced); err != nil {
+			return nil, err
+		}
+	}
+	if snap.Series, err = scanSeriesRows(tx, MaxSeriesRows+1); err != nil {
+		return nil, err
+	}
+	if len(snap.Series) > MaxSeriesRows {
+		return nil, &PreloadError{Table: "aggregate_series", Rows: len(snap.Series), Max: MaxSeriesRows}
+	}
+	if snap.Dict, err = scanDictRows(tx, MaxDictRows+1); err != nil {
+		return nil, err
+	}
+	if len(snap.Dict) > MaxDictRows {
+		return nil, &PreloadError{Table: "aggregate_dict", Rows: len(snap.Dict), Max: MaxDictRows}
+	}
+	if snap.Templates, err = scanTemplateRows(tx, maxTemplateRows+1); err != nil {
+		return nil, err
+	}
+	return snap, nil
+}
+
+// collectSeriesIDs folds one series-id projection into dst.
+func collectSeriesIDs(q queryer, query string, dst map[SeriesID]struct{}) error {
+	rows, err := q.Query(query)
+	if err != nil {
+		return fmt.Errorf("aggregate store: scan series references: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return fmt.Errorf("aggregate store: scan series references: %w", err)
+		}
+		dst[SeriesID(id)] = struct{}{}
+	}
+	return rows.Err()
+}
+
+// LoadTemplates implements GCStore.
+func (s *SQLiteStore) LoadTemplates(max int) ([]TemplateRow, error) {
+	return scanTemplateRows(s.reader, templateLimit(max))
+}
+
+// templateLimit clamps a template row limit to one past the supported bound.
+func templateLimit(max int) int {
+	if max <= 0 || max > maxTemplateRows+1 {
+		return maxTemplateRows + 1
+	}
+	return max
+}
+
+// scanTemplateRows reads the log-template table through q.
+func scanTemplateRows(q queryer, limit int) ([]TemplateRow, error) {
+	rows, err := q.Query(`SELECT template_id, tenant, service, pattern_version, tokens,
+		seq, is_other, alias_of, hit_count, first_ts, last_ts
+		FROM aggregate_log_template ORDER BY template_id LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate store: load templates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []TemplateRow
+	for rows.Next() {
+		var (
+			r                                          TemplateRow
+			id, version, seq, isOther, alias, hitCount int64
+		)
+		if err := rows.Scan(&id, &r.Tenant, &r.Service, &version, &r.Tokens,
+			&seq, &isOther, &alias, &hitCount, &r.FirstSeen, &r.LastSeen); err != nil {
+			return nil, fmt.Errorf("aggregate store: load templates: %w", err)
+		}
+		// #nosec G115 -- every id column is written from a uint32 by this
+		// package and nothing else writes the table.
+		r.ID, r.PatternVersion, r.AliasOf = uint32(id), uint32(version), uint32(alias)
+		r.Seq, r.Count = clampUint64(seq), clampUint64(hitCount)
+		r.IsOther = isOther != 0
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("aggregate store: load templates: %w", err)
+	}
+	if len(out) > maxTemplateRows {
+		return nil, &PreloadError{Table: "aggregate_log_template", Rows: len(out), Max: maxTemplateRows}
+	}
+	return out, nil
+}
+
+// SaveTemplateStats implements GCStore. Statistics only: it never creates a
+// row, so a template swept between the dirty mark and this write stays swept.
+func (s *SQLiteStore) SaveTemplateStats(rows []TemplateStatRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	s.lockWriter()
+	defer s.unlockWriter()
+	tx, err := s.writer.Begin()
+	if err != nil {
+		return fmt.Errorf("aggregate store: begin template stats: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	stmt, err := tx.Prepare(`UPDATE aggregate_log_template
+		SET hit_count = ?, first_ts = ?, last_ts = ? WHERE template_id = ?`)
+	if err != nil {
+		return fmt.Errorf("aggregate store: prepare template stats: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+	for _, r := range rows {
+		// #nosec G115 -- a hit count large enough to wrap int64 is not reachable
+		if _, err := stmt.Exec(int64(r.Count), r.FirstSeen, r.LastSeen, int64(r.ID)); err != nil {
+			return fmt.Errorf("aggregate store: template stats %d: %w", r.ID, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("aggregate store: commit template stats: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+// SweepIdentities implements GCStore: one transaction, series first, then the
+// dictionary rows the swept series released, then the template rows those
+// dictionary IDs backed.
+//
+// The order matters for exactly one reason: a crash between two transactions
+// could leave a series row naming a deleted dictionary ID. Inside one
+// transaction there is no such window, and the ordering is kept anyway so the
+// intent survives a future implementation that cannot span tables.
+func (s *SQLiteStore) SweepIdentities(series []SeriesID, dict []uint32, templates []uint32) (SweepStats, error) {
+	var stats SweepStats
+	if len(series) == 0 && len(dict) == 0 && len(templates) == 0 {
+		return stats, nil
+	}
+	start := time.Now()
+	s.lockWriter()
+	defer s.unlockWriter()
+	tx, err := s.writer.Begin()
+	if err != nil {
+		return stats, fmt.Errorf("aggregate store: begin sweep: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	seriesIDs := make([]int64, len(series))
+	for i, id := range series {
+		seriesIDs[i] = int64(id)
+	}
+	dictIDs := make([]int64, len(dict))
+	for i, id := range dict {
+		dictIDs[i] = int64(id)
+	}
+	templateIDs := make([]int64, len(templates))
+	for i, id := range templates {
+		templateIDs[i] = int64(id)
+	}
+	// The DELETE prefixes are literals, not composed from identifiers: SQLite
+	// cannot bind a table name, so the only safe way to vary one is not to.
+	for _, step := range []struct {
+		what   string
+		prefix string
+		ids    []int64
+		dst    *int64
+	}{
+		{"aggregate_series", `DELETE FROM aggregate_series WHERE id IN (`, seriesIDs, &stats.Series},
+		{"aggregate_dict", `DELETE FROM aggregate_dict WHERE id IN (`, dictIDs, &stats.Dict},
+		{"aggregate_log_template", `DELETE FROM aggregate_log_template WHERE template_id IN (`, templateIDs, &stats.Templates},
+	} {
+		n, err := deleteByID(tx, step.what, step.prefix, step.ids)
+		if err != nil {
+			return stats, err
+		}
+		*step.dst = n
+	}
+	if err := tx.Commit(); err != nil {
+		return stats, fmt.Errorf("aggregate store: commit sweep: %w", err)
+	}
+	committed = true
+	stats.Duration = time.Since(start)
+	return stats, nil
+}
+
+// deleteByID removes rows by primary key in bounded chunks. prefix is a
+// literal "DELETE FROM <table> WHERE <col> IN (" and what names the table for
+// error messages only.
+func deleteByID(tx *sql.Tx, what, prefix string, ids []int64) (int64, error) {
+	var total int64
+	for start := 0; start < len(ids); start += sweepChunk {
+		end := start + sweepChunk
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunk := ids[start:end]
+		args := make([]any, len(chunk))
+		for i, id := range chunk {
+			args[i] = id
+		}
+		res, err := tx.Exec(prefix+placeholders(len(chunk))+`)`, args...)
+		if err != nil {
+			return total, fmt.Errorf("aggregate store: sweep %s: %w", what, err)
+		}
+		if n, err := res.RowsAffected(); err == nil {
+			total += n
+		}
+	}
+	return total, nil
+}

--- a/internal/aggregate/template_miner.go
+++ b/internal/aggregate/template_miner.go
@@ -187,6 +187,21 @@ type TemplateMiner struct {
 	idxMu sync.RWMutex
 	text  map[uint32]string
 	alias map[uint32]uint32
+
+	// stageMu guards the durable-state staging maps (#200 Q4). Lock order is
+	// partition mutex -> stageMu, never the reverse.
+	//
+	// pending holds IDENTITY-critical mutations — a new template, a pattern
+	// generalization, an alias change. They ride the next group commit, so
+	// they become durable in the same transaction as the delta that used the
+	// identity. A periodic snapshot alone would let a crash acknowledge a
+	// bucket whose NameID the reloaded miner has never heard of.
+	//
+	// dirty holds the non-identity counters. Losing one costs a count, not an
+	// identity, so they take the cheap periodic path instead.
+	stageMu sync.Mutex
+	pending map[uint32]TemplateRow
+	dirty   map[uint32]TemplateStatRow
 }
 
 // NewTemplateMiner builds a miner from cfg, applying defaults.
@@ -201,6 +216,8 @@ func NewTemplateMiner(cfg TemplateMinerConfig) *TemplateMiner {
 		parts:        make(map[tmPartKey]*tmPartition),
 		text:         make(map[uint32]string),
 		alias:        make(map[uint32]uint32),
+		pending:      make(map[uint32]TemplateRow),
+		dirty:        make(map[uint32]TemplateStatRow),
 	}
 	if m.maxTemplates <= 0 {
 		m.maxTemplates = DefaultMaxLogTemplatesPerService
@@ -403,6 +420,10 @@ type tmTemplate struct {
 	id     uint32
 	seq    uint64 // partition-local creation ordinal; lower survives convergence
 	tokens []string
+	// version increments on every generalization of tokens. It is what makes
+	// a re-offered row from a failed commit unable to roll a newer pattern
+	// backwards, and what a reload uses to pick the winner (#200 Q4).
+	version uint32
 
 	count     uint64
 	firstSeen time.Time
@@ -493,13 +514,16 @@ func (m *TemplateMiner) mine(p *tmPartition, tokens []string, raw string, at tim
 		}
 		if changed {
 			// The ID does not move — only the text under it.
+			best.version++
 			m.setText(best.id, tmJoin(best.tokens))
+			m.stage(p, best)
 			if twin := p.findTwinLocked(best); twin != nil {
 				best = m.convergeLocked(p, best, twin)
 			}
 		}
 		best.count++
 		best.lastSeen = at
+		m.markDirty(best)
 
 		if !wantText {
 			return best.id, false, ""
@@ -546,6 +570,7 @@ func (m *TemplateMiner) mine(p *tmPartition, tokens []string, raw string, at tim
 	leaf.groups = append(leaf.groups, t)
 	p.templates[id] = t
 	m.setText(id, text)
+	m.stage(p, t)
 	return id, false, text
 }
 
@@ -568,6 +593,13 @@ func (m *TemplateMiner) ensureOtherLocked(p *tmPartition) {
 	}
 	p.otherID = id
 	m.setText(id, TemplateOther)
+	m.stageRow(TemplateRow{
+		ID:      id,
+		Tenant:  p.tenant,
+		Service: p.service,
+		Tokens:  TemplateOther,
+		IsOther: true,
+	})
 }
 
 // tmBestMatch scores the leaf's templates by Drain's simSeq. Ties go to the
@@ -649,6 +681,24 @@ func (m *TemplateMiner) convergeLocked(p *tmPartition, a, b *tmTemplate) *tmTemp
 	p.converged++
 
 	m.aliasID(retired.id, survivor.id)
+	// BOTH ends of the alias are staged. A historical series still names the
+	// retired ID, so the forwarding row is as identity-critical as the
+	// survivor's pattern — losing it turns a seven-day bucket into a template
+	// nothing can resolve (#200 Q5).
+	retired.version++
+	m.stageRow(TemplateRow{
+		ID:             retired.id,
+		Tenant:         p.tenant,
+		Service:        p.service,
+		PatternVersion: retired.version,
+		Tokens:         tmEncodeTokens(retired.tokens),
+		Seq:            retired.seq,
+		AliasOf:        survivor.id,
+		Count:          retired.count,
+		FirstSeen:      tmUnixNano(retired.firstSeen),
+		LastSeen:       tmUnixNano(retired.lastSeen),
+	})
+	m.stage(p, survivor)
 	return survivor
 }
 
@@ -908,4 +958,316 @@ func tmTokensEqual(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// --- durable miner state (#200 Q4, Q5) --------------------------------------
+//
+// What is persisted, and why exactly this much:
+//
+//	tenant/service     the partition a template belongs to, as STRINGS — a
+//	                   reload has to rebuild partitions before any dictionary
+//	                   cache is warm.
+//	template_id        the immutable surrogate identity. It IS the dictionary
+//	                   ID and IS the log series NameID; there is no second ID
+//	                   space.
+//	pattern_version    monotonic per template, so a stale write cannot roll a
+//	                   generalization backwards.
+//	tokens             the token pattern, which is everything the prefix tree
+//	                   needs to be rebuilt.
+//	seq                the partition-local ordinal convergence uses to pick a
+//	                   survivor. Two restarts must not pick differently.
+//	is_other           marks the partition's overflow identity.
+//	alias_of           the survivor a retired ID forwards to.
+//	count/first/last   statistics. Non-identity, periodic path.
+//
+// What is NOT persisted: the raw log sample. It is a credential and PII sink,
+// and exemplars already carry the raw line for the cases that need one.
+
+// tmTokenSep joins tokens for storage. The tokenizer splits on whitespace and
+// never emits an empty or NUL-bearing token, so NUL is an unambiguous
+// separator that survives any body a client can send.
+const tmTokenSep = "\x00"
+
+// tmEncodeTokens renders a token pattern for storage.
+func tmEncodeTokens(tokens []string) string { return strings.Join(tokens, tmTokenSep) }
+
+// tmDecodeTokens parses a stored token pattern. An empty string is no tokens,
+// not one empty token.
+func tmDecodeTokens(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, tmTokenSep)
+}
+
+// tmUnixNano renders a time for storage; the zero time stores as 0.
+func tmUnixNano(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UnixNano()
+}
+
+// tmTimeFromNano reverses tmUnixNano.
+func tmTimeFromNano(n int64) time.Time {
+	if n == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, n).UTC()
+}
+
+// stage records one template's identity state for the next group commit. The
+// partition mutex must be held.
+func (m *TemplateMiner) stage(p *tmPartition, t *tmTemplate) {
+	var aliasOf uint32
+	if t.aliasOf != nil {
+		aliasOf = t.aliasOf.id
+	}
+	m.stageRow(TemplateRow{
+		ID:             t.id,
+		Tenant:         p.tenant,
+		Service:        p.service,
+		PatternVersion: t.version,
+		Tokens:         tmEncodeTokens(t.tokens),
+		Seq:            t.seq,
+		AliasOf:        aliasOf,
+		Count:          t.count,
+		FirstSeen:      tmUnixNano(t.firstSeen),
+		LastSeen:       tmUnixNano(t.lastSeen),
+	})
+}
+
+// stageRow queues one identity mutation. A newer version for the same ID
+// replaces an older staged one: only the latest pattern is worth committing.
+func (m *TemplateMiner) stageRow(row TemplateRow) {
+	if row.ID == 0 {
+		return
+	}
+	m.stageMu.Lock()
+	if prev, ok := m.pending[row.ID]; !ok || row.PatternVersion >= prev.PatternVersion {
+		m.pending[row.ID] = row
+	}
+	m.stageMu.Unlock()
+}
+
+// markDirty records a statistics-only change. The partition mutex must be held.
+func (m *TemplateMiner) markDirty(t *tmTemplate) {
+	if t.id == 0 {
+		return
+	}
+	m.stageMu.Lock()
+	m.dirty[t.id] = TemplateStatRow{
+		ID:        t.id,
+		Count:     t.count,
+		FirstSeen: tmUnixNano(t.firstSeen),
+		LastSeen:  tmUnixNano(t.lastSeen),
+	}
+	m.stageMu.Unlock()
+}
+
+// DrainPending returns the staged identity mutations for the next group
+// commit, oldest ID first. They stay staged until Committed confirms them, so
+// a failed commit re-offers them rather than acknowledging a delta whose
+// template identity never became durable.
+func (m *TemplateMiner) DrainPending() []TemplateRow {
+	m.stageMu.Lock()
+	defer m.stageMu.Unlock()
+	if len(m.pending) == 0 {
+		return nil
+	}
+	out := make([]TemplateRow, 0, len(m.pending))
+	for _, row := range m.pending {
+		out = append(out, row)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// Committed marks drained rows durable. A row whose pattern moved on since the
+// drain stays staged: the version guard is what makes that safe.
+func (m *TemplateMiner) Committed(rows []TemplateRow) {
+	if len(rows) == 0 {
+		return
+	}
+	m.stageMu.Lock()
+	for _, row := range rows {
+		if cur, ok := m.pending[row.ID]; ok && cur.PatternVersion <= row.PatternVersion {
+			delete(m.pending, row.ID)
+		}
+	}
+	m.stageMu.Unlock()
+}
+
+// PendingCount reports how many identity mutations are staged but not durable.
+func (m *TemplateMiner) PendingCount() int {
+	m.stageMu.Lock()
+	defer m.stageMu.Unlock()
+	return len(m.pending)
+}
+
+// DrainDirtyStats returns the statistics-only updates for the periodic write
+// and clears the dirty set. These are fire-and-forget: a lost batch costs a
+// count that the next line restores, never an identity.
+func (m *TemplateMiner) DrainDirtyStats() []TemplateStatRow {
+	m.stageMu.Lock()
+	defer m.stageMu.Unlock()
+	if len(m.dirty) == 0 {
+		return nil
+	}
+	out := make([]TemplateStatRow, 0, len(m.dirty))
+	for _, row := range m.dirty {
+		out = append(out, row)
+	}
+	m.dirty = make(map[uint32]TemplateStatRow)
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// Roots returns every template ID the miner keeps alive: live templates, the
+// per-partition overflow sentinels, both ends of every alias, and every staged
+// mutation (#200 Q5).
+//
+// Both ends, deliberately. A historical series that named a retired template
+// keeps that ID, its alias row, AND the survivor alive: collecting the survivor
+// would leave the alias pointing at nothing, and collecting the alias would
+// leave the series unresolvable.
+func (m *TemplateMiner) Roots() map[uint32]struct{} {
+	m.mu.RLock()
+	parts := make([]*tmPartition, 0, len(m.parts))
+	for _, p := range m.parts {
+		parts = append(parts, p)
+	}
+	m.mu.RUnlock()
+
+	out := make(map[uint32]struct{}, len(parts)*(m.maxTemplates+1))
+	for _, p := range parts {
+		p.mu.Lock()
+		if p.otherID != 0 {
+			out[p.otherID] = struct{}{}
+		}
+		for id := range p.templates {
+			out[id] = struct{}{}
+		}
+		p.mu.Unlock()
+	}
+
+	m.idxMu.RLock()
+	for id := range m.text {
+		out[id] = struct{}{}
+	}
+	for from, to := range m.alias {
+		out[from] = struct{}{}
+		out[to] = struct{}{}
+	}
+	m.idxMu.RUnlock()
+
+	m.stageMu.Lock()
+	for id, row := range m.pending {
+		out[id] = struct{}{}
+		if row.AliasOf != 0 {
+			out[row.AliasOf] = struct{}{}
+		}
+	}
+	m.stageMu.Unlock()
+	return out
+}
+
+// Restore rebuilds the miner's partitions, prefix trees, alias index and cap
+// accounting from durable rows. It must run BEFORE ingest starts: a line mined
+// against an empty miner would mint a second identity for a pattern that
+// already has one, and both would be live.
+//
+// Restoring stages nothing: every row handed here is already durable.
+func (m *TemplateMiner) Restore(rows []TemplateRow) {
+	if len(rows) == 0 {
+		return
+	}
+	// Deterministic order so partition sequence counters and leaf group order
+	// rebuild identically on every boot.
+	ordered := append([]TemplateRow(nil), rows...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].Tenant != ordered[j].Tenant {
+			return ordered[i].Tenant < ordered[j].Tenant
+		}
+		if ordered[i].Service != ordered[j].Service {
+			return ordered[i].Service < ordered[j].Service
+		}
+		if ordered[i].Seq != ordered[j].Seq {
+			return ordered[i].Seq < ordered[j].Seq
+		}
+		return ordered[i].ID < ordered[j].ID
+	})
+
+	byID := make(map[uint32]*tmTemplate, len(ordered))
+	aliasTargets := make(map[uint32]uint32, len(ordered))
+	for _, row := range ordered {
+		p := m.partition(row.Tenant, row.Service)
+		p.mu.Lock()
+		if row.IsOther {
+			p.otherID = row.ID
+			p.mu.Unlock()
+			m.setText(row.ID, TemplateOther)
+			continue
+		}
+		tokens := tmDecodeTokens(row.Tokens)
+		t := &tmTemplate{
+			id:        row.ID,
+			seq:       row.Seq,
+			tokens:    tokens,
+			version:   row.PatternVersion,
+			count:     row.Count,
+			firstSeen: tmTimeFromNano(row.FirstSeen),
+			lastSeen:  tmTimeFromNano(row.LastSeen),
+		}
+		if row.Seq >= p.nextSeq {
+			p.nextSeq = row.Seq + 1
+		}
+		if row.AliasOf != 0 {
+			// A retired ID stays in its leaf as a forwarder so lines that used
+			// to match it resolve to the survivor, and it does NOT consume a
+			// slot against the per-partition cap.
+			aliasTargets[row.ID] = row.AliasOf
+		} else {
+			p.templates[row.ID] = t
+		}
+		if len(tokens) > 0 {
+			leaf := p.descend(tokens, m.depth, m.maxChildren)
+			t.leaf = leaf
+			leaf.groups = append(leaf.groups, t)
+		}
+		p.mu.Unlock()
+		byID[row.ID] = t
+		if row.AliasOf == 0 {
+			m.setText(row.ID, tmJoin(tokens))
+		}
+	}
+
+	// Second pass: alias edges, once every template object exists.
+	m.idxMu.Lock()
+	for from, to := range aliasTargets {
+		m.alias[from] = to
+		delete(m.text, from)
+	}
+	m.idxMu.Unlock()
+	for from, to := range aliasTargets {
+		if src, ok := byID[from]; ok {
+			src.aliasOf = byID[to]
+		}
+	}
+}
+
+// RestoreMiner warms miner from store before ingest starts. A store that
+// cannot carry templates (an older implementation) restores nothing, which is
+// the pre-#200 behaviour.
+func RestoreMiner(store Store, miner *TemplateMiner) (int, error) {
+	gcs, ok := store.(GCStore)
+	if !ok || miner == nil {
+		return 0, nil
+	}
+	rows, err := gcs.LoadTemplates(0)
+	if err != nil {
+		return 0, err
+	}
+	miner.Restore(rows)
+	return len(rows), nil
 }

--- a/internal/aggregate/writer.go
+++ b/internal/aggregate/writer.go
@@ -159,11 +159,18 @@ type Writer struct {
 	reg    *DurableRegistrar
 	series *seriesRegistry
 
+	miner *TemplateMiner
+
 	submissions chan *submission
-	stop        chan struct{}
-	stopOnce    sync.Once
-	wg          sync.WaitGroup
-	closed      atomic.Bool
+	// barriers carries identity-maintenance work onto the writer goroutine
+	// (#200 Q2). Running it here is what makes "no group commit interleaves
+	// with an identity delete" structural: there is one commit goroutine and
+	// the barrier IS that goroutine.
+	barriers chan *barrierRequest
+	stop     chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+	closed   atomic.Bool
 
 	// admission counters, guarded by mu.
 	mu            sync.Mutex
@@ -200,9 +207,76 @@ func NewWriter(cfg WriterConfig) (*Writer, error) {
 		engine:      cfg.Engine,
 		reg:         cfg.Registrar,
 		series:      series,
+		miner:       cfg.Engine.Miner(),
 		submissions: make(chan *submission, cfg.MaxWaiters),
+		barriers:    make(chan *barrierRequest),
 		stop:        make(chan struct{}),
 	}, nil
+}
+
+// barrierRequest is one unit of identity-maintenance work to run between
+// commits.
+type barrierRequest struct {
+	fn   func()
+	done chan struct{}
+}
+
+// RunBarrier implements Barrier. It parks fn on the commit goroutine, so no
+// group commit is in flight while it runs and none can start until it returns.
+//
+// fn must be bounded: every Export waiting on the writer is waiting on it too.
+// The collector honours that by keeping its full table scan OUTSIDE the
+// barrier and passing only the revalidate-fence-delete tail in here.
+func (w *Writer) RunBarrier(fn func()) error {
+	if fn == nil {
+		return nil
+	}
+	if w.closed.Load() {
+		return ErrStoreClosed
+	}
+	req := &barrierRequest{fn: fn, done: make(chan struct{})}
+	select {
+	case w.barriers <- req:
+	case <-w.stop:
+		return ErrStoreClosed
+	}
+	<-req.done
+	return nil
+}
+
+// CollectIdentities runs one identity garbage-collection pass. It is the entry
+// point retention's daily maintenance tick calls.
+func (w *Writer) CollectIdentities() (GCStats, error) {
+	return Collect(GCConfig{
+		Store:     w.store,
+		Registrar: w.reg,
+		Cache:     w.engine.Cache(),
+		Miner:     w.miner,
+		Engine:    w.engine,
+		Series:    w.series,
+		Barrier:   w,
+		Metrics:   w.cfg.Metrics,
+	})
+}
+
+// SaveTemplateStats writes the miner's dirty non-identity counters. Identity
+// mutations do NOT come through here — they ride the group commit — so a lost
+// batch costs a count that the next line restores.
+func (w *Writer) SaveTemplateStats() {
+	if w.miner == nil {
+		return
+	}
+	gcs, ok := w.store.(GCStore)
+	if !ok {
+		return
+	}
+	rows := w.miner.DrainDirtyStats()
+	if len(rows) == 0 {
+		return
+	}
+	if err := gcs.SaveTemplateStats(rows); err != nil {
+		slog.Warn("aggregate: template statistics write failed", "error", err, "rows", len(rows))
+	}
 }
 
 // Start launches the commit loop and, unless disabled, the finalize loop.
@@ -223,6 +297,10 @@ func (w *Writer) Stop() {
 		close(w.stop)
 	})
 	w.wg.Wait()
+	// Final best-effort statistics save, after the loops are gone so nothing
+	// races the writer lock. Identity is already durable — it rode the group
+	// commits — so this only saves counters.
+	w.SaveTemplateStats()
 }
 
 // Stats returns a snapshot of the writer counters.
@@ -323,6 +401,9 @@ func (w *Writer) commitLoop() {
 		case <-w.stop:
 			w.drain()
 			return
+		case req := <-w.barriers:
+			req.fn()
+			close(req.done)
 		case s := <-w.submissions:
 			w.collectAndCommit(s)
 		}
@@ -416,6 +497,13 @@ func (w *Writer) commit(batch []*submission) {
 	if w.reg != nil {
 		gb.Dicts = w.reg.DrainPending()
 	}
+	// Identity-critical miner mutations ride the same transaction as the
+	// delta that used the resulting identity (#200 Q4). A periodic snapshot
+	// alone would let a crash acknowledge a bucket whose NameID the reloaded
+	// miner has never heard of.
+	if w.miner != nil {
+		gb.Templates = w.miner.DrainPending()
+	}
 
 	err := w.store.CommitGroup(gb)
 	w.commits.Add(1)
@@ -434,6 +522,9 @@ func (w *Writer) commit(batch []*submission) {
 	w.series.Committed(gb.Series)
 	if w.reg != nil {
 		w.reg.Committed(gb.Dicts)
+	}
+	if w.miner != nil {
+		w.miner.Committed(gb.Templates)
 	}
 
 	// Commit-then-apply: the shards only ever see committed state.
@@ -463,6 +554,8 @@ func (w *Writer) finalizeLoop() {
 		case <-tick.C:
 			w.FinalizeDue(w.cfg.Now())
 			w.publishBacklog(w.cfg.Now())
+			// Non-identity template counters take the cheap periodic path.
+			w.SaveTemplateStats()
 		}
 	}
 }
@@ -534,6 +627,7 @@ func estimateDeltaBytes(m DeltaMap) int64 {
 var (
 	_ Applier         = (*Writer)(nil)
 	_ FailableApplier = (*Writer)(nil)
+	_ Barrier         = (*Writer)(nil)
 )
 
 // Writer construction errors.

--- a/internal/aggregate/writer_test.go
+++ b/internal/aggregate/writer_test.go
@@ -289,7 +289,7 @@ func TestWriterDurableRegistrationRidesTheCommit(t *testing.T) {
 	eng := newTestEngine(t, clock, reg)
 	w := newTestWriter(t, base, eng, clock, WriterConfig{Registrar: reg})
 
-	tenant := eng.Cache().InternTenant("acme")
+	tenant, _ := eng.Cache().InternTenant("acme")
 	nameID := eng.Cache().Intern(tenant, KindOperation, "GET /orders")
 	if reg.PendingCount() == 0 {
 		t.Fatal("registrations were not staged before the commit")

--- a/internal/api/aggregate_reads_test.go
+++ b/internal/api/aggregate_reads_test.go
@@ -83,7 +83,7 @@ func aggregateTestServer(t *testing.T, withEngine bool) (*Server, *rawTableCount
 // current window.
 func seedAggregate(t *testing.T, e *aggregate.Engine, tenant, service string, spans int, micros float64) {
 	t.Helper()
-	tenantID := e.TenantID(tenant)
+	tenantID, _ := e.TenantID(tenant)
 	key := aggregate.SeriesKey{
 		TenantID:    tenantID,
 		ServiceID:   e.Cache().Intern(tenantID, aggregate.KindService, service),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -368,6 +368,44 @@ type Config struct {
 	// whose lateness horizon has expired.
 	AggregateFinalizeIntervalSec int
 
+	// Identity lifecycle (#200). The aggregate dictionary and series table
+	// were append-only: every name a deployment ever emitted stayed on disk
+	// long after retention purged the last bucket naming it.
+
+	// AggregateGCEnabled runs the daily mark-and-sweep over the aggregate
+	// dictionary, series and log-template tables. On by default. Turning it
+	// off is a disk-growth decision, not a safety one — a pass that fails
+	// leaves memory untouched.
+	AggregateGCEnabled bool
+
+	// AggregateMaxValueBytes caps the ENCODED length of a dictionary value
+	// for every non-tenant kind: service names, metric names, operations,
+	// dimension keys, dimension values and dimension tuples. An over-length
+	// value routes to __other__ and is NEVER truncated — a truncated value is
+	// a different identity wearing the same name.
+	AggregateMaxValueBytes int
+
+	// AggregateMaxTenantBytes is the stricter cap on a tenant name, and
+	// AggregateMaxTenants is the instance-wide tenant-identity cap. A tenant
+	// that breaches either is REJECTED: the point is refused and counted, and
+	// the tenant is never collapsed into a shared identity, because a shared
+	// overflow tenant is precisely the cross-tenant merge the cap prevents.
+	AggregateMaxTenantBytes int
+	AggregateMaxTenants     int
+
+	// Per-tenant and instance-wide dictionary count caps for the namespaces
+	// that were uncapped before #200. The per-tenant cap bounds one tenant;
+	// the instance cap is the backstop for many tenants each staying just
+	// under their own. Overflow routes to __other__, per existing semantics.
+	AggregateMaxServicesPerTenant  int
+	AggregateMaxServices           int
+	AggregateMaxDimKeysPerTenant   int
+	AggregateMaxDimKeys            int
+	AggregateMaxDimValuesPerTenant int
+	AggregateMaxDimValues          int
+	AggregateMaxDimTuplesPerTenant int
+	AggregateMaxDimTuples          int
+
 	// AggregateMetricDims is the parsed AGGREGATE_METRIC_DIMS config:
 	// map of metric name -> sorted list of OTLP attribute keys.
 	// Empty map when AGGREGATE_METRIC_DIMS is unset/empty.
@@ -555,6 +593,20 @@ func Load(customPath string) (*Config, error) {
 		AggregateCommitMaxWaiters:       getEnvInt("AGGREGATE_COMMIT_MAX_WAITERS", 512),
 		AggregateCommitMaxPendingDeltas: getEnvInt("AGGREGATE_COMMIT_MAX_PENDING_DELTAS", 200000),
 		AggregateFinalizeIntervalSec:    getEnvInt("AGGREGATE_FINALIZE_INTERVAL_SEC", 30),
+
+		// Identity lifecycle (#200)
+		AggregateGCEnabled:             getEnvBool("AGGREGATE_GC_ENABLED", true),
+		AggregateMaxValueBytes:         getEnvInt("AGGREGATE_MAX_VALUE_BYTES", 512),
+		AggregateMaxTenantBytes:        getEnvInt("AGGREGATE_MAX_TENANT_BYTES", 128),
+		AggregateMaxTenants:            getEnvInt("AGGREGATE_MAX_TENANTS", 256),
+		AggregateMaxServicesPerTenant:  getEnvInt("AGGREGATE_MAX_SERVICES_PER_TENANT", 500),
+		AggregateMaxServices:           getEnvInt("AGGREGATE_MAX_SERVICES", 5000),
+		AggregateMaxDimKeysPerTenant:   getEnvInt("AGGREGATE_MAX_DIM_KEYS_PER_TENANT", 200),
+		AggregateMaxDimKeys:            getEnvInt("AGGREGATE_MAX_DIM_KEYS", 2000),
+		AggregateMaxDimValuesPerTenant: getEnvInt("AGGREGATE_MAX_DIM_VALUES_PER_TENANT", 5000),
+		AggregateMaxDimValues:          getEnvInt("AGGREGATE_MAX_DIM_VALUES", 50000),
+		AggregateMaxDimTuplesPerTenant: getEnvInt("AGGREGATE_MAX_DIM_TUPLES_PER_TENANT", 5000),
+		AggregateMaxDimTuples:          getEnvInt("AGGREGATE_MAX_DIM_TUPLES", 50000),
 		// Bounded exemplar retention (aggregate mode only)
 		ExemplarTracesPerServiceWindow:    getEnvInt("EXEMPLAR_TRACES_PER_SERVICE_WINDOW", 25),
 		ExemplarTracesGlobalWindow:        getEnvInt("EXEMPLAR_TRACES_GLOBAL_WINDOW", 1500),

--- a/internal/storage/retention.go
+++ b/internal/storage/retention.go
@@ -57,6 +57,14 @@ type RetentionScheduler struct {
 	// statistics of a table that is written and deleted every hour go stale.
 	aggregatePurge   func(cutoff time.Time) (int64, error)
 	aggregateAnalyze func() error
+
+	// aggregateGC is the aggregate store's identity mark-and-sweep (#200).
+	// It rides the DAILY maintenance tick, not the hourly purge: the mark
+	// phase is a full scan of three tables, and the sweep serializes with the
+	// durable-ACK group commit. Hourly would put that in the ACK budget
+	// twenty-four times a day for names that change on the timescale of a
+	// deployment.
+	aggregateGC func() error
 }
 
 // NewRetentionScheduler constructs a scheduler but does not start it.
@@ -95,6 +103,12 @@ func (r *RetentionScheduler) SetFullVacuum(enabled bool) { r.fullVacuum = enable
 func (r *RetentionScheduler) SetAggregateRetention(purge func(time.Time) (int64, error), analyze func() error) {
 	r.aggregatePurge = purge
 	r.aggregateAnalyze = analyze
+}
+
+// SetAggregateGC wires the aggregate store's identity garbage collection into
+// the daily maintenance pass. May be nil. Call before Start; not synchronized.
+func (r *RetentionScheduler) SetAggregateGC(collect func() error) {
+	r.aggregateGC = collect
 }
 
 // purgeAggregate runs the aggregate store's share of one retention tick.
@@ -552,6 +566,17 @@ func (r *RetentionScheduler) runMaintenance(ctx context.Context) {
 	if r.aggregateAnalyze != nil {
 		if err := r.aggregateAnalyze(); err != nil {
 			slog.Error("retention: aggregate analyze failed", "error", err)
+			maintFailed = true
+		}
+	}
+
+	// Identity GC after ANALYZE: the sweep deletes rows, and running the
+	// planner refresh first means the delete statements plan against current
+	// statistics. A failed pass changes nothing in memory, so it is a
+	// maintenance failure and not a data-integrity one.
+	if r.aggregateGC != nil {
+		if err := r.aggregateGC(); err != nil {
+			slog.Error("retention: aggregate identity gc failed", "error", err)
 			maintFailed = true
 		}
 	}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -278,6 +278,31 @@ type Metrics struct {
 	// last startup recovery. The gate allows 30s.
 	AggregateRecoveryDurationSeconds prometheus.Gauge
 	AggregateRecoveryRows            *prometheus.GaugeVec
+
+	// --- Aggregate identity lifecycle (#200) ---
+	// AggregateGCRunsTotal — identity garbage-collection passes by result
+	// (ok|error). A pass that fails leaves memory untouched, so a rising
+	// error count is disk growth, not corruption.
+	AggregateGCRunsTotal *prometheus.CounterVec
+	// AggregateGCDurationSeconds — GC wall time by phase. phase="mark" is the
+	// lock-free scan; phase="barrier" is the part that serializes with the
+	// group commit and is therefore the only one inside the ACK budget.
+	AggregateGCDurationSeconds *prometheus.HistogramVec
+	// AggregateGCSweptTotal — identity rows deleted by GC, by table.
+	AggregateGCSweptTotal *prometheus.CounterVec
+	// AggregateGCRetained — identity rows the last pass kept, by table. The
+	// ratio against the swept counter is what says whether the dictionary has
+	// reached a steady state.
+	AggregateGCRetained *prometheus.GaugeVec
+	// AggregateIdentityOverflowTotal — identities routed to __other__ by an
+	// identity BOUND rather than by a series cap, labeled by dictionary kind
+	// and the bound that tripped (length|count).
+	AggregateIdentityOverflowTotal *prometheus.CounterVec
+	// AggregateTenantRejectedTotal — points DROPPED because their tenant
+	// identity was refused. The tenant namespace never collapses into a
+	// shared __other__, so this is a drop, not a degradation: alert on any
+	// sustained value.
+	AggregateTenantRejectedTotal *prometheus.CounterVec
 	// --- Bounded exemplar retention (AGGREGATE_MODE=aggregate) ---
 	// ExemplarEligibleTotal — telemetry that qualified for raw retention,
 	// per signal and priority class. Eligible is not retained: the gap between
@@ -693,6 +718,31 @@ func New() *Metrics {
 		Name: "otelcontext_aggregate_recovery_rows",
 		Help: "Rows handled by the last aggregate startup recovery, by kind (replayed|finalized_windows).",
 	}, []string{"kind"})
+	m.AggregateGCRunsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_gc_runs_total",
+		Help: "Aggregate identity garbage-collection passes by result (ok|error).",
+	}, []string{"result"})
+	m.AggregateGCDurationSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "otelcontext_aggregate_gc_duration_seconds",
+		Help:    "Identity GC wall time by phase: mark is the lock-free scan, barrier is the part that serializes with the group commit.",
+		Buckets: []float64{0.001, 0.01, 0.05, 0.1, 0.5, 1, 5, 15, 60},
+	}, []string{"phase"})
+	m.AggregateGCSweptTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_gc_swept_total",
+		Help: "Identity rows deleted by aggregate GC, by table (aggregate_series|aggregate_dict|aggregate_log_template).",
+	}, []string{"table"})
+	m.AggregateGCRetained = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "otelcontext_aggregate_gc_retained",
+		Help: "Identity rows the last aggregate GC pass retained, by table.",
+	}, []string{"table"})
+	m.AggregateIdentityOverflowTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_identity_overflow_total",
+		Help: "Identities routed to __other__ by an identity bound, by dictionary kind and bound (length|count).",
+	}, []string{"kind", "bound"})
+	m.AggregateTenantRejectedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_aggregate_tenant_rejected_total",
+		Help: "Points dropped because the tenant identity was refused (over-length, empty, or past the tenant cap). Tenants are never collapsed into __other__.",
+	}, []string{"signal"})
 	m.ExemplarEligibleTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "otelcontext_exemplar_eligible_total",
 		Help: "Telemetry eligible for raw exemplar retention, by signal and priority class (error|slow|healthy|warn). Eligible is not retained.",

--- a/main.go
+++ b/main.go
@@ -529,11 +529,32 @@ func main() {
 		// the value resolves to __other__, the designed degradation. Service,
 		// tenant and dimension namespaces stay uncapped — they are bounded by
 		// the deployment and by AGGREGATE_METRIC_DIMS respectively.
-		registrar, err := aggregate.NewDurableRegistrar(aggStore, map[aggregate.Kind]int{
-			aggregate.KindOperation:   cfg.AggregateMaxSeriesTraces + cfg.AggregateMaxSeriesEdges,
-			aggregate.KindMetricName:  cfg.AggregateMaxSeriesMetrics,
-			aggregate.KindLogTemplate: cfg.AggregateMaxSeriesLogs,
-		})
+		//
+		// #200 Q3 closed the remaining holes: the service, dim-key, dim-value
+		// and dim-tuple namespaces are capped per tenant AND instance-wide,
+		// every value carries an encoded-length bound, and the tenant
+		// namespace is capped and REFUSES rather than degrading.
+		aggBounds := aggregate.Bounds{
+			MaxValueBytes:  cfg.AggregateMaxValueBytes,
+			MaxTenantBytes: cfg.AggregateMaxTenantBytes,
+			MaxTenants:     cfg.AggregateMaxTenants,
+			PerTenantKind: map[aggregate.Kind]int{
+				aggregate.KindOperation:   cfg.AggregateMaxSeriesTraces + cfg.AggregateMaxSeriesEdges,
+				aggregate.KindMetricName:  cfg.AggregateMaxSeriesMetrics,
+				aggregate.KindLogTemplate: cfg.AggregateMaxSeriesLogs,
+				aggregate.KindService:     cfg.AggregateMaxServicesPerTenant,
+				aggregate.KindDimKey:      cfg.AggregateMaxDimKeysPerTenant,
+				aggregate.KindDimValue:    cfg.AggregateMaxDimValuesPerTenant,
+				aggregate.KindDimTuple:    cfg.AggregateMaxDimTuplesPerTenant,
+			},
+			InstanceKind: map[aggregate.Kind]int{
+				aggregate.KindService:  cfg.AggregateMaxServices,
+				aggregate.KindDimKey:   cfg.AggregateMaxDimKeys,
+				aggregate.KindDimValue: cfg.AggregateMaxDimValues,
+				aggregate.KindDimTuple: cfg.AggregateMaxDimTuples,
+			},
+		}
+		registrar, err := aggregate.NewDurableRegistrarWithBounds(aggStore, aggBounds)
 		if err != nil {
 			fatal("❌ Aggregate dictionary could not be loaded", err, "path", cfg.AggregateDBPath)
 		}
@@ -541,6 +562,7 @@ func main() {
 		aggEngine, err = aggregate.NewEngine(aggregate.EngineConfig{
 			Mode:      cfg.AggregateMode,
 			Registrar: registrar,
+			Bounds:    aggBounds,
 			Limiter: aggregate.LimiterConfig{
 				MaxSeries:                 cfg.AggregateMaxSeries,
 				MaxSeriesMetrics:          cfg.AggregateMaxSeriesMetrics,
@@ -585,6 +607,16 @@ func main() {
 		})
 		if err != nil {
 			fatal("❌ Aggregate group-commit writer rejected", err)
+		}
+
+		// Log-template miner state is reloaded BEFORE anything can mine a line
+		// (#200 Q4). A line mined against an empty miner would mint a second
+		// identity for a pattern that already has one, and both would be live
+		// against the same seven-day buckets.
+		if restored, err := aggregate.RestoreMiner(aggStore, aggEngine.Miner()); err != nil {
+			fatal("❌ Aggregate log-template state could not be reloaded", err, "path", cfg.AggregateDBPath)
+		} else if restored > 0 {
+			slog.Info("🔤 Aggregate log templates reloaded", "templates", restored)
 		}
 
 		// Recovery runs BEFORE the writer starts accepting Exports and before
@@ -640,6 +672,20 @@ func main() {
 			},
 			aggStore.Analyze,
 		)
+
+		// Identity GC rides the same daily maintenance tick as ANALYZE
+		// (#200 Q1). Retention deletes the buckets; this is what deletes the
+		// names those buckets were the last reference to. The full mark scan
+		// runs lock-free — only the revalidate/fence/delete tail serializes
+		// with the group commit.
+		if cfg.AggregateGCEnabled {
+			writer := aggWriter
+			retention.SetAggregateGC(func() error {
+				stats, err := writer.CollectIdentities()
+				aggregate.LogGC(stats, err)
+				return err
+			})
+		}
 	}
 
 	// Aggregate READ path (#175). Only AGGREGATE_MODE=aggregate switches the


### PR DESCRIPTION
Implements the frozen contract of #200 (map #195, parent #194): aggregate
dictionary/series garbage collection plus durable log-template miner state.

The aggregate dictionary and series tables were append-only. Every name a
deployment ever emitted stayed on disk long after retention purged the last
bucket that referenced it, and the log-template miner was in-memory only, so a
restart re-mined identities that seven-day buckets already named.

## Q1 — Mark-and-sweep with transitive marking and persistent high-watermarks

- Runs on the **daily** maintenance tick (`RetentionScheduler.SetAggregateGC`,
  wired in `main.go` next to `aggStore.Analyze`; `AGGREGATE_GC_ENABLED=false`
  disables it).
- A series is collectible only when no row in `aggregate_buckets`,
  `aggregate_delta_log` or `aggregate_baseline` references it **and** it is
  absent from active shard keys, pending and staged in-memory state.
- Marking is transitive: surviving series mark tenant/service/name/dim-tuple
  IDs; surviving dim tuples are varint-decoded and mark the dim-key and
  dim-value IDs inside them; miner templates and persisted alias records mark
  their template IDs.
- Sweep order is series first, then dict rows, then template rows, in one
  transaction.
- The full mark scan runs through **one deferred read transaction on the read
  pool** — no writer lock. Only revalidate/fence/delete serializes.
- `dict_id_high_watermark` and `series_id_high_watermark` live in
  `aggregate_meta`, bumped inside the same transaction as the rows they cover,
  never decreasing. Both allocators reseed from them: `MAX(id)+1` stops being
  safe the moment GC can delete the highest ID.

## Q2 — Identity-maintenance barrier

One barrier covers the registrar, the series registry, the hot-path cache and
the miner. `Writer.RunBarrier` parks the work on the commit goroutine, so "no
group commit interleaves with an identity delete" is structural. Inside it:
revalidate candidates → fence survivors from new lookup → delete
transactionally → remove forward and reverse map entries **after** the commit.
A failed delete releases the fence and changes nothing in memory.

The race the lock-free scan opens is closed by a "handed out since the last
completed sweep" set on both the registrar and the series registry: an ID a
hot-path goroutine took before it ever reached the cache map is invisible to
every other root, and would otherwise be collected out from under it. The
dictionary registrar is fenced rather than locked because it is on the ingest
hot path; the series registry is the writer's own structure and is simply held.

## Q3 — Bounds

- `AGGREGATE_MAX_VALUE_BYTES` (512) caps the encoded length of service names,
  metric names, operations, dim keys, dim values and dim tuples. Over-length
  identities route to `__other__` and are **never truncated**.
- Per-tenant and instance-wide count caps for the previously uncapped
  `service`, `dim_key`, `dim_value` and `dim_tuple` namespaces.
- Tenants are **rejected**, never collapsed: `AGGREGATE_MAX_TENANT_BYTES` (128)
  and `AGGREGATE_MAX_TENANTS` (256); a breach drops the point and increments
  `otelcontext_aggregate_tenant_rejected_total`. There is no `__other__` tenant
  — `OtherID(_, KindTenant)` returns 0 by construction.
- Startup identity preloads ask for `limit+1` and fail with a `*PreloadError`
  when the table exceeds the supported bound, instead of a silent `LIMIT`.

## Q4/Q5 — Miner persistence and GC closure

- New `aggregate_log_template` table: tenant/service partition, stable template
  ID (which *is* the `log_template` dictionary ID and *is* the log series
  `NameID`), versioned token pattern, alias target, partition sequence, overflow
  flag, counters. **No raw log samples** — credential/PII sink; exemplars
  already carry the raw line.
- Identity-critical mutations (new template, pattern generalization, alias
  change) are staged into `GroupBatch.Templates` and commit atomically with the
  delta that used the identity. Counters take the periodic dirty-partition write
  plus a best-effort save at shutdown.
- `aggregate.RestoreMiner` rebuilds partitions and prefix trees in `main.go`
  before recovery and before ingest starts.
- GC roots include current miner templates, staged mutations, overflow sentinels
  and persisted alias records; both ends of every alias are marked and alias
  chains are followed transitively before sweeping.

`StoreSchemaVersion` 4 → 5. The fail-closed policy is unchanged: an older file
means an older binary or `AGGREGATE_ALLOW_REBUILD=true`.

## Observability

`otelcontext_aggregate_gc_runs_total{result}`,
`otelcontext_aggregate_gc_duration_seconds{phase=mark|barrier}`,
`otelcontext_aggregate_gc_swept_total{table}`,
`otelcontext_aggregate_gc_retained{table}`,
`otelcontext_aggregate_identity_overflow_total{kind,bound}`,
`otelcontext_aggregate_tenant_rejected_total{signal}`.

## Test results (real)

```
$ go build ./...        # Success
$ go vet ./...          # No issues found
$ go test -race ./internal/aggregate/... ./internal/ingest/... ./internal/storage/...
747 passed, 0 failed (3 packages)
$ go test ./...
1303 passed, 0 failed (29 packages)
$ golangci-lint run ./...
no findings in internal/aggregate, internal/config, internal/telemetry,
internal/storage/retention.go or main.go
```

New tests in `internal/aggregate/lifecycle_test.go` (13), all sharing one
fixture rather than per-test scaffolds:

| Contract point | Test |
|---|---|
| over-length → `__other__`, never truncated | `TestBoundsOverLengthRoutesToOtherNeverTruncates` |
| tenant rejected, never collapsed, no `__other__` tenant | `TestBoundsTenantIsRejectedNeverCollapsed` |
| rejected tenant drops the point and is counted | `TestBoundsRejectedTenantDropsThePoint` |
| per-tenant + instance-wide count caps | `TestBoundsPerTenantAndInstanceCaps` |
| preload fail-fast above the bound | `TestPreloadFailsFastAboveTheSupportedBound` |
| sweep only unreferenced identities | `TestGCSweepsOnlyUnreferencedIdentities` |
| dim-tuple → key/value transitive closure | `TestGCMarksDimTupleComponentsTransitively` |
| alias closure incl. retired chains (10→11→12) | `TestGCFollowsRetiredTemplateAliasChains` |
| watermark survives GC-of-highest-ID + restart | `TestGCHighWatermarkSurvivesSweepOfHighestID` |
| no lookup of fenced IDs; Unfence restores | `TestBarrierFencedIDsAreNotHandedOut` |
| delete failure leaves memory untouched | `TestSweepFailureLeavesMemoryUntouched` |
| identity rides the commit that used it | `TestMinerIdentityRidesTheGroupCommit` |
| crash between commit and snapshot keeps the template | `TestMinerSurvivesCrashBetweenCommitAndSnapshot` |
| reload rebuild equivalence (same IDs, no new rows) | `TestMinerReloadRebuildsEquivalentState` |
| v4 refusal + rebuild path | `TestStoreV4FileIsRefusedThenRebuilt` |

## Judgment calls

- **`GCStore`/`WatermarkStore` are optional capabilities**, not additions to
  `Store`. A `Store` implementation predating this change still compiles and
  simply never collects.
- **`MaxDictRows`/`MaxSeriesRows` became `var`** so the fail-fast path is
  testable without seeding two million rows, matching the existing precedent
  of `MaxReadRows`.
- **`Cache.InternTenant` now returns `(uint32, bool)`.** Five reducer call
  sites, `Engine.TenantID` and the query path were updated. A rejected tenant
  on the read path returns `ErrSelectorUnbounded` rather than minting an ID,
  so a query string cannot grow the dictionary.
- **Daily, not hourly.** The sweep is on the ACK path for its duration; names
  change on the timescale of a deployment, not an hour.
- **The tenant fence window.** While the barrier fences a tenant ID, points for
  that tenant are refused rather than routed. Single-digit milliseconds, once a
  day, and only for a tenant GC had already found nothing referencing. Noted in
  the code.
- **`ANALYZE` runs before GC** in the maintenance pass, so the delete statements
  plan against fresh statistics.
- **Unverified:** the jscpd 3% duplication gate could not be run locally (no
  network for `npx jscpd`). The CI config excludes `**/*_test.go`, and the new
  test file uses one shared fixture; production-side helpers
  (`scanDictRows`/`scanSeriesRows`/`scanTemplateRows`) are distinct queries.
- **Pre-existing, untouched:** `internal/api/log_handlers_trace_filter_test.go`
  and `internal/storage/tenant_sanitize_test.go` fail `gofmt` on `origin/main`.
  Flagged, not fixed — out of scope.
