### PR TITLE
feat(health): aggregate runtime readiness probes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -597,6 +597,63 @@ asserts the deltas are committed, and acknowledging data that was not stored is
 data loss with better branding. Shadow mode is unaffected: there the legacy raw
 path is still the source of truth.
 
+### Health probes — `/live` and `/ready`
+
+`/live` is **process-only** and has no dependencies: it answers 200 as long as
+the process is up. Nothing below can make it fail. Killing a process because
+its store went unreachable throws away the in-memory shards and buys a delta-log
+replay; that is a worse outage than the one it was reacting to.
+
+`/ready` is the dependency probe. It answers 200 only when every named check
+below passes and 503 with the full per-check breakdown otherwise. **Check names
+are an operator contract** (asserted by the #202 gate): they are stable, and
+each runtime probe carries its measured number in the payload so an alert can
+be built on a figure rather than on a word.
+
+| Check | Source | 503 when |
+|---|---|---|
+| `database` | main relational DB `PingContext` (2s) | ping fails |
+| `graphrag` | coordinator | not running (`skipped` when unconfigured) |
+| `dlq_disk` | DLQ bytes ÷ `DLQ_MAX_DISK_MB` | ≥ 0.95 |
+| `pipeline` | ingest queue depth ÷ capacity | ≥ 0.95 |
+| `aggregate_store` | `RecoveryGate` | delta-log replay not finished (#173) |
+| `disk` | disk watchdog state (#201 Q5) | `raw_off` |
+| `aggregate_db` | aggregate store **read pool** ping (2s) | ping fails |
+| `aggregate_commit` | consecutive group-commit failures | streak ≥ `READY_MAX_COMMIT_FAILURE_STREAK` |
+| `aggregate_finalizer` | consecutive window-finalize failures | streak ≥ `READY_MAX_FINALIZE_FAILURE_STREAK` |
+| `aggregate_admission` | fullest of pending bytes / pending deltas / waiters ÷ their bounds | ≥ `READY_MAX_ADMISSION_RATIO` |
+| `aggregate_delta_log` | age of the oldest un-finalized window | ≥ `READY_MAX_DELTA_LOG_AGE_S` seconds |
+| `aggregate_disk` | `aggregate.db` bytes ÷ `READY_AGGREGATE_DISK_BUDGET_MB` | ≥ `READY_MAX_AGGREGATE_DISK_RATIO` |
+
+The six `aggregate_*` runtime probes (#194 finding 18) are **degraded-not-dead**:
+each flips `/ready` to 503, none touches `/live`, none stops the process, and
+each recovers on its own the moment its signal does. `aggregate_store` gates
+startup; the rest cover the ways a process that finished recovery later stops
+being able to serve. Every check reports `skipped` when its source is not
+configured (`AGGREGATE_MODE=legacy`, no DLQ cap, no watchdog), so a legacy
+deployment's readiness is unchanged.
+
+Runtime signals are read from counters the group-commit writer already keeps —
+including the delta-log backlog sample the finalize loop publishes — so a
+readiness request never queries the aggregate store and never queues behind the
+single SQLite writer. The one exception is `aggregate_db`, which pings the
+**read** pool with a 2s deadline for the same reason: the writer pool is
+`MaxOpenConns(1)` behind the group commit, and a ping issued there would report
+"unreachable" for a database that is merely busy. The delta-log age carries the
+staleness of its sample (age + time since the sample was taken), so a wedged
+finalize loop cannot look healthy by simply never refreshing the number.
+
+Thresholds (`0` disables that probe):
+
+| Env var | Default | Rationale |
+|---|---|---|
+| `READY_MAX_COMMIT_FAILURE_STREAK` | 3 | One failed commit is a retry; three in a row is a store that stopped accepting writes. |
+| `READY_MAX_FINALIZE_FAILURE_STREAK` | 3 | Same shape, on the finalizer. |
+| `READY_MAX_ADMISSION_RATIO` | 0.9 | Below the 0.95 the DLQ/pipeline probes use: the writer's admission bound is what turns an Export into `RESOURCE_EXHAUSTED`, so readiness says "stop sending" before clients are refused, not while they are. |
+| `READY_MAX_DELTA_LOG_AGE_S` | 1800 | 2× (`WindowSize` 5m + `AllowedLateness` 10m). A window is finalizable 900s after it opens, so a healthy oldest entry tops out just past 900s plus one finalize tick. |
+| `READY_AGGREGATE_DISK_BUDGET_MB` | 1536 | `aggregate.db`'s share of the 8 GiB data budget (#201 Q1). The disk watchdog enforces the **volume**; this enforces the **tier**, so a runaway aggregate file is visible before it eats another tier's allocation. |
+| `READY_MAX_AGGREGATE_DISK_RATIO` | 0.9 | Warn inside the tier before the volume-level ladder starts shedding. |
+
 ## Security & Supply Chain
 
 OtelContext targets the OpenSSF Best Practices `passing` badge (project [12646](https://www.bestpractices.dev/en/projects/12646)) and ships a six-job OSS-CLI security stack, supplemented by **SonarCloud SAST as a required gate** (board reversal 2026-04-28). No CodeQL, no NVD-direct tooling. Cost: $0 for the OSS-CLI tier; SonarCloud is free for public repos.

--- a/internal/aggregate/store_sqlite.go
+++ b/internal/aggregate/store_sqlite.go
@@ -271,6 +271,20 @@ func (s *SQLiteStore) Path() string { return s.path }
 // operator "this is a different store", not "this is the same store rebuilt".
 func (s *SQLiteStore) UUID() string { return s.uuid }
 
+// PingContext verifies the aggregate database is reachable on the READ pool.
+//
+// The read pool, never the writer: the writer is MaxOpenConns(1) behind the
+// group commit, so a ping issued there would queue behind whatever commit is
+// in flight and report "unreachable" for a database that is merely busy. A
+// readiness probe has to answer "can this process still read its aggregates",
+// which is exactly what the read pool answers.
+func (s *SQLiteStore) PingContext(ctx context.Context) error {
+	if s == nil || s.reader == nil {
+		return ErrStoreClosed
+	}
+	return s.reader.PingContext(ctx)
+}
+
 // lockWriter acquires the exclusive write slot.
 func (s *SQLiteStore) lockWriter() { s.writeMu <- struct{}{} }
 

--- a/internal/aggregate/writer.go
+++ b/internal/aggregate/writer.go
@@ -2,6 +2,7 @@ package aggregate
 
 import (
 	"log/slog"
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -148,6 +149,72 @@ type WriterStats struct {
 	Waiters       int
 	// Finalized counts windows finalized by the writer's state machine.
 	Finalized uint64
+
+	// The runtime-readiness surface (#194 finding 18). Cumulative counters
+	// say what happened since boot; a readiness probe needs to know what is
+	// happening NOW, which is what the streaks and the cached backlog sample
+	// carry.
+	//
+	// CommitFailureStreak and FinalizeFailureStreak count CONSECUTIVE
+	// failures: any success resets them to zero. A handful of failures spread
+	// over a week is a log line; three in a row is a store that has stopped
+	// accepting writes.
+	CommitFailureStreak   uint64
+	FinalizeFailureStreak uint64
+	// FinalizeErrors counts finalization failures since boot.
+	FinalizeErrors uint64
+
+	// MaxPendingBytes, MaxPendingDeltas and MaxWaiters are the configured
+	// admission bounds the live occupancy above is measured against.
+	MaxPendingBytes  int64
+	MaxPendingDeltas int
+	MaxWaiters       int
+
+	// DeltaLogRows, DeltaLogAgeSeconds and BacklogSampledAt are the last
+	// delta-log backlog sample the finalize loop published. Cached rather
+	// than queried on demand so a readiness probe never stacks behind the
+	// single SQLite writer. BacklogSampledAt is zero before the first sample.
+	DeltaLogRows       int64
+	DeltaLogAgeSeconds float64
+	BacklogSampledAt   time.Time
+}
+
+// AdmissionRatio is the writer's admission occupancy as a fraction in
+// [0.0, 1.0+]: the fullest of the three bounds, because admission is refused
+// as soon as ANY of them is breached. Bounds that are unset (non-positive)
+// contribute nothing.
+func (s WriterStats) AdmissionRatio() float64 {
+	ratio := 0.0
+	if s.MaxPendingBytes > 0 {
+		ratio = math.Max(ratio, float64(s.PendingBytes)/float64(s.MaxPendingBytes))
+	}
+	if s.MaxPendingDeltas > 0 {
+		ratio = math.Max(ratio, float64(s.PendingDeltas)/float64(s.MaxPendingDeltas))
+	}
+	if s.MaxWaiters > 0 {
+		ratio = math.Max(ratio, float64(s.Waiters)/float64(s.MaxWaiters))
+	}
+	return ratio
+}
+
+// DeltaLogAge is the age of the oldest un-finalized window at now, carrying
+// the staleness of the sample it is derived from.
+//
+// Adding the time since the sample is not cosmetic: a wedged finalize loop
+// stops REFRESHING the sample, and an age frozen at its last healthy value is
+// exactly the reading that would let a stuck writer look ready forever. An
+// empty backlog ages at zero — there is no oldest window to get older.
+func (s WriterStats) DeltaLogAge(now time.Time) float64 {
+	if s.DeltaLogAgeSeconds <= 0 {
+		return 0
+	}
+	age := s.DeltaLogAgeSeconds
+	if !s.BacklogSampledAt.IsZero() {
+		if elapsed := now.Sub(s.BacklogSampledAt).Seconds(); elapsed > 0 {
+			age += elapsed
+		}
+	}
+	return age
 }
 
 // Writer is the group-commit writer. It is the engine's Applier once the
@@ -183,6 +250,17 @@ type Writer struct {
 	deltas       atomic.Uint64
 	rejections   atomic.Uint64
 	finalized    atomic.Uint64
+
+	// Consecutive-failure streaks and the cached backlog sample, read by the
+	// runtime readiness probes (#194 finding 18). Counters only: nothing here
+	// participates in a commit, a finalize or an admission decision.
+	commitFailStreak   atomic.Uint64
+	finalizeErrors     atomic.Uint64
+	finalizeFailStreak atomic.Uint64
+
+	backlogRows      atomic.Int64
+	backlogAgeBits   atomic.Uint64
+	backlogSampledAt atomic.Int64 // unix nanos; 0 before the first sample
 }
 
 // NewWriter builds a writer over store and engine. It does not start it.
@@ -308,7 +386,7 @@ func (w *Writer) Stats() WriterStats {
 	w.mu.Lock()
 	pendingBytes, pendingDeltas, waiters := w.pendingBytes, w.pendingDeltas, w.waiters
 	w.mu.Unlock()
-	return WriterStats{
+	stats := WriterStats{
 		Commits:       w.commits.Load(),
 		CommitErrors:  w.commitErrors.Load(),
 		Deltas:        w.deltas.Load(),
@@ -317,7 +395,22 @@ func (w *Writer) Stats() WriterStats {
 		PendingDeltas: pendingDeltas,
 		Waiters:       waiters,
 		Finalized:     w.finalized.Load(),
+
+		CommitFailureStreak:   w.commitFailStreak.Load(),
+		FinalizeFailureStreak: w.finalizeFailStreak.Load(),
+		FinalizeErrors:        w.finalizeErrors.Load(),
+
+		MaxPendingBytes:  w.cfg.MaxPendingBytes,
+		MaxPendingDeltas: w.cfg.MaxPendingDeltas,
+		MaxWaiters:       w.cfg.MaxWaiters,
+
+		DeltaLogRows:       w.backlogRows.Load(),
+		DeltaLogAgeSeconds: math.Float64frombits(w.backlogAgeBits.Load()),
 	}
+	if ns := w.backlogSampledAt.Load(); ns > 0 {
+		stats.BacklogSampledAt = time.Unix(0, ns)
+	}
+	return stats
 }
 
 // Apply implements Applier. It exists so a caller that cannot act on an error
@@ -509,6 +602,7 @@ func (w *Writer) commit(batch []*submission) {
 	w.commits.Add(1)
 	if err != nil {
 		w.commitErrors.Add(1)
+		w.commitFailStreak.Add(1)
 		// Nothing became durable, so nothing may keep the resources the write
 		// would have justified: release the cardinality reservation, hand the
 		// drained baselines back the increase this batch was carrying, and
@@ -518,6 +612,7 @@ func (w *Writer) commit(batch []*submission) {
 		w.finish(batch, commitResult{revision: w.engine.Revision(), err: err})
 		return
 	}
+	w.commitFailStreak.Store(0)
 	w.deltas.Add(uint64(len(gb.Deltas)))
 	w.series.Committed(gb.Series)
 	if w.reg != nil {
@@ -567,18 +662,23 @@ func (w *Writer) FinalizeDue(now time.Time) int {
 	windows, err := w.store.FinalizableWindows(FinalizeCutoff(now), finalizeWindowsPerPass)
 	if err != nil {
 		slog.Error("aggregate: list finalizable windows failed", "error", err)
+		w.finalizeErrors.Add(1)
+		w.finalizeFailStreak.Add(1)
 		return 0
 	}
 	done := 0
 	for _, window := range windows {
 		if _, err := w.store.FinalizeWindow(window); err != nil {
 			slog.Error("aggregate: finalize window failed", "window_start", window, "error", err)
+			w.finalizeErrors.Add(1)
+			w.finalizeFailStreak.Add(1)
 			continue
 		}
 		// The buckets are committed, so ownership of the window moves to the
 		// store in the same step that evicts it from the shards (#164).
 		w.engine.MarkFinalized(window)
 		w.finalized.Add(1)
+		w.finalizeFailStreak.Store(0)
 		done++
 	}
 	return done
@@ -595,6 +695,9 @@ func (w *Writer) publishBacklog(now time.Time) {
 	if stats.OldestWindow > 0 {
 		age = now.Sub(time.Unix(stats.OldestWindow, 0)).Seconds()
 	}
+	w.backlogRows.Store(stats.Rows)
+	w.backlogAgeBits.Store(math.Float64bits(age))
+	w.backlogSampledAt.Store(now.UnixNano())
 	w.cfg.Metrics.SetBacklog(stats.Rows, age)
 }
 

--- a/internal/aggregate/writer_health_test.go
+++ b/internal/aggregate/writer_health_test.go
@@ -1,0 +1,170 @@
+package aggregate
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// The runtime-readiness surface (#194 finding 18). /ready consults these
+// counters to decide whether a process that finished recovery can still
+// serve, so what they say has to be exact: streaks that reset on success,
+// an admission ratio that tracks the fullest bound, and a delta-log age that
+// keeps growing when the finalize loop stops refreshing it.
+
+func TestCommitFailureStreakResetsOnSuccess(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	store := &failableStore{Store: base}
+	eng := newTestEngine(t, clock, nil)
+	w := newTestWriter(t, store, eng, clock, WriterConfig{})
+
+	if got := w.Stats().CommitFailureStreak; got != 0 {
+		t.Fatalf("streak = %d before any commit, want 0", got)
+	}
+
+	store.failCommit.Store(true)
+	for i := 1; i <= 3; i++ {
+		if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), uint32(i), 1)); err == nil {
+			t.Fatalf("apply %d succeeded while commits are refused", i)
+		}
+		if got := w.Stats().CommitFailureStreak; got != uint64(i) {
+			t.Fatalf("streak after %d failures = %d, want %d", i, got, i)
+		}
+	}
+
+	store.failCommit.Store(false)
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 9, 1)); err != nil {
+		t.Fatalf("ApplyDeltasErr after recovery: %v", err)
+	}
+	st := w.Stats()
+	if st.CommitFailureStreak != 0 {
+		t.Fatalf("streak = %d after a successful commit, want 0", st.CommitFailureStreak)
+	}
+	if st.CommitErrors != 3 {
+		t.Fatalf("cumulative CommitErrors = %d, want 3", st.CommitErrors)
+	}
+}
+
+func TestFinalizeFailureStreakResetsOnSuccess(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	store := &failableStore{Store: base}
+	eng := newTestEngine(t, clock, nil)
+	w := newTestWriter(t, store, eng, clock, WriterConfig{})
+
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 5)); err != nil {
+		t.Fatalf("ApplyDeltasErr: %v", err)
+	}
+	clock.Advance(WindowSize + AllowedLateness + time.Minute)
+
+	store.failFinalize.Store(true)
+	for i := 1; i <= 2; i++ {
+		if n := w.FinalizeDue(clock.Now()); n != 0 {
+			t.Fatalf("finalized %d windows while finalization is refused", n)
+		}
+		if got := w.Stats().FinalizeFailureStreak; got != uint64(i) {
+			t.Fatalf("finalize streak after %d failures = %d, want %d", i, got, i)
+		}
+	}
+
+	store.failFinalize.Store(false)
+	if n := w.FinalizeDue(clock.Now()); n != 1 {
+		t.Fatalf("finalized %d windows after recovery, want 1", n)
+	}
+	st := w.Stats()
+	if st.FinalizeFailureStreak != 0 {
+		t.Fatalf("finalize streak = %d after a successful pass, want 0", st.FinalizeFailureStreak)
+	}
+	if st.FinalizeErrors != 2 {
+		t.Fatalf("cumulative FinalizeErrors = %d, want 2", st.FinalizeErrors)
+	}
+}
+
+func TestAdmissionRatioTracksTheFullestBound(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		stats WriterStats
+		want  float64
+	}{
+		{"empty", WriterStats{MaxPendingBytes: 100, MaxPendingDeltas: 10, MaxWaiters: 4}, 0},
+		{"bytes", WriterStats{PendingBytes: 90, MaxPendingBytes: 100, MaxPendingDeltas: 10, MaxWaiters: 4}, 0.9},
+		{"deltas", WriterStats{PendingDeltas: 8, MaxPendingBytes: 100, MaxPendingDeltas: 10, MaxWaiters: 4}, 0.8},
+		{"waiters", WriterStats{Waiters: 3, MaxPendingBytes: 100, MaxPendingDeltas: 10, MaxWaiters: 4}, 0.75},
+		{"fullest wins", WriterStats{PendingBytes: 50, PendingDeltas: 9, Waiters: 1, MaxPendingBytes: 100, MaxPendingDeltas: 10, MaxWaiters: 4}, 0.9},
+		{"unbounded", WriterStats{PendingBytes: 50, PendingDeltas: 9, Waiters: 1}, 0},
+	} {
+		if got := tc.stats.AdmissionRatio(); got != tc.want {
+			t.Errorf("%s: AdmissionRatio = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestDeltaLogAgeCarriesSampleStaleness(t *testing.T) {
+	now := time.Unix(3_000_000, 0).UTC()
+
+	empty := WriterStats{BacklogSampledAt: now.Add(-time.Hour)}
+	if got := empty.DeltaLogAge(now); got != 0 {
+		t.Fatalf("empty backlog ages to %v, want 0", got)
+	}
+
+	fresh := WriterStats{DeltaLogAgeSeconds: 120, BacklogSampledAt: now}
+	if got := fresh.DeltaLogAge(now); got != 120 {
+		t.Fatalf("fresh sample = %v, want 120", got)
+	}
+
+	// A wedged finalize loop stops refreshing the sample. The age has to keep
+	// growing anyway, or a stuck writer reads as healthy forever.
+	stale := WriterStats{DeltaLogAgeSeconds: 120, BacklogSampledAt: now.Add(-10 * time.Minute)}
+	if got := stale.DeltaLogAge(now); got != 720 {
+		t.Fatalf("stale sample = %v, want 720", got)
+	}
+
+	unsampled := WriterStats{DeltaLogAgeSeconds: 120}
+	if got := unsampled.DeltaLogAge(now); got != 120 {
+		t.Fatalf("never-sampled clock = %v, want 120", got)
+	}
+}
+
+func TestBacklogSampleIsCachedForReadinessProbes(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	eng := newTestEngine(t, clock, nil)
+	w := newTestWriter(t, base, eng, clock, WriterConfig{})
+
+	if st := w.Stats(); !st.BacklogSampledAt.IsZero() || st.DeltaLogRows != 0 {
+		t.Fatalf("stats before the first sample = %+v, want an unsampled backlog", st)
+	}
+
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 5)); err != nil {
+		t.Fatalf("ApplyDeltasErr: %v", err)
+	}
+	clock.Advance(2 * time.Minute)
+	w.publishBacklog(clock.Now())
+
+	st := w.Stats()
+	if st.DeltaLogRows != 1 {
+		t.Fatalf("DeltaLogRows = %d, want 1", st.DeltaLogRows)
+	}
+	if st.DeltaLogAgeSeconds != 120 {
+		t.Fatalf("DeltaLogAgeSeconds = %v, want 120", st.DeltaLogAgeSeconds)
+	}
+	if !st.BacklogSampledAt.Equal(clock.Now()) {
+		t.Fatalf("BacklogSampledAt = %v, want %v", st.BacklogSampledAt, clock.Now())
+	}
+}
+
+func TestPingContextReportsStoreReachability(t *testing.T) {
+	store := newTestStore(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := store.PingContext(ctx); err != nil {
+		t.Fatalf("PingContext on an open store: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := store.PingContext(ctx); err == nil {
+		t.Fatal("PingContext on a closed store returned nil")
+	}
+}

--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -13,6 +15,13 @@ import (
 // that brief spikes don't cause restart loops, low enough that orchestrators
 // stop sending traffic before the system fails outright.
 const readySaturationThreshold = 0.95
+
+// aggregateDBPingTimeout bounds the aggregate store reachability probe. Short
+// on purpose: a readiness request that waits on a database is a readiness
+// request an orchestrator will time out on anyway, and the answer it needs
+// ("this process cannot reach its aggregates right now") is the same either
+// way.
+const aggregateDBPingTimeout = 2 * time.Second
 
 // handleLive is a Kubernetes-style liveness probe.
 // Returns 200 OK as long as the process is up. Does not check dependencies.
@@ -113,6 +122,15 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Aggregate RUNTIME probes (#194 finding 18). Recovery completing is a
+	// one-time gate; these are the ways a process that finished recovery
+	// stops being able to serve afterwards. Degraded-not-dead: each one can
+	// flip /ready to 503, none of them touches /live and none of them stops
+	// the process.
+	if !s.aggregateRuntimeChecks(r.Context(), checks) {
+		ready = false
+	}
+
 	status := http.StatusOK
 	if !ready {
 		status = http.StatusServiceUnavailable
@@ -124,4 +142,83 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 		"ready":  ready,
 		"checks": checks,
 	})
+}
+
+// aggregateRuntimeChecks fills the aggregate runtime entries of the readiness
+// breakdown and reports whether all of them passed.
+//
+// Check names are part of the operator contract (#202 asserts them): keep
+// them stable and keep them documented in CLAUDE.md.
+func (s *Server) aggregateRuntimeChecks(ctx context.Context, checks map[string]string) bool {
+	ok := true
+
+	// Reachability first: every other number below is read from memory, so
+	// this is the only probe that can tell an operator the store itself is
+	// gone. The read pool, not the writer — see SQLiteStore.PingContext.
+	switch {
+	case s.aggregateDBPing == nil:
+		checks["aggregate_db"] = "skipped"
+	default:
+		pingCtx, cancel := context.WithTimeout(ctx, aggregateDBPingTimeout)
+		err := s.aggregateDBPing(pingCtx)
+		cancel()
+		if err != nil {
+			checks["aggregate_db"] = "ping failed: " + err.Error()
+			ok = false
+		} else {
+			checks["aggregate_db"] = "ok"
+		}
+	}
+
+	var rt AggregateRuntime
+	if s.aggregateRuntime != nil {
+		rt = s.aggregateRuntime()
+	}
+	th := s.thresholds()
+	for _, p := range []struct {
+		name, label  string
+		value, limit float64
+	}{
+		{"aggregate_commit", "failure streak", float64(rt.CommitFailureStreak), float64(th.MaxCommitFailureStreak)},
+		{"aggregate_finalizer", "failure streak", float64(rt.FinalizeFailureStreak), float64(th.MaxFinalizeFailureStreak)},
+		{"aggregate_admission", "saturation", rt.AdmissionRatio, th.MaxAdmissionRatio},
+		{"aggregate_delta_log", "age seconds", rt.DeltaLogAgeSeconds, th.MaxDeltaLogAgeSeconds},
+		{"aggregate_disk", "usage", rt.DiskRatio(), th.MaxAggregateDiskRatio},
+	} {
+		if s.aggregateRuntime == nil {
+			checks[p.name] = "skipped"
+			continue
+		}
+		if !runtimeProbe(checks, p.name, p.label, p.value, p.limit) {
+			ok = false
+		}
+	}
+	return ok
+}
+
+// runtimeProbe records one numeric readiness probe under name and reports
+// whether it passed. A non-positive limit disables the probe. The measured
+// number is in the payload either way: "ok" without a figure is not something
+// an operator can alarm on or graph.
+func runtimeProbe(checks map[string]string, name, label string, value, limit float64) bool {
+	switch {
+	case limit <= 0:
+		checks[name] = "skipped"
+		return true
+	case value >= limit:
+		checks[name] = fmt.Sprintf("%s %s >= %s", label, formatMeasure(value), formatMeasure(limit))
+		return false
+	default:
+		checks[name] = fmt.Sprintf("ok (%s %s)", label, formatMeasure(value))
+		return true
+	}
+}
+
+// formatMeasure renders a probe figure: whole numbers for counts and ages,
+// two decimals for ratios.
+func formatMeasure(v float64) string {
+	if v == math.Trunc(v) && math.Abs(v) < 1e9 {
+		return strconv.FormatFloat(v, 'f', 0, 64)
+	}
+	return strconv.FormatFloat(v, 'f', 2, 64)
 }

--- a/internal/api/health_runtime_test.go
+++ b/internal/api/health_runtime_test.go
@@ -1,0 +1,215 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Aggregate RUNTIME readiness probes (#194 finding 18). Recovery completing is
+// a one-time gate; these cover the ways a recovered process later stops being
+// able to serve. Every probe here must flip /ready at its threshold, recover
+// when the signal does, honour its configured limit, and leave /live alone.
+
+// runtimeCheckNames is the operator contract asserted by #202. Renaming one of
+// these is a breaking change to every readiness dashboard and alert built on
+// the payload.
+var runtimeCheckNames = []string{
+	"aggregate_db",
+	"aggregate_commit",
+	"aggregate_finalizer",
+	"aggregate_admission",
+	"aggregate_delta_log",
+	"aggregate_disk",
+}
+
+// healthyRuntime is an aggregate runtime snapshot that passes every default
+// threshold: no failures, a quarter-full writer, a draining delta log and an
+// aggregate file at half its budget.
+func healthyRuntime() AggregateRuntime {
+	return AggregateRuntime{
+		AdmissionRatio:     0.25,
+		DeltaLogAgeSeconds: 300,
+		DiskUsedBytes:      768 << 20,
+		DiskBudgetBytes:    1536 << 20,
+	}
+}
+
+func TestReadySkipsAggregateRuntimeWhenUnconfigured(t *testing.T) {
+	s := newTestServer(t)
+	code, checks := readyChecks(t, s)
+	if code != http.StatusOK {
+		t.Fatalf("/ready = %d without an aggregate store, want 200", code)
+	}
+	for _, name := range runtimeCheckNames {
+		if checks[name] != "skipped" {
+			t.Errorf("%s = %q without an aggregate store, want skipped", name, checks[name])
+		}
+	}
+}
+
+func TestReadyFlipsOnEachAggregateRuntimeProbe(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		check   string
+		breach  func(*AggregateRuntime)
+		wantNum string
+	}{
+		{"commit failure streak", "aggregate_commit", func(rt *AggregateRuntime) { rt.CommitFailureStreak = 3 }, "3"},
+		{"finalize failure streak", "aggregate_finalizer", func(rt *AggregateRuntime) { rt.FinalizeFailureStreak = 4 }, "4"},
+		{"admission saturation", "aggregate_admission", func(rt *AggregateRuntime) { rt.AdmissionRatio = 0.91 }, "0.91"},
+		{"delta log age", "aggregate_delta_log", func(rt *AggregateRuntime) { rt.DeltaLogAgeSeconds = 1801 }, "1801"},
+		{"aggregate disk", "aggregate_disk", func(rt *AggregateRuntime) { rt.DiskUsedBytes = 1400 << 20 }, "0.91"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestServer(t)
+			rt := healthyRuntime()
+			s.SetAggregateRuntimeProbe(func() AggregateRuntime { return rt })
+
+			code, checks := readyChecks(t, s)
+			if code != http.StatusOK {
+				t.Fatalf("/ready = %d while healthy, want 200 (checks: %v)", code, checks)
+			}
+			if !strings.HasPrefix(checks[tc.check], "ok (") {
+				t.Fatalf("%s = %q while healthy, want an ok reading", tc.check, checks[tc.check])
+			}
+
+			tc.breach(&rt)
+			code, checks = readyChecks(t, s)
+			if code != http.StatusServiceUnavailable {
+				t.Fatalf("/ready = %d at the threshold, want 503 (checks: %v)", code, checks)
+			}
+			if !strings.Contains(checks[tc.check], tc.wantNum) {
+				t.Fatalf("%s = %q, want the measured figure %s", tc.check, checks[tc.check], tc.wantNum)
+			}
+
+			rt = healthyRuntime()
+			code, checks = readyChecks(t, s)
+			if code != http.StatusOK {
+				t.Fatalf("/ready = %d after recovery, want 200 (checks: %v)", code, checks)
+			}
+			if !strings.HasPrefix(checks[tc.check], "ok (") {
+				t.Fatalf("%s = %q after recovery, want an ok reading", tc.check, checks[tc.check])
+			}
+		})
+	}
+}
+
+func TestAggregateRuntimeThresholdsAreConfigurable(t *testing.T) {
+	s := newTestServer(t)
+	rt := healthyRuntime()
+	rt.CommitFailureStreak = 2
+	rt.AdmissionRatio = 0.5
+	s.SetAggregateRuntimeProbe(func() AggregateRuntime { return rt })
+
+	// A stricter commit threshold fails the same snapshot the default passes.
+	th := DefaultReadinessThresholds()
+	th.MaxCommitFailureStreak = 2
+	s.SetReadinessThresholds(th)
+	code, checks := readyChecks(t, s)
+	if code != http.StatusServiceUnavailable {
+		t.Fatalf("/ready = %d at a stricter commit threshold, want 503 (checks: %v)", code, checks)
+	}
+
+	// Zero disables the probe outright — the escape hatch for an operator who
+	// disagrees with the default.
+	th.MaxCommitFailureStreak = 0
+	s.SetReadinessThresholds(th)
+	code, checks = readyChecks(t, s)
+	if code != http.StatusOK {
+		t.Fatalf("/ready = %d with the commit probe disabled, want 200 (checks: %v)", code, checks)
+	}
+	if checks["aggregate_commit"] != "skipped" {
+		t.Fatalf("aggregate_commit = %q with a zero threshold, want skipped", checks["aggregate_commit"])
+	}
+
+	// A looser admission threshold passes a snapshot the default would fail.
+	rt.AdmissionRatio = 0.93
+	s.SetReadinessThresholds(DefaultReadinessThresholds())
+	if code, _ = readyChecks(t, s); code != http.StatusServiceUnavailable {
+		t.Fatalf("/ready = %d at 0.93 saturation under the default, want 503", code)
+	}
+	th = DefaultReadinessThresholds()
+	th.MaxAdmissionRatio = 0.99
+	s.SetReadinessThresholds(th)
+	if code, checks = readyChecks(t, s); code != http.StatusOK {
+		t.Fatalf("/ready = %d at 0.93 saturation under a 0.99 limit, want 200 (checks: %v)", code, checks)
+	}
+}
+
+func TestReadyFlipsOnAggregateStoreUnreachable(t *testing.T) {
+	s := newTestServer(t)
+	var pingErr error
+	deadlineSeen := false
+	s.SetAggregateDBProbe(func(ctx context.Context) error {
+		_, deadlineSeen = ctx.Deadline()
+		return pingErr
+	})
+
+	code, checks := readyChecks(t, s)
+	if code != http.StatusOK {
+		t.Fatalf("/ready = %d with a reachable store, want 200 (checks: %v)", code, checks)
+	}
+	if checks["aggregate_db"] != "ok" {
+		t.Fatalf("aggregate_db = %q with a reachable store, want ok", checks["aggregate_db"])
+	}
+	if !deadlineSeen {
+		t.Fatal("aggregate_db probe ran without a deadline: a readiness request must never park on the store")
+	}
+
+	pingErr = errors.New("database is locked")
+	code, checks = readyChecks(t, s)
+	if code != http.StatusServiceUnavailable {
+		t.Fatalf("/ready = %d with an unreachable store, want 503", code)
+	}
+	if !strings.Contains(checks["aggregate_db"], "database is locked") {
+		t.Fatalf("aggregate_db = %q, want the ping error", checks["aggregate_db"])
+	}
+
+	pingErr = nil
+	if code, _ = readyChecks(t, s); code != http.StatusOK {
+		t.Fatalf("/ready = %d after the store came back, want 200", code)
+	}
+}
+
+// Liveness is process-only. Every runtime probe failing at once is a degraded
+// process, not a dead one: killing it would throw away the in-memory shards
+// and the delta log replay that come back with it.
+func TestLiveUnaffectedByRuntimeProbeFailures(t *testing.T) {
+	s := newTestServer(t)
+	s.SetAggregateDBProbe(func(context.Context) error { return errors.New("unreachable") })
+	s.SetAggregateRuntimeProbe(func() AggregateRuntime {
+		return AggregateRuntime{
+			CommitFailureStreak:   99,
+			FinalizeFailureStreak: 99,
+			AdmissionRatio:        1,
+			DeltaLogAgeSeconds:    99999,
+			DiskUsedBytes:         1536 << 20,
+			DiskBudgetBytes:       1536 << 20,
+		}
+	})
+	s.SetAggregateRecoveryProbe(func() bool { return false })
+	s.SetDiskPressureProbe(func() (string, bool) { return "raw_off", false })
+
+	if code, _ := readyChecks(t, s); code != http.StatusServiceUnavailable {
+		t.Fatalf("/ready = %d with every probe failing, want 503", code)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/live", nil)
+	rr := httptest.NewRecorder()
+	s.handleLive(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("/live = %d with every readiness probe failing, want 200", rr.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode /live body: %v", err)
+	}
+	if body["status"] != "alive" {
+		t.Fatalf("/live status = %q, want alive", body["status"])
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"time"
@@ -51,6 +52,83 @@ type Server struct {
 	// diagnostics anyone comes here for, and an orchestrator should stop
 	// routing fresh ingest at it. nil means "no watchdog" and is skipped.
 	diskPressure func() (string, bool)
+
+	// aggregateRuntime reports the aggregate engine's RUNTIME health — the
+	// signals that say a process which finished recovery has since stopped
+	// being able to serve (#194 finding 18). nil means "no aggregate store"
+	// and every runtime probe is skipped.
+	aggregateRuntime func() AggregateRuntime
+
+	// aggregateDBPing is a cheap reachability check on the aggregate store's
+	// READ pool. It takes a context so the probe carries its own deadline and
+	// cannot park a readiness request behind a slow database.
+	aggregateDBPing func(context.Context) error
+
+	// readyThresholds are the runtime-probe limits. nil takes
+	// DefaultReadinessThresholds; an explicitly-set zero struct disables
+	// every runtime probe, which is what a 0 in each env knob means.
+	readyThresholds *ReadinessThresholds
+}
+
+// AggregateRuntime is the aggregate runtime health snapshot /ready consults.
+// It is a plain value, sampled from counters the writer already maintains, so
+// a readiness request never queries the store and never stacks behind the
+// single SQLite writer.
+type AggregateRuntime struct {
+	// CommitFailureStreak and FinalizeFailureStreak are CONSECUTIVE failure
+	// counts: any success resets them.
+	CommitFailureStreak   uint64
+	FinalizeFailureStreak uint64
+	// AdmissionRatio is the group-commit writer's admission occupancy as a
+	// fraction of its bounds — the fullest of pending bytes, pending deltas
+	// and parked waiters.
+	AdmissionRatio float64
+	// DeltaLogAgeSeconds is the age of the oldest un-finalized window,
+	// including the staleness of the sample it came from.
+	DeltaLogAgeSeconds float64
+	// DiskUsedBytes and DiskBudgetBytes are the aggregate tier's on-disk size
+	// against its share of the data budget. A zero budget disables the check.
+	DiskUsedBytes   int64
+	DiskBudgetBytes int64
+}
+
+// DiskRatio is the aggregate tier's usage as a fraction of its budget.
+func (a AggregateRuntime) DiskRatio() float64 {
+	if a.DiskBudgetBytes <= 0 {
+		return 0
+	}
+	return float64(a.DiskUsedBytes) / float64(a.DiskBudgetBytes)
+}
+
+// ReadinessThresholds are the limits the aggregate runtime probes compare
+// against. A non-positive limit disables that probe: an operator who
+// disagrees with a default switches it off rather than patching the binary.
+type ReadinessThresholds struct {
+	MaxCommitFailureStreak   uint64
+	MaxFinalizeFailureStreak uint64
+	MaxAdmissionRatio        float64
+	MaxDeltaLogAgeSeconds    float64
+	MaxAggregateDiskRatio    float64
+}
+
+// DefaultReadinessThresholds mirrors the config defaults so a Server built
+// without explicit thresholds still probes rather than silently passing.
+func DefaultReadinessThresholds() ReadinessThresholds {
+	return ReadinessThresholds{
+		MaxCommitFailureStreak:   3,
+		MaxFinalizeFailureStreak: 3,
+		MaxAdmissionRatio:        0.9,
+		MaxDeltaLogAgeSeconds:    1800,
+		MaxAggregateDiskRatio:    0.9,
+	}
+}
+
+// thresholds resolves the configured limits, falling back to the defaults.
+func (s *Server) thresholds() ReadinessThresholds {
+	if s.readyThresholds == nil {
+		return DefaultReadinessThresholds()
+	}
+	return *s.readyThresholds
 }
 
 // NewServer creates a new API server.
@@ -115,6 +193,25 @@ func (s *Server) SetAggregateRecoveryProbe(fn func() bool) {
 // no watchdog is configured.
 func (s *Server) SetDiskPressureProbe(fn func() (string, bool)) {
 	s.diskPressure = fn
+}
+
+// SetAggregateRuntimeProbe registers the aggregate runtime health sampler.
+// Pass nil (the default) when no aggregate store is configured; every runtime
+// check then reports "skipped" and readiness is unaffected.
+func (s *Server) SetAggregateRuntimeProbe(fn func() AggregateRuntime) {
+	s.aggregateRuntime = fn
+}
+
+// SetAggregateDBProbe registers the aggregate store reachability check. The
+// callback must honour the context deadline the probe passes it.
+func (s *Server) SetAggregateDBProbe(fn func(context.Context) error) {
+	s.aggregateDBPing = fn
+}
+
+// SetReadinessThresholds overrides the runtime-probe limits. A zero value in
+// any field disables that probe.
+func (s *Server) SetReadinessThresholds(t ReadinessThresholds) {
+	s.readyThresholds = &t
 }
 
 // RegisterRoutes registers API endpoints on the provided mux.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -456,6 +456,24 @@ type Config struct {
 	// config says so.
 	DataDiskBudgetMB int    // Default 8192 (8 GiB)
 	DataDiskPath     string // Default ./data — any path on the data volume
+
+	// Aggregate runtime readiness thresholds (#194 finding 18).
+	//
+	// Startup recovery is not the only way an aggregate deployment stops
+	// being able to serve: the store can become unreachable, group commits
+	// can fail in a row, admission can saturate, the finalizer can wedge and
+	// the delta log can grow without bound. Each threshold below turns one of
+	// those into a /ready 503. Degraded-not-dead: none of them touches
+	// /live, and none of them stops the process.
+	//
+	// Every threshold takes 0 as "disable this probe" so an operator who
+	// disagrees with a default can switch it off without patching the binary.
+	ReadyMaxCommitFailureStreak   int     // READY_MAX_COMMIT_FAILURE_STREAK, default 3
+	ReadyMaxFinalizeFailureStreak int     // READY_MAX_FINALIZE_FAILURE_STREAK, default 3
+	ReadyMaxDeltaLogAgeS          int     // READY_MAX_DELTA_LOG_AGE_S, default 1800
+	ReadyMaxAdmissionRatio        float64 // READY_MAX_ADMISSION_RATIO, default 0.9
+	ReadyAggregateDiskBudgetMB    int     // READY_AGGREGATE_DISK_BUDGET_MB, default 1536
+	ReadyMaxAggregateDiskRatio    float64 // READY_MAX_AGGREGATE_DISK_RATIO, default 0.9
 }
 
 func Load(customPath string) (*Config, error) {
@@ -653,6 +671,30 @@ func Load(customPath string) (*Config, error) {
 		// 8 GiB data budget (#201 Q1).
 		DataDiskBudgetMB: getEnvInt("DATA_DISK_BUDGET_MB", 8192),
 		DataDiskPath:     getEnv("DATA_DISK_PATH", "./data"),
+		// Aggregate runtime readiness probes (#194 finding 18).
+		//
+		// Three consecutive failures, not one: a single failed group commit or
+		// finalize pass is a retry, and flipping an orchestrator's readiness on
+		// a retry is how a healthy process gets pulled out of rotation by a
+		// transient lock.
+		ReadyMaxCommitFailureStreak:   getEnvInt("READY_MAX_COMMIT_FAILURE_STREAK", 3),
+		ReadyMaxFinalizeFailureStreak: getEnvInt("READY_MAX_FINALIZE_FAILURE_STREAK", 3),
+		// 1800s = 2x (WindowSize 5m + AllowedLateness 10m). A window is
+		// finalizable 900s after it opens, so a healthy oldest delta-log entry
+		// tops out just past 900s plus one finalize tick; double that is
+		// margin, not a target.
+		ReadyMaxDeltaLogAgeS: getEnvInt("READY_MAX_DELTA_LOG_AGE_S", 1800),
+		// 0.9, below the 0.95 the DLQ and pipeline probes use: the writer's
+		// admission bound is what turns an Export into RESOURCE_EXHAUSTED, so
+		// readiness should say "stop sending" before clients are being refused,
+		// not while they are.
+		ReadyMaxAdmissionRatio: getEnvFloat("READY_MAX_ADMISSION_RATIO", 0.9),
+		// 1.5 GiB is aggregate.db's share of the 8 GiB data budget (#201 Q1).
+		// The disk watchdog enforces the VOLUME; this enforces the tier, so a
+		// runaway aggregate file is visible before it eats another tier's
+		// allocation and takes the whole volume past 95% with it.
+		ReadyAggregateDiskBudgetMB: getEnvInt("READY_AGGREGATE_DISK_BUDGET_MB", 1536),
+		ReadyMaxAggregateDiskRatio: getEnvFloat("READY_MAX_AGGREGATE_DISK_RATIO", 0.9),
 	}
 
 	// Parse AGGREGATE_METRIC_DIMS config
@@ -1097,6 +1139,24 @@ func (c *Config) Validate() error {
 	}
 	if strings.TrimSpace(c.DataDiskPath) == "" {
 		return fmt.Errorf("DATA_DISK_PATH must not be empty")
+	}
+	if c.ReadyMaxCommitFailureStreak < 0 {
+		return fmt.Errorf("READY_MAX_COMMIT_FAILURE_STREAK must be >= 0 (0 disables the probe), got %d", c.ReadyMaxCommitFailureStreak)
+	}
+	if c.ReadyMaxFinalizeFailureStreak < 0 {
+		return fmt.Errorf("READY_MAX_FINALIZE_FAILURE_STREAK must be >= 0 (0 disables the probe), got %d", c.ReadyMaxFinalizeFailureStreak)
+	}
+	if c.ReadyMaxDeltaLogAgeS < 0 {
+		return fmt.Errorf("READY_MAX_DELTA_LOG_AGE_S must be >= 0 (0 disables the probe), got %d", c.ReadyMaxDeltaLogAgeS)
+	}
+	if c.ReadyMaxAdmissionRatio < 0 || c.ReadyMaxAdmissionRatio > 1 {
+		return fmt.Errorf("READY_MAX_ADMISSION_RATIO must be between 0 and 1 (0 disables the probe), got %v", c.ReadyMaxAdmissionRatio)
+	}
+	if c.ReadyAggregateDiskBudgetMB < 0 {
+		return fmt.Errorf("READY_AGGREGATE_DISK_BUDGET_MB must be >= 0 (0 disables the probe), got %d", c.ReadyAggregateDiskBudgetMB)
+	}
+	if c.ReadyMaxAggregateDiskRatio < 0 || c.ReadyMaxAggregateDiskRatio > 1 {
+		return fmt.Errorf("READY_MAX_AGGREGATE_DISK_RATIO must be between 0 and 1 (0 disables the probe), got %v", c.ReadyMaxAggregateDiskRatio)
 	}
 
 	// Sum-of-caps validation: sub-caps must fit under global cap

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1008,3 +1008,65 @@ func TestValidate_DataDiskBudget(t *testing.T) {
 		t.Error("a blank DATA_DISK_PATH should be rejected")
 	}
 }
+
+// --- aggregate runtime readiness thresholds (#194 finding 18) ---------------
+
+// TestLoad_ReadinessThresholdDefaults pins the defaults the /ready probes ship
+// with. Three consecutive failures, not one; 0.9 admission saturation, below
+// the 0.95 the DLQ and pipeline probes use, because the writer's admission
+// bound is what turns an Export into RESOURCE_EXHAUSTED; 1800s delta-log age,
+// twice the 900s a window needs to become finalizable; 1.5 GiB, aggregate.db's
+// share of the 8 GiB data budget (#201 Q1).
+func TestLoad_ReadinessThresholdDefaults(t *testing.T) {
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.ReadyMaxCommitFailureStreak != 3 {
+		t.Errorf("READY_MAX_COMMIT_FAILURE_STREAK = %d, want 3", cfg.ReadyMaxCommitFailureStreak)
+	}
+	if cfg.ReadyMaxFinalizeFailureStreak != 3 {
+		t.Errorf("READY_MAX_FINALIZE_FAILURE_STREAK = %d, want 3", cfg.ReadyMaxFinalizeFailureStreak)
+	}
+	if cfg.ReadyMaxDeltaLogAgeS != 1800 {
+		t.Errorf("READY_MAX_DELTA_LOG_AGE_S = %d, want 1800", cfg.ReadyMaxDeltaLogAgeS)
+	}
+	if cfg.ReadyMaxAdmissionRatio != 0.9 {
+		t.Errorf("READY_MAX_ADMISSION_RATIO = %v, want 0.9", cfg.ReadyMaxAdmissionRatio)
+	}
+	if cfg.ReadyAggregateDiskBudgetMB != 1536 {
+		t.Errorf("READY_AGGREGATE_DISK_BUDGET_MB = %d, want 1536", cfg.ReadyAggregateDiskBudgetMB)
+	}
+	if cfg.ReadyMaxAggregateDiskRatio != 0.9 {
+		t.Errorf("READY_MAX_AGGREGATE_DISK_RATIO = %v, want 0.9", cfg.ReadyMaxAggregateDiskRatio)
+	}
+}
+
+// TestValidate_ReadinessThresholds: zero disables a probe and must stay
+// accepted; negatives and out-of-range ratios are typos, not policies.
+func TestValidate_ReadinessThresholds(t *testing.T) {
+	c := baseValid()
+	c.ReadyMaxCommitFailureStreak = 0
+	c.ReadyMaxAdmissionRatio = 0
+	if err := c.Validate(); err != nil {
+		t.Fatalf("zero thresholds should be accepted as disabled: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		apply func(*Config)
+	}{
+		{"READY_MAX_COMMIT_FAILURE_STREAK", func(c *Config) { c.ReadyMaxCommitFailureStreak = -1 }},
+		{"READY_MAX_FINALIZE_FAILURE_STREAK", func(c *Config) { c.ReadyMaxFinalizeFailureStreak = -1 }},
+		{"READY_MAX_DELTA_LOG_AGE_S", func(c *Config) { c.ReadyMaxDeltaLogAgeS = -1 }},
+		{"READY_MAX_ADMISSION_RATIO", func(c *Config) { c.ReadyMaxAdmissionRatio = 1.5 }},
+		{"READY_AGGREGATE_DISK_BUDGET_MB", func(c *Config) { c.ReadyAggregateDiskBudgetMB = -1 }},
+		{"READY_MAX_AGGREGATE_DISK_RATIO", func(c *Config) { c.ReadyMaxAggregateDiskRatio = -0.1 }},
+	} {
+		c := baseValid()
+		tc.apply(c)
+		if err := c.Validate(); err == nil || !strings.Contains(err.Error(), tc.name) {
+			t.Errorf("%s: expected a validation error, got %v", tc.name, err)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -924,6 +924,43 @@ func main() {
 		apiServer.SetAggregateRecoveryProbe(aggRecovery.Done)
 	}
 
+	// Aggregate RUNTIME readiness probes (#194 finding 18). Recovery is a
+	// one-time gate; these cover the ways a recovered process later stops
+	// being able to serve: the store goes unreachable, group commits fail in
+	// a row, admission saturates, the finalizer wedges, the delta log stops
+	// draining, or the aggregate tier outgrows its share of the disk budget.
+	// Every signal is read from counters the writer already maintains, so a
+	// readiness request never queues behind the single SQLite writer.
+	apiServer.SetReadinessThresholds(api.ReadinessThresholds{
+		MaxCommitFailureStreak:   uint64(cfg.ReadyMaxCommitFailureStreak),
+		MaxFinalizeFailureStreak: uint64(cfg.ReadyMaxFinalizeFailureStreak),
+		MaxAdmissionRatio:        cfg.ReadyMaxAdmissionRatio,
+		MaxDeltaLogAgeSeconds:    float64(cfg.ReadyMaxDeltaLogAgeS),
+		MaxAggregateDiskRatio:    cfg.ReadyMaxAggregateDiskRatio,
+	})
+	if aggStore != nil {
+		apiServer.SetAggregateDBProbe(aggStore.PingContext)
+	}
+	if aggWriter != nil {
+		aggDiskBudget := int64(cfg.ReadyAggregateDiskBudgetMB) * 1024 * 1024
+		aggDBPath := cfg.AggregateDBPath
+		writer := aggWriter
+		apiServer.SetAggregateRuntimeProbe(func() api.AggregateRuntime {
+			st := writer.Stats()
+			return api.AggregateRuntime{
+				CommitFailureStreak:   st.CommitFailureStreak,
+				FinalizeFailureStreak: st.FinalizeFailureStreak,
+				AdmissionRatio:        st.AdmissionRatio(),
+				DeltaLogAgeSeconds:    st.DeltaLogAge(time.Now()),
+				// Same figure the disk watchdog attributes to the
+				// aggregate_db component, measured against the tier's
+				// share of the budget instead of the whole volume.
+				DiskUsedBytes:   fileBytes(aggDBPath),
+				DiskBudgetBytes: aggDiskBudget,
+			}
+		})
+	}
+
 	// Wire up live log streaming + AI + DLQ metrics
 	logHandler := func(l storage.Log) {
 		start := time.Now()


### PR DESCRIPTION
Closes #194 finding 18 (map #195).

`/ready` gated on startup recovery completing and nothing else. A process that
finished recovery and then lost its store, stopped committing, saturated
admission, wedged its finalizer, stopped draining its delta log, or outgrew its
share of the disk kept answering 200.

## Probes

Six new named checks in the `/ready` payload, each carrying its measured number
so an alert can be built on a figure rather than a word:

| Check | Source | 503 when |
|---|---|---|
| `aggregate_db` | aggregate store **read pool** ping (2s deadline) | ping fails |
| `aggregate_commit` | consecutive group-commit failures | streak >= `READY_MAX_COMMIT_FAILURE_STREAK` (3) |
| `aggregate_finalizer` | consecutive window-finalize failures | streak >= `READY_MAX_FINALIZE_FAILURE_STREAK` (3) |
| `aggregate_admission` | fullest of pending bytes / pending deltas / waiters over their bounds | >= `READY_MAX_ADMISSION_RATIO` (0.9) |
| `aggregate_delta_log` | age of the oldest un-finalized window | >= `READY_MAX_DELTA_LOG_AGE_S` (1800) |
| `aggregate_disk` | `aggregate.db` bytes over `READY_AGGREGATE_DISK_BUDGET_MB` (1536) | >= `READY_MAX_AGGREGATE_DISK_RATIO` (0.9) |

Every threshold takes `0` as "disable this probe". Every check reports
`skipped` when its source is unconfigured, so `AGGREGATE_MODE=legacy`
readiness is unchanged.

## Semantics

- **Degraded-not-dead.** Each probe flips `/ready` to 503, none touches
  `/live`, none stops the process, and each recovers when its signal does.
  `/live` stays process-only: killing a process because its store went
  unreachable throws away the in-memory shards and buys a delta-log replay.
- **No probe queues behind the writer.** Runtime signals are read from counters
  the group-commit writer already maintains, including the delta-log backlog
  sample the finalize loop publishes. Reachability pings the **read** pool with
  a 2s deadline — the writer pool is `MaxOpenConns(1)` behind the group commit
  and would report "unreachable" for a database that is merely busy.
- **A wedged finalizer cannot look healthy.** The delta-log age carries the
  staleness of its sample (age + time since sampled), so freezing the number by
  never refreshing it does not pass the probe.
- **Complements #211, does not duplicate it.** The disk watchdog enforces the
  volume and already flips readiness at `raw_off`; `aggregate_disk` enforces the
  aggregate tier's 1.5 GiB share of the 8 GiB budget (#201 Q1), so a runaway
  aggregate file is visible before it eats another tier's allocation.

## Changes

- `internal/aggregate/writer.go` — consecutive commit/finalize failure streaks,
  finalize error count, admission bounds, and a cached delta-log backlog sample
  on `WriterStats`, plus `AdmissionRatio()` and `DeltaLogAge(now)`. Counters
  only: no commit, finalize or admission decision changed.
- `internal/aggregate/store_sqlite.go` — `PingContext` on the read pool.
- `internal/api/server.go` — `AggregateRuntime` snapshot, `ReadinessThresholds`,
  three setters.
- `internal/api/health_handlers.go` — the runtime check block and a shared
  numeric-probe helper.
- `internal/config/config.go` — six threshold knobs with validation.
- `main.go` — readiness wiring only.
- `CLAUDE.md` — the full `/live` + `/ready` check table, semantics and knobs.

## Verification

```
go build ./...                                   Success
go vet ./...                                     No issues found
go test -race ./internal/api/... ./internal/aggregate/...   524 passed, 3 packages
go test ./...                                    1382 passed, 29 packages
gofmt -l (touched files)                         clean
```

Pre-existing, untouched: `internal/api/log_handlers_trace_filter_test.go` is
already unformatted on `main` (`gofmt -l`); left alone as out of scope.
