### PR TITLE
feat(aggregate): retire legacy TSDB path in aggregate mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ is positive-only at scale 4.
 
 | Point type | Aggregate handling |
 |---|---|
-| `NumberDataPoint` (Gauge, Sum) | Gauge-like or baseline-converted per the temporality model. Also feeds the TSDB ring and the real-time bypass. |
+| `NumberDataPoint` (Gauge, Sum) | Gauge-like or baseline-converted per the temporality model. In legacy and shadow it also feeds the TSDB ring and the real-time bypass; in `AGGREGATE_MODE=aggregate` neither exists and no `tsdb.RawMetric` is built at all. |
 | `HistogramDataPoint` (delta) | Bucket counts folded as **weighted** synthetic observations at each finite positive bucket's geometric midpoint — one sketch add per bucket, never one per count. |
 | `ExponentialHistogramDataPoint` (delta) | Exact index transfer. Scale > 4 downscales by shifting indexes; scale 0–3 downscales the accumulating sketch to the source scale; `zero_count` folds into the zero bucket. |
 | `SummaryDataPoint` | **Wholly unsupported.** Producer-chosen quantiles cannot be merged across series or windows. |
@@ -127,6 +127,55 @@ population statistics and accuracy metadata; v5 added `aggregate_log_template`
 (durable log-template miner state) plus the `dict_id_high_watermark` /
 `series_id_high_watermark` meta keys. An older file cannot be migrated — start
 an older binary or set `AGGREGATE_ALLOW_REBUILD=true`.
+
+### Legacy TSDB retirement in aggregate mode (#194 finding 10)
+
+`AGGREGATE_MODE=aggregate` constructs **no** `tsdb.Aggregator`, **no**
+`tsdb.RingBuffer` and **no** metric callback. `main.go` gates all three on
+`legacyMetricPath(cfg.AggregateMode)`, which is false only for pure aggregate
+mode — legacy has no other metric store, and shadow's entire job is running both
+paths side by side.
+
+Consequences, all deliberate:
+
+- `MetricsServer.exportNumberPoints` skips the `tsdb.RawMetric` build (and its
+  per-point attribute map) when neither a TSDB aggregator nor a metric callback
+  is wired. The aggregate reducer still sees every point.
+- Nothing writes the `metric_buckets` table. The rows are not read in aggregate
+  mode either; `RetentionScheduler` keeps purging whatever an earlier legacy run
+  left behind.
+- `GraphRAG.OnMetricIngested` is not called. Metric nodes were already replaced
+  per topology revision in aggregate mode, so the callback was paying for a
+  channel hop and an allocation to have `processMetric` discard the event.
+- `EventHub.BroadcastMetric` is not called. The aggregate publisher already
+  short-circuited it; the coalesced revision-driven snapshot is the live feed.
+- The TSDB-specific Prometheus collectors are **unregistered** at startup via
+  `Metrics.DisableTSDBCollectors()`: `OtelContext_tsdb_ingest_total`,
+  `_tsdb_flush_duration_seconds`, `_tsdb_batches_dropped_total`,
+  `_tsdb_cardinality_overflow_total`,
+  `otelcontext_tsdb_cardinality_overflow_by_tenant_total`,
+  `otelcontext_tsdb_ring_series_active`, `otelcontext_tsdb_ring_series_rejected_total`.
+  A cardinality counter frozen at 0 reads as "no overflow" rather than "no
+  TSDB". The aggregate engine publishes its own admission and cardinality caps
+  (#200/#201) and must not be shadowed by dead series. `METRIC_MAX_CARDINALITY`
+  therefore has no effect in aggregate mode.
+
+**Metric read endpoints in aggregate mode.** Both are served from the engine's
+topology projection (`Engine.TopologySnapshot`), not from `metric_buckets`:
+
+| Endpoint | Aggregate-mode source | What changes |
+|---|---|---|
+| `GET /api/metrics?name=…` | Topology projection metric windows | Same bare-array shape and `time_bucket ASC` ordering. Bucket **width** is the engine's 5-minute window, not 30s. `id` is `0` and `attributes_json` is empty — an aggregate window has no row identity and the projection keys metrics by `(service, name)` only. |
+| `GET /api/metadata/metrics` | Distinct names in the projection | Same sorted bare array. |
+
+Both stamp the `OtelContext-Data-Coverage` header. `/api/metrics` is `full` when
+the requested range sits inside the retained horizon and no projection cap fired,
+`sampled` otherwise. `/api/metadata/metrics` is **always** `sampled`: the
+projection retains a bounded recent horizon (the mutable windows plus
+`TopologySnapshot.Horizon`, 30m by default) while the legacy answer spanned
+`HOT_RETENTION_DAYS`, so a metric that stopped reporting an hour ago is simply
+absent. History older than that horizon is unavailable in aggregate mode — it is
+reported as reduced coverage, never as a flat line.
 
 ### Aggregate identity lifecycle (#200)
 
@@ -193,7 +242,7 @@ Observability: `otelcontext_aggregate_gc_runs_total{result}`,
 | Layer | Package | Purpose |
 |-------|---------|---------|
 | GraphRAG (in-memory) | `internal/graphrag/` | Layered graph: 4 typed stores, error chains, root cause analysis, anomaly detection |
-| Time Series (in-memory) | `internal/tsdb/` | Ring buffer, sliding windows, pre-computed percentiles |
+| Time Series (in-memory) | `internal/tsdb/` | Ring buffer, sliding windows, pre-computed percentiles. **Not constructed in `AGGREGATE_MODE=aggregate`** — the aggregate engine owns metric storage and reads there (#194 finding 10). |
 | Graph (in-memory, legacy) | `internal/graph/` | Simple service topology — **being replaced by GraphRAG** |
 | Relational (persistent) | `internal/storage/` | GORM-based, multi-DB, single source of truth. Driven by `RetentionScheduler` (hourly batched purge + daily VACUUM/ANALYZE). `logs.body` is plain TEXT. **Log search**: SQLite FTS5 (`logs_fts`, porter+unicode61, ordered by `bm25()`, AFTER INSERT/DELETE/UPDATE triggers) is the default path — `LOG_FTS_ENABLED` defaults to `true` when `DB_DRIVER=sqlite` and `false` otherwise. Operators who want the ~30% disk savings can set `LOG_FTS_ENABLED=false` and reclaim the FTS table + indexes via `POST /api/admin/drop_fts`. Postgres uses `pg_trgm` GIN on `logs.body` and `logs.service_name`. `AttributesJSON` and `AIInsight` remain `CompressedText`. The `search_logs` MCP tool and the API `/api/logs?q=…` filter are clamped to the **last 24 hours** to bound the LIKE-fallback worst case. The `vectordb` package (TF-IDF semantic search) was removed on 2026-05-24 alongside the `find_similar_logs` MCP tool — `data/vectordb.snapshot` is left on disk for operators to delete by hand. |
 
@@ -250,6 +299,10 @@ TraceServer.Export() → DB persist → spanCallback → GraphRAG.OnSpanIngested
 LogsServer.Export()  → DB persist → logCallback  → GraphRAG.OnLogIngested()
 MetricsServer.Export() → TSDB    → metricCallback → GraphRAG.OnMetricIngested()
 ```
+
+In `AGGREGATE_MODE=aggregate` the metric line does not exist: no TSDB, no
+`metricCallback`, no `tsdb.RawMetric`. Metric state reaches GraphRAG through the
+engine's topology snapshot instead.
 
 **Pre-sample topology observer** (`internal/graphrag/topology_observer.go`): `TraceServer.Export()` also calls `GraphRAG.ObserveSpanTopology()` for **every** received span *before* the sampler's keep/drop decision, so cross-service CALLS edges are recorded independent of `SAMPLING_RATE`. Without it, an edge formed only when both the caller and callee spans survived sampling (~`rate²` joint probability), so at low sampling the service map showed nodes but almost no edges/flow. The observer is existence-only (`ServiceStore.EnsureService`/`EnsureCallEdge` create with zeroed aggregates, no-op if present) so the sampled path stays the **sole** source of CallCount/latency/error-rate; it's bounded by a per-tenant spanID→service LRU (cap 100k) + per-pair dedup (memory ≈ #service-pairs) and never touches TraceStore/eventCh, so the SQLite OOM-survival bounds are unaffected.
 
@@ -311,7 +364,7 @@ duplicate on replay.
 Proper LIFO ordering to prevent data loss:
 1. gRPC `GracefulStop()` + HTTP `Shutdown()` — stop ingestion
 2. WebSocket Hub + Event Hub + AI Service — stop real-time
-3. TSDB + Graph + GraphRAG — stop processing
+3. TSDB + Graph + GraphRAG — stop processing (TSDB is nil and skipped in aggregate mode)
 4. DLQ — stop replay
 5. RetentionScheduler `Stop()` — halt purge/maintenance ticks
 6. DB `Close()` — close database last
@@ -344,7 +397,7 @@ internal/
   realtime/     # WebSocket hub + event streaming
   storage/      # GORM repository, models, migrations, Close() method, SQLite PRAGMA stanza
   telemetry/    # Prometheus metrics + health (19 metrics)
-  tsdb/         # Time series aggregator + ring buffer (lock-free Windows())
+  tsdb/         # Time series aggregator + ring buffer (lock-free Windows()) — legacy/shadow only
   ui/           # Embedded React frontend
 ui/             # React frontend (Vite + token CSS Modules, no UI framework)
 test/           # Microservice simulation (7 services)
@@ -374,7 +427,7 @@ Key settings in `internal/config/config.go`:
 - `EXEMPLAR_SYNTH_LOGS_PER_SPAN` (8), `EXEMPLAR_SYNTH_LOGS_PER_TRACE` (64) — count caps on logs synthesized from span events and span status
 - `DATA_DISK_BUDGET_MB` (8192), `DATA_DISK_PATH` (`./data`) — disk watchdog ceiling and the volume it `statfs`-es
 - `SAMPLING_RATE` (1.0), `SAMPLING_ALWAYS_ON_ERRORS` (true), `SAMPLING_LATENCY_THRESHOLD_MS` (500)
-- `METRIC_MAX_CARDINALITY` (10000), `METRIC_MAX_CARDINALITY_PER_TENANT` (0 = unlimited), `API_RATE_LIMIT_RPS` (100). The per-tenant cap is checked first; when set, a noisy tenant cannot exhaust the global pool. Overflow is labeled by tenant via `otelcontext_tsdb_cardinality_overflow_by_tenant_total{tenant_id}` (`__global__` sentinel when the global cap was the trigger).
+- `METRIC_MAX_CARDINALITY` (10000), `METRIC_MAX_CARDINALITY_PER_TENANT` (0 = unlimited), `API_RATE_LIMIT_RPS` (100). The per-tenant cap is checked first; when set, a noisy tenant cannot exhaust the global pool. Overflow is labeled by tenant via `otelcontext_tsdb_cardinality_overflow_by_tenant_total{tenant_id}` (`__global__` sentinel when the global cap was the trigger). **Both caps are TSDB-only and inert in `AGGREGATE_MODE=aggregate`**, where the collectors are unregistered and the aggregate engine's own caps apply.
 - `MCP_ENABLED` (true), `MCP_PATH` (/mcp)
 - `MCP_MAX_CONCURRENT` (32), `MCP_CALL_TIMEOUT_MS` (30000), `MCP_CACHE_TTL_MS` (5000) — MCP HTTP streamable robustness. Counting semaphore gates concurrent `tools/call` (JSON-RPC `-32000` past the cap), per-call deadlines abort runaway handlers (JSON-RPC `-32001`), and a 5s TTL cache memoizes the cheap in-memory GraphRAG tools (`get_service_map`, `impact_analysis`, `root_cause_analysis`, `get_anomaly_timeline`, `get_service_health`). SSE GET sends a `: keep-alive\n\n` comment every 25s to keep the stream alive across reverse-proxy idle timeouts. Set any to 0 to disable.
 - `LOG_FTS_ENABLED` — when truthy (`true`/`yes`/`on`/`1`), provisions the SQLite FTS5 `logs_fts` virtual table + sync triggers at startup; when false, log-search uses a 24h-clamped LIKE fallback. **Defaults to `true` when `DB_DRIVER=sqlite`** (BM25 is dramatically faster than LIKE on the kept `search_logs` MCP tool) and `false` otherwise. Toggle off and reclaim the ~30% disk overhead via `POST /api/admin/drop_fts` (refused while the flag is on). The vectordb-backed semantic-search path was removed on 2026-05-24.
@@ -402,7 +455,7 @@ So a 100+ service deployment on SQLite survives without OOM, `config.Load()` ove
 | `INGEST_PIPELINE_MAX_BYTES` | 128 MB | 512 MB | Item count alone cannot bound queue memory; one batch may carry MBs of spans/logs. |
 | `GRAPHRAG_EVENT_QUEUE_SIZE` | 10000 | 100000 | Each queued event embeds a Span/Log by value (~0.5–2 KB); buffer less, drop sooner (metered). |
 | `GRAPHRAG_TRACE_TTL` | 30m | 1h | The in-memory span window is the largest legitimate GraphRAG consumer; anomaly/investigation lookbacks are ≤5min. |
-| `METRIC_MAX_CARDINALITY` | 3000 | 10000 | Bound the in-memory TSDB series map. |
+| `METRIC_MAX_CARDINALITY` | 3000 | 10000 | Bound the in-memory TSDB series map (no effect in aggregate mode). |
 | `SAMPLING_RATE` | 0.05 | 1.0 | Errors and slow spans are always kept by `SAMPLING_ALWAYS_ON_ERRORS`. |
 | `GRPC_MAX_CONCURRENT_STREAMS` | 240 | 1000 | ~2 streams per service at 120 services with headroom. |
 | `LOG_FTS_ENABLED` | `true` | n/a | FTS5 BM25 is dramatically faster than LIKE on the kept `search_logs` path. |

--- a/internal/api/metric_series_aggregate_test.go
+++ b/internal/api/metric_series_aggregate_test.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/api/views"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+// #194 finding 10: AGGREGATE_MODE=aggregate does not start the legacy TSDB, so
+// metric_buckets is never written. GET /api/metrics and GET /api/metadata/metrics
+// must therefore answer from the aggregate engine's topology projection — with
+// the same wire shape and an honest coverage header — instead of scanning a
+// table nothing fills.
+
+// seedAggregateMetric folds gauge samples for one (service, metric) through a
+// reducer. It must go through ApplyReducer rather than ApplyCommitted: only the
+// reducer path carries the string identities the topology projection is keyed
+// by, and the projection is what the metric endpoints read.
+func seedAggregateMetric(t *testing.T, e *aggregate.Engine, tenant, service, name string, values ...float64) {
+	t.Helper()
+	r := e.NewReducer(time.Now())
+	for _, v := range values {
+		r.ReduceMetricPoint(aggregate.MetricInput{
+			Tenant:      tenant,
+			Service:     service,
+			Name:        name,
+			Value:       v,
+			Timestamp:   time.Now(),
+			Temporality: aggregate.TemporalityUnspecified,
+		})
+	}
+	e.ApplyReducer(r)
+}
+
+// getArray issues a tenant-scoped GET and decodes the bare JSON array the
+// metric endpoints return. getJSON cannot be reused: it decodes into an object.
+func getArray[T any](t *testing.T, h http.HandlerFunc, target, tenant string) (*httptest.ResponseRecorder, []T) {
+	t.Helper()
+	ctx := storage.WithTenantContext(context.Background(), tenant)
+	req := httptest.NewRequest(http.MethodGet, target, nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET %s = %d: %s", target, rr.Code, rr.Body.String())
+	}
+	var out []T
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode %s: %v (%s)", target, err, rr.Body.String())
+	}
+	return rr, out
+}
+
+// metricWindowRange is a request window wide enough to contain the engine's
+// current five-minute window and still sit inside the projection horizon, so
+// the answer is expected to be full coverage.
+func metricWindowRange() (string, string) {
+	now := time.Now()
+	return now.Add(-10 * time.Minute).UTC().Format(time.RFC3339),
+		now.Add(10 * time.Minute).UTC().Format(time.RFC3339)
+}
+
+func TestMetricBucketsServedFromAggregateEngine(t *testing.T) {
+	const (
+		tenant = "default"
+		metric = "queue.depth"
+	)
+	s, counter, engine := aggregateTestServer(t, true)
+	seedAggregateMetric(t, engine, tenant, "checkout", metric, 4, 9, 2)
+	seedAggregateMetric(t, engine, tenant, "orders", "other.metric", 1)
+
+	start, end := metricWindowRange()
+	rr, buckets := getArray[views.MetricBucket](t, s.handleGetMetricBuckets,
+		"/api/metrics?name="+metric+"&start="+start+"&end="+end, tenant)
+
+	if len(buckets) != 1 {
+		t.Fatalf("want one projected window for %s, got %d: %+v", metric, len(buckets), buckets)
+	}
+	got := buckets[0]
+	if got.Name != metric || got.ServiceName != "checkout" {
+		t.Errorf("bucket identity = %q/%q, want %q/checkout", got.Name, got.ServiceName, metric)
+	}
+	if got.Count != 3 || got.Sum != 15 || got.Min != 2 || got.Max != 9 {
+		t.Errorf("bucket stats = count %d sum %v min %v max %v, want 3/15/2/9",
+			got.Count, got.Sum, got.Min, got.Max)
+	}
+	if got.TimeBucket.IsZero() {
+		t.Error("bucket carries no time_bucket")
+	}
+	if cov := rr.Header().Get(aggregate.CoverageHeader); cov != string(aggregate.CoverageFull) {
+		t.Errorf("coverage header = %q, want %q", cov, aggregate.CoverageFull)
+	}
+	if len(counter.hits) != 0 {
+		t.Errorf("aggregate-mode metric read touched raw tables: %v", counter.hits)
+	}
+}
+
+// A request reaching back past the projection horizon must not be presented as
+// complete: outside the horizon the engine holds nothing, and a flat stretch of
+// chart is not evidence the metric was flat.
+func TestMetricBucketsBeyondHorizonReportSampled(t *testing.T) {
+	const tenant = "default"
+	s, _, engine := aggregateTestServer(t, true)
+	seedAggregateMetric(t, engine, tenant, "checkout", "queue.depth", 1)
+
+	start := time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339)
+	end := time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)
+	rr, _ := getArray[views.MetricBucket](t, s.handleGetMetricBuckets,
+		"/api/metrics?name=queue.depth&start="+start+"&end="+end, tenant)
+
+	if cov := rr.Header().Get(aggregate.CoverageHeader); cov != string(aggregate.CoverageSampled) {
+		t.Errorf("coverage header = %q, want %q", cov, aggregate.CoverageSampled)
+	}
+}
+
+func TestMetricNamesServedFromAggregateEngine(t *testing.T) {
+	const tenant = "default"
+	s, counter, engine := aggregateTestServer(t, true)
+	seedAggregateMetric(t, engine, tenant, "checkout", "queue.depth", 1)
+	seedAggregateMetric(t, engine, tenant, "checkout", "cache.hits", 1)
+	seedAggregateMetric(t, engine, tenant, "orders", "orders.pending", 1)
+
+	rr, names := getArray[string](t, s.handleGetMetricNames, "/api/metadata/metrics", tenant)
+	if len(names) != 3 || names[0] != "cache.hits" || names[1] != "orders.pending" || names[2] != "queue.depth" {
+		t.Errorf("names = %v, want sorted [cache.hits orders.pending queue.depth]", names)
+	}
+	// Never "full": the projection retains a bounded recent horizon while the
+	// legacy answer spanned HOT_RETENTION_DAYS.
+	if cov := rr.Header().Get(aggregate.CoverageHeader); cov != string(aggregate.CoverageSampled) {
+		t.Errorf("coverage header = %q, want %q", cov, aggregate.CoverageSampled)
+	}
+
+	_, scoped := getArray[string](t, s.handleGetMetricNames, "/api/metadata/metrics?service_name=orders", tenant)
+	if len(scoped) != 1 || scoped[0] != "orders.pending" {
+		t.Errorf("service-scoped names = %v, want [orders.pending]", scoped)
+	}
+	if len(counter.hits) != 0 {
+		t.Errorf("aggregate-mode metric-name read touched raw tables: %v", counter.hits)
+	}
+}
+
+// Legacy mode is untouched: both endpoints still read metric_buckets and neither
+// stamps a coverage header.
+func TestMetricEndpointsUnchangedInLegacyMode(t *testing.T) {
+	const tenant = "default"
+	s, _, _ := aggregateTestServer(t, false)
+	now := time.Now().UTC()
+	if err := s.repo.BatchCreateMetrics([]storage.MetricBucket{{
+		TenantID: tenant, Name: "queue.depth", ServiceName: "checkout",
+		TimeBucket: now, Min: 2, Max: 9, Sum: 15, Count: 3,
+	}}); err != nil {
+		t.Fatalf("seed metric bucket: %v", err)
+	}
+
+	start := now.Add(-10 * time.Minute).Format(time.RFC3339)
+	end := now.Add(10 * time.Minute).Format(time.RFC3339)
+	rr, buckets := getArray[views.MetricBucket](t, s.handleGetMetricBuckets,
+		"/api/metrics?name=queue.depth&start="+start+"&end="+end, tenant)
+	if len(buckets) != 1 || buckets[0].Count != 3 || buckets[0].Sum != 15 {
+		t.Fatalf("legacy buckets = %+v, want the seeded row", buckets)
+	}
+	if cov := rr.Header().Get(aggregate.CoverageHeader); cov != "" {
+		t.Errorf("legacy response stamped a coverage header: %q", cov)
+	}
+
+	_, names := getArray[string](t, s.handleGetMetricNames, "/api/metadata/metrics", tenant)
+	if len(names) != 1 || names[0] != "queue.depth" {
+		t.Errorf("legacy names = %v, want [queue.depth]", names)
+	}
+}

--- a/internal/api/metrics_handlers.go
+++ b/internal/api/metrics_handlers.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"math"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
@@ -312,6 +314,18 @@ func (s *Server) handleGetMetricBuckets(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Aggregate mode has no metric_buckets rows to read: the legacy TSDB that
+	// wrote them is not started (#194 finding 10). The series come from the
+	// engine's topology projection instead.
+	if s.aggregateReads() {
+		snap := s.aggregateEngine.TopologySnapshot(storage.TenantFromContext(r.Context()))
+		buckets, coverage := metricBucketsFromTopology(snap, name, serviceName, start, end)
+		setCoverage(w, coverage)
+		w.Header().Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
+		_ = json.NewEncoder(w).Encode(buckets)
+		return
+	}
+
 	buckets, err := s.repo.GetMetricBuckets(r.Context(), start, end, serviceName, name)
 	if err != nil {
 		slog.Error("Failed to get metric buckets", "error", err)
@@ -323,9 +337,107 @@ func (s *Server) handleGetMetricBuckets(w http.ResponseWriter, r *http.Request) 
 	_ = json.NewEncoder(w).Encode(views.MetricBucketsFromModels(buckets))
 }
 
+// metricBucketsFromTopology projects a tenant's aggregate topology snapshot
+// into the /api/metrics wire shape. The contract is unchanged — same fields,
+// same bare array, same time_bucket ASC ordering — but two properties of the
+// data differ and neither is hidden from the caller:
+//
+//   - Bucket WIDTH is the engine's five-minute window, not the TSDB's 30s.
+//   - HISTORY reaches back only as far as the projection retains (the mutable
+//     set plus TopologySnapshot.Horizon), not HOT_RETENTION_DAYS. A request
+//     reaching further back is reported as sampled coverage, never as full.
+//
+// ID is 0: an aggregate window has no row identity. AttributesJSON is empty:
+// the projection keys metric series by (service, name) only, so there are no
+// grouped attributes to restate. Both fields keep their place in the shape.
+//
+// The start/end filter is inclusive at both ends, matching the legacy
+// `time_bucket BETWEEN ? AND ?` predicate exactly — including the degenerate
+// zero-time case, where both paths return an empty array.
+func metricBucketsFromTopology(
+	snap aggregate.TopologySnapshot,
+	name, service string,
+	start, end time.Time,
+) ([]views.MetricBucket, aggregate.Coverage) {
+	out := make([]views.MetricBucket, 0, 8)
+	for _, m := range snap.Metrics {
+		if m.Metric != name {
+			continue
+		}
+		if service != "" && m.Service != service {
+			continue
+		}
+		for _, win := range m.Windows {
+			// A window the metric was not observed in carries no value
+			// statistics; emitting it would report a fabricated zero sample.
+			if win.ValueCount == 0 {
+				continue
+			}
+			if win.Start.Before(start) || win.Start.After(end) {
+				continue
+			}
+			out = append(out, views.MetricBucket{
+				Name:        m.Metric,
+				ServiceName: m.Service,
+				TimeBucket:  win.Start,
+				Min:         win.ValueMin,
+				Max:         win.ValueMax,
+				Sum:         win.ValueSum,
+				Count:       clampToInt64(win.ValueCount),
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].TimeBucket.Equal(out[j].TimeBucket) {
+			return out[i].TimeBucket.Before(out[j].TimeBucket)
+		}
+		return out[i].ServiceName < out[j].ServiceName
+	})
+	return out, metricSeriesCoverage(snap, start)
+}
+
+// metricSeriesCoverage reports whether a projected metric answer is complete.
+// It is not when a projection cap refused metric facts, and it is not when the
+// caller asked for history older than the projection retains: outside that
+// horizon the engine holds nothing, and an empty stretch of chart must not read
+// as "the metric was flat".
+func metricSeriesCoverage(snap aggregate.TopologySnapshot, start time.Time) aggregate.Coverage {
+	if snap.DroppedMetrics > 0 {
+		return aggregate.CoverageSampled
+	}
+	if snap.Horizon > 0 && !snap.Now.IsZero() && start.Before(snap.Now.Add(-snap.Horizon)) {
+		return aggregate.CoverageSampled
+	}
+	return aggregate.CoverageFull
+}
+
+// clampToInt64 narrows a projection counter for the wire shape. The counters
+// are bounded by accepted data points inside one retained window, so the clamp
+// is unreachable in practice and exists so the conversion is total.
+func clampToInt64(v uint64) int64 {
+	if v > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(v)
+}
+
 // handleGetMetricNames handles GET /api/metadata/metrics
 func (s *Server) handleGetMetricNames(w http.ResponseWriter, r *http.Request) {
 	serviceName := r.URL.Query().Get("service_name")
+
+	// Aggregate mode: metric_buckets is not written, so the DISTINCT scan has
+	// nothing to find. The names come from the engine's topology projection.
+	if s.aggregateReads() {
+		snap := s.aggregateEngine.TopologySnapshot(storage.TenantFromContext(r.Context()))
+		// Always sampled, never full: the projection holds a bounded recent
+		// horizon while the legacy answer spanned HOT_RETENTION_DAYS. A metric
+		// that stopped reporting an hour ago is absent from this list, and the
+		// header is what says so.
+		setCoverage(w, aggregate.CoverageSampled)
+		w.Header().Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
+		_ = json.NewEncoder(w).Encode(metricNamesFromTopology(snap, serviceName))
+		return
+	}
 
 	names, err := s.repo.GetMetricNames(r.Context(), serviceName)
 	if err != nil {
@@ -358,4 +470,27 @@ func (s *Server) handleGetServices(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
 	_ = json.NewEncoder(w).Encode(services)
+}
+
+// metricNamesFromTopology lists the distinct metric names the projection holds
+// for a tenant, optionally narrowed to one service. Sorted ascending and never
+// nil, matching the legacy DISTINCT ... ORDER BY name ASC answer.
+func metricNamesFromTopology(snap aggregate.TopologySnapshot, service string) []string {
+	seen := make(map[string]struct{}, len(snap.Metrics))
+	names := make([]string, 0, len(snap.Metrics))
+	for _, m := range snap.Metrics {
+		if service != "" && m.Service != service {
+			continue
+		}
+		if m.Metric == "" {
+			continue
+		}
+		if _, dup := seen[m.Metric]; dup {
+			continue
+		}
+		seen[m.Metric] = struct{}{}
+		names = append(names, m.Metric)
+	}
+	sort.Strings(names)
+	return names
 }

--- a/internal/ingest/otlp.go
+++ b/internal/ingest/otlp.go
@@ -401,9 +401,10 @@ func (s *MetricsServer) Export(ctx context.Context, req *colmetricspb.ExportMetr
 }
 
 // exportNumberPoints handles the Gauge and Sum data points of one metric: the
-// aggregate reduction, the TSDB ring buffer and the real-time bypass, in that
-// order. It is a method rather than a closure so the histogram branches above
-// stay flat and the loop body is not duplicated per instrument type.
+// aggregate reduction, then — only when a legacy consumer exists — the TSDB
+// ring buffer and the real-time bypass. It is a method rather than a closure so
+// the histogram branches above stay flat and the loop body is not duplicated
+// per instrument type.
 func (s *MetricsServer) exportNumberPoints(
 	reducer *aggregate.Reducer,
 	m *metricspb.Metric,
@@ -411,6 +412,13 @@ func (s *MetricsServer) exportNumberPoints(
 	serviceName, tenantID string,
 	producerIdentity aggregate.ResourceIdentity,
 ) {
+	// In AGGREGATE_MODE=aggregate main.go constructs neither the TSDB
+	// aggregator nor the metric callback, and this collapses to zero: no
+	// RawMetric, no per-point attribute map, no channel hop (#194 finding 10).
+	// The attribute map alone is an allocation per data point, and at 120
+	// services it is the single largest allocator left on the metric path.
+	legacy := s.aggregator != nil || s.metricCallback != nil
+
 	for _, p := range points {
 		if p == nil {
 			continue
@@ -423,19 +431,7 @@ func (s *MetricsServer) exportNumberPoints(
 			val = float64(v.AsInt)
 		}
 
-		raw := tsdb.RawMetric{
-			Name:        m.Name,
-			ServiceName: serviceName,
-			Value:       val,
-			Timestamp:   time.Unix(0, int64(p.TimeUnixNano)), // #nosec G115 -- OTLP time in nanos: uint64 source fits int64 until year 2262
-			Attributes:  make(map[string]any),
-			TenantID:    tenantID,
-		}
-
-		// Convert attributes to map for TSDB grouping
-		for _, kv := range p.Attributes {
-			raw.Attributes[kv.Key] = kv.Value.String()
-		}
+		ts := time.Unix(0, int64(p.TimeUnixNano)) // #nosec G115 -- OTLP time in nanos: uint64 source fits int64 until year 2262
 
 		// 0. Aggregate accounting, ahead of every other consumer.
 		if reducer != nil {
@@ -445,13 +441,31 @@ func (s *MetricsServer) exportNumberPoints(
 				Service:     serviceName,
 				Name:        m.Name,
 				Value:       val,
-				Timestamp:   raw.Timestamp,
+				Timestamp:   ts,
 				StartTime:   time.Unix(0, int64(p.StartTimeUnixNano)), // #nosec G115 -- OTLP time in nanos: uint64 source fits int64 until year 2262
 				Temporality: temporality,
 				Monotonic:   monotonic,
 				Resource:    producerIdentity,
 				Attributes:  p.Attributes,
 			})
+		}
+
+		if !legacy {
+			continue
+		}
+
+		raw := tsdb.RawMetric{
+			Name:        m.Name,
+			ServiceName: serviceName,
+			Value:       val,
+			Timestamp:   ts,
+			Attributes:  make(map[string]any, len(p.Attributes)),
+			TenantID:    tenantID,
+		}
+
+		// Convert attributes to map for TSDB grouping
+		for _, kv := range p.Attributes {
+			raw.Attributes[kv.Key] = kv.Value.String()
 		}
 
 		// 1. Process via TSDB Aggregator (for storage)

--- a/internal/ingest/otlp_metric_rawmetric_test.go
+++ b/internal/ingest/otlp_metric_rawmetric_test.go
@@ -1,0 +1,95 @@
+package ingest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/tsdb"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+)
+
+// #194 finding 10: in AGGREGATE_MODE=aggregate main.go constructs neither the
+// TSDB aggregator nor the metric callback, and Export must then stop building
+// tsdb.RawMetric values. RawMetric is not just a struct copy — it carries a
+// per-point attribute map, which at 120 services is the largest remaining
+// allocator on the metric path.
+//
+// The assertion is per-point allocation GROWTH rather than an absolute count:
+// the fixed cost of one Export (response struct, tenant resolution) is
+// irrelevant and would make the test a brittle transcription of the current
+// implementation.
+
+// gaugeMetricPoints builds one gauge metric carrying n data points, each with
+// two attributes so a RawMetric build has a map to populate.
+func gaugeMetricPoints(name string, n int, ts time.Time) *metricspb.Metric {
+	points := make([]*metricspb.NumberDataPoint, 0, n)
+	for i := 0; i < n; i++ {
+		points = append(points, &metricspb.NumberDataPoint{
+			TimeUnixNano: uint64(ts.UnixNano()), // #nosec G115 -- test timestamps are positive
+			Value:        &metricspb.NumberDataPoint_AsDouble{AsDouble: float64(i)},
+			Attributes: []*commonpb.KeyValue{
+				{Key: "http.route", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "/cart"}}},
+				{Key: "http.method", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "GET"}}},
+			},
+		})
+	}
+	return &metricspb.Metric{
+		Name: name,
+		Data: &metricspb.Metric_Gauge{Gauge: &metricspb.Gauge{DataPoints: points}},
+	}
+}
+
+// exportAllocsPerPoint returns the mean allocations of one Export of a gauge
+// with n points.
+func exportAllocsPerPoint(t *testing.T, s *MetricsServer, n int) float64 {
+	t.Helper()
+	ctx := context.Background()
+	req := metricsRequest(gaugeMetricPoints("queue.depth", n, time.Now()))
+	// Warm any lazily-built state (tenant interning, service list parse) so it
+	// is not charged to the measured runs.
+	if _, err := s.Export(ctx, req); err != nil {
+		t.Fatalf("Export warmup: %v", err)
+	}
+	return testing.AllocsPerRun(20, func() {
+		if _, err := s.Export(ctx, req); err != nil {
+			t.Fatalf("Export: %v", err)
+		}
+	})
+}
+
+func TestExportBuildsNoRawMetricWithoutLegacyConsumers(t *testing.T) {
+	const (
+		few  = 4
+		many = 260
+	)
+
+	// Aggregate mode's wiring: no TSDB aggregator, no metric callback.
+	quiet := NewMetricsServer(nil, nil, nil, aggTestConfig())
+	small := exportAllocsPerPoint(t, quiet, few)
+	large := exportAllocsPerPoint(t, quiet, many)
+	if large > small {
+		t.Errorf("no-consumer Export allocates per data point: %d points = %.1f allocs, %d points = %.1f allocs",
+			few, small, many, large)
+	}
+
+	// Legacy wiring: the callback alone is enough to require the RawMetric.
+	loud := NewMetricsServer(nil, nil, nil, aggTestConfig())
+	var seen int
+	loud.SetMetricCallback(func(m tsdb.RawMetric) {
+		seen++
+		if m.Attributes["http.route"] == nil {
+			t.Errorf("RawMetric lost its attributes: %+v", m)
+		}
+	})
+	loudSmall := exportAllocsPerPoint(t, loud, few)
+	loudLarge := exportAllocsPerPoint(t, loud, many)
+	if seen == 0 {
+		t.Fatal("metric callback was never invoked; the legacy comparison is meaningless")
+	}
+	if growth := loudLarge - loudSmall; growth < float64(many-few) {
+		t.Errorf("legacy Export should allocate at least one object per extra data point, got %.1f for %d extra points",
+			growth, many-few)
+	}
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -986,3 +986,43 @@ func (m *Metrics) HealthHandler() http.HandlerFunc {
 func PrometheusHandler() http.Handler {
 	return promhttp.Handler()
 }
+
+// DisableTSDBCollectors unregisters the collectors that only the legacy TSDB
+// aggregator and ring buffer can move. Call it exactly once, at startup, when
+// that path is not constructed (AGGREGATE_MODE=aggregate, #194 finding 10).
+//
+// Leaving them registered would publish TSDB ingest, drop and cardinality
+// series pinned at 0, which a dashboard reads as "no overflow" rather than
+// "no TSDB". The aggregate engine reports its own admission and cardinality
+// caps; these must not shadow them. The struct fields stay non-nil so any
+// residual call site is inert rather than a nil dereference.
+func (m *Metrics) DisableTSDBCollectors() {
+	if m == nil {
+		return
+	}
+	// Each field is checked in its own concrete type: a nil *CounterVec stored
+	// in a Collector interface is NOT interface-nil, and Unregister would
+	// Describe it straight into a nil dereference. Partially-populated Metrics
+	// literals exist in tests, so this has to hold.
+	if m.TSDBIngestTotal != nil {
+		prometheus.Unregister(m.TSDBIngestTotal)
+	}
+	if m.TSDBFlushDuration != nil {
+		prometheus.Unregister(m.TSDBFlushDuration)
+	}
+	if m.TSDBBatchesDropped != nil {
+		prometheus.Unregister(m.TSDBBatchesDropped)
+	}
+	if m.TSDBCardinalityOverflow != nil {
+		prometheus.Unregister(m.TSDBCardinalityOverflow)
+	}
+	if m.TSDBCardinalityOverflowByTenant != nil {
+		prometheus.Unregister(m.TSDBCardinalityOverflowByTenant)
+	}
+	if m.TSDBRingSeriesActive != nil {
+		prometheus.Unregister(m.TSDBRingSeriesActive)
+	}
+	if m.TSDBRingSeriesRejected != nil {
+		prometheus.Unregister(m.TSDBRingSeriesRejected)
+	}
+}

--- a/legacy_metric_path_test.go
+++ b/legacy_metric_path_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+)
+
+// TestLegacyMetricPathByMode pins the wiring decision behind #194 finding 10:
+// aggregate mode constructs no TSDB aggregator, no ring buffer and no metric
+// callback, while legacy and shadow keep all three. Shadow especially — it runs
+// both paths side by side, and dropping the legacy one would leave nothing to
+// shadow.
+func TestLegacyMetricPathByMode(t *testing.T) {
+	for _, tc := range []struct {
+		mode string
+		want bool
+	}{
+		{aggregate.ModeLegacy, true},
+		{aggregate.ModeShadow, true},
+		{aggregate.ModeAggregate, false},
+		{"", true}, // empty config value means legacy
+	} {
+		if got := legacyMetricPath(tc.mode); got != tc.want {
+			t.Errorf("legacyMetricPath(%q) = %v, want %v", tc.mode, got, tc.want)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -365,33 +365,56 @@ func main() {
 	// needs the publisher wired before the first tick.
 	ctxEvents, cancelEvents := context.WithCancel(context.Background())
 
-	// 4c. Initialize TSDB Aggregator + Ring Buffer
-	tsdbAgg := tsdb.NewAggregator(repo, 30*time.Second)
-	if cfg.MetricMaxCardinality > 0 || cfg.MetricMaxCardinalityPerTenant > 0 {
-		tsdbAgg.SetCardinalityLimit(cfg.MetricMaxCardinality, cfg.MetricMaxCardinalityPerTenant, func(tenantID string) {
-			// Maintain the legacy unlabeled counter for back-compat dashboards
-			// AND emit the labeled by-tenant counter for fairness diagnostics.
-			metrics.TSDBCardinalityOverflow.Inc()
-			if metrics.TSDBCardinalityOverflowByTenant != nil {
-				metrics.TSDBCardinalityOverflowByTenant.WithLabelValues(tenantID).Inc()
-			}
-		})
-		slog.Info("📈 TSDB cardinality limits configured",
-			"global_max", cfg.MetricMaxCardinality,
-			"per_tenant_max", cfg.MetricMaxCardinalityPerTenant,
+	// 4c. Initialize TSDB Aggregator + Ring Buffer.
+	//
+	// Retired outright in AGGREGATE_MODE=aggregate (#194 finding 10). There the
+	// aggregate engine owns every metric read, so the ring buffer, the 30s
+	// flush into metric_buckets, the per-point RawMetric allocation and the
+	// metric callback are all pure waste on the hot path. Legacy keeps the path
+	// because it IS the metric store; shadow keeps it because shadow's whole
+	// job is running both paths side by side.
+	legacyTSDB := legacyMetricPath(cfg.AggregateMode)
+	var (
+		tsdbAgg *tsdb.Aggregator
+		ringBuf *tsdb.RingBuffer
+	)
+	ctxTSDB, cancelTSDB := context.WithCancel(context.Background())
+	if legacyTSDB {
+		tsdbAgg = tsdb.NewAggregator(repo, 30*time.Second)
+		if cfg.MetricMaxCardinality > 0 || cfg.MetricMaxCardinalityPerTenant > 0 {
+			tsdbAgg.SetCardinalityLimit(cfg.MetricMaxCardinality, cfg.MetricMaxCardinalityPerTenant, func(tenantID string) {
+				// Maintain the legacy unlabeled counter for back-compat dashboards
+				// AND emit the labeled by-tenant counter for fairness diagnostics.
+				metrics.TSDBCardinalityOverflow.Inc()
+				if metrics.TSDBCardinalityOverflowByTenant != nil {
+					metrics.TSDBCardinalityOverflowByTenant.WithLabelValues(tenantID).Inc()
+				}
+			})
+			slog.Info("📈 TSDB cardinality limits configured",
+				"global_max", cfg.MetricMaxCardinality,
+				"per_tenant_max", cfg.MetricMaxCardinalityPerTenant,
+			)
+		}
+		tsdbAgg.SetMetrics(
+			func() { metrics.TSDBIngestTotal.Inc() },
+			func() { metrics.TSDBBatchesDropped.Inc() },
+		)
+		ringBuf = tsdb.NewRingBuffer(120, 30*time.Second, cfg.MetricMaxCardinality, metrics.TSDBRingSeriesRejected.Inc)
+		tsdbAgg.SetRingBuffer(ringBuf)
+		slog.Info("📈 TSDB ring buffer attached (120 slots × 30s = 1h retention)")
+
+		go tsdbAgg.Start(ctxTSDB)
+		slog.Info("📈 TSDB Aggregator started (30s window)")
+	} else {
+		// Nothing can move these counters once the aggregator is gone, and a
+		// TSDB-specific cardinality gauge frozen at 0 reads as "no overflow"
+		// rather than "no TSDB". The aggregate engine publishes its own caps
+		// (#200/#201); these are unregistered so no scrape can confuse them.
+		metrics.DisableTSDBCollectors()
+		slog.Info("📈 Legacy TSDB aggregator and ring buffer disabled (AGGREGATE_MODE=aggregate)",
+			"note", "metric reads are served by the aggregate engine; TSDB metrics unregistered",
 		)
 	}
-	tsdbAgg.SetMetrics(
-		func() { metrics.TSDBIngestTotal.Inc() },
-		func() { metrics.TSDBBatchesDropped.Inc() },
-	)
-	ringBuf := tsdb.NewRingBuffer(120, 30*time.Second, cfg.MetricMaxCardinality, metrics.TSDBRingSeriesRejected.Inc)
-	tsdbAgg.SetRingBuffer(ringBuf)
-	slog.Info("📈 TSDB ring buffer attached (120 slots × 30s = 1h retention)")
-
-	ctxTSDB, cancelTSDB := context.WithCancel(context.Background())
-	go tsdbAgg.Start(ctxTSDB)
-	slog.Info("📈 TSDB Aggregator started (30s window)")
 
 	// 4e. Initialize In-Memory Service Graph (rebuilds from spans every 30s)
 	svcGraph := graph.New(func(since time.Time) ([]graph.SpanRow, error) {
@@ -492,6 +515,8 @@ func main() {
 	// 7. Initialize OTLP Ingestion (gRPC)
 	traceServer := ingest.NewTraceServer(repo, metrics, cfg)
 	logsServer := ingest.NewLogsServer(repo, metrics, cfg)
+	// tsdbAgg is nil in aggregate mode: MetricsServer then skips the RawMetric
+	// build entirely (see exportNumberPoints).
 	metricsServer := ingest.NewMetricsServer(repo, metrics, tsdbAgg, cfg)
 
 	// Aggregate engine + durable store (AGGREGATE_MODE != legacy). The reducer
@@ -945,17 +970,24 @@ func main() {
 		})
 	}
 
-	metricsServer.SetMetricCallback(func(m tsdb.RawMetric) {
-		eventHub.BroadcastMetric(realtime.MetricEntry{
-			Tenant:      m.TenantID,
-			Name:        m.Name,
-			ServiceName: m.ServiceName,
-			Value:       m.Value,
-			Timestamp:   m.Timestamp,
-			Attributes:  m.Attributes,
+	// Per-point metric fan-out. Not wired in aggregate mode: the event hub
+	// publishes from the engine snapshot instead (BroadcastMetric is already a
+	// no-op behind the aggregate publisher) and GraphRAG replaces its metric
+	// nodes per topology revision, so processMetric would discard every event
+	// after paying for the channel hop and the RawMetric allocation.
+	if legacyTSDB {
+		metricsServer.SetMetricCallback(func(m tsdb.RawMetric) {
+			eventHub.BroadcastMetric(realtime.MetricEntry{
+				Tenant:      m.TenantID,
+				Name:        m.Name,
+				ServiceName: m.ServiceName,
+				Value:       m.Value,
+				Timestamp:   m.Timestamp,
+				Attributes:  m.Attributes,
+			})
+			graphRAG.OnMetricIngested(m)
 		})
-		graphRAG.OnMetricIngested(m)
-	})
+	}
 
 	// Update DLQ size metric periodically. Tied to appCtx so the goroutine
 	// exits before dlq.Stop() — otherwise it keeps polling Size()/DiskBytes()
@@ -1264,7 +1296,9 @@ func main() {
 				edg.WithLabelValues("trace").Set(float64(c.TraceEdges))
 				edg.WithLabelValues("signal").Set(float64(c.SignalEdges))
 				edg.WithLabelValues("anomaly").Set(float64(c.AnomalyEdges))
-				metrics.TSDBRingSeriesActive.Set(float64(ringBuf.MetricCount()))
+				if ringBuf != nil {
+					metrics.TSDBRingSeriesActive.Set(float64(ringBuf.MetricCount()))
+				}
 				metrics.DrainTemplatesActive.Set(float64(graphRAG.DrainTemplateCount()))
 			}
 		}
@@ -1353,7 +1387,9 @@ func main() {
 	aiService.Stop()
 
 	// 3. Stop processing engines (TSDB flush, graph, GraphRAG)
-	tsdbAgg.Stop()
+	if tsdbAgg != nil {
+		tsdbAgg.Stop()
+	}
 	cancelTSDB()
 	cancelGraph()
 	graphRAG.Stop()
@@ -1583,3 +1619,14 @@ func sqliteMainDBPath(cfg *config.Config) string {
 	}
 	return cfg.DBDSN
 }
+
+// legacyMetricPath reports whether the legacy metric path — the TSDB
+// aggregator, its ring buffer, the 30s flush into metric_buckets and the
+// per-point metric callback — is constructed for a given AGGREGATE_MODE.
+//
+// Only AGGREGATE_MODE=aggregate retires it (#194 finding 10). Legacy has no
+// other metric store, and shadow's entire purpose is running both paths at
+// once and comparing them, so both keep it. It is a function rather than an
+// inline comparison so the wiring decision is assertable without booting the
+// process.
+func legacyMetricPath(mode string) bool { return mode != aggregate.ModeAggregate }


### PR DESCRIPTION
Closes #194 finding 10 (map #195).

## What

`AGGREGATE_MODE=aggregate` started the legacy TSDB aggregator and ring buffer regardless of mode, and every OTLP metric data point allocated a `tsdb.RawMetric` with a per-point attribute map to feed consumers that threw it away:

- `EventHub.BroadcastMetric` short-circuits behind the aggregate publisher.
- `GraphRAG.processMetric` returns early — metric nodes are replaced per topology revision.

This retires all of it in pure aggregate mode. Legacy and shadow are byte-for-byte unchanged: legacy has no other metric store, and shadow's entire job is running both paths side by side.

## Changes

- **`main.go`** — the aggregator, the ring buffer, the `ctxTSDB` goroutine and the metric callback are all gated on `legacyMetricPath(cfg.AggregateMode)`, false only for `aggregate`. `tsdbAgg`/`ringBuf` are nil there; the ring-series gauge sampler and the shutdown `Stop()` are nil-guarded.
- **`internal/ingest/otlp.go`** — `exportNumberPoints` skips the `tsdb.RawMetric` build (and its attribute map) when neither a TSDB aggregator nor a metric callback is wired. The aggregate reducer still sees every point, first, unchanged.
- **`internal/telemetry/metrics.go`** — new `Metrics.DisableTSDBCollectors()`, called once at startup in aggregate mode. Unregisters the seven TSDB-only collectors (ingest, flush duration, batches dropped, cardinality overflow global + by-tenant, ring series active + rejected). A cardinality counter pinned at 0 reads as "no overflow" rather than "no TSDB", and the aggregate engine's own caps (#200/#201) must not be shadowed by dead series.
- **`internal/api/metrics_handlers.go`** — `metric_buckets` is no longer written in aggregate mode, so both metric read endpoints move to `Engine.TopologySnapshot`.
- **`CLAUDE.md`** — new "Legacy TSDB retirement in aggregate mode" section plus the storage table, callback diagram, shutdown order, key-directories and `METRIC_MAX_CARDINALITY` entries.

## Endpoint behaviour changes (aggregate mode only)

| Endpoint | Before | After |
|---|---|---|
| `GET /api/metrics?name=…` | `metric_buckets` scan (empty in aggregate mode — nothing writes it) | Topology-projection metric windows. Same bare array, same `time_bucket ASC` ordering. Bucket **width** is the engine's 5-minute window, not 30s. `id` is `0` and `attributes_json` is `""` — an aggregate window has no row identity and the projection keys metrics by `(service, name)` only. Windows with no observation are omitted rather than emitted as a fabricated zero sample. |
| `GET /api/metadata/metrics` | `DISTINCT name` over `metric_buckets` (empty) | Distinct names in the projection, same sorted bare array. |

Coverage is stamped on the `OtelContext-Data-Coverage` header (both are bare-array endpoints, so an envelope would break the shape):

- `/api/metrics` — `full` when the requested range sits inside the retained horizon and no projection cap fired; `sampled` otherwise.
- `/api/metadata/metrics` — **always** `sampled`. The projection retains a bounded recent horizon (mutable windows plus `TopologySnapshot.Horizon`, 30m by default) while the legacy answer spanned `HOT_RETENTION_DAYS`, so a metric that stopped reporting an hour ago is absent.

**Known degradation, documented rather than papered over:** metric history older than the projection horizon is unavailable in aggregate mode. The engine's exported query surface (`QueryBuckets`/`QueryDashboard`/`QueryTopology`/`TopologySnapshot`) has no arbitrary-range metric-series read, and adding one means touching `internal/aggregate/` internals, which this change is scoped out of. It is reported as reduced coverage, never as a flat line.

## Tests

- `legacy_metric_path_test.go` — `legacyMetricPath` across legacy / shadow / aggregate / empty. Constructor-not-called seam for the wiring decision without booting `main()`.
- `internal/ingest/otlp_metric_rawmetric_test.go` — per-point **allocation growth** is zero without legacy consumers, and at least one allocation per extra point with a callback wired. Growth rather than an absolute count, so it is not a brittle transcription of the current implementation. Verified failing without the guard (4 points = 97.0 allocs vs 260 points = far more).
- `internal/api/metric_series_aggregate_test.go` — both endpoints answered from a real engine with zero raw-table hits (reuses the existing `rawTableCounter`), exact projected stats, the `full`/`sampled` coverage split, and an explicit legacy-mode regression case asserting the repo path and no coverage header. Verified failing without the aggregate branches.

## Results

```
go build ./...                    OK
go vet ./...                      OK
go test -race ./internal/ingest/... ./internal/api/... ./internal/tsdb/... \
               ./internal/graphrag/... ./internal/aggregate/...
                                  803 passed, 0 failed (6 packages)
go test ./...                     1364 passed, 0 failed (29 packages)
golangci-lint run ./...           19 issues, all pre-existing, none in touched files
jscpd (threshold 3, min-tokens 100, internal + ui/src)
                                  exit 0; 3 clones, all pre-existing start/end
                                  parsing blocks in metrics_handlers.go
```

`gofmt -l` is clean on every touched file. Three files remain unformatted on `main` (`internal/api/log_handlers_trace_filter_test.go`, `internal/storage/tenant_sanitize_test.go`, `test/loadsim/main_test.go`) — pre-existing, untouched, and the last is owned by another agent right now.
