### PR TITLE
feat(exemplar): disk budget arithmetic inside 8 GiB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,6 +369,10 @@ Key settings in `internal/config/config.go`:
 - `OTEL_EXPORTER_OTLP_ENDPOINT` — enables self-instrumentation (empty = off)
 - `DEFAULT_TENANT` (`default`) — assigned to rows ingested without explicit tenant
 - `HOT_RETENTION_DAYS` (7) — drives `RetentionScheduler`; range 1..36500
+- `EXEMPLAR_RETENTION_DAYS` (2) — separate, shorter retention for the raw exemplar tier in aggregate mode; validated 1..`HOT_RETENTION_DAYS`. See the Data Disk Budget section
+- `EXEMPLAR_BYTES_GLOBAL_WINDOW` (**3 MiB**, was 8 MiB) / `EXEMPLAR_BYTES_PER_SERVICE_WINDOW` (512 KiB) — instance-wide and per-service byte budget per 5-minute window
+- `EXEMPLAR_SYNTH_LOGS_PER_SPAN` (8), `EXEMPLAR_SYNTH_LOGS_PER_TRACE` (64) — count caps on logs synthesized from span events and span status
+- `DATA_DISK_BUDGET_MB` (8192), `DATA_DISK_PATH` (`./data`) — disk watchdog ceiling and the volume it `statfs`-es
 - `SAMPLING_RATE` (1.0), `SAMPLING_ALWAYS_ON_ERRORS` (true), `SAMPLING_LATENCY_THRESHOLD_MS` (500)
 - `METRIC_MAX_CARDINALITY` (10000), `METRIC_MAX_CARDINALITY_PER_TENANT` (0 = unlimited), `API_RATE_LIMIT_RPS` (100). The per-tenant cap is checked first; when set, a noisy tenant cannot exhaust the global pool. Overflow is labeled by tenant via `otelcontext_tsdb_cardinality_overflow_by_tenant_total{tenant_id}` (`__global__` sentinel when the global cap was the trigger).
 - `MCP_ENABLED` (true), `MCP_PATH` (/mcp)
@@ -448,6 +452,97 @@ Failure-mode gauges (prefix `OtelContext_`):
 - `retention_consecutive_failures` — reset to 0 on success; alert when > 3
 - `retention_last_success_timestamp` — Unix seconds; alert when stale relative to the hourly tick
 - `retention_rows_purged_total`, `retention_purge_duration_seconds`, `retention_vacuum_duration_seconds` — throughput and latency
+
+### Data Disk Budget — 8 GiB (#201)
+
+The platform targets a single 8 GiB data volume. The budget is a promise about
+that volume, not about a table, so **enforcement reads `statfs` on
+`DATA_DISK_PATH`** — the only figure that also counts WAL frames, SQLite temp
+files, free pages the file has not handed back, and anything else sharing the
+volume. Per-component file sizes are attribution, never enforcement: a budget
+enforced against summed file sizes reports 60% while `write()` returns ENOSPC.
+
+| Tier | Allocation | Covers |
+|---|---|---|
+| Main relational tier | **4.5 GiB** | Raw trace/span/log exemplars, synthesized logs, investigations and other main-DB metadata, indexes, FTS5, database free pages |
+| `aggregate.db` | **1.5 GiB** | Aggregate buckets, delta log, baselines, identity tables, and their indexes |
+| DLQ | **0.5 GiB** | Existing `DLQ_MAX_DISK_MB` cap |
+| WAL/SHM + temp | **0.5 GiB** | `-wal`/`-shm` sidecars of both databases, SQLite temp files, TLS material, transient maintenance overhead |
+| Headroom | **1 GiB** | Mandatory and unused |
+
+**Unused allocation in one tier does not authorize another tier to consume the
+final 1 GiB.** The seven-day gate (#202) validates these numbers against
+measured high-water marks; it does not quietly reallocate them after a failure.
+
+Gauges: `otelcontext_disk_budget_bytes` (the effective ceiling — min of
+`DATA_DISK_BUDGET_MB` and the usable volume capacity),
+`otelcontext_disk_used_bytes`, `otelcontext_disk_used_ratio`,
+`otelcontext_disk_component_bytes{component}` and
+`otelcontext_disk_component_high_water_bytes{component}` for
+`main_db|aggregate_db|dlq|wal`, `otelcontext_disk_shedding_state`,
+`otelcontext_disk_shedding_transitions_total{from,to}`.
+
+#### Exemplar-tier retention
+
+`EXEMPLAR_RETENTION_DAYS=2` runs a **separate transactional purge** of exemplar
+traces, spans, logs, their FTS rows and expired weak references (spans whose
+trace row is gone), ahead of the `HOT_RETENTION_DAYS` purge on the same hourly
+tick. Trace and span deletes share one transaction per batch, so a reader never
+sees spans whose trace row has already gone. `logs_fts` is content-linked and
+trigger-synced, so index entries die with their rows. Aggregate retention stays
+seven days. Wired only in `AGGREGATE_MODE=aggregate`: in legacy and shadow the
+raw rows ARE the dataset and a two-day purge would be data loss.
+
+Arithmetic behind the 3 MiB default: two days = 576 five-minute windows;
+576 × 3 MiB = 1.69 GiB of charged payload; at the provisional 2× DB/index/FTS
+amplification ≈ 3.38 GiB, leaving ≈ 1.12 GiB of margin inside the 4.5 GiB main
+tier. 4 MiB/window consumes the whole tier under the same optimistic assumption
+— it stays configurable, it is not the default until #202 proves it fits.
+Throughput: `otelcontext_exemplar_rows_purged_total{table}`,
+`otelcontext_exemplar_purge_duration_seconds`.
+
+#### Synthesized-log metering
+
+Every log synthesized from a span event or span status reserves
+`len(body) + len(attributesJSON) + logRowFixedBytes` against its trace's
+per-trace budget AND the shared per-service/global window budgets, under
+`EXEMPLAR_SYNTH_LOGS_PER_SPAN` and `EXEMPLAR_SYNTH_LOGS_PER_TRACE`. They do
+**not** consume the ordinary log-exemplar quota — that budget is for logs a
+client actually sent — but they are not weightless either: a span carrying two
+hundred exception events used to write two hundred rows no budget had ever
+seen. Refusals drop the log, count
+`otelcontext_exemplar_dropped_total{signal="logs",reason}` with
+`synth_per_span|synth_per_trace|budget_bytes`, and stamp the trace `truncated`.
+
+#### Reservation lifecycle (no unconditional refunds)
+
+Bytes are **reserved** before a row is constructed, **committed** when the
+primary queue or the DLQ accepts the batch, and **released** only when the row
+is dropped before submission or permanently lost because both destinations
+refused it. Reserved bytes bind the cap exactly like committed ones. Once a
+submission is accepted the charge is **monotonic for that window**: displacing
+the trace later releases the count slot (a slot is a seat, not a byte) and
+never the bytes — refunding bytes already on disk is how a window writes past
+its cap. `Batch.Reservation` carries the charge to the submit boundary.
+
+#### Staged shedding, hysteresis, and the one ENOSPC exception
+
+| Volume usage | State | Behaviour |
+|---|---|---|
+| ≥ 90% | `errors_only` | Only error trace/log exemplars are admitted; healthy/slow/WARN raw retention off |
+| ≥ 95% | `raw_off` | ALL new raw exemplar admission off, exemplar DLQ fallback closed, immediate expired-exemplar purge + `wal_checkpoint(TRUNCATE)`, `/ready` → 503 |
+
+Hysteresis: recover from `raw_off` only below 90%, from `errors_only` only
+below 85%. A failed `statfs` HOLDS the current state — shedding because a
+syscall failed would be an outage caused by the safety mechanism.
+
+Raw shedding **never** turns a successful aggregate Export into a retryable
+failure. One exception: if the **authoritative** aggregate commit fails with
+`ENOSPC` or `SQLITE_FULL` (`aggregate.IsDiskFull`), the Export MUST fail with
+`RESOURCE_EXHAUSTED`/429 — under the durable-ACK contract a success response
+asserts the deltas are committed, and acknowledging data that was not stored is
+data loss with better branding. Shadow mode is unaffected: there the legacy raw
+path is still the source of truth.
 
 ## Security & Supply Chain
 

--- a/internal/aggregate/diskfull.go
+++ b/internal/aggregate/diskfull.go
@@ -1,0 +1,60 @@
+package aggregate
+
+import (
+	"errors"
+	"io/fs"
+	"strings"
+	"syscall"
+)
+
+// Disk-exhaustion classification for the authoritative commit path (#201 Q5).
+//
+// Raw exemplar shedding is explicitly forbidden from turning a successful
+// aggregate Export into a retryable failure — the aggregate numbers are the
+// dataset, the exemplars are diagnostics, and refusing telemetry because a
+// diagnostic could not be stored is the wrong trade in every direction.
+//
+// There is exactly one exception, and it is not really about shedding: if the
+// AUTHORITATIVE aggregate commit itself fails because the device is out of
+// space, the Export must fail. Under the durable-ACK contract (#160) a success
+// response asserts the deltas are in a committed transaction. Answering OK for
+// data that hit ENOSPC is data loss with better branding, and the client's
+// retry is the only thing that can still save it.
+//
+// Detection is by error inspection rather than by asking the filesystem,
+// because the only reading that matters is the one the write actually got.
+
+// sqliteFullMessages are the message fragments SQLITE_FULL (13) and its ENOSPC
+// cousins surface through the pure-Go driver, which does not export a typed
+// error the way mattn/go-sqlite3 does. Matched case-insensitively.
+var sqliteFullMessages = []string{
+	"database or disk is full", // SQLITE_FULL
+	"no space left on device",  // ENOSPC surfaced as text
+	"disk is full",
+}
+
+// IsDiskFull reports whether err is a device-out-of-space failure.
+//
+// It checks the typed errno first (errors.Is unwraps *fs.PathError and any
+// wrapping the storage layer added) and falls back to the driver's message
+// text, which is the only channel the pure-Go SQLite driver offers for
+// SQLITE_FULL.
+func IsDiskFull(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ENOSPC) || errors.Is(err, syscall.EDQUOT) {
+		return true
+	}
+	var pathErr *fs.PathError
+	if errors.As(err, &pathErr) && errors.Is(pathErr.Err, syscall.ENOSPC) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	for _, frag := range sqliteFullMessages {
+		if strings.Contains(msg, frag) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/aggregate/diskfull_test.go
+++ b/internal/aggregate/diskfull_test.go
@@ -1,0 +1,42 @@
+package aggregate
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"syscall"
+	"testing"
+)
+
+// The classifier decides whether a failed authoritative commit is a disk-full
+// failure, which is the one condition that MUST fail an Export (#201 Q5). A
+// false negative acknowledges data that was never stored.
+func TestIsDiskFull(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", errors.New("constraint violation"), false},
+		{"bare ENOSPC", syscall.ENOSPC, true},
+		{"wrapped ENOSPC", fmt.Errorf("commit deltas: %w", syscall.ENOSPC), true},
+		{"path error", &fs.PathError{Op: "write", Path: "/data/aggregate.db", Err: syscall.ENOSPC}, true},
+		{"wrapped path error", fmt.Errorf("group commit: %w", &fs.PathError{Op: "write", Path: "/data/aggregate.db", Err: syscall.ENOSPC}), true},
+		{"quota exceeded", fmt.Errorf("write wal: %w", syscall.EDQUOT), true},
+		{"SQLITE_FULL text", errors.New("database or disk is full (13)"), true},
+		{"ENOSPC text", errors.New("write /data/aggregate.db-wal: no space left on device"), true},
+		{"mixed case", errors.New("SQL logic error: Database Or Disk Is Full"), true},
+		// Adjacent failures that are NOT disk-full: misclassifying them would
+		// turn an ordinary commit error into a different gRPC code.
+		{"disk io error", errors.New("disk I/O error"), false},
+		{"readonly", errors.New("attempt to write a readonly database"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsDiskFull(tc.err); got != tc.want {
+				t.Fatalf("IsDiskFull(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/api/health_disk_test.go
+++ b/internal/api/health_disk_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+)
+
+// Readiness reflects disk pressure (#201 Q5). At raw-off the process still
+// serves reads and still accounts aggregates, but it can no longer retain the
+// diagnostics anyone comes here for; an orchestrator should stop aiming fresh
+// ingest at it. Errors-only is degraded coverage, not an unready process.
+//
+// readyChecks is shared with health_aggregate_test.go.
+func TestReadyReflectsDiskPressure(t *testing.T) {
+	s := newTestServer(t)
+
+	code, checks := readyChecks(t, s)
+	if checks["disk"] != "skipped" {
+		t.Fatalf("disk check = %q without a watchdog, want skipped", checks["disk"])
+	}
+	if code != http.StatusOK {
+		t.Fatalf("/ready = %d with no watchdog, want 200", code)
+	}
+
+	state, healthy := "none", true
+	s.SetDiskPressureProbe(func() (string, bool) { return state, healthy })
+
+	for _, tc := range []struct {
+		state   string
+		healthy bool
+		want    int
+	}{
+		{"none", true, http.StatusOK},
+		{"errors_only", true, http.StatusOK},
+		{"raw_off", false, http.StatusServiceUnavailable},
+	} {
+		state, healthy = tc.state, tc.healthy
+		code, checks = readyChecks(t, s)
+		if code != tc.want {
+			t.Errorf("/ready = %d at disk state %q, want %d", code, tc.state, tc.want)
+		}
+		if checks["disk"] != tc.state {
+			t.Errorf("disk check = %q, want %q", checks["disk"], tc.state)
+		}
+	}
+}

--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -100,6 +100,19 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 		checks["aggregate_store"] = "ok"
 	}
 
+	// Disk pressure. At >=95% of the enforcement ceiling the raw exemplar
+	// path is off entirely; readiness says so rather than letting an
+	// orchestrator keep aiming ingest at a nearly full volume.
+	if s.diskPressure == nil {
+		checks["disk"] = "skipped"
+	} else {
+		state, ok := s.diskPressure()
+		checks["disk"] = state
+		if !ok {
+			ready = false
+		}
+	}
+
 	status := http.StatusOK
 	if !ready {
 		status = http.StatusServiceUnavailable

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -43,6 +43,14 @@ type Server struct {
 	// no orchestrator routes traffic to a process whose shards are only
 	// half-replayed (#173). nil means "no store configured" and is skipped.
 	aggregateRecovered func() bool
+
+	// diskPressure reports the disk watchdog's state (#201 Q5): a label for
+	// the readiness breakdown and whether the process should still be
+	// considered ready. At raw-off it is not — the platform still serves
+	// reads and still accounts aggregates, but it can no longer retain the
+	// diagnostics anyone comes here for, and an orchestrator should stop
+	// routing fresh ingest at it. nil means "no watchdog" and is skipped.
+	diskPressure func() (string, bool)
 }
 
 // NewServer creates a new API server.
@@ -100,6 +108,13 @@ func (s *Server) aggregateReads() bool { return s.aggregateEngine != nil }
 // until it does. Pass nil (the default) when no aggregate store is configured.
 func (s *Server) SetAggregateRecoveryProbe(fn func() bool) {
 	s.aggregateRecovered = fn
+}
+
+// SetDiskPressureProbe registers a callback returning the disk watchdog's
+// state label and whether readiness should pass. Pass nil (the default) when
+// no watchdog is configured.
+func (s *Server) SetDiskPressureProbe(fn func() (string, bool)) {
+	s.diskPressure = fn
 }
 
 // RegisterRoutes registers API endpoints on the provided mux.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -432,6 +432,30 @@ type Config struct {
 	ExemplarLogsWarnPerServiceWindow  int     // Default 20
 	ExemplarMaxSpansPerTrace          int     // Default 500
 	ExemplarMaxBytesPerTrace          int     // Default 262144 (256 KiB)
+
+	// Exemplar-tier retention and synthesized-log metering (#201 Q2/Q3).
+	//
+	// ExemplarRetentionDays is SHORTER than HotRetentionDays on purpose: in
+	// aggregate mode the raw rows are exemplars attached to a seven-day
+	// aggregate dataset, and 576 five-minute windows (two days) at the 3 MiB
+	// global window budget is 1.69 GiB of charged payload — 3.38 GiB at the
+	// provisional 2x DB/index/FTS amplification, inside the 4.5 GiB main tier
+	// with ~1.12 GiB of margin. Seven days of the same rate does not fit.
+	ExemplarRetentionDays    int // Default 2, validated 1..HotRetentionDays
+	ExemplarSynthLogsPerSpan int // Default 8
+	// ExemplarSynthLogsPerTrace bounds the synthesized logs one retained trace
+	// may carry across all its spans.
+	ExemplarSynthLogsPerTrace int // Default 64
+
+	// Data-volume budget and disk watchdog (#201 Q1/Q5).
+	//
+	// DataDiskBudgetMB is the configured ceiling for everything this process
+	// writes: main relational tier, aggregate.db, DLQ, WAL/temp, and the
+	// mandatory unused headroom. Enforcement uses the LOWER of this and the
+	// usable volume capacity — a 4 GiB PVC does not become 8 GiB because the
+	// config says so.
+	DataDiskBudgetMB int    // Default 8192 (8 GiB)
+	DataDiskPath     string // Default ./data — any path on the data volume
 }
 
 func Load(customPath string) (*Config, error) {
@@ -608,10 +632,14 @@ func Load(customPath string) (*Config, error) {
 		AggregateMaxDimTuplesPerTenant: getEnvInt("AGGREGATE_MAX_DIM_TUPLES_PER_TENANT", 5000),
 		AggregateMaxDimTuples:          getEnvInt("AGGREGATE_MAX_DIM_TUPLES", 50000),
 		// Bounded exemplar retention (aggregate mode only)
-		ExemplarTracesPerServiceWindow:    getEnvInt("EXEMPLAR_TRACES_PER_SERVICE_WINDOW", 25),
-		ExemplarTracesGlobalWindow:        getEnvInt("EXEMPLAR_TRACES_GLOBAL_WINDOW", 1500),
-		ExemplarBytesPerServiceWindow:     getEnvInt("EXEMPLAR_BYTES_PER_SERVICE_WINDOW", 512*1024),
-		ExemplarBytesGlobalWindow:         getEnvInt("EXEMPLAR_BYTES_GLOBAL_WINDOW", 8*1024*1024),
+		ExemplarTracesPerServiceWindow: getEnvInt("EXEMPLAR_TRACES_PER_SERVICE_WINDOW", 25),
+		ExemplarTracesGlobalWindow:     getEnvInt("EXEMPLAR_TRACES_GLOBAL_WINDOW", 1500),
+		ExemplarBytesPerServiceWindow:  getEnvInt("EXEMPLAR_BYTES_PER_SERVICE_WINDOW", 512*1024),
+		// 3 MiB, not 4 (#201 Q2). 4 MiB/window consumes the entire 4.5 GiB
+		// main tier under the optimistic 2x amplification assumption and
+		// leaves no operational margin; it stays configurable, it is not the
+		// default until the seven-day gate (#202) proves it fits.
+		ExemplarBytesGlobalWindow:         getEnvInt("EXEMPLAR_BYTES_GLOBAL_WINDOW", 3*1024*1024),
 		ExemplarHealthyRate:               getEnvFloat("EXEMPLAR_HEALTHY_RATE", 0.005),
 		ExemplarStratumTopK:               getEnvInt("EXEMPLAR_STRATUM_TOP_K", 5),
 		ExemplarLogsErrorPerServiceWindow: getEnvInt("EXEMPLAR_LOGS_ERROR_PER_SERVICE_WINDOW", 50),
@@ -619,6 +647,12 @@ func Load(customPath string) (*Config, error) {
 		ExemplarLogsWarnPerServiceWindow:  getEnvInt("EXEMPLAR_LOGS_WARN_PER_SERVICE_WINDOW", 20),
 		ExemplarMaxSpansPerTrace:          getEnvInt("EXEMPLAR_MAX_SPANS_PER_TRACE", 500),
 		ExemplarMaxBytesPerTrace:          getEnvInt("EXEMPLAR_MAX_BYTES_PER_TRACE", 256*1024),
+		ExemplarRetentionDays:             getEnvInt("EXEMPLAR_RETENTION_DAYS", 2),
+		ExemplarSynthLogsPerSpan:          getEnvInt("EXEMPLAR_SYNTH_LOGS_PER_SPAN", 8),
+		ExemplarSynthLogsPerTrace:         getEnvInt("EXEMPLAR_SYNTH_LOGS_PER_TRACE", 64),
+		// 8 GiB data budget (#201 Q1).
+		DataDiskBudgetMB: getEnvInt("DATA_DISK_BUDGET_MB", 8192),
+		DataDiskPath:     getEnv("DATA_DISK_PATH", "./data"),
 	}
 
 	// Parse AGGREGATE_METRIC_DIMS config
@@ -1048,6 +1082,21 @@ func (c *Config) Validate() error {
 	}
 	if c.ExemplarMaxBytesPerTrace < 1024 {
 		return fmt.Errorf("EXEMPLAR_MAX_BYTES_PER_TRACE must be >= 1024, got %d", c.ExemplarMaxBytesPerTrace)
+	}
+	if c.ExemplarRetentionDays < 1 || c.ExemplarRetentionDays > c.HotRetentionDays {
+		return fmt.Errorf("EXEMPLAR_RETENTION_DAYS must be between 1 and HOT_RETENTION_DAYS (%d), got %d: the exemplar tier is a shorter-lived subset of hot retention, never a longer-lived one", c.HotRetentionDays, c.ExemplarRetentionDays)
+	}
+	if c.ExemplarSynthLogsPerSpan < 1 {
+		return fmt.Errorf("EXEMPLAR_SYNTH_LOGS_PER_SPAN must be >= 1, got %d", c.ExemplarSynthLogsPerSpan)
+	}
+	if c.ExemplarSynthLogsPerTrace < c.ExemplarSynthLogsPerSpan {
+		return fmt.Errorf("EXEMPLAR_SYNTH_LOGS_PER_TRACE (%d) must be >= EXEMPLAR_SYNTH_LOGS_PER_SPAN (%d): a per-trace cap below the per-span cap makes the per-span cap unreachable", c.ExemplarSynthLogsPerTrace, c.ExemplarSynthLogsPerSpan)
+	}
+	if c.DataDiskBudgetMB < 64 {
+		return fmt.Errorf("DATA_DISK_BUDGET_MB must be >= 64, got %d", c.DataDiskBudgetMB)
+	}
+	if strings.TrimSpace(c.DataDiskPath) == "" {
+		return fmt.Errorf("DATA_DISK_PATH must not be empty")
 	}
 
 	// Sum-of-caps validation: sub-caps must fit under global cap

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -73,7 +73,7 @@ func baseValid() *Config {
 		ExemplarTracesPerServiceWindow:    25,
 		ExemplarTracesGlobalWindow:        1500,
 		ExemplarBytesPerServiceWindow:     512 * 1024,
-		ExemplarBytesGlobalWindow:         8 * 1024 * 1024,
+		ExemplarBytesGlobalWindow:         3 * 1024 * 1024,
 		ExemplarHealthyRate:               0.005,
 		ExemplarStratumTopK:               5,
 		ExemplarLogsErrorPerServiceWindow: 50,
@@ -81,6 +81,12 @@ func baseValid() *Config {
 		ExemplarLogsWarnPerServiceWindow:  20,
 		ExemplarMaxSpansPerTrace:          500,
 		ExemplarMaxBytesPerTrace:          256 * 1024,
+		// 8 GiB data budget (#201)
+		ExemplarRetentionDays:     2,
+		ExemplarSynthLogsPerSpan:  8,
+		ExemplarSynthLogsPerTrace: 64,
+		DataDiskBudgetMB:          8192,
+		DataDiskPath:              "./data",
 	}
 }
 
@@ -915,7 +921,14 @@ func TestLoad_ExemplarDefaultsMatchResolution(t *testing.T) {
 		{"EXEMPLAR_TRACES_PER_SERVICE_WINDOW", cfg.ExemplarTracesPerServiceWindow, 25},
 		{"EXEMPLAR_TRACES_GLOBAL_WINDOW", cfg.ExemplarTracesGlobalWindow, 1500},
 		{"EXEMPLAR_BYTES_PER_SERVICE_WINDOW", cfg.ExemplarBytesPerServiceWindow, 512 * 1024},
-		{"EXEMPLAR_BYTES_GLOBAL_WINDOW", cfg.ExemplarBytesGlobalWindow, 8 * 1024 * 1024},
+		// 3 MiB, frozen in #201 Q2. 4 MiB stays configurable but is not the
+		// default: it consumes the whole 4.5 GiB main tier under the
+		// optimistic 2x amplification assumption.
+		{"EXEMPLAR_BYTES_GLOBAL_WINDOW", cfg.ExemplarBytesGlobalWindow, 3 * 1024 * 1024},
+		{"EXEMPLAR_RETENTION_DAYS", cfg.ExemplarRetentionDays, 2},
+		{"EXEMPLAR_SYNTH_LOGS_PER_SPAN", cfg.ExemplarSynthLogsPerSpan, 8},
+		{"EXEMPLAR_SYNTH_LOGS_PER_TRACE", cfg.ExemplarSynthLogsPerTrace, 64},
+		{"DATA_DISK_BUDGET_MB", cfg.DataDiskBudgetMB, 8192},
 		{"EXEMPLAR_LOGS_ERROR_PER_SERVICE_WINDOW", cfg.ExemplarLogsErrorPerServiceWindow, 50},
 		{"EXEMPLAR_LOGS_WARN_PER_SERVICE_WINDOW", cfg.ExemplarLogsWarnPerServiceWindow, 20},
 	}
@@ -929,5 +942,69 @@ func TestLoad_ExemplarDefaultsMatchResolution(t *testing.T) {
 	}
 	if cfg.ExemplarLogsWarnEnabled {
 		t.Error("EXEMPLAR_LOGS_WARN_ENABLED should default off — WARN raw retention is opt-in")
+	}
+}
+
+// --- 8 GiB data budget knobs (#201) -----------------------------------------
+
+// TestValidate_ExemplarRetentionDays_Bounds: the exemplar tier is a
+// shorter-lived subset of hot retention. Longer than HOT_RETENTION_DAYS is not
+// a tuning choice, it is a contradiction — the rows would be purged by the
+// other scheduler anyway.
+func TestValidate_ExemplarRetentionDays_Bounds(t *testing.T) {
+	for _, days := range []int{0, -1, 8, 100} {
+		c := baseValid()
+		c.HotRetentionDays = 7
+		c.ExemplarRetentionDays = days
+		if err := c.Validate(); err == nil {
+			t.Errorf("EXEMPLAR_RETENTION_DAYS=%d should be rejected against HOT_RETENTION_DAYS=7", days)
+		}
+	}
+	for _, days := range []int{1, 2, 7} {
+		c := baseValid()
+		c.HotRetentionDays = 7
+		c.ExemplarRetentionDays = days
+		if err := c.Validate(); err != nil {
+			t.Errorf("EXEMPLAR_RETENTION_DAYS=%d should validate: %v", days, err)
+		}
+	}
+}
+
+// TestValidate_ExemplarSynthLogCaps: a per-trace cap below the per-span cap
+// makes the per-span cap unreachable, which is a config that lies.
+func TestValidate_ExemplarSynthLogCaps(t *testing.T) {
+	c := baseValid()
+	c.ExemplarSynthLogsPerSpan = 0
+	if err := c.Validate(); err == nil {
+		t.Error("EXEMPLAR_SYNTH_LOGS_PER_SPAN=0 should be rejected")
+	}
+
+	c = baseValid()
+	c.ExemplarSynthLogsPerSpan = 16
+	c.ExemplarSynthLogsPerTrace = 8
+	if err := c.Validate(); err == nil {
+		t.Error("a per-trace synth cap below the per-span cap should be rejected")
+	}
+
+	c = baseValid()
+	c.ExemplarSynthLogsPerSpan = 8
+	c.ExemplarSynthLogsPerTrace = 8
+	if err := c.Validate(); err != nil {
+		t.Errorf("equal synth caps should validate: %v", err)
+	}
+}
+
+// TestValidate_DataDiskBudget: the watchdog needs a ceiling and a path.
+func TestValidate_DataDiskBudget(t *testing.T) {
+	c := baseValid()
+	c.DataDiskBudgetMB = 63
+	if err := c.Validate(); err == nil {
+		t.Error("DATA_DISK_BUDGET_MB=63 should be rejected")
+	}
+
+	c = baseValid()
+	c.DataDiskPath = "   "
+	if err := c.Validate(); err == nil {
+		t.Error("a blank DATA_DISK_PATH should be rejected")
 	}
 }

--- a/internal/ingest/aggregate_bridge.go
+++ b/internal/ingest/aggregate_bridge.go
@@ -42,6 +42,17 @@ func applyAggregate(eng *aggregate.Engine, r *aggregate.Reducer) error {
 		return grpcstatus.Errorf(codes.ResourceExhausted, "aggregate store at capacity")
 	}
 	if eng.Mode() == aggregate.ModeAggregate {
+		// The one case where a disk problem MUST fail the Export (#201 Q5).
+		// Raw exemplar shedding never does this — diagnostics are droppable.
+		// The authoritative aggregate commit is not: a success response
+		// asserts the deltas are in a committed transaction, and answering OK
+		// for data that hit ENOSPC or SQLITE_FULL is data loss with better
+		// branding. ResourceExhausted so the client backs off and retries
+		// rather than hammering a full disk.
+		if aggregate.IsDiskFull(err) {
+			slog.Error("aggregate commit failed: device out of space — failing the Export so the client retries", "error", err)
+			return grpcstatus.Errorf(codes.ResourceExhausted, "aggregate store commit failed: no space left on device")
+		}
 		return grpcstatus.Errorf(codes.Unavailable, "aggregate store commit failed")
 	}
 	slog.Error("aggregate shadow commit failed (legacy path remains the source of truth)", "error", err)
@@ -137,41 +148,71 @@ func (o exemplarOutcome) message() string {
 // continues with the remaining tenant groups. Non-ErrQueueFull errors are
 // still returned — those are not backpressure.
 //
+// dlqDisabled closes the DLQ fallback. Set when the disk watchdog is in
+// raw-off (#201 Q5): at >=95% of the enforcement ceiling, deferring an
+// exemplar to the DLQ is still writing to the disk that is about to fill.
+//
 // exemplars(b) counts the selected raw exemplars carried by one batch.
+//
+// Byte accounting: each batch carries the reservation for the rows in it
+// (#201 Q4). Accepted by the primary queue or the DLQ => Commit, and the
+// charge is monotonic for that window from then on. Refused by both, or
+// abandoned because this Export is going to fail => Release.
 func submitExemplars(
 	p *Pipeline,
 	metrics *telemetry.Metrics,
 	signal SignalType,
 	batches []*Batch,
 	ackedByAggregate bool,
+	dlqDisabled bool,
 	exemplars func(*Batch) int,
 ) (exemplarOutcome, error) {
 	var out exemplarOutcome
-	for _, b := range batches {
+	for i, b := range batches {
 		_, err := p.Submit(b)
 		if err == nil {
+			b.Reservation.Commit()
 			if ackedByAggregate {
 				observeExemplarSubmit(metrics, signal, "queued", "none")
 			}
 			continue
 		}
 		if !ackedByAggregate || !errors.Is(err, ErrQueueFull) {
+			// The Export fails, so nothing in this batch or any batch after it
+			// reached a destination. Their bytes were never written.
+			releaseFrom(batches, i)
 			return out, err
 		}
 
 		// Aggregate mode, primary queue saturated: one bounded attempt at the
-		// DLQ. Accepted => deferred; refused or errored => permanent counted
-		// loss. Neither changes the Export result.
+		// DLQ. Accepted => deferred; refused, errored, or closed by the disk
+		// watchdog => permanent counted loss. Neither changes the Export
+		// result.
 		n := exemplars(b)
+		if dlqDisabled {
+			b.Reservation.Release()
+			out.lost += n
+			observeExemplarSubmit(metrics, signal, "lost", "disk_shed")
+			observeExemplarLost(metrics, signal, "disk_shed")
+			slog.Warn("exemplar batch dropped: raw pipeline saturated and DLQ closed by disk pressure",
+				"signal", signalLabel(signal),
+				"tenant", b.Tenant,
+				"exemplars", n,
+			)
+			continue
+		}
 		switch dlqErr := p.OfferToDLQ(b); {
 		case dlqErr == nil:
+			b.Reservation.Commit()
 			out.deferred += n
 			observeExemplarSubmit(metrics, signal, "dlq", "queue_full")
 		case errors.Is(dlqErr, ErrDLQFull):
+			b.Reservation.Release()
 			out.lost += n
 			observeExemplarSubmit(metrics, signal, "lost", "dlq_full")
 			observeExemplarLost(metrics, signal, "dlq_full")
 		default:
+			b.Reservation.Release()
 			out.lost += n
 			observeExemplarSubmit(metrics, signal, "lost", "dlq_error")
 			observeExemplarLost(metrics, signal, "dlq_error")
@@ -184,6 +225,14 @@ func submitExemplars(
 		}
 	}
 	return out, nil
+}
+
+// releaseFrom hands back the reservations of batches[i:] — the batch that just
+// failed and every one that will never be attempted.
+func releaseFrom(batches []*Batch, i int) {
+	for _, b := range batches[i:] {
+		b.Reservation.Release()
+	}
 }
 
 func observeExemplarSubmit(m *telemetry.Metrics, signal SignalType, outcome, reason string) {

--- a/internal/ingest/aggregate_diskfull_test.go
+++ b/internal/ingest/aggregate_diskfull_test.go
@@ -1,0 +1,78 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+)
+
+// Raw exemplar shedding never turns a successful aggregate Export into a
+// retryable failure. The authoritative aggregate commit failing on ENOSPC or
+// SQLITE_FULL is the one exception (#201 Q5): a durable ACK asserts the deltas
+// are committed, and answering OK for data that hit a full disk is data loss
+// with better branding.
+//
+// The stub applier and reducer helpers are shared with
+// aggregate_saturation_test.go.
+
+func TestAggregateCommitDiskFullFailsTheExport(t *testing.T) {
+	diskFull := []struct {
+		name string
+		err  error
+	}{
+		{"ENOSPC", fmt.Errorf("group commit: %w", syscall.ENOSPC)},
+		{"path ENOSPC", &fs.PathError{Op: "write", Path: "/data/aggregate.db-wal", Err: syscall.ENOSPC}},
+		{"SQLITE_FULL", fmt.Errorf("commit: %s", "database or disk is full")},
+	}
+	for _, tc := range diskFull {
+		t.Run(tc.name, func(t *testing.T) {
+			eng := engineWithApplier(t, aggregate.ModeAggregate, tc.err)
+			err := applyAggregate(eng, reducerWithOneSpan(eng))
+			if err == nil {
+				t.Fatal("a commit that hit a full disk was acknowledged as success")
+			}
+			st, ok := grpcstatus.FromError(err)
+			if !ok || st.Code() != codes.ResourceExhausted {
+				t.Fatalf("error = %v, want RESOURCE_EXHAUSTED so the client backs off and retries", err)
+			}
+			if !isQueueFull(err) {
+				t.Fatal("the HTTP OTLP handler would not map this to a retryable 429")
+			}
+		})
+	}
+}
+
+// TestTraceExportFailsOnDiskFullCommit is the same contract at the Export
+// boundary, which is the surface an OTLP client actually sees.
+func TestTraceExportFailsOnDiskFullCommit(t *testing.T) {
+	now := time.Now().UTC()
+	eng := engineWithApplier(t, aggregate.ModeAggregate, fmt.Errorf("commit deltas: %w", syscall.ENOSPC))
+	srv := NewTraceServer(nil, nil, aggTestConfig())
+	srv.SetAggregateEngine(eng)
+
+	resp, err := srv.Export(context.Background(), ackErrorSpanRequest(3, now))
+	if err == nil {
+		t.Fatalf("Export succeeded (resp=%v) on a commit that hit a full disk", resp)
+	}
+	st, ok := grpcstatus.FromError(err)
+	if !ok || st.Code() != codes.ResourceExhausted {
+		t.Fatalf("Export error = %v, want RESOURCE_EXHAUSTED", err)
+	}
+}
+
+// TestShadowModeDiskFullDoesNotFailTheExport: in shadow mode the legacy raw
+// path is still the source of truth. Failing the Export there would convert a
+// shadow-side disk problem into raw telemetry loss.
+func TestShadowModeDiskFullDoesNotFailTheExport(t *testing.T) {
+	eng := engineWithApplier(t, aggregate.ModeShadow, fmt.Errorf("group commit: %w", syscall.ENOSPC))
+	if err := applyAggregate(eng, reducerWithOneSpan(eng)); err != nil {
+		t.Fatalf("shadow-mode disk-full commit failed the Export: %v", err)
+	}
+}

--- a/internal/ingest/exemplar.go
+++ b/internal/ingest/exemplar.go
@@ -4,6 +4,7 @@ import (
 	"hash/fnv"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
@@ -70,6 +71,14 @@ const (
 	exemplarReasonBudgetCount = "budget_count"
 	exemplarReasonBudgetBytes = "budget_bytes"
 	exemplarReasonStratum     = "stratum"
+	// Synthesized-log metering (#201 Q3). Synthesized logs ride a selected
+	// trace and never touch the ordinary log-exemplar quota, so their
+	// refusals need their own reasons or they would be invisible.
+	exemplarReasonSynthPerSpan  = "synth_per_span"
+	exemplarReasonSynthPerTrace = "synth_per_trace"
+	// Disk watchdog shedding (#201 Q5).
+	exemplarReasonShedErrorsOnly = "shed_errors_only"
+	exemplarReasonShedRawOff     = "shed_raw_off"
 )
 
 // ExemplarMetrics is the policy's view of the metric surface. It mirrors the
@@ -129,6 +138,13 @@ type ExemplarConfig struct {
 	MaxSpansPerTrace int   // Default 500
 	MaxBytesPerTrace int64 // Default 256 KiB
 
+	// SynthLogsPerSpan / SynthLogsPerTrace bound the logs synthesized from
+	// span events and span status (#201 Q3). Before this they were
+	// unmetered: a span carrying two hundred exception events wrote two
+	// hundred log rows that no budget had ever seen. Defaults 8 and 64.
+	SynthLogsPerSpan  int
+	SynthLogsPerTrace int
+
 	// WindowSize is the tumbling budget window. Defaults to the aggregate
 	// engine's window so exemplar budgets and aggregate buckets share edges.
 	WindowSize time.Duration
@@ -141,13 +157,15 @@ const (
 	DefaultExemplarTracesPerServiceWindow    = 25
 	DefaultExemplarTracesGlobalWindow        = 1500
 	DefaultExemplarBytesPerServiceWindow     = 512 * 1024
-	DefaultExemplarBytesGlobalWindow         = 8 * 1024 * 1024
+	DefaultExemplarBytesGlobalWindow         = 3 * 1024 * 1024
 	DefaultExemplarHealthyRate               = 0.005
 	DefaultExemplarStratumTopK               = 5
 	DefaultExemplarLogsErrorPerServiceWindow = 50
 	DefaultExemplarLogsWarnPerServiceWindow  = 20
 	DefaultExemplarMaxSpansPerTrace          = 500
 	DefaultExemplarMaxBytesPerTrace          = 256 * 1024
+	DefaultExemplarSynthLogsPerSpan          = 8
+	DefaultExemplarSynthLogsPerTrace         = 64
 )
 
 func (c *ExemplarConfig) applyDefaults() {
@@ -184,6 +202,12 @@ func (c *ExemplarConfig) applyDefaults() {
 	if c.MaxBytesPerTrace <= 0 {
 		c.MaxBytesPerTrace = DefaultExemplarMaxBytesPerTrace
 	}
+	if c.SynthLogsPerSpan <= 0 {
+		c.SynthLogsPerSpan = DefaultExemplarSynthLogsPerSpan
+	}
+	if c.SynthLogsPerTrace <= 0 {
+		c.SynthLogsPerTrace = DefaultExemplarSynthLogsPerTrace
+	}
 	if c.WindowSize <= 0 {
 		c.WindowSize = aggregate.WindowSize
 	}
@@ -196,14 +220,24 @@ func (c *ExemplarConfig) applyDefaults() {
 // complete-retained-trace contract (#163). Only SELECTED traces get one, so the
 // map is bounded by the per-service budget.
 type traceState struct {
-	hash      uint64
-	class     int
-	stratum   string
-	observed  int   // spans of this trace seen by the policy
-	retained  int   // spans actually handed to persistence
-	bytes     int64 // bytes actually handed to persistence
+	hash     uint64
+	class    int
+	stratum  string
+	observed int // spans of this trace seen by the policy
+	retained int // spans actually handed to persistence
+	// bytes is COMMITTED: rows a downstream destination accepted. It never
+	// decreases while the window lives (#201 Q4).
+	bytes int64
+	// reserved is held for rows built but not yet accepted anywhere. It
+	// converts to bytes on commit and evaporates on release.
+	reserved  int64
 	truncated bool
 	evicted   bool // displaced by a better-ranked trace; future spans stop
+	// synthPerSpan / synthTotal meter the logs synthesized from this trace's
+	// spans (#201 Q3). The map is bounded by MaxSpansPerTrace because only
+	// spans that actually synthesized a log get an entry.
+	synthPerSpan map[string]int
+	synthTotal   int
 }
 
 // stratumState holds the top-K smallest hashes selected for one
@@ -218,8 +252,13 @@ type serviceWindow struct {
 	traces  map[string]*traceState
 	strata  map[string]*stratumState
 	perName [exemplarClassCount]int
-	bytes   int64
-	logs    [2]int // [0] = ERROR/FATAL raw logs, [1] = WARN raw logs
+	// bytes is committed, reservedBytes is in flight. Both count against
+	// BytesPerServiceWindow: a reservation that has not committed yet is a
+	// row that is about to be written, and pretending otherwise is how a
+	// budget gets overshot by exactly one Export.
+	bytes         int64
+	reservedBytes int64
+	logs          [2]int // [0] = ERROR/FATAL raw logs, [1] = WARN raw logs
 }
 
 func newServiceWindow() *serviceWindow {
@@ -235,8 +274,9 @@ func (sw *serviceWindow) selectedCount() int {
 
 // globalWindow carries the instance-wide budgets for one window.
 type globalWindow struct {
-	traces int
-	bytes  int64
+	traces   int
+	bytes    int64
+	reserved int64
 }
 
 // windowKey identifies a (tenant, service, window) budget cell. Budgets are
@@ -264,6 +304,11 @@ type ExemplarPolicy struct {
 
 	globalMu sync.Mutex
 	global   map[int64]*globalWindow
+
+	// shed carries the disk watchdog's SheddingState (#201 Q5). Read on every
+	// admission, written rarely by the watchdog goroutine, so an atomic beats
+	// putting the hot path behind another mutex.
+	shed atomic.Int32
 }
 
 const exemplarShardCount = 16
@@ -366,6 +411,20 @@ func (p *ExemplarPolicy) AdmitSpan(in ExemplarSpan) bool {
 	sh.mu.Lock()
 	sw := sh.window(windowKey{tenant: in.Tenant, service: in.Service, window: window})
 
+	// Disk shedding outranks the complete-retained-trace contract (#201 Q5).
+	// At >=90% only error exemplars are admitted; at >=95% none are. A trace
+	// already selected in this window is cut short rather than continued, and
+	// stamped truncated so the persisted data says so instead of implying a
+	// short trace was all there was.
+	if reason, shed := p.shedSpan(class); shed {
+		if st, ok := sw.traces[in.TraceID]; ok && !st.evicted {
+			p.markTruncated(st)
+		}
+		sh.mu.Unlock()
+		p.cfg.Metrics.RecordExemplarDropped("traces", reason)
+		return false
+	}
+
 	// Already decided? Duplicates and later spans of the same trace re-select
 	// the same slot.
 	if st, ok := sw.traces[in.TraceID]; ok {
@@ -457,11 +516,175 @@ func (p *ExemplarPolicy) AdmitSpan(in ExemplarSpan) bool {
 	return true
 }
 
-// ChargeSpan meters the bytes a retained span actually hands to persistence and
+// Reservation lifecycle (#201 Q4).
+//
+// The old model charged bytes the moment a row was built and refunded the
+// global pool on nothing at all, while eviction refunded the count slot. That
+// is unsound in one direction that matters: a refund for bytes a queue had
+// already accepted lets the window write more than its budget, because the
+// refunded bytes are on disk. So:
+//
+//	reserve  before the row is constructed
+//	commit   when the primary queue or the DLQ accepts the batch
+//	release  only when the row is dropped BEFORE submission, or when both
+//	         destinations refused it and it is permanently gone
+//
+// Once a submission is accepted the charge is monotonic for that window. A
+// later, better-ranked trace displacing the selection releases the COUNT slot
+// (a slot is a seat, not a byte) and nothing else.
+//
+// Reservations are not safe for concurrent use. One per per-resource goroutine,
+// merged after the group finishes — which is exactly how Export already
+// structures its work.
+
+// exemplarReservationEntry is one reserved charge. It holds pointers to the
+// budget cells rather than their keys: a window cell can be pruned between
+// reserve and commit, and mutating a detached cell is harmless, whereas
+// re-looking-up a pruned key would silently drop the accounting.
+type exemplarReservationEntry struct {
+	shard *exemplarShard
+	sw    *serviceWindow
+	st    *traceState // nil for client logs, which belong to no selected trace
+	gw    *globalWindow
+	bytes int64
+	// span marks the entry as holding a retained-SPAN slot, so a release hands
+	// that slot back too. Synthesized logs also carry a traceState but never a
+	// span slot; decrementing st.retained for one would understate the
+	// retained/observed counts stamped on the trace row.
+	span bool
+}
+
+// ExemplarReservation accumulates one submission unit's reserved bytes.
+type ExemplarReservation struct {
+	p       *ExemplarPolicy
+	entries []exemplarReservationEntry
+	settled bool
+}
+
+// NewReservation opens a reservation. A nil policy yields a nil reservation,
+// and every method below is nil-safe, so the legacy and shadow paths need no
+// branches.
+func (p *ExemplarPolicy) NewReservation() *ExemplarReservation {
+	if p == nil {
+		return nil
+	}
+	return &ExemplarReservation{p: p}
+}
+
+// Bytes reports the total reserved so far. Diagnostic surface.
+func (r *ExemplarReservation) Bytes() int64 {
+	if r == nil {
+		return 0
+	}
+	var n int64
+	for _, e := range r.entries {
+		n += e.bytes
+	}
+	return n
+}
+
+// Len reports how many rows are reserved.
+func (r *ExemplarReservation) Len() int {
+	if r == nil {
+		return 0
+	}
+	return len(r.entries)
+}
+
+// Merge folds other into r and neutralizes other, so exactly one of them can
+// ever settle the charges.
+func (r *ExemplarReservation) Merge(other *ExemplarReservation) {
+	if r == nil || other == nil || other.settled {
+		return
+	}
+	if r.p == nil {
+		r.p = other.p
+	}
+	r.entries = append(r.entries, other.entries...)
+	other.entries = nil
+	other.settled = true
+}
+
+// Commit converts every reserved byte into a committed byte. Call it exactly
+// when a destination has accepted the rows. Idempotent.
+func (r *ExemplarReservation) Commit() {
+	if r == nil || r.settled || r.p == nil {
+		return
+	}
+	r.settled = true
+	for _, e := range r.entries {
+		r.p.commitEntry(e)
+	}
+	r.entries = nil
+}
+
+// Release gives every reserved byte back. Legitimate only while the rows have
+// NOT been accepted anywhere: dropped before submission, or refused by both the
+// primary queue and the DLQ. Idempotent.
+func (r *ExemplarReservation) Release() {
+	if r == nil || r.settled || r.p == nil {
+		return
+	}
+	r.settled = true
+	for _, e := range r.entries {
+		r.p.releaseEntry(e)
+	}
+	r.entries = nil
+}
+
+// commitEntry moves one charge from reserved to committed.
+func (p *ExemplarPolicy) commitEntry(e exemplarReservationEntry) {
+	e.shard.mu.Lock()
+	e.sw.reservedBytes -= e.bytes
+	e.sw.bytes += e.bytes
+	if e.st != nil {
+		e.st.reserved -= e.bytes
+		e.st.bytes += e.bytes
+	}
+	e.shard.mu.Unlock()
+
+	p.globalMu.Lock()
+	e.gw.reserved -= e.bytes
+	e.gw.bytes += e.bytes
+	p.globalMu.Unlock()
+}
+
+// releaseEntry drops one un-committed charge.
+func (p *ExemplarPolicy) releaseEntry(e exemplarReservationEntry) {
+	e.shard.mu.Lock()
+	e.sw.reservedBytes -= e.bytes
+	if e.st != nil {
+		e.st.reserved -= e.bytes
+		if e.span {
+			e.st.retained--
+		}
+	}
+	e.shard.mu.Unlock()
+
+	p.globalMu.Lock()
+	e.gw.reserved -= e.bytes
+	p.globalMu.Unlock()
+}
+
+// settle files an entry: into res when there is a submission boundary to wait
+// for, straight to committed when there is not. Caller must NOT hold the shard
+// lock.
+func (p *ExemplarPolicy) settle(res *ExemplarReservation, e exemplarReservationEntry) {
+	if res == nil {
+		p.commitEntry(e)
+		return
+	}
+	res.entries = append(res.entries, e)
+}
+
+// ReserveSpan meters the bytes a retained span will hand to persistence and
 // reports whether it fits. A false return means the row must be dropped: the
 // byte budget bound before the count budget did, and the trace is marked
 // truncated so the gap is visible in the persisted data rather than inferred.
-func (p *ExemplarPolicy) ChargeSpan(tenant, service, traceID string, ts time.Time, size int) bool {
+//
+// res may be nil, in which case the charge commits immediately — the caller is
+// asserting it has no submission boundary. Production paths always pass one.
+func (p *ExemplarPolicy) ReserveSpan(res *ExemplarReservation, tenant, service, traceID string, ts time.Time, size int) bool {
 	window := p.windowOf(ts)
 	sh := p.shardFor(service)
 	sh.mu.Lock()
@@ -472,22 +695,25 @@ func (p *ExemplarPolicy) ChargeSpan(tenant, service, traceID string, ts time.Tim
 		return false
 	}
 	n := int64(size)
-	if st.bytes+n > p.cfg.MaxBytesPerTrace || sw.bytes+n > p.cfg.BytesPerServiceWindow {
+	if st.bytes+st.reserved+n > p.cfg.MaxBytesPerTrace || sw.bytes+sw.reservedBytes+n > p.cfg.BytesPerServiceWindow {
 		p.markTruncated(st)
 		sh.mu.Unlock()
 		p.cfg.Metrics.RecordExemplarDropped("traces", exemplarReasonBudgetBytes)
 		return false
 	}
-	if !p.reserveGlobalBytes(window, n) {
+	gw, ok := p.reserveGlobalBytes(window, n)
+	if !ok {
 		p.markTruncated(st)
 		sh.mu.Unlock()
 		p.cfg.Metrics.RecordExemplarDropped("traces", exemplarReasonBudgetBytes)
 		return false
 	}
-	st.bytes += n
+	st.reserved += n
 	st.retained++
-	sw.bytes += n
+	sw.reservedBytes += n
 	sh.mu.Unlock()
+
+	p.settle(res, exemplarReservationEntry{shard: sh, sw: sw, st: st, gw: gw, bytes: n, span: true})
 	return true
 }
 
@@ -527,18 +753,22 @@ func (p *ExemplarPolicy) TraceStats(tenant, service, traceID string, ts time.Tim
 	return ExemplarTraceStats{Truncated: st.truncated, Retained: st.retained, Observed: st.observed}, true
 }
 
-// AdmitLog reports whether a raw log row may be persisted in aggregate mode.
-// INFO/DEBUG are aggregate-only and never raw; ERROR/FATAL get a per-service
-// window budget; WARN is opt-in (#161). Bytes are charged to the same
-// service/global byte budgets as spans — one pool, so a log flood cannot buy
-// itself past the trace budget.
+// ReserveLog reports whether a raw client log row may be persisted in
+// aggregate mode. INFO/DEBUG are aggregate-only and never raw; ERROR/FATAL get
+// a per-service window budget; WARN is opt-in (#161). Bytes are reserved
+// against the same service/global byte budgets as spans — one pool, so a log
+// flood cannot buy itself past the trace budget.
 //
 // size is the variable-length payload (body + serialized attributes); the
 // fixed row overhead is added here so callers do not have to know it.
-func (p *ExemplarPolicy) AdmitLog(tenant, service, severity string, ts time.Time, size int) bool {
+func (p *ExemplarPolicy) ReserveLog(res *ExemplarReservation, tenant, service, severity string, ts time.Time, size int) bool {
 	slot, ok := p.logSlot(severity)
 	if !ok {
 		// Not eligible at all — not an exemplar drop, never was one.
+		return false
+	}
+	if reason, shed := p.shedLog(slot); shed {
+		p.cfg.Metrics.RecordExemplarDropped("logs", reason)
 		return false
 	}
 	budget := p.cfg.LogsErrorPerServiceWindow
@@ -559,29 +789,168 @@ func (p *ExemplarPolicy) AdmitLog(tenant, service, severity string, ts time.Time
 		return false
 	}
 	n := int64(size + logRowFixedBytes)
-	if sw.bytes+n > p.cfg.BytesPerServiceWindow {
+	if sw.bytes+sw.reservedBytes+n > p.cfg.BytesPerServiceWindow {
 		sh.mu.Unlock()
 		p.cfg.Metrics.RecordExemplarDropped("logs", exemplarReasonBudgetBytes)
 		return false
 	}
-	if !p.reserveGlobalBytes(window, n) {
+	gw, ok := p.reserveGlobalBytes(window, n)
+	if !ok {
 		sh.mu.Unlock()
 		p.cfg.Metrics.RecordExemplarDropped("logs", exemplarReasonBudgetBytes)
 		return false
 	}
 	sw.logs[slot]++
-	sw.bytes += n
+	sw.reservedBytes += n
 	sh.mu.Unlock()
+
+	p.settle(res, exemplarReservationEntry{shard: sh, sw: sw, gw: gw, bytes: n})
 	return true
 }
 
-// AllowSynthesizedLog gates logs synthesized from span events / span status.
-// These ride along with a span the policy already admitted and budgeted, so
-// only the severity floor applies — re-budgeting them would punch holes in the
-// complete-retained-trace contract for no bytes saved.
-func (p *ExemplarPolicy) AllowSynthesizedLog(severity string) bool {
-	_, ok := p.logSlot(severity)
-	return ok
+// ReserveSynthesizedLog gates and METERS logs synthesized from span events and
+// span status (#201 Q3).
+//
+// These used to pass on a severity check alone, on the theory that they ride a
+// span the policy had already budgeted. They do ride it — and they are not
+// weightless. A span carrying two hundred exception events wrote two hundred
+// log rows that no budget had ever seen, which is precisely the kind of
+// unmetered write the 4.5 GiB main tier cannot absorb.
+//
+// So a synthesized log now reserves len(body) + len(attributesJSON) +
+// logRowFixedBytes against the selected trace's per-trace budget AND the shared
+// per-service and global window budgets, under its own per-span and per-trace
+// count caps. It does NOT consume the ordinary log-exemplar quota: that budget
+// exists for logs a client sent, and charging synthesized rows against it would
+// silently evict real ones.
+//
+// A refusal drops the log, counts a reasoned drop, and marks the trace
+// truncated so the gap appears in the persisted data.
+func (p *ExemplarPolicy) ReserveSynthesizedLog(res *ExemplarReservation, tenant, service, traceID, spanID, severity string, ts time.Time, size int) bool {
+	slot, ok := p.logSlot(severity)
+	if !ok {
+		// Aggregate-only severity. Never eligible, never a drop.
+		return false
+	}
+	if reason, shed := p.shedLog(slot); shed {
+		p.cfg.Metrics.RecordExemplarDropped("logs", reason)
+		return false
+	}
+
+	window := p.windowOf(ts)
+	sh := p.shardFor(service)
+	sh.mu.Lock()
+	sw := sh.window(windowKey{tenant: tenant, service: service, window: window})
+	st, ok := sw.traces[traceID]
+	if !ok || st.evicted {
+		// Its span is not retained, so the log would be dangling evidence.
+		sh.mu.Unlock()
+		return false
+	}
+	if st.synthTotal >= p.cfg.SynthLogsPerTrace {
+		p.markTruncated(st)
+		sh.mu.Unlock()
+		p.cfg.Metrics.RecordExemplarDropped("logs", exemplarReasonSynthPerTrace)
+		return false
+	}
+	if st.synthPerSpan[spanID] >= p.cfg.SynthLogsPerSpan {
+		p.markTruncated(st)
+		sh.mu.Unlock()
+		p.cfg.Metrics.RecordExemplarDropped("logs", exemplarReasonSynthPerSpan)
+		return false
+	}
+	n := int64(size + logRowFixedBytes)
+	if st.bytes+st.reserved+n > p.cfg.MaxBytesPerTrace || sw.bytes+sw.reservedBytes+n > p.cfg.BytesPerServiceWindow {
+		p.markTruncated(st)
+		sh.mu.Unlock()
+		p.cfg.Metrics.RecordExemplarDropped("logs", exemplarReasonBudgetBytes)
+		return false
+	}
+	gw, ok := p.reserveGlobalBytes(window, n)
+	if !ok {
+		p.markTruncated(st)
+		sh.mu.Unlock()
+		p.cfg.Metrics.RecordExemplarDropped("logs", exemplarReasonBudgetBytes)
+		return false
+	}
+	if st.synthPerSpan == nil {
+		st.synthPerSpan = make(map[string]int, 4)
+	}
+	st.synthPerSpan[spanID]++
+	st.synthTotal++
+	st.reserved += n
+	sw.reservedBytes += n
+	sh.mu.Unlock()
+
+	p.settle(res, exemplarReservationEntry{shard: sh, sw: sw, st: st, gw: gw, bytes: n})
+	return true
+}
+
+// SynthesizedLogEligible is the CHEAP half of ReserveSynthesizedLog: the
+// severity floor plus the shedding ladder, with no locks and no accounting.
+//
+// It exists so the OTLP path can refuse an INFO span event before marshaling
+// its attributes. Passing it is necessary, not sufficient — the caller must
+// still ReserveSynthesizedLog once it knows the row's size, and that call
+// re-checks everything this one did.
+func (p *ExemplarPolicy) SynthesizedLogEligible(severity string) bool {
+	slot, ok := p.logSlot(severity)
+	if !ok {
+		return false
+	}
+	_, shed := p.shedLog(slot)
+	return !shed
+}
+
+// SetShedding publishes the disk watchdog's current state to the policy.
+// Called from the watchdog goroutine; safe on a nil policy.
+func (p *ExemplarPolicy) SetShedding(s storage.SheddingState) {
+	if p == nil {
+		return
+	}
+	p.shed.Store(int32(s))
+}
+
+// Shedding reports the current shedding state. Safe on a nil policy.
+func (p *ExemplarPolicy) Shedding() storage.SheddingState {
+	if p == nil {
+		return storage.SheddingNone
+	}
+	return storage.SheddingState(p.shed.Load())
+}
+
+// DLQDisabled reports whether the exemplar DLQ fallback is closed. True at
+// raw-off: deferring an exemplar to the DLQ at 95% is still writing to the
+// disk that is about to fill (#201 Q5).
+func (p *ExemplarPolicy) DLQDisabled() bool {
+	return p.Shedding() >= storage.SheddingRawOff
+}
+
+// shedSpan applies the shedding ladder to a span's priority class.
+func (p *ExemplarPolicy) shedSpan(class int) (string, bool) {
+	switch p.Shedding() {
+	case storage.SheddingRawOff:
+		return exemplarReasonShedRawOff, true
+	case storage.SheddingErrorsOnly:
+		if class != exemplarClassError {
+			return exemplarReasonShedErrorsOnly, true
+		}
+	}
+	return "", false
+}
+
+// shedLog applies the shedding ladder to a log slot, returning the drop reason
+// when the log must be refused. slot 0 is ERROR/FATAL, slot 1 is WARN.
+func (p *ExemplarPolicy) shedLog(slot int) (string, bool) {
+	switch p.Shedding() {
+	case storage.SheddingRawOff:
+		return exemplarReasonShedRawOff, true
+	case storage.SheddingErrorsOnly:
+		if slot != 0 {
+			return exemplarReasonShedErrorsOnly, true
+		}
+	}
+	return "", false
 }
 
 // logSlot maps a severity onto its raw-retention slot: 0 = ERROR/FATAL,
@@ -723,8 +1092,11 @@ func (p *ExemplarPolicy) evictLocked(sw *serviceWindow, window int64, traceID st
 		}
 	}
 	// The evicted trace keeps its traceState (so its own future spans are
-	// refused deterministically) but returns its global slot; its already
-	// charged bytes are NOT refunded, because those bytes really were written.
+	// refused deterministically) and returns its global COUNT slot. Its bytes
+	// are not touched here in either direction (#201 Q4): committed bytes are
+	// on disk and refunding them would let the window write past its budget,
+	// and reserved bytes belong to rows already handed to the submit path,
+	// which will commit or release them itself.
 	p.releaseGlobalTrace(window)
 	p.cfg.Metrics.RecordExemplarEviction()
 	p.pruneEvictedLocked(sw)
@@ -761,8 +1133,9 @@ func (p *ExemplarPolicy) reserveGlobalTrace(window int64) bool {
 	return true
 }
 
-// releaseGlobalTrace returns one instance-wide slot for the window. Bytes are
-// deliberately not refunded — those bytes really were written.
+// releaseGlobalTrace returns one instance-wide COUNT slot for the window. Bytes
+// are never refunded here: they are settled by the reservation lifecycle, which
+// is the only place that knows whether a destination accepted the row.
 func (p *ExemplarPolicy) releaseGlobalTrace(window int64) {
 	p.globalMu.Lock()
 	defer p.globalMu.Unlock()
@@ -771,16 +1144,22 @@ func (p *ExemplarPolicy) releaseGlobalTrace(window int64) {
 	}
 }
 
-// reserveGlobalBytes takes n bytes from the instance-wide window budget.
-func (p *ExemplarPolicy) reserveGlobalBytes(window int64, n int64) bool {
+// reserveGlobalBytes holds n bytes of the instance-wide window budget and
+// returns the cell holding them, so commit/release can find it again without a
+// map lookup that a window prune could have invalidated.
+//
+// Reserved bytes count against the cap exactly like committed ones. They are
+// rows that are about to be written; treating them as free is how a budget
+// overshoots by one Export per window.
+func (p *ExemplarPolicy) reserveGlobalBytes(window int64, n int64) (*globalWindow, bool) {
 	p.globalMu.Lock()
 	defer p.globalMu.Unlock()
 	gw := p.globalFor(window)
-	if gw.bytes+n > p.cfg.BytesGlobalWindow {
-		return false
+	if gw.bytes+gw.reserved+n > p.cfg.BytesGlobalWindow {
+		return nil, false
 	}
-	gw.bytes += n
-	return true
+	gw.reserved += n
+	return gw, true
 }
 
 // globalFor returns the global cell for a window, pruning older ones. Caller
@@ -818,6 +1197,46 @@ func (p *ExemplarPolicy) SelectedTraces(tenant, service string, ts time.Time) []
 		}
 	}
 	return out
+}
+
+// WindowBytes returns the instance-wide (committed, reserved) bytes for the
+// window containing ts. Test and diagnostic surface: the monotonicity property
+// of #201 Q4 is stated over the committed number.
+func (p *ExemplarPolicy) WindowBytes(ts time.Time) (committed, reserved int64) {
+	window := p.windowOf(ts)
+	p.globalMu.Lock()
+	defer p.globalMu.Unlock()
+	gw, ok := p.global[window]
+	if !ok {
+		return 0, 0
+	}
+	return gw.bytes, gw.reserved
+}
+
+// GlobalTraceSlots returns how many instance-wide trace slots the window
+// containing ts is holding. Test and diagnostic surface.
+func (p *ExemplarPolicy) GlobalTraceSlots(ts time.Time) int {
+	window := p.windowOf(ts)
+	p.globalMu.Lock()
+	defer p.globalMu.Unlock()
+	if gw, ok := p.global[window]; ok {
+		return gw.traces
+	}
+	return 0
+}
+
+// ServiceWindowBytes returns the (committed, reserved) bytes of one
+// (tenant, service, window) budget cell. Test and diagnostic surface.
+func (p *ExemplarPolicy) ServiceWindowBytes(tenant, service string, ts time.Time) (committed, reserved int64) {
+	window := p.windowOf(ts)
+	sh := p.shardFor(service)
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	sw, ok := sh.services[windowKey{tenant: tenant, service: service, window: window}]
+	if !ok {
+		return 0, 0
+	}
+	return sw.bytes, sw.reservedBytes
 }
 
 // spanRowBytes estimates the bytes a span row hands to persistence. It counts

--- a/internal/ingest/exemplar_budget_test.go
+++ b/internal/ingest/exemplar_budget_test.go
@@ -1,0 +1,593 @@
+package ingest
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+// Reservation lifecycle, synthesized-log metering and disk shedding (#201
+// Q3/Q4/Q5). The recorder, offer helpers and admission scaffolding are shared
+// with exemplar_test.go — these tests add cases, not a second harness.
+
+// budgetPolicy builds a policy with the shared recorder and the caller's
+// overrides applied on top of the frozen defaults.
+func budgetPolicy(t *testing.T, mutate func(*ExemplarConfig)) (*ExemplarPolicy, *countingExemplarMetrics) {
+	t.Helper()
+	rec := newCountingExemplarMetrics()
+	cfg := ExemplarConfig{
+		LatencyThresholdMs: 500,
+		Metrics:            rec,
+	}
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	return NewExemplarPolicy(cfg), rec
+}
+
+// admitOne selects one trace and returns its span input.
+func admitOne(t *testing.T, p *ExemplarPolicy, traceID string, ts time.Time) ExemplarSpan {
+	t.Helper()
+	in := ExemplarSpan{
+		Tenant:    storage.DefaultTenantID,
+		Service:   "checkout",
+		TraceID:   traceID,
+		Operation: "GET /checkout",
+		Status:    storage.StatusCodeError,
+		Timestamp: ts,
+	}
+	if !p.AdmitSpan(in) {
+		t.Fatalf("AdmitSpan(%s) refused a first error span", traceID)
+	}
+	return in
+}
+
+// TestReservationCommitMovesBytesFromReservedToCommitted is the base case of
+// the lifecycle: reserved bytes bind the budget immediately, and commit is a
+// state change rather than a second charge.
+func TestReservationCommitMovesBytesFromReservedToCommitted(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, _ := budgetPolicy(t, nil)
+	in := admitOne(t, p, fmt.Sprintf("%032x", 1), ts)
+
+	res := p.NewReservation()
+	if !p.ReserveSpan(res, in.Tenant, in.Service, in.TraceID, ts, 4096) {
+		t.Fatal("ReserveSpan refused a span inside every budget")
+	}
+	committed, reserved := p.WindowBytes(ts)
+	if committed != 0 || reserved != 4096 {
+		t.Fatalf("after reserve: committed=%d reserved=%d, want 0/4096", committed, reserved)
+	}
+	if svcCommitted, svcReserved := p.ServiceWindowBytes(in.Tenant, in.Service, ts); svcCommitted != 0 || svcReserved != 4096 {
+		t.Fatalf("service window after reserve: committed=%d reserved=%d, want 0/4096", svcCommitted, svcReserved)
+	}
+
+	res.Commit()
+	committed, reserved = p.WindowBytes(ts)
+	if committed != 4096 || reserved != 0 {
+		t.Fatalf("after commit: committed=%d reserved=%d, want 4096/0", committed, reserved)
+	}
+
+	// Idempotent: a second Commit must not double-charge.
+	res.Commit()
+	if committed, _ = p.WindowBytes(ts); committed != 4096 {
+		t.Fatalf("second Commit charged again: committed=%d, want 4096", committed)
+	}
+}
+
+// TestReservationReleaseReturnsBytes covers the only legitimate refund: rows
+// that reached no destination at all.
+func TestReservationReleaseReturnsBytes(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, _ := budgetPolicy(t, nil)
+	in := admitOne(t, p, fmt.Sprintf("%032x", 1), ts)
+
+	res := p.NewReservation()
+	if !p.ReserveSpan(res, in.Tenant, in.Service, in.TraceID, ts, 4096) {
+		t.Fatal("ReserveSpan refused a span inside every budget")
+	}
+	res.Release()
+
+	committed, reserved := p.WindowBytes(ts)
+	if committed != 0 || reserved != 0 {
+		t.Fatalf("after release: committed=%d reserved=%d, want 0/0", committed, reserved)
+	}
+	if svcCommitted, svcReserved := p.ServiceWindowBytes(in.Tenant, in.Service, ts); svcCommitted != 0 || svcReserved != 0 {
+		t.Fatalf("service window after release: committed=%d reserved=%d, want 0/0", svcCommitted, svcReserved)
+	}
+
+	// Release after Release must not underflow the pools.
+	res.Release()
+	if committed, reserved = p.WindowBytes(ts); committed != 0 || reserved != 0 {
+		t.Fatalf("double release moved the pools: committed=%d reserved=%d", committed, reserved)
+	}
+}
+
+// TestCommittedBytesSurvivePostAcceptanceEviction is the property #201 Q4 was
+// written for: once a destination accepted the rows, displacing the trace
+// must NOT hand the bytes back. Those bytes are on disk; refunding them would
+// let the window write past its cap.
+func TestCommittedBytesSurvivePostAcceptanceEviction(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	// One trace slot per service, so the second trace must displace the first.
+	p, rec := budgetPolicy(t, func(c *ExemplarConfig) {
+		c.TracesPerServiceWindow = 1
+		c.StratumTopK = 1
+	})
+
+	// A high hash first so a lower one can displace it.
+	var high, low string
+	for i := 0; i < 500; i++ {
+		id := fmt.Sprintf("%032x", i)
+		if high == "" || exemplarHash(id) > exemplarHash(high) {
+			high = id
+		}
+		if low == "" || exemplarHash(id) < exemplarHash(low) {
+			low = id
+		}
+	}
+
+	first := admitOne(t, p, high, ts)
+	res := p.NewReservation()
+	if !p.ReserveSpan(res, first.Tenant, first.Service, first.TraceID, ts, 8192) {
+		t.Fatal("ReserveSpan refused the first span")
+	}
+	res.Commit() // the queue accepted the batch: the bytes are written
+
+	if committed, _ := p.WindowBytes(ts); committed != 8192 {
+		t.Fatalf("committed=%d before eviction, want 8192", committed)
+	}
+	slotsBefore := p.GlobalTraceSlots(ts)
+
+	// Displace it with a strictly better-ranked trace.
+	second := ExemplarSpan{
+		Tenant: storage.DefaultTenantID, Service: "checkout", TraceID: low,
+		Operation: "GET /checkout", Status: storage.StatusCodeError, Timestamp: ts,
+	}
+	if !p.AdmitSpan(second) {
+		t.Fatal("a strictly better-ranked error trace was refused the full window")
+	}
+	if _, _, evictions, _ := rec.snapshot(); evictions == 0 {
+		t.Fatal("no eviction recorded; the test did not exercise displacement")
+	}
+
+	committed, reserved := p.WindowBytes(ts)
+	if committed != 8192 {
+		t.Fatalf("eviction refunded committed bytes: committed=%d, want 8192 — bytes on disk are never refunded", committed)
+	}
+	if reserved != 0 {
+		t.Fatalf("reserved=%d after eviction, want 0", reserved)
+	}
+
+	// Count slots, unlike bytes, ARE released on eviction: a slot is a seat,
+	// not a byte. The evicted trace returned its seat and the newcomer took
+	// one, so the instance-wide count is unchanged.
+	if got := p.GlobalTraceSlots(ts); got != slotsBefore {
+		t.Fatalf("global trace slots = %d after displacement, want %d (evicted trace must return its slot)", got, slotsBefore)
+	}
+}
+
+// TestReservedBytesBindTheBudgetBeforeCommit: an uncommitted reservation is a
+// row about to be written, so it must count against the cap. Otherwise one
+// Export per window overshoots by the whole cap.
+func TestReservedBytesBindTheBudgetBeforeCommit(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, rec := budgetPolicy(t, func(c *ExemplarConfig) {
+		c.BytesGlobalWindow = 8192
+		c.BytesPerServiceWindow = 8192
+	})
+	in := admitOne(t, p, fmt.Sprintf("%032x", 1), ts)
+
+	res := p.NewReservation()
+	if !p.ReserveSpan(res, in.Tenant, in.Service, in.TraceID, ts, 8192) {
+		t.Fatal("first reservation should fit exactly")
+	}
+	// Nothing committed yet — and the budget must still be full.
+	if p.ReserveSpan(res, in.Tenant, in.Service, in.TraceID, ts, 1) {
+		t.Fatal("a second byte was reserved past a full window: reserved bytes are not binding the cap")
+	}
+	if _, dropped, _, _ := rec.snapshot(); dropped["traces/"+exemplarReasonBudgetBytes] == 0 {
+		t.Error("over-budget reservation was not counted as a budget_bytes drop")
+	}
+}
+
+// TestReservationMergeSettlesOnce: merged reservations settle exactly once, so
+// the per-resource goroutines can be folded into one per-tenant batch.
+func TestReservationMergeSettlesOnce(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, _ := budgetPolicy(t, nil)
+	in := admitOne(t, p, fmt.Sprintf("%032x", 1), ts)
+
+	a := p.NewReservation()
+	b := p.NewReservation()
+	if !p.ReserveSpan(a, in.Tenant, in.Service, in.TraceID, ts, 1024) {
+		t.Fatal("reserve a")
+	}
+	if !p.ReserveSpan(b, in.Tenant, in.Service, in.TraceID, ts, 2048) {
+		t.Fatal("reserve b")
+	}
+	a.Merge(b)
+	if got := a.Bytes(); got != 3072 {
+		t.Fatalf("merged reservation holds %d bytes, want 3072", got)
+	}
+	a.Commit()
+	b.Release() // neutralized by the merge; must be a no-op
+
+	committed, reserved := p.WindowBytes(ts)
+	if committed != 3072 || reserved != 0 {
+		t.Fatalf("after merge+commit: committed=%d reserved=%d, want 3072/0", committed, reserved)
+	}
+}
+
+// --- Q3: synthesized-log metering -------------------------------------------
+
+// TestSynthesizedLogsAreMetered: they ride the selected trace and they are not
+// weightless. Bytes land on the same pools as spans.
+func TestSynthesizedLogsAreMetered(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, _ := budgetPolicy(t, nil)
+	in := admitOne(t, p, fmt.Sprintf("%032x", 1), ts)
+
+	res := p.NewReservation()
+	if !p.ReserveSynthesizedLog(res, in.Tenant, in.Service, in.TraceID, "span-1", "ERROR", ts, 100) {
+		t.Fatal("ReserveSynthesizedLog refused a log inside every budget")
+	}
+	want := int64(100 + logRowFixedBytes)
+	if _, reserved := p.WindowBytes(ts); reserved != want {
+		t.Fatalf("synthesized log reserved %d bytes, want %d", reserved, want)
+	}
+	res.Commit()
+	if committed, _ := p.WindowBytes(ts); committed != want {
+		t.Fatalf("synthesized log committed %d bytes, want %d", committed, want)
+	}
+}
+
+// TestSynthesizedLogsDoNotConsumeTheClientLogQuota: the ordinary log-exemplar
+// budget exists for logs a client actually sent. Charging synthesized rows to
+// it would silently evict real ones.
+func TestSynthesizedLogsDoNotConsumeTheClientLogQuota(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, _ := budgetPolicy(t, func(c *ExemplarConfig) { c.LogsErrorPerServiceWindow = 2 })
+	in := admitOne(t, p, fmt.Sprintf("%032x", 1), ts)
+
+	res := p.NewReservation()
+	for i := 0; i < 5; i++ {
+		if !p.ReserveSynthesizedLog(res, in.Tenant, in.Service, in.TraceID, "span-1", "ERROR", ts, 10) {
+			t.Fatalf("synthesized log %d refused below the per-span cap", i)
+		}
+	}
+	// The client log quota must be untouched: two client ERROR logs still fit.
+	for i := 0; i < 2; i++ {
+		if !p.ReserveLog(res, in.Tenant, in.Service, "ERROR", ts, 10) {
+			t.Fatalf("client log %d refused: synthesized logs ate the client quota", i)
+		}
+	}
+	if p.ReserveLog(res, in.Tenant, in.Service, "ERROR", ts, 10) {
+		t.Fatal("client log quota did not bind at 2")
+	}
+}
+
+// TestSynthesizedLogPerSpanCap: one pathological span cannot write an
+// unbounded number of log rows.
+func TestSynthesizedLogPerSpanCap(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, rec := budgetPolicy(t, func(c *ExemplarConfig) { c.SynthLogsPerSpan = 3 })
+	in := admitOne(t, p, fmt.Sprintf("%032x", 1), ts)
+
+	res := p.NewReservation()
+	admitted := 0
+	for i := 0; i < 10; i++ {
+		if p.ReserveSynthesizedLog(res, in.Tenant, in.Service, in.TraceID, "span-1", "ERROR", ts, 10) {
+			admitted++
+		}
+	}
+	if admitted != 3 {
+		t.Fatalf("admitted %d synthesized logs for one span, want 3", admitted)
+	}
+	_, dropped, _, truncations := rec.snapshot()
+	if dropped["logs/"+exemplarReasonSynthPerSpan] == 0 {
+		t.Error("per-span refusals were not counted as synth_per_span")
+	}
+	if truncations == 0 {
+		t.Error("per-span refusal did not mark the trace truncated")
+	}
+	stats, ok := p.TraceStats(in.Tenant, in.Service, in.TraceID, ts)
+	if !ok || !stats.Truncated {
+		t.Fatalf("TraceStats truncated=%v ok=%v, want a truncated trace", stats.Truncated, ok)
+	}
+
+	// A different span of the same trace gets its own per-span allowance.
+	if !p.ReserveSynthesizedLog(res, in.Tenant, in.Service, in.TraceID, "span-2", "ERROR", ts, 10) {
+		t.Fatal("a second span was refused its own per-span allowance")
+	}
+}
+
+// TestSynthesizedLogPerTraceCap: the per-trace cap binds across spans.
+func TestSynthesizedLogPerTraceCap(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, rec := budgetPolicy(t, func(c *ExemplarConfig) {
+		c.SynthLogsPerSpan = 2
+		c.SynthLogsPerTrace = 5
+	})
+	in := admitOne(t, p, fmt.Sprintf("%032x", 1), ts)
+
+	res := p.NewReservation()
+	admitted := 0
+	for span := 0; span < 10; span++ {
+		for i := 0; i < 2; i++ {
+			if p.ReserveSynthesizedLog(res, in.Tenant, in.Service, in.TraceID, fmt.Sprintf("span-%d", span), "ERROR", ts, 10) {
+				admitted++
+			}
+		}
+	}
+	if admitted != 5 {
+		t.Fatalf("admitted %d synthesized logs for one trace, want 5", admitted)
+	}
+	if _, dropped, _, _ := rec.snapshot(); dropped["logs/"+exemplarReasonSynthPerTrace] == 0 {
+		t.Error("per-trace refusals were not counted as synth_per_trace")
+	}
+}
+
+// TestSynthesizedLogByteBudgetMarksTruncated: byte refusals are counted as
+// budget_bytes and stamp the trace, so the gap is in the data.
+func TestSynthesizedLogByteBudgetMarksTruncated(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, rec := budgetPolicy(t, func(c *ExemplarConfig) {
+		c.MaxBytesPerTrace = 1024
+		c.SynthLogsPerSpan = 1000
+		c.SynthLogsPerTrace = 1000
+	})
+	in := admitOne(t, p, fmt.Sprintf("%032x", 1), ts)
+
+	res := p.NewReservation()
+	admitted := 0
+	for i := 0; i < 100; i++ {
+		if p.ReserveSynthesizedLog(res, in.Tenant, in.Service, in.TraceID, "span-1", "ERROR", ts, 64) {
+			admitted++
+		}
+	}
+	perLog := int64(64 + logRowFixedBytes)
+	if want := int(1024 / perLog); admitted != want {
+		t.Fatalf("admitted %d synthesized logs, want %d — the per-trace byte budget did not bind", admitted, want)
+	}
+	_, dropped, _, truncations := rec.snapshot()
+	if dropped["logs/"+exemplarReasonBudgetBytes] == 0 {
+		t.Error("byte refusals were not counted as budget_bytes")
+	}
+	if truncations == 0 {
+		t.Error("byte refusal did not mark the trace truncated")
+	}
+}
+
+// TestSynthesizedLogsRefusedForUnselectedTrace: a synthesized log whose span
+// is not retained would be dangling evidence.
+func TestSynthesizedLogsRefusedForUnselectedTrace(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, _ := budgetPolicy(t, nil)
+	if p.ReserveSynthesizedLog(nil, storage.DefaultTenantID, "checkout", "never-selected", "span-1", "ERROR", ts, 10) {
+		t.Fatal("a synthesized log was admitted for a trace the policy never selected")
+	}
+}
+
+// TestSynthesizedLogSeverityFloorUnchanged: INFO/DEBUG remain aggregate-only.
+func TestSynthesizedLogSeverityFloorUnchanged(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, _ := budgetPolicy(t, nil)
+	in := admitOne(t, p, fmt.Sprintf("%032x", 1), ts)
+	for _, sev := range []string{"INFO", "DEBUG", "TRACE", "WARN"} {
+		if p.ReserveSynthesizedLog(nil, in.Tenant, in.Service, in.TraceID, "span-1", sev, ts, 10) {
+			t.Fatalf("severity %s was raw-retained; only ERROR/FATAL are (WARN is opt-in)", sev)
+		}
+	}
+}
+
+// --- Q5: shedding ------------------------------------------------------------
+
+// TestSheddingErrorsOnlyKeepsErrors: at >=90% healthy and slow raw retention
+// is off and errors still land.
+func TestSheddingErrorsOnlyKeepsErrors(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, rec := budgetPolicy(t, func(c *ExemplarConfig) { c.HealthyRate = 1.0 })
+	p.SetShedding(storage.SheddingErrorsOnly)
+
+	healthy := ExemplarSpan{
+		Tenant: storage.DefaultTenantID, Service: "checkout", TraceID: fmt.Sprintf("%032x", 7),
+		Operation: "GET /checkout", Status: "STATUS_CODE_OK", Timestamp: ts,
+	}
+	if p.AdmitSpan(healthy) {
+		t.Fatal("a healthy span was admitted while shedding to errors only")
+	}
+	slow := healthy
+	slow.TraceID = fmt.Sprintf("%032x", 8)
+	slow.DurationMs = 5000
+	if p.AdmitSpan(slow) {
+		t.Fatal("a slow span was admitted while shedding to errors only")
+	}
+	errSpan := healthy
+	errSpan.TraceID = fmt.Sprintf("%032x", 9)
+	errSpan.Status = storage.StatusCodeError
+	if !p.AdmitSpan(errSpan) {
+		t.Fatal("an error span was refused while shedding to errors only")
+	}
+	if _, dropped, _, _ := rec.snapshot(); dropped["traces/"+exemplarReasonShedErrorsOnly] != 2 {
+		t.Fatalf("shed_errors_only drops = %d, want 2", dropped["traces/"+exemplarReasonShedErrorsOnly])
+	}
+
+	// WARN logs go with the healthy traffic; ERROR logs stay.
+	pw, _ := budgetPolicy(t, func(c *ExemplarConfig) { c.LogsWarnEnabled = true })
+	pw.SetShedding(storage.SheddingErrorsOnly)
+	if pw.ReserveLog(nil, storage.DefaultTenantID, "checkout", "WARN", ts, 16) {
+		t.Fatal("a WARN log was admitted while shedding to errors only")
+	}
+	if !pw.ReserveLog(nil, storage.DefaultTenantID, "checkout", "ERROR", ts, 16) {
+		t.Fatal("an ERROR log was refused while shedding to errors only")
+	}
+}
+
+// TestSheddingRawOffRefusesEverything: at >=95% nothing raw is admitted, and
+// the DLQ fallback closes with it.
+func TestSheddingRawOffRefusesEverything(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, rec := budgetPolicy(t, nil)
+	in := admitOne(t, p, fmt.Sprintf("%032x", 1), ts)
+	p.SetShedding(storage.SheddingRawOff)
+
+	next := in
+	next.TraceID = fmt.Sprintf("%032x", 2)
+	if p.AdmitSpan(next) {
+		t.Fatal("an error span was admitted at raw-off")
+	}
+	if p.ReserveLog(nil, in.Tenant, in.Service, "ERROR", ts, 16) {
+		t.Fatal("an ERROR log was admitted at raw-off")
+	}
+	if p.ReserveSynthesizedLog(nil, in.Tenant, in.Service, in.TraceID, "span-1", "ERROR", ts, 16) {
+		t.Fatal("a synthesized log was admitted at raw-off")
+	}
+	if !p.DLQDisabled() {
+		t.Fatal("the exemplar DLQ fallback is still open at raw-off")
+	}
+	_, dropped, _, _ := rec.snapshot()
+	if dropped["traces/"+exemplarReasonShedRawOff] == 0 || dropped["logs/"+exemplarReasonShedRawOff] == 0 {
+		t.Fatalf("raw-off drops were not counted: %v", dropped)
+	}
+}
+
+// TestSheddingCutsAnAlreadySelectedTraceShort: shedding outranks the
+// complete-retained-trace contract, and says so in the data.
+func TestSheddingCutsAnAlreadySelectedTraceShort(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, _ := budgetPolicy(t, func(c *ExemplarConfig) { c.HealthyRate = 1.0 })
+
+	healthy := ExemplarSpan{
+		Tenant: storage.DefaultTenantID, Service: "checkout", TraceID: fmt.Sprintf("%032x", 7),
+		Operation: "GET /checkout", Status: "STATUS_CODE_OK", Timestamp: ts,
+	}
+	if !p.AdmitSpan(healthy) {
+		t.Fatal("healthy span refused before shedding")
+	}
+	p.SetShedding(storage.SheddingErrorsOnly)
+	if p.AdmitSpan(healthy) {
+		t.Fatal("a later span of a selected healthy trace was admitted while shedding")
+	}
+	stats, ok := p.TraceStats(healthy.Tenant, healthy.Service, healthy.TraceID, ts)
+	if !ok || !stats.Truncated {
+		t.Fatalf("TraceStats truncated=%v ok=%v: a trace cut short by shedding must be stamped", stats.Truncated, ok)
+	}
+}
+
+// TestNilPolicyShedAccessorsAreSafe: legacy and shadow mode carry a nil
+// policy and must not need a branch at every call site.
+func TestNilPolicyShedAccessorsAreSafe(t *testing.T) {
+	var p *ExemplarPolicy
+	p.SetShedding(storage.SheddingRawOff)
+	if p.Shedding() != storage.SheddingNone {
+		t.Fatal("nil policy reported a shedding state")
+	}
+	if p.DLQDisabled() {
+		t.Fatal("nil policy closed the DLQ")
+	}
+	if r := p.NewReservation(); r != nil {
+		t.Fatal("nil policy handed out a reservation")
+	}
+	var r *ExemplarReservation
+	r.Commit()
+	r.Release()
+	r.Merge(nil)
+	if r.Bytes() != 0 || r.Len() != 0 {
+		t.Fatal("nil reservation reported bytes")
+	}
+}
+
+// --- Q4 at the Export boundary ----------------------------------------------
+
+// exportPolicy wires a TraceServer in aggregate mode over pipeline p with a
+// live exemplar policy, and returns the policy so the byte pools can be read.
+func exportPolicy(t *testing.T, p *Pipeline, now time.Time) (*TraceServer, *ExemplarPolicy) {
+	t.Helper()
+	pol := NewExemplarPolicy(ExemplarConfig{
+		LatencyThresholdMs: 500,
+		Metrics:            newCountingExemplarMetrics(),
+	})
+	srv := NewTraceServer(nil, nil, aggTestConfig())
+	srv.SetPipeline(p)
+	srv.SetAggregateEngine(ackEngine(t, "aggregate", now))
+	srv.SetExemplarPolicy(pol)
+	return srv, pol
+}
+
+// TestExportCommitsReservationsOnQueueAcceptance: the queue took the rows, so
+// the bytes are a charge, not a reservation.
+func TestExportCommitsReservationsOnQueueAcceptance(t *testing.T) {
+	now := time.Now().UTC()
+	p := NewPipeline(&fakeWriter{}, nil, PipelineConfig{Capacity: 16, Workers: 1})
+	srv, pol := exportPolicy(t, p, now)
+
+	if _, err := srv.Export(t.Context(), ackErrorSpanRequest(3, now)); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	committed, reserved := pol.WindowBytes(now)
+	if committed == 0 {
+		t.Fatal("nothing was committed after the queue accepted the batch")
+	}
+	if reserved != 0 {
+		t.Fatalf("reserved=%d after acceptance, want 0 — the reservation never settled", reserved)
+	}
+}
+
+// TestExportReleasesReservationsWhenNothingAcceptsTheBatch: the primary queue
+// is full and there is no DLQ, so the rows reached nothing. Their bytes must
+// go back, or the window is charged for writes that never happened.
+func TestExportReleasesReservationsWhenNothingAcceptsTheBatch(t *testing.T) {
+	now := time.Now().UTC()
+	p := saturatedPipeline(t, nil, nil) // no DLQ sink
+	srv, pol := exportPolicy(t, p, now)
+
+	// Aggregate mode acknowledges the Export even though the raw rows are
+	// lost — that is the #196 contract and it does not change here.
+	resp, err := srv.Export(t.Context(), ackErrorSpanRequest(3, now))
+	if err != nil {
+		t.Fatalf("Export must still succeed once the aggregate commit landed: %v", err)
+	}
+	if resp.GetPartialSuccess() == nil {
+		t.Fatal("partial_success not populated for permanently lost exemplars")
+	}
+	committed, reserved := pol.WindowBytes(now)
+	if committed != 0 || reserved != 0 {
+		t.Fatalf("committed=%d reserved=%d after a batch nothing accepted, want 0/0", committed, reserved)
+	}
+}
+
+// TestReleaseReturnsSpanSlotsButNotSynthesizedOnes: releasing a reservation
+// hands back the retained-SPAN count for spans and leaves it alone for
+// synthesized logs, which never took one. Getting this wrong drives
+// retained_span_count negative on the persisted trace row.
+func TestReleaseReturnsSpanSlotsButNotSynthesizedOnes(t *testing.T) {
+	ts := time.Unix(1_700_000_000, 0).UTC()
+	p, _ := budgetPolicy(t, nil)
+	in := admitOne(t, p, fmt.Sprintf("%032x", 1), ts)
+
+	keep := p.NewReservation()
+	if !p.ReserveSpan(keep, in.Tenant, in.Service, in.TraceID, ts, 512) {
+		t.Fatal("reserve the span that stays")
+	}
+	keep.Commit()
+
+	drop := p.NewReservation()
+	if !p.ReserveSpan(drop, in.Tenant, in.Service, in.TraceID, ts, 512) {
+		t.Fatal("reserve the span that is dropped")
+	}
+	if !p.ReserveSynthesizedLog(drop, in.Tenant, in.Service, in.TraceID, "span-1", "ERROR", ts, 32) {
+		t.Fatal("reserve the synthesized log that is dropped")
+	}
+	drop.Release()
+
+	stats, ok := p.TraceStats(in.Tenant, in.Service, in.TraceID, ts)
+	if !ok {
+		t.Fatal("TraceStats missing for a selected trace")
+	}
+	if stats.Retained != 1 {
+		t.Fatalf("retained = %d after releasing one span and one synthesized log, want 1", stats.Retained)
+	}
+}

--- a/internal/ingest/exemplar_test.go
+++ b/internal/ingest/exemplar_test.go
@@ -101,7 +101,7 @@ func offerAll(p *ExemplarPolicy, service string, ts time.Time, offers []exemplar
 			// Real callers always follow an admission with a charge; skipping
 			// it here would leave the byte budget untouched and make the count
 			// tests silently depend on charge-free admission.
-			p.ChargeSpan(in.Tenant, service, o.traceID, ts, 512)
+			p.ReserveSpan(nil, in.Tenant, service, o.traceID, ts, 512)
 		}
 	}
 	return admitted
@@ -291,7 +291,7 @@ func TestExemplarByteBudgetBindsIndependentlyOfCount(t *testing.T) {
 		if !p.AdmitSpan(in) {
 			continue
 		}
-		if p.ChargeSpan(in.Tenant, "checkout", id, ts, spanBytes) {
+		if p.ReserveSpan(nil, in.Tenant, "checkout", id, ts, spanBytes) {
 			charged++
 		}
 	}
@@ -322,7 +322,7 @@ func TestExemplarWarnLogsAreOptIn(t *testing.T) {
 	admitN := func(p *ExemplarPolicy, severity string, n int) int {
 		admitted := 0
 		for i := 0; i < n; i++ {
-			if p.AdmitLog(storage.DefaultTenantID, "checkout", severity, ts, 64) {
+			if p.ReserveLog(nil, storage.DefaultTenantID, "checkout", severity, ts, 64) {
 				admitted++
 			}
 		}
@@ -693,7 +693,7 @@ func TestExemplarConcurrentAdmissionIsRaceFree(t *testing.T) {
 					Operation: fmt.Sprintf("op-%d", i%7), Status: storage.StatusCodeError, Timestamp: ts,
 				}
 				if p.AdmitSpan(in) {
-					p.ChargeSpan(in.Tenant, in.Service, id, ts, 256)
+					p.ReserveSpan(nil, in.Tenant, in.Service, id, ts, 256)
 					p.TraceStats(in.Tenant, in.Service, id, ts)
 				}
 			}

--- a/internal/ingest/otlp.go
+++ b/internal/ingest/otlp.go
@@ -483,6 +483,11 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 		// request-local and lock-free, so each goroutine owns its own reducer
 		// and they are merged once below.
 		reducer *aggregate.Reducer
+		// exemplarRes holds the exemplar bytes this resource batch RESERVED
+		// (#201 Q4). Reservations are per-goroutine and merged by tenant
+		// below, then committed when a destination accepts the batch or
+		// released when nothing does.
+		exemplarRes *ExemplarReservation
 	}
 
 	results := make([]batchResult, len(req.ResourceSpans))
@@ -508,6 +513,9 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 			// exactly one Trace row per trace instead of one per span.
 			traceIdx := make(map[string]int)
 			var localHasErr, localHasSlow bool
+			// One reservation per resource batch; nil when no exemplar policy
+			// is wired (legacy/shadow), which every method tolerates.
+			exemplarRes := s.exemplar.NewReservation()
 
 			// Aggregate accounting. One arrival time for the whole Export
 			// request (#160), captured above as `start`.
@@ -611,13 +619,15 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 					}
 					// Byte metering happens here, on the row that is actually
 					// handed to persistence, not on the OTLP wire message —
-					// the byte budget is a budget on what gets written. A
-					// refusal drops this span and marks the trace truncated;
-					// the trace row below still lands so the gap is recorded
-					// in the data rather than left to be inferred.
+					// the byte budget is a budget on what gets written. The
+					// bytes are RESERVED, not charged: they become a charge
+					// when a destination accepts the batch and evaporate if
+					// none does (#201 Q4). A refusal drops this span and marks
+					// the trace truncated; the trace row below still lands so
+					// the gap is recorded in the data rather than inferred.
 					keepSpan := true
 					if s.exemplar != nil {
-						keepSpan = s.exemplar.ChargeSpan(tenantID, serviceName, traceIDHex, startTime, spanRowBytes(&sModel))
+						keepSpan = s.exemplar.ReserveSpan(exemplarRes, tenantID, serviceName, traceIDHex, startTime, spanRowBytes(&sModel))
 					}
 					if keepSpan {
 						localSpans = append(localSpans, sModel)
@@ -678,10 +688,10 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 						if !shouldIngestSeverity(severity, s.minSeverity) {
 							continue
 						}
-						// Aggregate mode: INFO/DEBUG never persist raw (#161).
-						// Only the severity floor applies — these logs belong
-						// to a span the policy already selected and budgeted.
-						if s.exemplar != nil && !s.exemplar.AllowSynthesizedLog(severity) {
+						// Cheap gate before the attribute marshal: an INFO span
+						// event is aggregate-only in aggregate mode and must
+						// not cost a JSON encode to find that out.
+						if s.exemplar != nil && !s.exemplar.SynthesizedLogEligible(severity) {
 							continue
 						}
 
@@ -694,6 +704,19 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 						}
 
 						eventAttrs, _ := json.Marshal(event.Attributes)
+
+						// Aggregate mode: INFO/DEBUG never persist raw (#161),
+						// and every synthesized log that does is METERED
+						// against its trace's per-trace budget and the shared
+						// window budgets (#201 Q3). Riding a selected trace is
+						// not the same as being free.
+						if s.exemplar != nil && !s.exemplar.ReserveSynthesizedLog(
+							exemplarRes, tenantID, serviceName, traceIDHex, spanIDHex, severity,
+							time.Unix(0, int64(event.TimeUnixNano)), // #nosec G115 -- OTLP time in nanos: uint64 source fits int64 until year 2262
+							len(body)+len(eventAttrs),
+						) {
+							continue
+						}
 
 						l := storage.Log{
 							TenantID:       tenantID,
@@ -716,6 +739,16 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 							msg := span.Status.Message
 							if msg == "" {
 								msg = fmt.Sprintf("Span '%s' failed", span.Name)
+							}
+
+							// Metered like the event-derived logs above: the
+							// status fallback is one more row on the same
+							// budget. "{}" is the attributes payload.
+							if s.exemplar != nil && !s.exemplar.ReserveSynthesizedLog(
+								exemplarRes, tenantID, serviceName, traceIDHex, spanIDHex, "ERROR",
+								endTime, len(msg)+len("{}"),
+							) {
+								continue
 							}
 
 							l := storage.Log{
@@ -752,13 +785,14 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 
 			// Store results in pre-allocated slot (no mutex needed)
 			results[idx] = batchResult{
-				spans:   localSpans,
-				traces:  localTraces,
-				logs:    localLogs,
-				tenant:  tenantID,
-				hasErr:  localHasErr,
-				hasSlow: localHasSlow,
-				reducer: reducer,
+				spans:       localSpans,
+				traces:      localTraces,
+				logs:        localLogs,
+				tenant:      tenantID,
+				hasErr:      localHasErr,
+				hasSlow:     localHasSlow,
+				reducer:     reducer,
+				exemplarRes: exemplarRes,
 			}
 
 			return nil
@@ -779,11 +813,15 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 	// this collapses to exactly one group, i.e. the previous single-batch
 	// behaviour with Tenant now populated.
 	groups := newTenantGroups()
+	// Reservations merge along the same tenant boundary the batches do, so one
+	// Submit outcome settles exactly the bytes that Submit carried.
+	reservations := make(map[string]*ExemplarReservation, len(results))
 	for _, r := range results {
 		spansToInsert = append(spansToInsert, r.spans...)
 		tracesToUpsert = append(tracesToUpsert, r.traces...)
 		synthesizedLogs = append(synthesizedLogs, r.logs...)
 		groups.add(r.tenant, r.traces, r.spans, r.logs, r.hasErr, r.hasSlow)
+		mergeReservation(reservations, r.tenant, r.exemplarRes)
 		if r.reducer == nil {
 			continue
 		}
@@ -801,6 +839,10 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 	// it is a no-op here and runs after the submit loop instead; see the
 	// mode-conditional ordering note on applyAggregatePre.
 	if err := applyAggregatePre(s.aggregateEngine, merged); err != nil {
+		// Nothing was submitted, so nothing was written: the reserved bytes
+		// belong back in the window budget (#201 Q4). The client will retry
+		// and reserve them again.
+		releaseReservations(reservations)
 		return nil, err
 	}
 
@@ -836,13 +878,15 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 				HasSlow:      g.hasSlow,
 				SpanCallback: s.spanCallback,
 				LogCallback:  s.logCallback,
+				Reservation:  reservations[g.tenant],
 			})
 		}
 		// Selected raw exemplars for the trace signal are the retained SPANS.
 		// Trace rows are per-trace bookkeeping and synthesized logs were never
 		// sent by the client, so neither is reportable to OTLP (#196).
 		out, err := submitExemplars(s.pipeline, s.metrics, SignalTraces, batches,
-			aggregateACK(s.aggregateEngine), func(b *Batch) int { return len(b.Spans) })
+			aggregateACK(s.aggregateEngine), s.exemplar.DLQDisabled(),
+			func(b *Batch) int { return len(b.Spans) })
 		if err != nil {
 			if errors.Is(err, ErrQueueFull) {
 				return nil, grpcstatus.Errorf(codes.ResourceExhausted, "ingest pipeline at capacity")
@@ -883,6 +927,7 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 	if len(spansToInsert) > 0 {
 		if err := s.repo.BatchCreateSpans(spansToInsert); err != nil {
 			slog.Error("❌ Failed to insert spans", "error", err)
+			releaseReservations(reservations)
 			return nil, err
 		}
 		// Notify GraphRAG of persisted spans
@@ -892,6 +937,12 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 			}
 		}
 	}
+
+	// Synchronous fallback has no queue: the rows are either in the DB by now
+	// or they errored out above (which returns before this point for spans).
+	// Either way the submission boundary has passed, so the reservation
+	// settles here.
+	commitReservations(reservations)
 
 	if len(synthesizedLogs) > 0 {
 		if err := s.repo.BatchCreateLogs(synthesizedLogs); err != nil {
@@ -929,6 +980,8 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 	// One reducer per resource batch (reduction is request-local and not
 	// concurrency-safe); merged into one after the group finishes.
 	reducers := make([]*aggregate.Reducer, len(req.ResourceLogs))
+	// Per-resource exemplar reservations, merged by tenant below (#201 Q4).
+	logReservations := make([]*ExemplarReservation, len(req.ResourceLogs))
 
 	g, _ := errgroup.WithContext(ctx)
 
@@ -944,6 +997,7 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 			tenantID := resolveTenant(ctx, resourceLogs.Resource.Attributes, s.defaultTenant, s.trustResourceTenant)
 
 			localLogs := make([]storage.Log, 0)
+			exemplarRes := s.exemplar.NewReservation()
 
 			var reducer *aggregate.Reducer
 			if s.aggregateEngine != nil {
@@ -989,7 +1043,7 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 					// WARN opt-in, INFO/DEBUG aggregate-only (#161). The
 					// reduction above already accounted every one of them.
 					if s.exemplar != nil {
-						if !s.exemplar.AdmitLog(tenantID, serviceName, severity, timestamp, len(bodyStr)+len(attrs)) {
+						if !s.exemplar.ReserveLog(exemplarRes, tenantID, serviceName, severity, timestamp, len(bodyStr)+len(attrs)) {
 							continue
 						}
 					}
@@ -1010,6 +1064,7 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 
 			logResults[idx] = localLogs
 			logTenants[idx] = tenantID
+			logReservations[idx] = exemplarRes
 
 			return nil
 		})
@@ -1022,9 +1077,11 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 	// See the TraceServer.Export merge for the grouping rationale; with
 	// TRUST_RESOURCE_TENANT off this yields exactly one group.
 	groups := newTenantGroups()
+	reservations := make(map[string]*ExemplarReservation, len(logResults))
 	for idx, lr := range logResults {
 		logsToInsert = append(logsToInsert, lr...)
 		groups.add(logTenants[idx], nil, nil, lr, hasPriorityLog(lr), false)
+		mergeReservation(reservations, logTenants[idx], logReservations[idx])
 	}
 
 	// Apply the request's aggregate deltas. This happens before the early
@@ -1044,10 +1101,14 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 	// Mode-conditional ordering, same contract as TraceServer.Export: pre in
 	// aggregate/legacy, post (after the submit loop) in shadow.
 	if err := applyAggregatePre(s.aggregateEngine, mergedReducer); err != nil {
+		releaseReservations(reservations)
 		return nil, err
 	}
 
 	if len(logsToInsert) == 0 {
+		// No rows means no reservations, but settle explicitly rather than
+		// relying on that: a released empty reservation costs nothing.
+		releaseReservations(reservations)
 		// Nothing raw to submit, so the raw path's outcome is trivially
 		// non-retry and the shadow aggregate applies immediately.
 		if err := applyAggregatePost(s.aggregateEngine, mergedReducer); err != nil {
@@ -1075,12 +1136,14 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 				Logs:        g.logs,
 				HasError:    g.hasErr,
 				LogCallback: s.logCallback,
+				Reservation: reservations[g.tenant],
 			})
 		}
 		// Every log row here came off the wire — the log signal synthesizes
 		// nothing — so the whole batch is selected raw exemplars.
 		out, err := submitExemplars(s.pipeline, s.metrics, SignalLogs, batches,
-			aggregateACK(s.aggregateEngine), func(b *Batch) int { return len(b.Logs) })
+			aggregateACK(s.aggregateEngine), s.exemplar.DLQDisabled(),
+			func(b *Batch) int { return len(b.Logs) })
 		if err != nil {
 			if errors.Is(err, ErrQueueFull) {
 				return nil, grpcstatus.Errorf(codes.ResourceExhausted, "ingest pipeline at capacity")
@@ -1103,8 +1166,10 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 	// Synchronous fallback (preserves original behavior when async is disabled).
 	if err := s.repo.BatchCreateLogs(logsToInsert); err != nil {
 		slog.Error("❌ Failed to insert logs", "error", err)
+		releaseReservations(reservations)
 		return nil, err
 	}
+	commitReservations(reservations)
 	if s.logCallback != nil {
 		for _, l := range logsToInsert {
 			s.logCallback(l)
@@ -1117,6 +1182,34 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 	}
 
 	return &collogspb.ExportLogsServiceResponse{}, nil
+}
+
+// mergeReservation folds one resource batch's exemplar reservation into the
+// per-tenant reservation the matching Batch will carry.
+func mergeReservation(dst map[string]*ExemplarReservation, tenant string, res *ExemplarReservation) {
+	if res == nil || res.Len() == 0 {
+		return
+	}
+	if cur, ok := dst[tenant]; ok {
+		cur.Merge(res)
+		return
+	}
+	dst[tenant] = res
+}
+
+// commitReservations settles every tenant's reservation as written.
+func commitReservations(m map[string]*ExemplarReservation) {
+	for _, r := range m {
+		r.Commit()
+	}
+}
+
+// releaseReservations hands every tenant's reserved bytes back. Only correct
+// when nothing was submitted anywhere.
+func releaseReservations(m map[string]*ExemplarReservation) {
+	for _, r := range m {
+		r.Release()
+	}
 }
 
 // tenantGroup accumulates one Export's rows for a single tenant so the async

--- a/internal/ingest/pipeline.go
+++ b/internal/ingest/pipeline.go
@@ -59,6 +59,12 @@ type Batch struct {
 	SpanCallback func(storage.Span)
 	LogCallback  func(storage.Log)
 
+	// Reservation carries the exemplar bytes reserved for the rows in this
+	// batch (#201 Q4). submitExemplars commits it when a destination accepts
+	// the batch and releases it when none does. Nil outside aggregate mode,
+	// and every method on it is nil-safe.
+	Reservation *ExemplarReservation
+
 	enqueuedAt time.Time
 
 	// sizeBytes is the approxBytes() estimate computed once at Submit time

--- a/internal/storage/disk_statfs_darwin.go
+++ b/internal/storage/disk_statfs_darwin.go
@@ -1,0 +1,19 @@
+//go:build darwin
+
+package storage
+
+import "syscall"
+
+// statfsUsage reads filesystem capacity for the volume holding path. See the
+// linux build for why Bavail rather than Bfree.
+func statfsUsage(path string) (DiskUsage, error) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(path, &st); err != nil {
+		return DiskUsage{}, err
+	}
+	bsize := int64(st.Bsize)
+	return DiskUsage{
+		TotalBytes: int64(st.Blocks) * bsize, // #nosec G115 -- block counts on a real volume are far below 2^63/bsize
+		AvailBytes: int64(st.Bavail) * bsize, // #nosec G115 -- same
+	}, nil
+}

--- a/internal/storage/disk_statfs_linux.go
+++ b/internal/storage/disk_statfs_linux.go
@@ -1,0 +1,23 @@
+//go:build linux
+
+package storage
+
+import "syscall"
+
+// statfsUsage reads filesystem capacity for the volume holding path.
+//
+// Avail (not Free) is the enforcement number: the reserved-for-root blocks in
+// Free are not usable by this process, and counting them as headroom is how a
+// watchdog reports 8% free while writes are already returning ENOSPC.
+func statfsUsage(path string) (DiskUsage, error) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(path, &st); err != nil {
+		return DiskUsage{}, err
+	}
+	// Bsize is already int64 on linux; darwin's is uint32 and converts there.
+	bsize := st.Bsize
+	return DiskUsage{
+		TotalBytes: int64(st.Blocks) * bsize, // #nosec G115 -- block counts on a real volume are far below 2^63/bsize
+		AvailBytes: int64(st.Bavail) * bsize, // #nosec G115 -- same
+	}, nil
+}

--- a/internal/storage/disk_statfs_other.go
+++ b/internal/storage/disk_statfs_other.go
@@ -1,0 +1,12 @@
+//go:build !linux && !darwin
+
+package storage
+
+import "errors"
+
+// errStatfsUnsupported is returned on platforms without statfs. The watchdog
+// treats an unreadable sample as "no new information" and holds its current
+// state rather than shedding on a platform detail.
+var errStatfsUnsupported = errors.New("statfs is not available on this platform")
+
+func statfsUsage(string) (DiskUsage, error) { return DiskUsage{}, errStatfsUnsupported }

--- a/internal/storage/disk_watchdog.go
+++ b/internal/storage/disk_watchdog.go
@@ -1,0 +1,376 @@
+package storage
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/telemetry"
+)
+
+// Disk watchdog with staged shedding and hysteresis (#201 Q5).
+//
+// The 8 GiB data budget (#201 Q1) is a promise about a volume, not about a
+// table. Per-component gauges attribute what is on disk; the ENFORCEMENT
+// number is statfs on the data directory, because that is the only figure
+// that also counts WAL frames, SQLite temp files, free pages the file has not
+// given back, and anything else sharing the volume. A budget enforced against
+// summed file sizes is a budget that reports 60% while write() returns ENOSPC.
+//
+// What shedding does NOT do: it never converts a successful aggregate Export
+// into a retryable failure. Aggregate accounting is complete telemetry; raw
+// exemplars are diagnostics. When the disk fills, the diagnostics go first.
+// The single exception lives on the aggregate commit path — see
+// aggregate.IsDiskFull.
+
+// Shedding thresholds as a fraction of the enforcement ceiling. Entry and exit
+// differ on purpose: a volume hovering at the line would otherwise flap raw
+// retention on and off every tick, and every flap is a discontinuity in the
+// exemplar coverage an operator is trying to read during an incident.
+const (
+	diskEnterErrorsOnly = 0.90
+	diskEnterRawOff     = 0.95
+	diskExitRawOff      = 0.90 // raw-off -> errors-only
+	diskExitErrorsOnly  = 0.85 // errors-only -> none
+)
+
+// DefaultDiskWatchdogInterval is how often the volume is sampled. statfs is a
+// single syscall; 30s is far below the time it takes to fill the remaining 5%
+// of an 8 GiB volume at any ingest rate this platform survives.
+const DefaultDiskWatchdogInterval = 30 * time.Second
+
+// DiskUsage is one statfs sample.
+type DiskUsage struct {
+	TotalBytes int64
+	AvailBytes int64
+}
+
+// UsedBytes is the allocated portion of the volume.
+func (d DiskUsage) UsedBytes() int64 {
+	if d.TotalBytes <= 0 {
+		return 0
+	}
+	used := d.TotalBytes - d.AvailBytes
+	if used < 0 {
+		return 0
+	}
+	return used
+}
+
+// DiskWatchdogConfig configures a watchdog. Stat defaults to the platform
+// statfs; tests inject a fake.
+type DiskWatchdogConfig struct {
+	// Path is any path on the data volume. statfs reports the filesystem, not
+	// the path, so the data directory and the DB file give the same answer.
+	Path string
+	// BudgetBytes is DATA_DISK_BUDGET_MB expressed in bytes.
+	BudgetBytes int64
+	// Interval between samples. <= 0 uses DefaultDiskWatchdogInterval.
+	Interval time.Duration
+	// Stat overrides the platform statfs. nil uses the real one.
+	Stat func(path string) (DiskUsage, error)
+	// Metrics receives the disk gauges. nil is a no-op.
+	Metrics *telemetry.Metrics
+	// OnRawOff fires once on every transition INTO SheddingRawOff. It is where
+	// the immediate expired-exemplar purge and the WAL checkpoint are wired.
+	// Runs on the watchdog goroutine; keep it bounded.
+	OnRawOff func()
+}
+
+// diskComponent is one attribution gauge: a named byte sampler plus the
+// highest value it has ever reported.
+type diskComponent struct {
+	name      string
+	sample    func() int64
+	highWater int64
+}
+
+// DiskWatchdog samples the data volume and publishes a shedding state.
+type DiskWatchdog struct {
+	path     string
+	budget   int64
+	interval time.Duration
+	stat     func(string) (DiskUsage, error)
+	metrics  *telemetry.Metrics
+	onRawOff func()
+
+	state atomic.Int32 // SheddingState
+	ratio atomic.Uint64
+	used  atomic.Int64
+
+	mu         sync.Mutex
+	components []*diskComponent
+	observers  []func(SheddingState)
+
+	started atomic.Bool
+	cancel  context.CancelFunc
+	done    chan struct{}
+}
+
+// NewDiskWatchdog constructs a watchdog. It does not sample until Sample() or
+// Start() is called.
+func NewDiskWatchdog(cfg DiskWatchdogConfig) *DiskWatchdog {
+	if cfg.Interval <= 0 {
+		cfg.Interval = DefaultDiskWatchdogInterval
+	}
+	if cfg.Stat == nil {
+		cfg.Stat = statfsUsage
+	}
+	if cfg.Path == "" {
+		cfg.Path = "."
+	}
+	return &DiskWatchdog{
+		path:     cfg.Path,
+		budget:   cfg.BudgetBytes,
+		interval: cfg.Interval,
+		stat:     cfg.Stat,
+		metrics:  cfg.Metrics,
+		onRawOff: cfg.OnRawOff,
+		done:     make(chan struct{}),
+	}
+}
+
+// AddComponent registers a per-component byte sampler. The value is published
+// as a gauge and its running maximum as a high-water gauge, so the seven-day
+// gate (#202) can check each tier against its share of the budget table
+// instead of against a number someone remembers from a demo.
+//
+// Attribution only: components never drive the shedding decision.
+func (w *DiskWatchdog) AddComponent(name string, sample func() int64) {
+	if sample == nil {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.components = append(w.components, &diskComponent{name: name, sample: sample})
+}
+
+// AddObserver registers a callback fired on every state CHANGE, with the new
+// state. Called synchronously on the sampling goroutine.
+func (w *DiskWatchdog) AddObserver(fn func(SheddingState)) {
+	if fn == nil {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.observers = append(w.observers, fn)
+}
+
+// State returns the current shedding state. Safe on a nil receiver.
+func (w *DiskWatchdog) State() SheddingState {
+	if w == nil {
+		return SheddingNone
+	}
+	return SheddingState(w.state.Load())
+}
+
+// Healthy reports whether readiness should pass. False at SheddingRawOff:
+// the process is still serving reads and still accounting aggregates, but it
+// can no longer retain the diagnostics an operator would come here for, and
+// an orchestrator should stop routing fresh ingest at it.
+func (w *DiskWatchdog) Healthy() bool { return w.State() < SheddingRawOff }
+
+// UsedRatio returns the last sampled usage as a fraction of the enforcement
+// ceiling.
+func (w *DiskWatchdog) UsedRatio() float64 {
+	if w == nil {
+		return 0
+	}
+	return math.Float64frombits(w.ratio.Load())
+}
+
+// ceiling is the enforcement ceiling: the lower of the configured budget and
+// the usable volume capacity, where the latter is detectable. A 4 GiB volume
+// does not become 8 GiB because the config says so.
+func (w *DiskWatchdog) ceiling(u DiskUsage) int64 {
+	ceiling := w.budget
+	if u.TotalBytes > 0 && (ceiling <= 0 || u.TotalBytes < ceiling) {
+		ceiling = u.TotalBytes
+	}
+	return ceiling
+}
+
+// nextState applies the threshold ladder with hysteresis to a usage ratio.
+// Pure function of (current, ratio) so the transition table is testable
+// without a filesystem.
+func nextState(cur SheddingState, ratio float64) SheddingState {
+	switch {
+	case ratio >= diskEnterRawOff:
+		return SheddingRawOff
+	case ratio >= diskEnterErrorsOnly:
+		// Already raw-off: stay there. Recovery from raw-off needs < 90%.
+		if cur == SheddingRawOff {
+			return SheddingRawOff
+		}
+		return SheddingErrorsOnly
+	case ratio >= diskExitErrorsOnly:
+		// 85%..90%: raw-off recovers to errors-only here; errors-only holds.
+		if cur == SheddingNone {
+			return SheddingNone
+		}
+		return SheddingErrorsOnly
+	default:
+		return SheddingNone
+	}
+}
+
+// Sample takes one statfs reading, updates the gauges and applies the state
+// ladder. Exported so tests drive transitions deterministically and so the
+// startup path can establish a state before ingest opens.
+//
+// A failed stat holds the current state: shedding raw retention because a
+// syscall failed would be an outage caused by the safety mechanism.
+func (w *DiskWatchdog) Sample() SheddingState {
+	u, err := w.stat(w.path)
+	if err != nil {
+		slog.Warn("disk watchdog: statfs failed, holding current shedding state",
+			"path", w.path, "state", w.State().String(), "error", err)
+		w.sampleComponents()
+		return w.State()
+	}
+
+	ceiling := w.ceiling(u)
+	used := u.UsedBytes()
+	ratio := 0.0
+	if ceiling > 0 {
+		ratio = float64(used) / float64(ceiling)
+	}
+	w.used.Store(used)
+	w.ratio.Store(math.Float64bits(ratio))
+	w.publishVolume(ceiling, used, ratio)
+	w.sampleComponents()
+
+	cur := w.State()
+	next := nextState(cur, ratio)
+	if next == cur {
+		return cur
+	}
+	w.state.Store(int32(next))
+	slog.Warn("disk watchdog: shedding state changed",
+		"from", cur.String(),
+		"to", next.String(),
+		"used_bytes", used,
+		"ceiling_bytes", ceiling,
+		"used_ratio", ratio,
+	)
+	if w.metrics != nil && w.metrics.DiskSheddingTransitionsTotal != nil {
+		w.metrics.DiskSheddingTransitionsTotal.WithLabelValues(cur.String(), next.String()).Inc()
+	}
+	w.notify(next)
+	if next == SheddingRawOff && w.onRawOff != nil {
+		w.onRawOff()
+	}
+	return next
+}
+
+// notify fans the new state out to observers under a snapshot of the slice, so
+// an observer that registers another observer cannot deadlock.
+func (w *DiskWatchdog) notify(s SheddingState) {
+	w.mu.Lock()
+	obs := make([]func(SheddingState), len(w.observers))
+	copy(obs, w.observers)
+	w.mu.Unlock()
+	for _, fn := range obs {
+		fn(s)
+	}
+}
+
+// publishVolume writes the volume-level gauges.
+func (w *DiskWatchdog) publishVolume(ceiling, used int64, ratio float64) {
+	m := w.metrics
+	if m == nil {
+		return
+	}
+	if m.DiskBudgetBytes != nil {
+		m.DiskBudgetBytes.Set(float64(ceiling))
+	}
+	if m.DiskUsedBytes != nil {
+		m.DiskUsedBytes.Set(float64(used))
+	}
+	if m.DiskUsedRatio != nil {
+		m.DiskUsedRatio.Set(ratio)
+	}
+	if m.DiskSheddingState != nil {
+		m.DiskSheddingState.Set(float64(w.state.Load()))
+	}
+}
+
+// sampleComponents refreshes the per-component attribution and high-water
+// gauges.
+func (w *DiskWatchdog) sampleComponents() {
+	w.mu.Lock()
+	comps := make([]*diskComponent, len(w.components))
+	copy(comps, w.components)
+	w.mu.Unlock()
+
+	m := w.metrics
+	for _, c := range comps {
+		n := c.sample()
+		if n < 0 {
+			n = 0
+		}
+		if n > c.highWater {
+			c.highWater = n
+		}
+		if m == nil {
+			continue
+		}
+		if m.DiskComponentBytes != nil {
+			m.DiskComponentBytes.WithLabelValues(c.name).Set(float64(n))
+		}
+		if m.DiskComponentHighWaterBytes != nil {
+			m.DiskComponentHighWaterBytes.WithLabelValues(c.name).Set(float64(c.highWater))
+		}
+	}
+}
+
+// HighWater returns the recorded high-water mark for a component. Test and
+// diagnostic surface.
+func (w *DiskWatchdog) HighWater(name string) int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, c := range w.components {
+		if c.name == name {
+			return c.highWater
+		}
+	}
+	return 0
+}
+
+// Start samples immediately and then on every tick until ctx is cancelled or
+// Stop is called. Idempotent.
+func (w *DiskWatchdog) Start(parent context.Context) {
+	if !w.started.CompareAndSwap(false, true) {
+		return
+	}
+	ctx, cancel := context.WithCancel(parent)
+	w.cancel = cancel
+	go func() {
+		defer close(w.done)
+		t := time.NewTicker(w.interval)
+		defer t.Stop()
+		w.Sample()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				w.Sample()
+			}
+		}
+	}()
+}
+
+// Stop halts the sampling loop and waits for it to exit. No-op before Start.
+func (w *DiskWatchdog) Stop() {
+	if !w.started.Load() {
+		return
+	}
+	if w.cancel != nil {
+		w.cancel()
+	}
+	<-w.done
+}

--- a/internal/storage/disk_watchdog_test.go
+++ b/internal/storage/disk_watchdog_test.go
@@ -1,0 +1,214 @@
+package storage
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+// Disk watchdog thresholds and hysteresis (#201 Q5). A fake statfs makes the
+// ladder deterministic; a real volume would make it a coin flip.
+
+const testBudget = int64(8 * 1024 * 1024 * 1024) // 8 GiB
+
+// fakeVolume is a settable statfs source sized to the budget, so a usage
+// fraction maps directly onto the enforcement ratio.
+type fakeVolume struct {
+	total int64
+	used  atomic.Int64
+	err   error
+}
+
+func newFakeVolume(total int64) *fakeVolume { return &fakeVolume{total: total} }
+
+func (f *fakeVolume) setRatio(r float64) {
+	f.used.Store(int64(float64(f.total) * r))
+}
+
+func (f *fakeVolume) stat(string) (DiskUsage, error) {
+	if f.err != nil {
+		return DiskUsage{}, f.err
+	}
+	used := f.used.Load()
+	return DiskUsage{TotalBytes: f.total, AvailBytes: f.total - used}, nil
+}
+
+// watchdogAt builds a watchdog over a fake volume at the given usage fraction.
+func watchdogAt(ratio float64) (*DiskWatchdog, *fakeVolume) {
+	vol := newFakeVolume(testBudget)
+	vol.setRatio(ratio)
+	w := NewDiskWatchdog(DiskWatchdogConfig{
+		Path:        "/does/not/exist",
+		BudgetBytes: testBudget,
+		Stat:        vol.stat,
+	})
+	return w, vol
+}
+
+// TestNextStateLadder pins the entry and exit thresholds. The table IS the
+// contract: 90/95 to enter, 90/85 to leave.
+func TestNextStateLadder(t *testing.T) {
+	cases := []struct {
+		cur   SheddingState
+		ratio float64
+		want  SheddingState
+	}{
+		// Entry.
+		{SheddingNone, 0.50, SheddingNone},
+		{SheddingNone, 0.8999, SheddingNone},
+		{SheddingNone, 0.90, SheddingErrorsOnly},
+		{SheddingNone, 0.9499, SheddingErrorsOnly},
+		{SheddingNone, 0.95, SheddingRawOff},
+		{SheddingNone, 1.00, SheddingRawOff},
+		// Hysteresis: raw-off holds until below 90%.
+		{SheddingRawOff, 0.949, SheddingRawOff},
+		{SheddingRawOff, 0.90, SheddingRawOff},
+		{SheddingRawOff, 0.8999, SheddingErrorsOnly},
+		// Hysteresis: errors-only holds until below 85%.
+		{SheddingErrorsOnly, 0.899, SheddingErrorsOnly},
+		{SheddingErrorsOnly, 0.85, SheddingErrorsOnly},
+		{SheddingErrorsOnly, 0.8499, SheddingNone},
+		// The gap between the two exits is the whole point: at 87% a
+		// recovering raw-off lands on errors-only rather than none.
+		{SheddingRawOff, 0.87, SheddingErrorsOnly},
+	}
+	for _, tc := range cases {
+		if got := nextState(tc.cur, tc.ratio); got != tc.want {
+			t.Errorf("nextState(%s, %.4f) = %s, want %s", tc.cur, tc.ratio, got, tc.want)
+		}
+	}
+}
+
+// TestWatchdogTransitionsAndHysteresis walks a volume up and back down and
+// checks the observed sequence, which is what an operator sees.
+func TestWatchdogTransitionsAndHysteresis(t *testing.T) {
+	w, vol := watchdogAt(0.10)
+	var seen []string
+	w.AddObserver(func(s SheddingState) { seen = append(seen, s.String()) })
+	var rawOffCalls int
+	w.onRawOff = func() { rawOffCalls++ }
+
+	steps := []struct {
+		ratio float64
+		want  SheddingState
+	}{
+		{0.10, SheddingNone},
+		{0.91, SheddingErrorsOnly},
+		{0.96, SheddingRawOff},
+		{0.92, SheddingRawOff},     // above 90%: no recovery from raw-off
+		{0.88, SheddingErrorsOnly}, // below 90%: one rung down only
+		{0.86, SheddingErrorsOnly}, // above 85%: errors-only holds
+		{0.20, SheddingNone},
+	}
+	for _, st := range steps {
+		vol.setRatio(st.ratio)
+		if got := w.Sample(); got != st.want {
+			t.Fatalf("at %.2f: state = %s, want %s", st.ratio, got, st.want)
+		}
+	}
+
+	want := []string{"errors_only", "raw_off", "errors_only", "none"}
+	if len(seen) != len(want) {
+		t.Fatalf("observed transitions %v, want %v", seen, want)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Fatalf("observed transitions %v, want %v", seen, want)
+		}
+	}
+	if rawOffCalls != 1 {
+		t.Fatalf("OnRawOff fired %d times, want exactly 1 (once per transition INTO raw-off)", rawOffCalls)
+	}
+}
+
+// TestWatchdogHealthyOnlyFalseAtRawOff: readiness flips at 95%, not at 90%.
+// Errors-only is degraded coverage, not an unready process.
+func TestWatchdogHealthyOnlyFalseAtRawOff(t *testing.T) {
+	w, vol := watchdogAt(0.50)
+	if w.Sample(); !w.Healthy() {
+		t.Fatal("healthy volume reported unready")
+	}
+	vol.setRatio(0.91)
+	if w.Sample(); !w.Healthy() {
+		t.Fatal("errors-only reported unready; only raw-off should")
+	}
+	vol.setRatio(0.99)
+	if w.Sample(); w.Healthy() {
+		t.Fatal("raw-off reported ready")
+	}
+}
+
+// TestWatchdogCeilingIsTheLowerOfBudgetAndVolume: a 4 GiB volume does not
+// become 8 GiB because the config says so.
+func TestWatchdogCeilingIsTheLowerOfBudgetAndVolume(t *testing.T) {
+	small := int64(4 * 1024 * 1024 * 1024)
+	vol := newFakeVolume(small)
+	vol.setRatio(0.96) // 96% of the REAL volume, 48% of the configured budget
+	w := NewDiskWatchdog(DiskWatchdogConfig{Path: "/x", BudgetBytes: testBudget, Stat: vol.stat})
+	if got := w.Sample(); got != SheddingRawOff {
+		t.Fatalf("state = %s at 96%% of a volume smaller than the budget, want raw_off", got)
+	}
+	if r := w.UsedRatio(); r < 0.95 {
+		t.Fatalf("used ratio = %.3f, want >= 0.95 — the ceiling was not clamped to the volume", r)
+	}
+}
+
+// TestWatchdogStatFailureHoldsState: shedding raw retention because a syscall
+// failed would be an outage caused by the safety mechanism.
+func TestWatchdogStatFailureHoldsState(t *testing.T) {
+	w, vol := watchdogAt(0.96)
+	if got := w.Sample(); got != SheddingRawOff {
+		t.Fatalf("state = %s, want raw_off", got)
+	}
+	vol.err = errStatFailed
+	if got := w.Sample(); got != SheddingRawOff {
+		t.Fatalf("state = %s after a failed stat, want the held raw_off", got)
+	}
+	vol.err = nil
+	vol.setRatio(0.10)
+	if got := w.Sample(); got != SheddingNone {
+		t.Fatalf("state = %s once stat recovered, want none", got)
+	}
+}
+
+// TestWatchdogComponentHighWaterMarks: the budget table (#201 Q1) is validated
+// against peaks, and an instantaneous gauge does not remember the peak.
+func TestWatchdogComponentHighWaterMarks(t *testing.T) {
+	w, _ := watchdogAt(0.10)
+	var size int64 = 100
+	w.AddComponent("main_db", func() int64 { return atomic.LoadInt64(&size) })
+	w.AddComponent("negative", func() int64 { return -5 })
+
+	w.Sample()
+	atomic.StoreInt64(&size, 900)
+	w.Sample()
+	atomic.StoreInt64(&size, 300)
+	w.Sample()
+
+	if got := w.HighWater("main_db"); got != 900 {
+		t.Fatalf("main_db high water = %d, want 900", got)
+	}
+	if got := w.HighWater("negative"); got != 0 {
+		t.Fatalf("a negative sample became a high water mark of %d, want 0", got)
+	}
+	if got := w.HighWater("absent"); got != 0 {
+		t.Fatalf("unknown component reported %d, want 0", got)
+	}
+}
+
+// TestNilWatchdogAccessors: legacy deployments carry no watchdog.
+func TestNilWatchdogAccessors(t *testing.T) {
+	var w *DiskWatchdog
+	if w.State() != SheddingNone {
+		t.Fatal("nil watchdog reported a shedding state")
+	}
+	if w.UsedRatio() != 0 {
+		t.Fatal("nil watchdog reported usage")
+	}
+}
+
+// errStatFailed stands in for a statfs syscall failure.
+var errStatFailed = errStatfsTest{}
+
+type errStatfsTest struct{}
+
+func (errStatfsTest) Error() string { return "statfs: simulated failure" }

--- a/internal/storage/exemplar_purge.go
+++ b/internal/storage/exemplar_purge.go
@@ -1,0 +1,191 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// Exemplar-tier retention (#201 Q2).
+//
+// In AGGREGATE_MODE=aggregate the raw rows in traces/spans/logs are not the
+// dataset — they are EXEMPLARS attached to a dataset that lives in
+// aggregate.db. The aggregate tier keeps seven days because it is what the
+// dashboards read; the exemplar tier keeps two, because 576 five-minute
+// windows at the 3 MiB global window budget is 1.69 GiB of charged payload,
+// and at the provisional 2x database/index/FTS amplification that is 3.38 GiB
+// of the 4.5 GiB main relational tier. Seven days of the same rate is not a
+// tighter fit, it is a full volume.
+//
+// This purge is separate from the HOT_RETENTION_DAYS purge and runs BEFORE it
+// on the same hourly tick, so the cheap deletes happen while the volume still
+// has room to write the journal for them.
+//
+// Transactionality: each pass deletes a bounded batch of traces AND the spans
+// left dangling by that batch inside ONE transaction. A reader therefore never
+// observes spans whose trace row has already gone — the partial state the
+// old two-phase sweep exposed between its trace loop and its span loop.
+// Batching keeps the SQLite writer lock held for a chunk, not for the whole
+// multi-GB purge.
+
+// ExemplarPurgeStats reports what one exemplar-tier purge removed.
+type ExemplarPurgeStats struct {
+	Traces      int64
+	Spans       int64
+	Logs        int64
+	OrphanSpans int64
+}
+
+// Total is every row the pass deleted.
+func (s ExemplarPurgeStats) Total() int64 {
+	return s.Traces + s.Spans + s.Logs + s.OrphanSpans
+}
+
+// PurgeExemplarsBatched deletes exemplar traces, their spans, exemplar logs
+// and expired weak references (spans whose trace row no longer exists) older
+// than cutoff.
+//
+// FTS: `logs_fts` is content-linked to `logs` and kept in sync by the
+// AFTER DELETE trigger created in fts5.go, so deleting a log row inside the
+// transaction removes its index entry inside the same transaction. There is
+// no separate FTS delete to get wrong.
+//
+// Tenant scope: SYSTEM-WIDE, like every other retention path. It scopes by
+// age, never by tenant. Never expose it on a tenant-scoped API surface.
+func (r *Repository) PurgeExemplarsBatched(ctx context.Context, cutoff time.Time, batchSize int, sleep time.Duration) (ExemplarPurgeStats, error) {
+	var stats ExemplarPurgeStats
+	if batchSize <= 0 {
+		batchSize = 10_000
+	}
+
+	// Phase 1: traces + the spans that batch orphans, one transaction per batch.
+	for {
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+		var traces, spans int64
+		err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			res := tx.Exec(
+				"DELETE FROM traces WHERE id IN (SELECT id FROM traces WHERE timestamp < ? ORDER BY id LIMIT ?)",
+				cutoff, batchSize,
+			)
+			if res.Error != nil {
+				return fmt.Errorf("purge exemplar traces: %w", res.Error)
+			}
+			traces = res.RowsAffected
+
+			// Same transaction: the spans this batch just detached. Bounded to
+			// start_time < cutoff so a span whose trace row has not committed
+			// yet (Export writes traces and spans separately) is never a
+			// candidate.
+			res = tx.Exec(
+				"DELETE FROM spans WHERE id IN (SELECT id FROM spans WHERE start_time < ? AND trace_id NOT IN (SELECT trace_id FROM traces) ORDER BY id LIMIT ?)",
+				cutoff, batchSize,
+			)
+			if res.Error != nil {
+				return fmt.Errorf("purge exemplar spans: %w", res.Error)
+			}
+			spans = res.RowsAffected
+			return nil
+		})
+		if err != nil {
+			return stats, err
+		}
+		stats.Traces += traces
+		stats.Spans += spans
+		if traces < int64(batchSize) && spans < int64(batchSize) {
+			break
+		}
+		if err := yield(ctx, sleep); err != nil {
+			return stats, err
+		}
+	}
+
+	// Phase 2: exemplar logs. Their FTS rows go with them via the trigger.
+	for {
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+		var logs int64
+		err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			res := tx.Exec(
+				"DELETE FROM logs WHERE id IN (SELECT id FROM logs WHERE timestamp < ? ORDER BY id LIMIT ?)",
+				cutoff, batchSize,
+			)
+			if res.Error != nil {
+				return fmt.Errorf("purge exemplar logs: %w", res.Error)
+			}
+			logs = res.RowsAffected
+			return nil
+		})
+		if err != nil {
+			return stats, err
+		}
+		stats.Logs += logs
+		if logs < int64(batchSize) {
+			break
+		}
+		if err := yield(ctx, sleep); err != nil {
+			return stats, err
+		}
+	}
+
+	// Phase 3: expired weak references left by ANY earlier purge — spans older
+	// than the cutoff whose trace row is gone. Phase 1 catches the ones this
+	// pass created; this catches the residue of a pass that was cancelled or
+	// crashed halfway.
+	for {
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+		res := r.db.WithContext(ctx).Exec(
+			"DELETE FROM spans WHERE id IN (SELECT id FROM spans WHERE start_time < ? AND trace_id NOT IN (SELECT trace_id FROM traces) ORDER BY id LIMIT ?)",
+			cutoff, batchSize,
+		)
+		if res.Error != nil {
+			return stats, fmt.Errorf("sweep expired weak references: %w", res.Error)
+		}
+		stats.OrphanSpans += res.RowsAffected
+		if res.RowsAffected < int64(batchSize) {
+			break
+		}
+		if err := yield(ctx, sleep); err != nil {
+			return stats, err
+		}
+	}
+
+	return stats, nil
+}
+
+// yield pauses between purge batches so the single SQLite writer lock is
+// actually released rather than merely re-acquired.
+func yield(ctx context.Context, sleep time.Duration) error {
+	if sleep <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(sleep)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// CheckpointWAL truncates the write-ahead log. Called when the disk watchdog
+// enters raw-off: at 95% the WAL is a live claim on the volume, and the pages
+// it holds are pages the purge just freed but cannot hand back until the log
+// is checkpointed. No-op on non-SQLite drivers.
+func (r *Repository) CheckpointWAL(ctx context.Context) error {
+	if r.driver != "sqlite" && r.driver != "" {
+		return nil
+	}
+	sqlDB, err := r.db.DB()
+	if err != nil {
+		return fmt.Errorf("checkpoint wal: %w", err)
+	}
+	return drainQuery(ctx, sqlDB, "PRAGMA wal_checkpoint(TRUNCATE)")
+}

--- a/internal/storage/exemplar_purge_test.go
+++ b/internal/storage/exemplar_purge_test.go
@@ -1,0 +1,224 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Exemplar-tier retention (#201 Q2). The exemplar tier keeps two days while
+// HOT_RETENTION_DAYS keeps seven, so these tests are about the boundary
+// between them: two-day-old rows go, six-day-old rows stay, and the FTS index
+// goes with the logs rather than accumulating references to rows that no
+// longer exist.
+//
+// Scaffolding (newTestRepo, seedTrace, seedLogs, mustCount) is shared with
+// purge_test.go.
+
+// ftsRowCount counts entries in the FTS5 shadow index.
+func ftsRowCount(t *testing.T, repo *Repository) int64 {
+	t.Helper()
+	var n int64
+	if err := repo.db.Raw("SELECT count(*) FROM logs_fts").Scan(&n).Error; err != nil {
+		t.Fatalf("count logs_fts: %v", err)
+	}
+	return n
+}
+
+func TestPurgeExemplars_DeletesPastExemplarRetentionKeepsHotTier(t *testing.T) {
+	repo := newTestRepo(t)
+	if err := setupSQLiteFTS5(repo.db); err != nil {
+		t.Fatalf("setupSQLiteFTS5: %v", err)
+	}
+	now := time.Now().UTC()
+	exemplarCutoff := now.Add(-2 * 24 * time.Hour)
+
+	// Past the exemplar cutoff but inside HOT_RETENTION_DAYS=7: exactly the
+	// rows the exemplar tier is supposed to reclaim and the old purge kept.
+	seedTrace(t, repo.db, "t-3d", now.Add(-3*24*time.Hour), []time.Time{
+		now.Add(-3 * 24 * time.Hour),
+		now.Add(-3 * 24 * time.Hour).Add(time.Second),
+	})
+	seedLogs(t, repo.db, 5, now.Add(-3*24*time.Hour), "checkout")
+
+	// Inside the exemplar window: must survive untouched.
+	seedTrace(t, repo.db, "t-1d", now.Add(-24*time.Hour), []time.Time{now.Add(-24 * time.Hour)})
+	seedLogs(t, repo.db, 3, now.Add(-24*time.Hour), "payments")
+
+	ftsBefore := ftsRowCount(t, repo)
+	if ftsBefore != 8 {
+		t.Fatalf("logs_fts holds %d rows before the purge, want 8", ftsBefore)
+	}
+
+	stats, err := repo.PurgeExemplarsBatched(context.Background(), exemplarCutoff, 10, 0)
+	if err != nil {
+		t.Fatalf("PurgeExemplarsBatched: %v", err)
+	}
+	if stats.Traces != 1 {
+		t.Fatalf("purged %d traces, want 1", stats.Traces)
+	}
+	if stats.Spans != 2 {
+		t.Fatalf("purged %d spans, want 2", stats.Spans)
+	}
+	if stats.Logs != 5 {
+		t.Fatalf("purged %d logs, want 5", stats.Logs)
+	}
+
+	if got := mustCount(t, repo.db, &Trace{}); got != 1 {
+		t.Fatalf("%d traces remain, want 1 (the one inside the exemplar window)", got)
+	}
+	if got := mustCount(t, repo.db, &Span{}); got != 1 {
+		t.Fatalf("%d spans remain, want 1", got)
+	}
+	if got := mustCount(t, repo.db, &Log{}); got != 3 {
+		t.Fatalf("%d logs remain, want 3", got)
+	}
+
+	// FTS is content-linked and trigger-synced: deleting a log must delete its
+	// index entry. An index that outlives its rows is disk the budget table
+	// never accounted for.
+	if got := ftsRowCount(t, repo); got != 3 {
+		t.Fatalf("logs_fts holds %d rows after the purge, want 3 — the AFTER DELETE trigger did not fire", got)
+	}
+
+	// And the index must still answer for what survived.
+	var hits int64
+	if err := repo.db.Raw("SELECT count(*) FROM logs_fts WHERE logs_fts MATCH ?", "payments").Scan(&hits).Error; err != nil {
+		t.Fatalf("MATCH query: %v", err)
+	}
+	if hits != 3 {
+		t.Fatalf("FTS MATCH returned %d rows for the surviving service, want 3", hits)
+	}
+}
+
+// TestPurgeExemplars_SweepsExpiredWeakReferences: a span whose trace row is
+// already gone is a dangling weak reference, and it is charged to the main
+// tier until something deletes it.
+func TestPurgeExemplars_SweepsExpiredWeakReferences(t *testing.T) {
+	repo := newTestRepo(t)
+	now := time.Now().UTC()
+	cutoff := now.Add(-2 * 24 * time.Hour)
+
+	seedTrace(t, repo.db, "t-orphan", now.Add(-3*24*time.Hour), []time.Time{now.Add(-3 * 24 * time.Hour)})
+	// Delete the trace row only, leaving the span behind — the state a
+	// cancelled or crashed purge pass leaves on disk.
+	if err := repo.db.Unscoped().Where("trace_id = ?", "t-orphan").Delete(&Trace{}).Error; err != nil {
+		t.Fatalf("detach trace: %v", err)
+	}
+
+	// A fresh trace with clock-skewed old spans must NOT be swept: its trace
+	// row still exists, so the reference is live, not expired.
+	seedTrace(t, repo.db, "t-skew", now, []time.Time{now.Add(-5 * 24 * time.Hour)})
+
+	stats, err := repo.PurgeExemplarsBatched(context.Background(), cutoff, 10, 0)
+	if err != nil {
+		t.Fatalf("PurgeExemplarsBatched: %v", err)
+	}
+	if stats.Spans+stats.OrphanSpans != 1 {
+		t.Fatalf("swept %d weak references, want 1", stats.Spans+stats.OrphanSpans)
+	}
+	var skew int64
+	repo.db.Model(&Span{}).Where("trace_id = ?", "t-skew").Count(&skew)
+	if skew != 1 {
+		t.Fatalf("the clock-skewed span under a live trace was swept: %d remain, want 1", skew)
+	}
+}
+
+// TestPurgeExemplars_TraceAndSpanDeletesShareATransaction: a reader must never
+// observe spans whose trace row has already gone. The assertion is behavioural
+// — the two deletes are issued inside one transaction, so a failure injected
+// into the span delete rolls the trace delete back with it.
+func TestPurgeExemplars_TraceAndSpanDeletesShareATransaction(t *testing.T) {
+	repo := newTestRepo(t)
+	now := time.Now().UTC()
+	cutoff := now.Add(-2 * 24 * time.Hour)
+	seedTrace(t, repo.db, "t-old", now.Add(-3*24*time.Hour), []time.Time{now.Add(-3 * 24 * time.Hour)})
+
+	// Drop the spans table out from under the pass: the span DELETE fails,
+	// and the trace DELETE in the same transaction must not survive it.
+	if err := repo.db.Exec("ALTER TABLE spans RENAME TO spans_hidden").Error; err != nil {
+		t.Fatalf("hide spans table: %v", err)
+	}
+	if _, err := repo.PurgeExemplarsBatched(context.Background(), cutoff, 10, 0); err == nil {
+		t.Fatal("purge reported success with a broken spans table")
+	}
+	if err := repo.db.Exec("ALTER TABLE spans_hidden RENAME TO spans").Error; err != nil {
+		t.Fatalf("restore spans table: %v", err)
+	}
+
+	if got := mustCount(t, repo.db, &Trace{}); got != 1 {
+		t.Fatalf("%d traces remain after a rolled-back pass, want 1 — the trace delete was not transactional with the span delete", got)
+	}
+	if got := mustCount(t, repo.db, &Span{}); got != 1 {
+		t.Fatalf("%d spans remain, want 1", got)
+	}
+}
+
+// TestPurgeExemplars_EmptyAndCancelled: the boring paths, because a purge that
+// spins on an empty table is a purge that holds the writer lock for nothing.
+func TestPurgeExemplars_EmptyAndCancelled(t *testing.T) {
+	repo := newTestRepo(t)
+	now := time.Now().UTC()
+
+	stats, err := repo.PurgeExemplarsBatched(context.Background(), now.Add(-2*24*time.Hour), 100, 0)
+	if err != nil {
+		t.Fatalf("empty purge: %v", err)
+	}
+	if stats.Total() != 0 {
+		t.Fatalf("empty purge deleted %d rows", stats.Total())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := repo.PurgeExemplarsBatched(ctx, now, 100, 0); err == nil {
+		t.Fatal("cancelled purge returned nil error")
+	}
+}
+
+// TestRetentionSchedulerRunsExemplarPurgeAheadOfHotRetention: the wiring, not
+// the SQL. Without SetExemplarRetention nothing in the exemplar tier is
+// touched — which is exactly what legacy and shadow mode need.
+func TestRetentionSchedulerRunsExemplarPurgeAheadOfHotRetention(t *testing.T) {
+	repo := newTestRepo(t)
+	now := time.Now().UTC()
+
+	// Three days old: past the 2-day exemplar tier, inside 7-day hot retention.
+	seedTrace(t, repo.db, "t-3d", now.Add(-3*24*time.Hour), []time.Time{now.Add(-3 * 24 * time.Hour)})
+	seedLogs(t, repo.db, 4, now.Add(-3*24*time.Hour), "checkout")
+
+	// No exemplar retention configured: the hot purge alone keeps everything.
+	s := NewRetentionScheduler(repo, 7, 100, 0)
+	s.runPurge(context.Background())
+	if got := mustCount(t, repo.db, &Trace{}); got != 1 {
+		t.Fatalf("%d traces after a hot-only purge, want 1", got)
+	}
+
+	// With it configured, the same rows go.
+	s.SetExemplarRetention(2)
+	s.runPurge(context.Background())
+	if got := mustCount(t, repo.db, &Trace{}); got != 0 {
+		t.Fatalf("%d traces after the exemplar purge, want 0", got)
+	}
+	if got := mustCount(t, repo.db, &Log{}); got != 0 {
+		t.Fatalf("%d logs after the exemplar purge, want 0", got)
+	}
+}
+
+// TestPurgeExemplarsNow_RunsOffTick covers the watchdog's on-demand trigger.
+func TestPurgeExemplarsNow_RunsOffTick(t *testing.T) {
+	repo := newTestRepo(t)
+	now := time.Now().UTC()
+	seedLogs(t, repo.db, 4, now.Add(-3*24*time.Hour), "checkout")
+
+	s := NewRetentionScheduler(repo, 7, 100, 0)
+	s.PurgeExemplarsNow(context.Background())
+	if got := mustCount(t, repo.db, &Log{}); got != 4 {
+		t.Fatalf("%d logs, want 4 — an unconfigured exemplar tier must purge nothing", got)
+	}
+
+	s.SetExemplarRetention(2)
+	s.PurgeExemplarsNow(context.Background())
+	if got := mustCount(t, repo.db, &Log{}); got != 0 {
+		t.Fatalf("%d logs after the on-demand purge, want 0", got)
+	}
+}

--- a/internal/storage/retention.go
+++ b/internal/storage/retention.go
@@ -65,6 +65,12 @@ type RetentionScheduler struct {
 	// twenty-four times a day for names that change on the timescale of a
 	// deployment.
 	aggregateGC func() error
+
+	// exemplarRetentionDays is the separate, shorter retention of the raw
+	// exemplar tier (#201 Q2, EXEMPLAR_RETENTION_DAYS). 0 disables it, which
+	// is the correct setting in legacy and shadow mode: there the raw rows ARE
+	// the dataset and a two-day purge is data loss, not budget enforcement.
+	exemplarRetentionDays int
 }
 
 // NewRetentionScheduler constructs a scheduler but does not start it.
@@ -109,6 +115,76 @@ func (r *RetentionScheduler) SetAggregateRetention(purge func(time.Time) (int64,
 // the daily maintenance pass. May be nil. Call before Start; not synchronized.
 func (r *RetentionScheduler) SetAggregateGC(collect func() error) {
 	r.aggregateGC = collect
+}
+
+// SetExemplarRetention enables the exemplar-tier purge with the given retention
+// in days. Call before Start; not synchronized. Only meaningful in
+// AGGREGATE_MODE=aggregate — see the field comment.
+func (r *RetentionScheduler) SetExemplarRetention(days int) {
+	r.exemplarRetentionDays = days
+}
+
+// PurgeExemplarsNow runs one exemplar-tier purge immediately, outside the
+// hourly tick. The disk watchdog calls it on the transition into raw-off:
+// the point of that transition is that waiting up to an hour for the next
+// tick is no longer an option.
+//
+// It respects the same overlap guard as the scheduled passes; a tick already
+// in flight is doing this work anyway.
+func (r *RetentionScheduler) PurgeExemplarsNow(ctx context.Context) {
+	if r.exemplarRetentionDays <= 0 {
+		return
+	}
+	if !r.running.CompareAndSwap(false, true) {
+		r.skippedRuns.Add(1)
+		slog.Warn("retention: previous run still in progress, skipping on-demand exemplar purge")
+		return
+	}
+	defer r.running.Store(false)
+	r.runExemplarPurge(ctx)
+}
+
+// runExemplarPurge deletes the raw exemplar tier past EXEMPLAR_RETENTION_DAYS.
+// Caller holds the running guard.
+func (r *RetentionScheduler) runExemplarPurge(ctx context.Context) {
+	if r.exemplarRetentionDays <= 0 {
+		return
+	}
+	cutoff := time.Now().UTC().Add(-time.Duration(r.exemplarRetentionDays) * 24 * time.Hour)
+	start := time.Now()
+	stats, err := r.repo.PurgeExemplarsBatched(ctx, cutoff, r.purgeBatchSize, r.purgeBatchSleep)
+	metrics := r.repo.metrics
+	if metrics != nil {
+		if metrics.ExemplarPurgeDurationSeconds != nil {
+			metrics.ExemplarPurgeDurationSeconds.Observe(time.Since(start).Seconds())
+		}
+		if metrics.ExemplarRowsPurgedTotal != nil {
+			for table, n := range map[string]int64{
+				"traces":       stats.Traces,
+				"spans":        stats.Spans,
+				"logs":         stats.Logs,
+				"orphan_spans": stats.OrphanSpans,
+			} {
+				if n > 0 {
+					metrics.ExemplarRowsPurgedTotal.WithLabelValues(table).Add(float64(n))
+				}
+			}
+		}
+	}
+	if err != nil {
+		slog.Error("retention: exemplar purge failed",
+			"cutoff", cutoff.Format(time.RFC3339), "rows_deleted", stats.Total(), "error", err)
+		return
+	}
+	slog.Info("retention: exemplar purge complete",
+		"cutoff", cutoff.Format(time.RFC3339),
+		"retention_days", r.exemplarRetentionDays,
+		"traces_deleted", stats.Traces,
+		"spans_deleted", stats.Spans,
+		"logs_deleted", stats.Logs,
+		"weak_refs_deleted", stats.OrphanSpans,
+		"duration", time.Since(start),
+	)
 }
 
 // purgeAggregate runs the aggregate store's share of one retention tick.
@@ -225,6 +301,11 @@ func (r *RetentionScheduler) runPurge(ctx context.Context) {
 		driver = "sqlite"
 	}
 	cutoff := time.Now().UTC().Add(-time.Duration(r.retentionDays) * 24 * time.Hour)
+
+	// Exemplar tier first (#201 Q2). It has the shorter retention, so it frees
+	// the most pages per second of writer lock, and doing it before the 7-day
+	// pass means the long pass runs against a smaller table.
+	r.runExemplarPurge(ctx)
 
 	// The aggregate store is a separate database file with its own writer, so
 	// its purge never contends with the relational one (ADR 0003).

--- a/internal/storage/shedding.go
+++ b/internal/storage/shedding.go
@@ -1,0 +1,36 @@
+package storage
+
+// SheddingState is the staged raw-retention shedding level driven by the disk
+// watchdog (#201 Q5). It lives in this package because the watchdog owns it;
+// internal/ingest already imports storage, so the exemplar policy can read the
+// same type without a new dependency edge.
+//
+// The ladder is deliberately short. Every extra rung is another state an
+// operator has to reason about at 3am while the volume fills.
+type SheddingState int32
+
+const (
+	// SheddingNone is normal operation: the raw exemplar policy's own budgets
+	// are the only gate.
+	SheddingNone SheddingState = iota
+	// SheddingErrorsOnly (>=90% of the enforcement ceiling) keeps error trace
+	// and log exemplars and refuses healthy/slow/WARN raw retention. Aggregate
+	// accounting is untouched — it is the thing that stays complete.
+	SheddingErrorsOnly
+	// SheddingRawOff (>=95%) refuses ALL new raw exemplar admission and the
+	// exemplar DLQ fallback with it. Writing an exemplar to the DLQ at 95% is
+	// still writing to the disk that is about to fill.
+	SheddingRawOff
+)
+
+// String renders the state as its metric label.
+func (s SheddingState) String() string {
+	switch s {
+	case SheddingErrorsOnly:
+		return "errors_only"
+	case SheddingRawOff:
+		return "raw_off"
+	default:
+		return "none"
+	}
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -321,6 +321,33 @@ type Metrics struct {
 	// and causal-analysis tools report partial coverage for them (#163).
 	ExemplarTruncatedTotal prometheus.Counter
 
+	// --- 8 GiB data budget and disk watchdog (#201 Q1/Q5) ---
+	// DiskBudgetBytes — the ENFORCEMENT ceiling actually in effect: the lower
+	// of DATA_DISK_BUDGET_MB and the usable volume capacity. A volume smaller
+	// than the configured budget does not grow because the config says so.
+	DiskBudgetBytes prometheus.Gauge
+	// DiskUsedBytes / DiskUsedRatio — statfs allocation on the data volume and
+	// its fraction of DiskBudgetBytes. This pair, not summed file sizes, is
+	// what the shedding ladder reads.
+	DiskUsedBytes prometheus.Gauge
+	DiskUsedRatio prometheus.Gauge
+	// DiskComponentBytes / DiskComponentHighWaterBytes — per-tier attribution
+	// against the budget table (main_db, aggregate_db, dlq, wal). The
+	// high-water gauge is what the seven-day gate (#202) validates the table
+	// against; the instantaneous gauge alone hides the peak that mattered.
+	DiskComponentBytes          *prometheus.GaugeVec
+	DiskComponentHighWaterBytes *prometheus.GaugeVec
+	// DiskSheddingState — 0 none, 1 errors_only, 2 raw_off.
+	DiskSheddingState prometheus.Gauge
+	// DiskSheddingTransitionsTotal — every state change, labeled from/to.
+	// Flapping is visible here and nowhere else.
+	DiskSheddingTransitionsTotal *prometheus.CounterVec
+	// ExemplarRowsPurgedTotal / ExemplarPurgeDurationSeconds — throughput of
+	// the exemplar-tier purge (EXEMPLAR_RETENTION_DAYS), separate from the
+	// HOT_RETENTION_DAYS counters so the two retentions are distinguishable.
+	ExemplarRowsPurgedTotal      *prometheus.CounterVec
+	ExemplarPurgeDurationSeconds prometheus.Histogram
+
 	// Atomic counters for JSON health endpoint (avoids scraping Prometheus)
 	totalIngested  atomic.Int64
 	activeConns    atomic.Int64
@@ -758,6 +785,43 @@ func New() *Metrics {
 	m.ExemplarTruncatedTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "otelcontext_exemplar_truncated_total",
 		Help: "Retained traces forced past max spans/bytes. Persisted with truncated=true plus retained/observed span counts.",
+	})
+	m.DiskBudgetBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "otelcontext_disk_budget_bytes",
+		Help: "Enforcement ceiling for the data volume: min(DATA_DISK_BUDGET_MB, usable volume capacity).",
+	})
+	m.DiskUsedBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "otelcontext_disk_used_bytes",
+		Help: "statfs allocation on the data volume in bytes.",
+	})
+	m.DiskUsedRatio = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "otelcontext_disk_used_ratio",
+		Help: "Data volume allocation as a fraction of the enforcement ceiling. Shedding starts at 0.90, raw-off at 0.95.",
+	})
+	m.DiskComponentBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "otelcontext_disk_component_bytes",
+		Help: "Per-component disk attribution against the 8 GiB budget table. component=main_db|aggregate_db|dlq|wal.",
+	}, []string{"component"})
+	m.DiskComponentHighWaterBytes = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "otelcontext_disk_component_high_water_bytes",
+		Help: "Highest observed value of otelcontext_disk_component_bytes since process start, by component.",
+	}, []string{"component"})
+	m.DiskSheddingState = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "otelcontext_disk_shedding_state",
+		Help: "Raw-retention shedding level: 0 none, 1 errors_only (>=90%), 2 raw_off (>=95%).",
+	})
+	m.DiskSheddingTransitionsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_disk_shedding_transitions_total",
+		Help: "Disk shedding state changes, labeled by the states moved between.",
+	}, []string{"from", "to"})
+	m.ExemplarRowsPurgedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_exemplar_rows_purged_total",
+		Help: "Rows removed by the exemplar-tier purge (EXEMPLAR_RETENTION_DAYS), by table.",
+	}, []string{"table"})
+	m.ExemplarPurgeDurationSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "otelcontext_exemplar_purge_duration_seconds",
+		Help:    "Wall time of one exemplar-tier purge pass.",
+		Buckets: prometheus.DefBuckets,
 	})
 	return m
 }

--- a/main.go
+++ b/main.go
@@ -663,6 +663,12 @@ func main() {
 			"note", "durable ACK: Export returns only after the group commit",
 		)
 
+		// Exemplar-tier retention (#201 Q2). Only in aggregate mode: there the
+		// raw rows are exemplars attached to a seven-day aggregate dataset and
+		// a two-day purge is budget enforcement. In legacy and shadow the raw
+		// rows ARE the dataset and the same purge would be data loss.
+		retention.SetExemplarRetention(cfg.ExemplarRetentionDays)
+
 		// Retention owns the hourly aggregate purge and the conservative daily
 		// ANALYZE. No VACUUM on this file, by decision (#162).
 		retention.SetAggregateRetention(
@@ -720,6 +726,11 @@ func main() {
 		"aggregate_store", cfg.AggregateMode != aggregate.ModeLegacy,
 	)
 
+	// diskWatchdogPolicy is the exemplar policy the disk watchdog sheds
+	// through. nil outside aggregate mode, where there is no exemplar policy
+	// to shed and the raw rows are the dataset.
+	var diskWatchdogPolicy *ingest.ExemplarPolicy
+
 	// Bounded exemplar retention (#176). In AGGREGATE_MODE=aggregate this is
 	// the ONLY raw-retention gate — the adaptive sampler below is skipped
 	// entirely, so SAMPLING_RATE has no effect on what gets persisted (#161).
@@ -738,10 +749,13 @@ func main() {
 			LogsWarnPerServiceWindow:  cfg.ExemplarLogsWarnPerServiceWindow,
 			MaxSpansPerTrace:          cfg.ExemplarMaxSpansPerTrace,
 			MaxBytesPerTrace:          int64(cfg.ExemplarMaxBytesPerTrace),
+			SynthLogsPerSpan:          cfg.ExemplarSynthLogsPerSpan,
+			SynthLogsPerTrace:         cfg.ExemplarSynthLogsPerTrace,
 			Metrics:                   metrics,
 		})
 		traceServer.SetExemplarPolicy(exemplarPolicy)
 		logsServer.SetExemplarPolicy(exemplarPolicy)
+		diskWatchdogPolicy = exemplarPolicy
 		slog.Info("🎚️  Bounded exemplar retention enabled (adaptive sampler retired)",
 			"traces_per_service_window", cfg.ExemplarTracesPerServiceWindow,
 			"traces_global_window", cfg.ExemplarTracesGlobalWindow,
@@ -749,6 +763,9 @@ func main() {
 			"bytes_global_window", cfg.ExemplarBytesGlobalWindow,
 			"healthy_rate", cfg.ExemplarHealthyRate,
 			"latency_threshold_ms", cfg.SamplingLatencyThresholdMs,
+			"retention_days", cfg.ExemplarRetentionDays,
+			"synth_logs_per_span", cfg.ExemplarSynthLogsPerSpan,
+			"synth_logs_per_trace", cfg.ExemplarSynthLogsPerTrace,
 		)
 	} else if cfg.SamplingRate > 0 && cfg.SamplingRate < 1.0 {
 		// Wire adaptive sampler (only when rate < 1.0 to avoid unnecessary overhead)
@@ -760,6 +777,49 @@ func main() {
 			"latency_threshold_ms", cfg.SamplingLatencyThresholdMs,
 		)
 	}
+
+	// Disk watchdog (#201 Q5). statfs on the data volume drives staged
+	// shedding with hysteresis; per-component file sizes attribute the 8 GiB
+	// budget table (#201 Q1) so the seven-day gate (#202) validates it against
+	// measurements rather than intent.
+	diskWatchdog := storage.NewDiskWatchdog(storage.DiskWatchdogConfig{
+		Path:        cfg.DataDiskPath,
+		BudgetBytes: int64(cfg.DataDiskBudgetMB) * 1024 * 1024,
+		Metrics:     metrics,
+		OnRawOff: func() {
+			// At >=95% waiting up to an hour for the next retention tick is
+			// not a plan. Purge the expired exemplar tier now, then checkpoint
+			// the WAL so the freed pages are actually handed back.
+			retention.PurgeExemplarsNow(ctxRetention)
+			if err := repo.CheckpointWAL(ctxRetention); err != nil {
+				slog.Error("disk watchdog: WAL checkpoint failed", "error", err)
+			}
+		},
+	})
+	diskWatchdog.AddComponent("main_db", func() int64 { return repo.HotDBSizeBytes() })
+	diskWatchdog.AddComponent("wal", func() int64 {
+		return sidecarBytes(sqliteMainDBPath(cfg)) + sidecarBytes(cfg.AggregateDBPath)
+	})
+	if cfg.AggregateMode != aggregate.ModeLegacy {
+		diskWatchdog.AddComponent("aggregate_db", func() int64 { return fileBytes(cfg.AggregateDBPath) })
+	}
+	if dlq != nil {
+		diskWatchdog.AddComponent("dlq", func() int64 { return dlq.DiskBytes() })
+	}
+	if diskWatchdogPolicy != nil {
+		diskWatchdog.AddObserver(diskWatchdogPolicy.SetShedding)
+	}
+	apiServer.SetDiskPressureProbe(func() (string, bool) {
+		return diskWatchdog.State().String(), diskWatchdog.Healthy()
+	})
+	ctxDisk, cancelDisk := context.WithCancel(context.Background())
+	diskWatchdog.Start(ctxDisk)
+	slog.Info("💽 Disk watchdog started",
+		"path", cfg.DataDiskPath,
+		"budget_mb", cfg.DataDiskBudgetMB,
+		"errors_only_at", "90%",
+		"raw_off_at", "95%",
+	)
 
 	// Wire async ingest pipeline. Decouples OTLP Export() from synchronous
 	// DB writes — caller returns as soon as the parsed batch is enqueued.
@@ -1317,6 +1377,8 @@ func main() {
 	dlq.Stop()
 
 	// 4a. Stop retention + partition schedulers before closing DB (both issue queries).
+	cancelDisk()
+	diskWatchdog.Stop()
 	cancelRetention()
 	retention.Stop()
 	cancelPartitions()
@@ -1483,4 +1545,41 @@ func graphRAGServiceEdges(ctx context.Context, g *graphrag.GraphRAG) []storage.S
 		})
 	}
 	return edges
+}
+
+// fileBytes returns the size of one file, or 0 when it cannot be stat'ed.
+// Attribution only: a missing file is a component that is not using disk.
+func fileBytes(path string) int64 {
+	if path == "" {
+		return 0
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return fi.Size()
+}
+
+// sidecarBytes returns the combined size of a SQLite file's -wal and -shm
+// sidecars. They are charged to the WAL/temp tier of the budget table, not to
+// the database tier: a checkpoint moves bytes between the two and the gauges
+// should show that rather than double-count it.
+func sidecarBytes(path string) int64 {
+	if path == "" {
+		return 0
+	}
+	return fileBytes(path+"-wal") + fileBytes(path+"-shm")
+}
+
+// sqliteMainDBPath resolves the main relational DB file for SQLite. Mirrors the
+// default in storage.NewDatabase; returns "" for every server-backed driver,
+// where there is no local file to stat.
+func sqliteMainDBPath(cfg *config.Config) string {
+	if strings.ToLower(cfg.DBDriver) != "sqlite" && cfg.DBDriver != "" {
+		return ""
+	}
+	if cfg.DBDSN == "" {
+		return "OtelContext.db"
+	}
+	return cfg.DBDSN
 }


### PR DESCRIPTION
Implements the frozen contract from #201 (map #195, parent #194). Branched from `origin/main` at 8f0f524 (post-#210).

## Q1 — 8 GiB budget table

| Tier | Allocation | Covers |
|---|---|---|
| Main relational tier | 4.5 GiB | Raw trace/span/log exemplars, synthesized logs, investigations and other main-DB metadata, indexes, FTS5, free pages |
| `aggregate.db` | 1.5 GiB | Buckets, delta log, baselines, identity tables, indexes |
| DLQ | 0.5 GiB | Existing `DLQ_MAX_DISK_MB` cap |
| WAL/SHM + temp | 0.5 GiB | `-wal`/`-shm` sidecars of both DBs, SQLite temp, TLS, transient maintenance |
| Headroom | 1 GiB | Mandatory, unused |

Documented in `CLAUDE.md` (no separate budget doc exists). Every component gets a measured high-water gauge: `otelcontext_disk_component_bytes{component}` and `otelcontext_disk_component_high_water_bytes{component}` for `main_db|aggregate_db|dlq|wal`. Unused allocation in one tier never authorizes another to consume the final 1 GiB — the tiers are separate gauges, not a shared pool.

## Q2 — Exemplar retention + window budget

- `EXEMPLAR_BYTES_GLOBAL_WINDOW` default **8 MiB → 3 MiB**. 4 MiB remains configurable, is not the default. Per-service stays 512 KiB.
- New `EXEMPLAR_RETENTION_DAYS=2`, validated `1..HOT_RETENTION_DAYS`. Drives `Repository.PurgeExemplarsBatched`: exemplar traces + the spans that batch orphans inside **one transaction per batch**, then logs (FTS rows follow via the content-linked `AFTER DELETE` trigger — verified in test), then a sweep of expired weak references left by a cancelled pass. Runs on the existing purge tick **ahead of** the 7-day purge. Aggregate retention unchanged at 7 days.
- Wired only in `AGGREGATE_MODE=aggregate`. **Judgment call:** in legacy/shadow the raw rows are the dataset, so a 2-day purge would be data loss rather than budget enforcement.

## Q3 — Synthesized-log metering

`AllowSynthesizedLog` (severity floor only) is replaced by `ReserveSynthesizedLog`, which reserves `len(body)+len(attributesJSON)+logRowFixedBytes` against the selected trace's per-trace budget AND the shared per-service/global window budgets, under new `EXEMPLAR_SYNTH_LOGS_PER_SPAN=8` / `EXEMPLAR_SYNTH_LOGS_PER_TRACE=64`. Refusals drop the log, increment `otelcontext_exemplar_dropped_total{signal="logs",reason}` with `synth_per_span|synth_per_trace|budget_bytes`, and stamp the trace truncated. They do not consume the ordinary log-exemplar quota. A cheap `SynthesizedLogEligible` pre-gate keeps INFO span events from paying for a JSON marshal before refusal.

## Q4 — Reservation lifecycle

`ChargeSpan`/`AdmitLog` → `ReserveSpan`/`ReserveLog` taking an `*ExemplarReservation`. Reserve before row construction → commit when the primary queue or DLQ accepts the batch → release only when the row never reached a destination (dropped pre-submission, or both destinations refused). Reserved bytes bind the cap exactly like committed ones. Once accepted the charge is monotonic for that window: eviction releases the count slot and never the bytes. `Batch.Reservation` carries the charge to the submit boundary; `submitExemplars` settles it.

## Q5 — Disk watchdog

`internal/storage/disk_watchdog.go`. `statfs` on `DATA_DISK_PATH` is the enforcement source (build-tagged shims for linux/darwin/other, stdlib `syscall`, no new dependency); ceiling = `min(DATA_DISK_BUDGET_MB, usable volume capacity)`. ≥90% → `errors_only` (error exemplars only; healthy/slow/WARN off). ≥95% → `raw_off` (all raw admission off, exemplar DLQ fallback closed, immediate expired-exemplar purge + `wal_checkpoint(TRUNCATE)`, `/ready` → 503). Hysteresis: leave `raw_off` below 90%, `errors_only` below 85%. A failed `statfs` holds the current state rather than shedding on a syscall error.

Raw shedding never converts a successful aggregate Export into a retryable failure. The exception: `aggregate.IsDiskFull` classifies `ENOSPC`/`EDQUOT`/`SQLITE_FULL` on the authoritative commit path and maps it to `RESOURCE_EXHAUSTED` (429 over HTTP OTLP), so the Export fails and the client retries. Shadow mode still swallows it — there the legacy raw path is the source of truth.

## Test results (real)

```
go build ./...                                  ok
go vet ./...                                    ok
go test -race -count=1 ./internal/ingest/... ./internal/storage/... ./internal/aggregate/...
                                                798 passed, 3 packages
go test -count=1 ./...                          1358 passed, 29 packages
golangci-lint run (touched packages)            no new findings
```

New tests: reservation commit/release/idempotence/merge, reserved bytes binding the cap, committed bytes surviving post-acceptance eviction with the count slot still released, span-slot vs synthesized-log release, Export-boundary commit and release; synthesized-log per-span/per-trace/byte caps with truncation stamping and quota isolation; shedding ladder + hysteresis transition table over a fake `statfs`, ceiling clamping, stat-failure hold, high-water marks; exemplar purge (2-day gone incl. FTS, hot-tier intact, weak-reference sweep, transactional rollback, scheduler wiring, on-demand trigger); `IsDiskFull` classification incl. adjacent non-disk-full errors; `ENOSPC`/`SQLITE_FULL` → Export failure at both `applyAggregate` and `TraceServer.Export`; readiness disk probe; config validation for all four new knobs.

## Judgment calls

1. **Enforcement is pure `statfs`**, not summed component file sizes. Per the contract, file sizes are attribution gauges only.
2. **Exemplar purge is aggregate-mode-only** (see Q2 above).
3. **"Expired weak references"** has no dedicated table in this codebase; the closest real referent is spans whose trace row is gone (the existing `PurgeTracesBatched` orphan sweep). Implemented as that, bounded to `start_time < cutoff` so clock-skewed spans under a live trace are never swept.
4. **Eviction releases the count slot only.** Reserved bytes belonging to an evicted trace stay with the reservation, which commits or releases them at the submit boundary — a second refund path would double-count.
5. **`ENOSPC` maps to `RESOURCE_EXHAUSTED`**, not `UNAVAILABLE`, so the existing HTTP OTLP mapping produces a retryable 429.
6. **New metrics use the `otelcontext_` prefix**, matching the #199/#200 surface rather than the older `OtelContext_` gauges.
7. **No new SQLite per-driver default flips.** The contract did not ask for one and the 3 MiB window is already the SQLite-survival number.

## Unverified

The 4.5/1.5/0.5/0.5/1 GiB split is arithmetic and policy; only the seven-day gate (#202) can confirm the real amplification factor. The `2x` DB/index/FTS amplification is the contract's provisional assumption, carried into the docs as provisional. Nothing here was run against a real 8 GiB volume under load — the watchdog is exercised through an injected `statfs`.
