### PR TITLE
feat(aggregate): engine-sourced topology edges and finalized-horizon restore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,50 @@ projection retains a bounded recent horizon (the mutable windows plus
 absent. History older than that horizon is unavailable in aggregate mode — it is
 reported as reduced coverage, never as a flat line.
 
+### Engine-sourced topology and finalized-horizon restore (#194 finding 15)
+
+`Engine.QueryTopology` returns **nodes and edges from one query**: one tenant,
+one range, one ownership snapshot. The store half is SQL `GROUP BY` on both
+sides — one row per service for the nodes, one row per `(caller, callee)` for
+the edges (`GroupByService|GroupByName` under a `SignalServiceEdge` selector) —
+so neither half can be truncated by a row cap. A `Services` filter selects a
+**subgraph**: an edge survives only when both ends do, so the result never
+carries an edge hanging off a node the response omits.
+
+The GraphRAG edge side-channel is **gone** from aggregate-mode responses.
+`GET /api/metrics/service-map` and the WebSocket `live_snapshot` used to take
+their nodes from the engine and their edges from the GraphRAG service store — a
+different range, a different retention rule, exemplar-fed counts — and marked
+the whole response `sampled` to cover for it. Both now carry the engine's own
+coverage (`full`) and its edges. GraphRAG itself is untouched: `/api/graph`
+still reads it, and in aggregate mode its topology is already replaced per
+revision from `TopologySnapshot`.
+
+**Startup restore.** `aggregate.Recover` takes a `RecoverOptions` and, when
+`TopologyHorizon > 0`, rebuilds the topology projection from **finalized bucket
+rows** inside that horizon (`Store.ReadFinalizedSince`, newest window first)
+plus the mutable delta rows it just replayed. Without it a restart erased the
+recent service map — every node, edge and metric baseline — while the numbers
+sat in the bucket table.
+
+This is the **only** exception to "finalized history never hydrates", and it
+stops short of the shards: it writes to the projection only, so no finalized
+window can re-enter the mutable set through it. It is bounded three ways — the
+configured horizon, a row cap (`RecoverOptions.TopologyMaxRows`, default
+20,000, clamped to `MaxReadRows`), and the projection's own retention cutoff,
+which is why recovery reports what the fold **accepted**, not what the store
+returned.
+
+- `AGGREGATE_TOPOLOGY_RESTORE_HORIZON` (Go duration, default `30m`, `0`
+  disables, validated `0..24h`) — clamped internally to
+  `TopologySnapshot.Horizon`; reading a window the projection would prune on
+  arrival is startup cost with nothing to show for it.
+- Recovery reports `restored_topology_rows`, `restored_topology_windows` and
+  `restored_topology_truncated` on the recovery log line, and
+  `otelcontext_aggregate_recovery_rows{kind="topology_restored_rows"|"topology_restored_windows"}`.
+  A truncated restore logs a warning: the topology is real but incomplete at
+  its oldest end.
+
 ### Aggregate identity lifecycle (#200)
 
 The dictionary and series tables were append-only. They are not any more.

--- a/internal/aggregate/engine.go
+++ b/internal/aggregate/engine.go
@@ -392,6 +392,24 @@ func (e *Engine) TopologySnapshot(tenant string) TopologySnapshot {
 // gone silent.
 func (e *Engine) PruneTopology() { e.topology.Prune(e.now()) }
 
+// TopologyHorizon is how much finalized history the projection retains behind
+// the mutable set. Startup restore reads no further back than this: a window
+// the projection would immediately prune is a window there is no point paying
+// to read.
+func (e *Engine) TopologyHorizon() time.Duration { return e.topology.cfg.Horizon }
+
+// RestoreTopology folds durable rows into the TOPOLOGY PROJECTION ONLY.
+//
+// It is the read side of the bounded startup exception (#194 finding 15): the
+// mutable shards are untouched, so nothing here can resurrect finalized
+// history as mutable state or double-count a window the delta-log replay
+// already restored. Identities come from reversed dictionary IDs rather than
+// from a reducer, and the projection's own retention cutoff still applies —
+// which is why the folded count, not the row count, is what recovery reports.
+func (e *Engine) RestoreTopology(ids map[SeriesWindowKey]topoIdentity, deltas DeltaMap) int {
+	return e.topology.fold(e.now(), e.revision.Load(), ids, deltas)
+}
+
 // SetTemplateFactSink installs the log-fact consumer on the ingest-owned
 // template miner (#163). GraphRAG performs no mining of its own in shadow and
 // aggregate modes; it consumes these facts. Passing nil detaches the sink.

--- a/internal/aggregate/lifecycle_test.go
+++ b/internal/aggregate/lifecycle_test.go
@@ -29,13 +29,17 @@ type lifecycleFixture struct {
 // identity stack over it.
 func newLifecycleFixture(t *testing.T, b Bounds) *lifecycleFixture {
 	t.Helper()
-	return openLifecycleFixture(t, filepath.Join(t.TempDir(), "aggregate.db"), b, nil)
+	return openLifecycleFixture(t, filepath.Join(t.TempDir(), "aggregate.db"), b, nil, nil)
 }
 
 // openLifecycleFixture wires a cold identity stack over the store at path,
 // which is what a restart looks like: durable rows are there, every in-memory
 // map starts empty. wrap, when set, decorates the store the writer sees.
-func openLifecycleFixture(t *testing.T, path string, b Bounds, wrap func(*SQLiteStore) Store) *lifecycleFixture {
+//
+// clock, when non-nil, is adopted rather than replaced: a restart must not
+// rewind the wall clock, or "the process was down for twenty minutes" cannot
+// be expressed.
+func openLifecycleFixture(t *testing.T, path string, b Bounds, wrap func(*SQLiteStore) Store, clock *fixedClock) *lifecycleFixture {
 	t.Helper()
 	sqlite := newTestStoreAt(t, path, StoreConfig{})
 	var store Store = sqlite
@@ -46,7 +50,9 @@ func openLifecycleFixture(t *testing.T, path string, b Bounds, wrap func(*SQLite
 	if err != nil {
 		t.Fatalf("NewDurableRegistrarWithBounds: %v", err)
 	}
-	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	if clock == nil {
+		clock = newClock(time.Unix(3_000_000, 0).UTC())
+	}
 	eng, err := NewEngine(EngineConfig{
 		Mode:      ModeAggregate,
 		Registrar: reg,
@@ -70,7 +76,7 @@ func (f *lifecycleFixture) restart(b Bounds) *lifecycleFixture {
 	if err := f.sqlite.Close(); err != nil {
 		f.t.Fatalf("close store: %v", err)
 	}
-	return openLifecycleFixture(f.t, f.path, b, nil)
+	return openLifecycleFixture(f.t, f.path, b, nil, f.clock)
 }
 
 // collect runs one GC pass through the fixture's writer barrier.
@@ -448,7 +454,7 @@ func TestSweepFailureLeavesMemoryUntouched(t *testing.T) {
 	f := openLifecycleFixture(t, path, Bounds{}, func(s *SQLiteStore) Store {
 		failing = &failingSweepStore{SQLiteStore: s, err: boom}
 		return failing
-	})
+	}, nil)
 
 	_, err := f.writer.CollectIdentities()
 	if !errors.Is(err, boom) {
@@ -547,7 +553,7 @@ func TestMinerSurvivesCrashBetweenCommitAndSnapshot(t *testing.T) {
 		t.Fatalf("close: %v", err)
 	}
 
-	cold := openLifecycleFixture(t, f.path, Bounds{}, nil)
+	cold := openLifecycleFixture(t, f.path, Bounds{}, nil, nil)
 	restored, err := RestoreMiner(cold.store, cold.eng.Miner())
 	if err != nil {
 		t.Fatalf("RestoreMiner: %v", err)

--- a/internal/aggregate/metrics.go
+++ b/internal/aggregate/metrics.go
@@ -236,8 +236,14 @@ func (r promStoreRecorder) RecordGC(stats GCStats, err error) {
 }
 
 // RecordRecovery implements StoreMetrics.
-func (r promStoreRecorder) RecordRecovery(d time.Duration, replayed, finalized int) {
-	r.m.AggregateRecoveryDurationSeconds.Set(d.Seconds())
-	r.m.AggregateRecoveryRows.WithLabelValues("replayed").Set(float64(replayed))
-	r.m.AggregateRecoveryRows.WithLabelValues("finalized_windows").Set(float64(finalized))
+func (r promStoreRecorder) RecordRecovery(stats RecoveryStats) {
+	r.m.AggregateRecoveryDurationSeconds.Set(stats.Duration.Seconds())
+	for class, n := range map[string]int{
+		"replayed":                  stats.ReplayedRows,
+		"finalized_windows":         stats.FinalizedWindows,
+		"topology_restored_rows":    stats.RestoredTopologyRows,
+		"topology_restored_windows": stats.RestoredTopologyWindows,
+	} {
+		r.m.AggregateRecoveryRows.WithLabelValues(class).Set(float64(n))
+	}
 }

--- a/internal/aggregate/query.go
+++ b/internal/aggregate/query.go
@@ -237,6 +237,12 @@ type TopologyEdge struct {
 }
 
 // TopologyResult is the answer to QueryTopology.
+//
+// Nodes and Edges come from ONE query over ONE tenant and ONE range, read
+// under ONE ownership snapshot. That is the whole point (#194 finding 15):
+// before it, edges were supplemented into API responses from GraphRAG, a store
+// with a different range, a different tenant scope and a different retention
+// rule, and nothing in the response said so.
 type TopologyResult struct {
 	Nodes    []ServiceStat
 	Edges    []TopologyEdge
@@ -431,12 +437,25 @@ func (e *Engine) serviceName(key SeriesKey) string {
 
 // serviceNameByID is serviceName for the SQL aggregation path, which knows the
 // dictionary ID but never builds a SeriesKey.
-func (e *Engine) serviceNameByID(id uint32) string {
+func (e *Engine) serviceNameByID(id uint32) string { return e.nameByID(id) }
+
+// nameByID reverses one dictionary ID. The dictionary is keyed by ID alone, so
+// the same reversal serves every namespace; the CALLER is responsible for
+// having taken the ID out of the right field of the right signal's key.
+func (e *Engine) nameByID(id uint32) string {
 	entry, ok := e.cache.Lookup(id)
 	if !ok {
 		return ""
 	}
 	return string(entry.Value)
+}
+
+// edgeEnds resolves a service-edge series to (caller, callee). ReduceEdge puts
+// the caller in ServiceID and the callee in NameID — the callee is the edge's
+// "name" inside the caller's operation namespace, which is what makes a
+// caller's fan-out subject to MAX_OPERATIONS_PER_SERVICE.
+func (e *Engine) edgeEnds(key SeriesKey) (caller, callee string) {
+	return e.nameByID(key.ServiceID), e.nameByID(key.NameID)
 }
 
 // serviceFilter turns the query's service list into a membership test. A nil
@@ -740,13 +759,32 @@ func topFailing(perSvc map[string]*dashAccum, limit int) []ServiceStat {
 }
 
 // QueryTopology returns the service topology: one node per service with its
-// aggregate accounting, plus whatever caller/callee edge series exist.
+// aggregate accounting, plus the caller/callee edges of the SAME tenant and
+// range, read under the SAME ownership snapshot.
 //
-// Like the other two, its store half is a SQL GROUP BY — one row per service,
-// not one per series — so CoverageFull here means what it says.
+// Both halves are SQL GROUP BY on the store side — one row per service for the
+// nodes, one row per (caller, callee) for the edges, never one per series — so
+// CoverageFull here means what it says and no row cap can truncate the answer.
+//
+// A Services filter selects a SUBGRAPH: an edge survives only when both of its
+// ends survive, so the result is never a graph with edges hanging off nodes it
+// does not contain.
 func (e *Engine) QueryTopology(q Query) (*TopologyResult, error) {
-	q.Signal = SignalTraceOp
+	// No signal filter: the trace-op series carry the nodes and the
+	// service-edge series carry the edges, and both must be read through the
+	// one plan that pins tenant, range and ownership.
+	q.Signal = SignalUnspecified
 	filter := serviceFilter(q.Services)
+	keep := func(name string) bool {
+		if name == "" {
+			return false
+		}
+		if filter == nil {
+			return true
+		}
+		_, ok := filter[name]
+		return ok
+	}
 	nodes := make(map[string]*dashAccum)
 	at := func(name string) *dashAccum {
 		acc := nodes[name]
@@ -756,38 +794,66 @@ func (e *Engine) QueryTopology(q Query) (*TopologyResult, error) {
 		}
 		return acc
 	}
+	edges := make(map[topoPair]*dashAccum)
+	edgeAt := func(caller, callee string) *dashAccum {
+		key := topoPair{caller, callee}
+		acc := edges[key]
+		if acc == nil {
+			acc = &dashAccum{}
+			edges[key] = acc
+		}
+		return acc
+	}
 
 	own, sel, hasStore, err := e.plan(q, func(_ int64, key SeriesKey, d *AggregateDelta) {
-		name := e.serviceName(key)
-		if name == "" {
-			return
-		}
-		if filter != nil {
-			if _, ok := filter[name]; !ok {
+		switch key.Signal {
+		case SignalTraceOp:
+			name := e.serviceName(key)
+			if !keep(name) {
 				return
 			}
+			at(name).addDelta(d)
+		case SignalServiceEdge:
+			caller, callee := e.edgeEnds(key)
+			if !keep(caller) || !keep(callee) {
+				return
+			}
+			edgeAt(caller, callee).addDelta(d)
 		}
-		at(name).addDelta(d)
 	})
 	if err != nil {
 		return nil, err
 	}
 	if hasStore {
-		sums, err := e.sumStore(sel, GroupByService)
+		nodeSel := sel
+		nodeSel.Signal = SignalTraceOp
+		sums, err := e.sumStore(nodeSel, GroupByService)
 		if err != nil {
 			return nil, err
 		}
 		for _, r := range sums {
 			name := e.serviceNameByID(r.ServiceID)
-			if name == "" {
+			if !keep(name) {
 				continue
 			}
-			if filter != nil {
-				if _, ok := filter[name]; !ok {
-					continue
-				}
-			}
 			at(name).addSum(r)
+		}
+
+		// One row per (caller, callee): the callee is the series NAME, so the
+		// edge grouping is GroupByService|GroupByName under a single-signal
+		// selector — the only shape in which a NameID means one namespace.
+		edgeSel := sel
+		edgeSel.Signal = SignalServiceEdge
+		edgeSums, err := e.sumStore(edgeSel, GroupByService|GroupByName)
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range edgeSums {
+			caller, callee := e.nameByID(r.ServiceID), e.nameByID(r.NameID)
+			if !keep(caller) || !keep(callee) {
+				continue
+			}
+			edgeAt(caller, callee).addSum(r)
 		}
 	}
 
@@ -812,9 +878,37 @@ func (e *Engine) QueryTopology(q Query) (*TopologyResult, error) {
 
 	return &TopologyResult{
 		Nodes:    out,
-		Edges:    []TopologyEdge{},
+		Edges:    topologyEdges(edges),
 		Coverage: CoverageFull,
 		Epoch:    own.Epoch,
 		Revision: own.Revision,
 	}, nil
+}
+
+// topologyEdges renders the accumulated caller/callee pairs, sorted by
+// (caller, callee) so a client diffing two responses sees data changes rather
+// than map-iteration noise.
+func topologyEdges(acc map[topoPair]*dashAccum) []TopologyEdge {
+	out := make([]TopologyEdge, 0, len(acc))
+	for pair, a := range acc {
+		edge := TopologyEdge{
+			Source:    pair.a,
+			Target:    pair.b,
+			CallCount: asInt64(a.count),
+		}
+		if a.count > 0 {
+			edge.ErrorRate = float64(a.errors) / float64(a.count)
+		}
+		if a.durCount > 0 {
+			edge.AvgLatencyMs = a.durSum / float64(a.durCount) / 1000.0
+		}
+		out = append(out, edge)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Source != out[j].Source {
+			return out[i].Source < out[j].Source
+		}
+		return out[i].Target < out[j].Target
+	})
+	return out
 }

--- a/internal/aggregate/query_test.go
+++ b/internal/aggregate/query_test.go
@@ -109,12 +109,15 @@ func (s *stubStore) SumBuckets(sel Selector, by GroupBy) ([]SumRow, error) {
 		if by&GroupByService != 0 {
 			g.ServiceID = key.ServiceID
 		}
+		if by&GroupByName != 0 {
+			g.NameID = key.NameID
+		}
 		if by&GroupBySignal != 0 {
 			g.Signal = key.Signal
 		}
 		acc := groups[g]
 		if acc == nil {
-			acc = &SumRow{WindowStart: g.WindowStart, ServiceID: g.ServiceID, Signal: g.Signal}
+			acc = &SumRow{WindowStart: g.WindowStart, ServiceID: g.ServiceID, NameID: g.NameID, Signal: g.Signal}
 			groups[g] = acc
 			order = append(order, g)
 		}
@@ -133,7 +136,46 @@ func (s *stubStore) SumBuckets(sel Selector, by GroupBy) ([]SumRow, error) {
 	return out, nil
 }
 
-func (s *stubStore) ReplayMutable(int64) ([]DeltaRow, error)  { return nil, nil }
+func (s *stubStore) ReplayMutable(int64) ([]DeltaRow, error) { return nil, nil }
+
+// ReadFinalizedSince is the naive reference: filter by window and signal in
+// Go, newest window first, cap with the same limit+1 probe the SQLite store
+// uses.
+func (s *stubStore) ReadFinalizedSince(since int64, signals []Signal, limit int) (FinalizedPage, error) {
+	if limit <= 0 || limit > MaxReadRows {
+		limit = MaxReadRows
+	}
+	want := make(map[Signal]struct{}, len(signals))
+	for _, sig := range signals {
+		want[sig] = struct{}{}
+	}
+	out := make([]Bucket, 0, len(s.buckets))
+	for _, b := range s.buckets {
+		if b.WindowStart < since || b.Source != SourceFinalized {
+			continue
+		}
+		if len(want) > 0 {
+			if _, ok := want[s.infos[b.SeriesID].Signal]; !ok {
+				continue
+			}
+		}
+		out = append(out, b)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].WindowStart != out[j].WindowStart {
+			return out[i].WindowStart > out[j].WindowStart
+		}
+		return out[i].SeriesID < out[j].SeriesID
+	})
+	page := FinalizedPage{}
+	if len(out) > limit {
+		out = out[:limit]
+		page.Truncated = true
+	}
+	page.Buckets = out
+	return page, nil
+}
+
 func (s *stubStore) LoadBaselines(int) ([]BaselineRow, error) { return nil, nil }
 func (s *stubStore) ResolveSeries(ids []SeriesID) ([]SeriesInfo, error) {
 	out := make([]SeriesInfo, 0, len(ids))
@@ -175,6 +217,20 @@ func (f *queryFixture) traceKey(service, op string) SeriesKey {
 		Signal:      SignalTraceOp,
 		StatusClass: StatusOK,
 		Variant:     SpanKindServer,
+	}
+}
+
+// edgeKey builds a service-edge series key for a caller/callee pair. The
+// CALLER is the series' service and the CALLEE is its name, interned in the
+// operation namespace — the identity ReduceEdge writes.
+func (f *queryFixture) edgeKey(caller, callee string) SeriesKey {
+	return SeriesKey{
+		TenantID:    f.tenantID,
+		ServiceID:   f.engine.Cache().Intern(f.tenantID, KindService, caller),
+		NameID:      f.engine.Cache().Intern(f.tenantID, KindOperation, callee),
+		Signal:      SignalServiceEdge,
+		StatusClass: StatusOK,
+		Variant:     SpanKindClient,
 	}
 }
 
@@ -482,5 +538,92 @@ func TestFinalizeHandsOwnershipToTheStore(t *testing.T) {
 	}
 	if own.FinalizedWatermark < old {
 		t.Errorf("FinalizedWatermark = %d, want at least %d", own.FinalizedWatermark, old)
+	}
+}
+
+// TestQueryTopologyEdgesShareTheNodeQuery is #194 finding 15: edges come out of
+// the SAME plan as the nodes — same tenant, same range, same ownership
+// snapshot — with the memory-owned and store-owned halves added rather than one
+// of them silently winning.
+func TestQueryTopologyEdgesShareTheNodeQuery(t *testing.T) {
+	f := newQueryFixture(t)
+	st := newStubStore()
+	f.engine.SetStore(st)
+
+	w := f.window()
+	old := w - 3*int64(WindowSize/time.Second)
+
+	f.apply(f.traceKey("cart", "op"), w, spanDelta(3, 2000))
+	f.apply(f.traceKey("checkout", "op"), w, spanDelta(6, 1000))
+	f.apply(f.edgeKey("cart", "checkout"), w, spanDelta(6, 1000))
+
+	// Store-owned rows in the same range: they must ADD to the memory half.
+	st.put(1, f.traceKey("cart", "op"), old, spanDelta(3, 2000))
+	st.put(2, f.edgeKey("cart", "checkout"), old, spanDelta(3, 2000))
+
+	// Another tenant's edge over the same window must never leak in.
+	otherID, ok := f.engine.TenantID("other")
+	if !ok {
+		t.Fatal("second tenant was refused")
+	}
+	st.put(3, SeriesKey{
+		TenantID:  otherID,
+		ServiceID: f.engine.Cache().Intern(otherID, KindService, "cart"),
+		NameID:    f.engine.Cache().Intern(otherID, KindOperation, "checkout"),
+		Signal:    SignalServiceEdge,
+	}, old, spanDelta(30, 1000))
+
+	res, err := f.engine.QueryTopology(f.rangeQuery())
+	if err != nil {
+		t.Fatalf("QueryTopology: %v", err)
+	}
+	if len(res.Edges) != 1 {
+		t.Fatalf("edges = %+v, want exactly one cart->checkout edge", res.Edges)
+	}
+	edge := res.Edges[0]
+	if edge.Source != "cart" || edge.Target != "checkout" {
+		t.Fatalf("edge = %s->%s, want cart->checkout", edge.Source, edge.Target)
+	}
+	if edge.CallCount != 9 {
+		t.Errorf("edge call count = %d, want 9 (6 memory-owned + 3 store-owned)", edge.CallCount)
+	}
+	// spanDelta marks every third observation an error: 2 of 6 plus 1 of 3.
+	if math.Abs(edge.ErrorRate-3.0/9.0) > 1e-9 {
+		t.Errorf("edge error rate = %v, want %v", edge.ErrorRate, 3.0/9.0)
+	}
+	wantLatency := (6*1000.0 + 3*2000.0) / 9 / 1000.0
+	if math.Abs(edge.AvgLatencyMs-wantLatency) > 1e-9 {
+		t.Errorf("edge avg latency = %v ms, want %v", edge.AvgLatencyMs, wantLatency)
+	}
+	// The edge series must not be counted as a service node.
+	if len(res.Nodes) != 2 {
+		t.Fatalf("nodes = %+v, want cart and checkout only", res.Nodes)
+	}
+	if res.Coverage != CoverageFull {
+		t.Errorf("coverage = %q, want %q", res.Coverage, CoverageFull)
+	}
+}
+
+// TestQueryTopologyServiceFilterKeepsTheGraphClosed proves a filtered topology
+// is a SUBGRAPH: an edge whose other end was filtered out is dropped rather
+// than left hanging off a node the response does not contain.
+func TestQueryTopologyServiceFilterKeepsTheGraphClosed(t *testing.T) {
+	f := newQueryFixture(t)
+	w := f.window()
+	f.apply(f.traceKey("cart", "op"), w, spanDelta(3, 2000))
+	f.apply(f.traceKey("checkout", "op"), w, spanDelta(6, 1000))
+	f.apply(f.edgeKey("cart", "checkout"), w, spanDelta(6, 1000))
+
+	q := f.rangeQuery()
+	q.Services = []string{"checkout"}
+	res, err := f.engine.QueryTopology(q)
+	if err != nil {
+		t.Fatalf("QueryTopology: %v", err)
+	}
+	if len(res.Nodes) != 1 || res.Nodes[0].Service != "checkout" {
+		t.Fatalf("nodes = %+v, want checkout only", res.Nodes)
+	}
+	if len(res.Edges) != 0 {
+		t.Fatalf("edges = %+v, want none: cart was filtered out", res.Edges)
 	}
 }

--- a/internal/aggregate/recovery.go
+++ b/internal/aggregate/recovery.go
@@ -19,9 +19,17 @@ import (
 //  3. Durable cumulative baselines are seeded into the tracker, so the first
 //     cumulative point after a restart converts instead of re-seeding.
 //
-// FINALIZED HISTORY NEVER HYDRATES INTO RAM. Only the delta log is read, and
-// only for windows still inside the mutable set — the bucket table is a read
-// path, not a startup path.
+// FINALIZED HISTORY NEVER HYDRATES INTO THE SHARDS. Only the delta log is
+// replayed, and only for windows still inside the mutable set.
+//
+// There is exactly ONE bounded exception, and it stops short of the shards:
+// step 4 rebuilds the engine's TOPOLOGY PROJECTION over a configured horizon
+// (#194 finding 15). Without it a restart erases the recent service map —
+// every node, edge and metric baseline — until enough new telemetry arrives to
+// re-derive one, while the numbers those entities describe are sitting in the
+// bucket table. The exception is bounded three ways: a horizon, a row cap, and
+// the projection's own retention cutoff. It writes to the projection only, so
+// no finalized window can re-enter the mutable set through it.
 //
 // Readiness is held false until this completes. A process that answers /ready
 // while its shards are half-populated would serve numbers that are wrong in a
@@ -38,6 +46,17 @@ type RecoveryStats struct {
 	ReplayedSeries int
 	// SeededBaselines counts cumulative baselines restored.
 	SeededBaselines int
+	// RestoredTopologyRows counts the durable rows the topology restore read:
+	// finalized bucket rows inside the horizon plus the replayed mutable rows,
+	// which are in the shards but not in the projection.
+	RestoredTopologyRows int
+	// RestoredTopologyWindows counts the (series, window) pairs that actually
+	// LANDED in the projection. It is lower than RestoredTopologyRows whenever
+	// the projection's cutoff or one of its caps refused a row.
+	RestoredTopologyWindows int
+	// RestoredTopologyTruncated reports that the row cap cut the horizon
+	// short. The restored topology is real but incomplete at its oldest end.
+	RestoredTopologyTruncated bool
 	// SkippedSeries counts delta rows whose series id no longer resolves —
 	// structurally impossible while registration and first delta share a
 	// transaction, so a non-zero value here is a corruption signal.
@@ -45,6 +64,31 @@ type RecoveryStats struct {
 	// Duration is the wall time of the whole recovery.
 	Duration time.Duration
 }
+
+// RecoverOptions configures the parts of recovery that are policy rather than
+// correctness. The zero value is the pre-#194 behaviour: replay only.
+type RecoverOptions struct {
+	// TopologyHorizon is how much FINALIZED history is rebuilt into the
+	// engine's topology projection. Zero disables the restore; anything past
+	// the projection's own horizon is clamped down to it, because a window the
+	// projection would prune on arrival is not worth reading.
+	TopologyHorizon time.Duration
+	// TopologyMaxRows caps the finalized rows one restore may read. Zero takes
+	// DefaultTopologyRestoreMaxRows. It is the second bound on startup cost:
+	// the horizon says how far back, this says how much.
+	TopologyMaxRows int
+}
+
+// DefaultTopologyRestoreMaxRows caps the finalized rows a topology restore
+// reads. At the default series budget a 30-minute horizon is six windows of at
+// most a few thousand series, so the cap is headroom rather than a routine
+// truncation — and when it does bind, it is reported, not hidden.
+const DefaultTopologyRestoreMaxRows = 20000
+
+// topologyRestoreSignals are the durable signals the projection is built from.
+// Log series are absent on purpose: the projection holds no log entities, so
+// reading them would be startup cost with no restored fact to show for it.
+var topologyRestoreSignals = []Signal{SignalTraceOp, SignalServiceEdge, SignalMetric}
 
 // RecoveryGate reports whether startup recovery has completed. The readiness
 // probe holds /ready at 503 until Done() is true.
@@ -72,7 +116,7 @@ func (g *RecoveryGate) Complete() {
 
 // Recover replays the durable store into the engine. It must run before the
 // writer starts accepting Exports and before readiness flips.
-func Recover(store Store, engine *Engine, w *Writer, now time.Time) (RecoveryStats, error) {
+func Recover(store Store, engine *Engine, w *Writer, now time.Time, opts RecoverOptions) (RecoveryStats, error) {
 	start := time.Now()
 	var stats RecoveryStats
 	if store == nil || engine == nil {
@@ -109,8 +153,99 @@ func Recover(store Store, engine *Engine, w *Writer, now time.Time) (RecoverySta
 	}
 	stats.SeededBaselines = seeded
 
+	// 4. Rebuild the topology projection over the configured finalized
+	//    horizon. It runs LAST because it reads what step 1 finalized, and it
+	//    touches no shard.
+	if err := restoreTopology(store, engine, w, now, rows, opts, &stats); err != nil {
+		return stats, err
+	}
+
 	stats.Duration = time.Since(start)
 	return stats, nil
+}
+
+// restoreTopology rebuilds the engine's topology projection from durable rows.
+//
+// Two sources, one fold. The finalized buckets inside the horizon are the part
+// that #194 finding 15 is about; the mutable delta rows step 2 replayed are
+// added because they are back in the SHARDS but not in the PROJECTION, and a
+// topology that stopped at the finalized watermark would show a hole between
+// the horizon and now.
+//
+// Nothing here writes to a shard, and the projection's retention cutoff still
+// applies — which is why the count reported is what the fold accepted, not
+// what the store returned.
+func restoreTopology(
+	store Store,
+	engine *Engine,
+	w *Writer,
+	now time.Time,
+	mutable []DeltaRow,
+	opts RecoverOptions,
+	stats *RecoveryStats,
+) error {
+	horizon := opts.TopologyHorizon
+	if horizon <= 0 {
+		return nil
+	}
+	if projected := engine.TopologyHorizon(); horizon > projected {
+		horizon = projected
+	}
+	limit := opts.TopologyMaxRows
+	if limit <= 0 {
+		limit = DefaultTopologyRestoreMaxRows
+	}
+	page, err := store.ReadFinalizedSince(WindowStart(now.Add(-horizon)), topologyRestoreSignals, limit)
+	if err != nil {
+		return fmt.Errorf("aggregate recovery: read finalized topology: %w", err)
+	}
+	rows := make([]DeltaRow, 0, len(page.Buckets)+len(mutable))
+	for _, b := range page.Buckets {
+		if b.Delta == nil {
+			continue
+		}
+		rows = append(rows, DeltaRow{SeriesID: b.SeriesID, WindowStart: b.WindowStart, Delta: b.Delta})
+	}
+	rows = append(rows, mutable...)
+	stats.RestoredTopologyRows = len(rows)
+	stats.RestoredTopologyTruncated = page.Truncated
+	if len(rows) == 0 {
+		return nil
+	}
+
+	keys, err := seriesKeys(store, w, distinctSeriesIDs(rows))
+	if err != nil {
+		return err
+	}
+	ids := make(map[SeriesWindowKey]topoIdentity, len(rows))
+	deltas := make(DeltaMap, len(rows))
+	for _, row := range rows {
+		key, ok := keys[row.SeriesID]
+		if !ok {
+			continue
+		}
+		id, ok := engine.topoIdentityFor(key)
+		if !ok {
+			continue
+		}
+		swk := SeriesWindowKey{Key: key, WindowStart: row.WindowStart}
+		if cur, ok := deltas[swk]; ok {
+			// Structurally unreachable — both sources are unique per
+			// (series, window) and cover disjoint windows — but merging into
+			// a FRESH delta rather than in place is what keeps it harmless if
+			// it ever happens: the mutable deltas are the same pointers the
+			// shards already hold.
+			merged := &AggregateDelta{}
+			merged.Merge(cur)
+			merged.Merge(row.Delta)
+			deltas[swk] = merged
+			continue
+		}
+		deltas[swk] = row.Delta
+		ids[swk] = id
+	}
+	stats.RestoredTopologyWindows = engine.RestoreTopology(ids, deltas)
+	return nil
 }
 
 // finalizeExpired finalizes every window whose lateness horizon expired.
@@ -246,9 +381,17 @@ func LogRecovery(stats RecoveryStats, path string) {
 		"replayed_rows", stats.ReplayedRows,
 		"replayed_series_windows", stats.ReplayedSeries,
 		"seeded_baselines", stats.SeededBaselines,
+		"restored_topology_rows", stats.RestoredTopologyRows,
+		"restored_topology_windows", stats.RestoredTopologyWindows,
+		"restored_topology_truncated", stats.RestoredTopologyTruncated,
 		"unresolved_series", stats.SkippedSeries,
 		"duration", stats.Duration,
 	)
+	if stats.RestoredTopologyTruncated {
+		slog.Warn("aggregate recovery: topology restore hit its row cap — the oldest part of the horizon was not restored",
+			"restored_rows", stats.RestoredTopologyRows,
+		)
+	}
 	if stats.SkippedSeries > 0 {
 		slog.Error("aggregate recovery: delta rows referenced unknown series — the store may be corrupt",
 			"rows", stats.SkippedSeries)

--- a/internal/aggregate/recovery_test.go
+++ b/internal/aggregate/recovery_test.go
@@ -36,7 +36,7 @@ func TestRecoveryReplaysMutableWindowsOnly(t *testing.T) {
 	}
 
 	eng := newTestEngine(t, clock, nil)
-	stats, err := Recover(store, eng, nil, clock.Now())
+	stats, err := Recover(store, eng, nil, clock.Now(), RecoverOptions{})
 	if err != nil {
 		t.Fatalf("Recover: %v", err)
 	}
@@ -78,7 +78,7 @@ func TestRecoverySeedsBaselines(t *testing.T) {
 	}
 
 	eng := newTestEngine(t, clock, nil)
-	stats, err := Recover(store, eng, nil, clock.Now())
+	stats, err := Recover(store, eng, nil, clock.Now(), RecoverOptions{})
 	if err != nil {
 		t.Fatalf("Recover: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestRecoveryFinalizesDowntimeExpiredWindows(t *testing.T) {
 	// The process was down long enough for the window's lateness to expire.
 	clock.Advance(2 * (WindowSize + AllowedLateness))
 	eng2 := newTestEngine(t, clock, nil)
-	stats, err := Recover(store, eng2, nil, clock.Now())
+	stats, err := Recover(store, eng2, nil, clock.Now(), RecoverOptions{})
 	if err != nil {
 		t.Fatalf("Recover: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestCrashAfterACKSurvivesKill9(t *testing.T) {
 	clock := newClock(time.Unix(3_000_000, 0).UTC())
 	store := newTestStoreAt(t, path, StoreConfig{})
 	eng := newTestEngine(t, clock, nil)
-	stats, err := Recover(store, eng, nil, clock.Now())
+	stats, err := Recover(store, eng, nil, clock.Now(), RecoverOptions{})
 	if err != nil {
 		t.Fatalf("Recover after kill -9: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestReopenWithoutCheckpointKeepsAcknowledgedDeltas(t *testing.T) {
 
 	reopened := newTestStoreAt(t, path, StoreConfig{})
 	eng2 := newTestEngine(t, clock, nil)
-	if _, err := Recover(reopened, eng2, nil, clock.Now()); err != nil {
+	if _, err := Recover(reopened, eng2, nil, clock.Now(), RecoverOptions{}); err != nil {
 		t.Fatalf("Recover: %v", err)
 	}
 	if count, _ := eng2.Snapshot().Totals(SignalTraceOp); count != 6 {

--- a/internal/aggregate/store.go
+++ b/internal/aggregate/store.go
@@ -352,6 +352,20 @@ type BucketPage struct {
 	Next BucketCursor
 }
 
+// FinalizedPage is one bounded, cross-tenant read of finalized bucket rows.
+//
+// It carries no resume cursor on purpose: its caller restores a bounded
+// horizon, and a caller that could page past the cap would no longer have a
+// bounded startup. Truncated is the honest end of the answer, not an
+// invitation to ask again.
+type FinalizedPage struct {
+	// Buckets are the rows, ordered by (window DESC, series). Newest first, so
+	// a cap drops the OLDEST part of the horizon rather than the freshest.
+	Buckets []Bucket
+	// Truncated reports that more rows matched than the cap allowed.
+	Truncated bool
+}
+
 // BucketSource says which durable table a row came from. It exists so a paged
 // read has a TOTAL order to resume from: (window_start, series_id) is unique
 // within each table but a window can legitimately hold a materialized bucket
@@ -428,6 +442,11 @@ const (
 	GroupByWindow GroupBy = 1 << iota
 	// GroupByService emits one row per service dictionary ID.
 	GroupByService
+	// GroupByName emits one row per name dictionary ID. The namespace of a
+	// NameID is the signal's (see NameKind), so this flag is only meaningful
+	// on a single-signal selector — joining NameIDs across signals is exactly
+	// the mistake the namespace split exists to prevent.
+	GroupByName
 	// GroupBySignal emits one row per signal.
 	GroupBySignal
 )
@@ -442,7 +461,10 @@ const (
 type SumRow struct {
 	WindowStart int64
 	ServiceID   uint32
-	Signal      Signal
+	// NameID is set only when GroupByName was requested. It resolves through
+	// NameKind(Signal), never through the service namespace.
+	NameID uint32
+	Signal Signal
 
 	Count             uint64
 	ErrorCount        uint64
@@ -563,6 +585,20 @@ type Store interface {
 	// the mutable set only. Finalized history never hydrates into RAM (#160).
 	ReplayMutable(since int64) ([]DeltaRow, error)
 
+	// ReadFinalizedSince returns MATERIALIZED bucket rows at or after since
+	// for the given signals, across every tenant, NEWEST window first, capped
+	// at limit rows.
+	//
+	// It is the one bounded exception to "finalized history never hydrates"
+	// (#194 finding 15): the topology projection is rebuilt from it at
+	// startup so a restart does not erase the recent service map. It feeds
+	// the projection ONLY — never the mutable shards — and the two bounds
+	// that keep it a startup cost rather than a startup stall are the caller's
+	// horizon (since) and the row cap. Truncated reports that the cap cut the
+	// answer, so a restored topology is never presented as complete when it
+	// is not.
+	ReadFinalizedSince(since int64, signals []Signal, limit int) (FinalizedPage, error)
+
 	// LoadBaselines returns every durable cumulative baseline, capped at max.
 	LoadBaselines(max int) ([]BaselineRow, error)
 
@@ -599,9 +635,9 @@ type StoreMetrics interface {
 	RecordPurge(stats PurgeStats, err error)
 	// SetBacklog publishes the delta-log backlog health bounds.
 	SetBacklog(rows int64, ageSeconds float64)
-	// RecordRecovery publishes the startup recovery duration and how many
-	// delta rows were replayed.
-	RecordRecovery(d time.Duration, replayed int, finalized int)
+	// RecordRecovery publishes one startup recovery: its duration and every
+	// row class it moved.
+	RecordRecovery(stats RecoveryStats)
 	// RecordGC publishes one identity garbage-collection pass.
 	RecordGC(stats GCStats, err error)
 }
@@ -614,7 +650,7 @@ func (noopStoreMetrics) RecordAdmissionRejected(string)                {}
 func (noopStoreMetrics) RecordFinalize(FinalizeStats, error)           {}
 func (noopStoreMetrics) RecordPurge(PurgeStats, error)                 {}
 func (noopStoreMetrics) SetBacklog(int64, float64)                     {}
-func (noopStoreMetrics) RecordRecovery(time.Duration, int, int)        {}
+func (noopStoreMetrics) RecordRecovery(RecoveryStats)                  {}
 func (noopStoreMetrics) RecordGC(GCStats, error)                       {}
 
 // MutableSince returns the oldest window start still inside the mutable set at

--- a/internal/aggregate/store_sqlite.go
+++ b/internal/aggregate/store_sqlite.go
@@ -1286,6 +1286,7 @@ func (s *SQLiteStore) SumBuckets(sel Selector, by GroupBy) ([]SumRow, error) {
 	}{
 		{GroupByWindow, "window_start"},
 		{GroupByService, "service_id"},
+		{GroupByName, "name_id"},
 		{GroupBySignal, "signal"},
 	} {
 		if by&g.flag != 0 {
@@ -1301,7 +1302,8 @@ func (s *SQLiteStore) SumBuckets(sel Selector, by GroupBy) ([]SumRow, error) {
 		COALESCE(SUM(duration_count),0), COALESCE(SUM(duration_sum),0),
 		COALESCE(SUM(log_count),0) FROM (`)
 	args = appendBucketUnion(&sb, sel,
-		`t.window_start AS window_start, s.service_id AS service_id, s.signal AS signal, `+
+		`t.window_start AS window_start, s.service_id AS service_id,
+			s.name_id AS name_id, s.signal AS signal, `+
 			aliasColumns("t.", sumColumnList), args)
 	sb.WriteString(`)`)
 	if len(group) > 0 {
@@ -1317,17 +1319,18 @@ func (s *SQLiteStore) SumBuckets(sel Selector, by GroupBy) ([]SumRow, error) {
 	for rows.Next() {
 		var (
 			r                              SumRow
-			window, service, signal        int64
+			window, service, name, signal  int64
 			count, errCount, reqs, errReqs int64
 			durCount, logCount             int64
 			durSum                         float64
 		)
-		if err := rows.Scan(&window, &service, &signal,
+		if err := rows.Scan(&window, &service, &name, &signal,
 			&count, &errCount, &reqs, &errReqs, &durCount, &durSum, &logCount); err != nil {
 			return nil, fmt.Errorf("aggregate store: sum buckets: %w", err)
 		}
 		r.WindowStart = window
 		r.ServiceID = uint32(service)         // #nosec G115 -- dictionary IDs are uint32
+		r.NameID = uint32(name)               // #nosec G115 -- dictionary IDs are uint32
 		r.Signal = Signal(signal)             // #nosec G115 -- signal is written from the bounded Signal enum
 		r.Count = uint64(count)               // #nosec G115 -- counters are written from uint64
 		r.ErrorCount = uint64(errCount)       // #nosec G115 -- counters are written from uint64
@@ -1423,6 +1426,67 @@ func (s *SQLiteStore) ReplayMutable(since int64) ([]DeltaRow, error) {
 		out = append(out, DeltaRow{SeriesID: SeriesID(id), WindowStart: window, Delta: d})
 	}
 	return out, rows.Err()
+}
+
+// ReadFinalizedSince implements Store. It reads MATERIALIZED bucket rows only:
+// the delta log holds the mutable set, which recovery replays through its own
+// path, so reading both here would fold the same contribution twice.
+//
+// Newest window first. The cap is the store's own row cap, applied with the
+// limit+1 probe every read in this file uses, so a caller learns that its
+// horizon was cut instead of silently receiving a partial service map.
+func (s *SQLiteStore) ReadFinalizedSince(since int64, signals []Signal, limit int) (FinalizedPage, error) {
+	if limit <= 0 || limit > MaxReadRows {
+		limit = MaxReadRows
+	}
+	var (
+		sb   strings.Builder
+		args []any
+	)
+	sb.WriteString(`SELECT t.window_start, t.series_id, ` + aliasColumns("t.", deltaColumnList) +
+		` FROM aggregate_buckets t JOIN aggregate_series s ON s.id = t.series_id
+		  WHERE t.window_start >= ?`)
+	args = append(args, since)
+	if len(signals) > 0 {
+		sb.WriteString(` AND s.signal IN (` + placeholders(len(signals)) + `)`)
+		for _, sig := range signals {
+			args = append(args, int64(sig))
+		}
+	}
+	sb.WriteString(` ORDER BY t.window_start DESC, t.series_id LIMIT ?`)
+	args = append(args, limit+1)
+
+	rows, err := s.reader.Query(sb.String(), args...)
+	if err != nil {
+		return FinalizedPage{}, fmt.Errorf("aggregate store: read finalized: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	page := FinalizedPage{Buckets: make([]Bucket, 0, 64)}
+	for rows.Next() {
+		var window, id int64
+		d, err := scanDelta(func(dst ...any) error {
+			return rows.Scan(append([]any{&window, &id}, dst...)...)
+		}, nil)
+		if err != nil {
+			return FinalizedPage{}, fmt.Errorf("aggregate store: read finalized: %w", err)
+		}
+		if len(page.Buckets) == limit {
+			// The limit+1'th row is never returned; it only proves the answer
+			// is incomplete.
+			page.Truncated = true
+			break
+		}
+		page.Buckets = append(page.Buckets, Bucket{
+			WindowStart: window,
+			SeriesID:    SeriesID(id),
+			Delta:       d,
+			Source:      SourceFinalized,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return FinalizedPage{}, fmt.Errorf("aggregate store: read finalized: %w", err)
+	}
+	return page, nil
 }
 
 // LoadBaselines implements Store.

--- a/internal/aggregate/store_test.go
+++ b/internal/aggregate/store_test.go
@@ -578,3 +578,60 @@ func assertEmpty(t *testing.T, s *SQLiteStore, table string) {
 	t.Helper()
 	assertCount(t, s, table, 0)
 }
+
+// TestSumBucketsGroupsByNameWithinASignal covers the grouping QueryTopology's
+// edge half rests on: one row per (service, name) under a single-signal
+// selector. The name namespace is the signal's, so the selector pins the signal
+// and the grouping never joins a NameID across two of them.
+func TestSumBucketsGroupsByNameWithinASignal(t *testing.T) {
+	store := newTestStore(t)
+	edge := func(caller, callee uint32) SeriesKey {
+		return SeriesKey{
+			TenantID: 1, ServiceID: caller, NameID: callee,
+			Signal: SignalServiceEdge, StatusClass: StatusOK, Variant: SpanKindClient,
+		}
+	}
+	window := int64(1_800_000)
+	if err := store.CommitGroup(&GroupBatch{
+		Series: []SeriesRow{
+			{ID: 1, Key: edge(10, 20)},
+			{ID: 2, Key: edge(10, 30)},
+			{ID: 3, Key: storeKey(20)},
+		},
+		Deltas: []DeltaRow{
+			{SeriesID: 1, WindowStart: window, Delta: spanDelta(4, 100)},
+			{SeriesID: 1, WindowStart: window + int64(WindowSize/time.Second), Delta: spanDelta(2, 100)},
+			{SeriesID: 2, WindowStart: window, Delta: spanDelta(3, 100)},
+			{SeriesID: 3, WindowStart: window, Delta: spanDelta(9, 100)},
+		},
+	}); err != nil {
+		t.Fatalf("CommitGroup: %v", err)
+	}
+
+	sums, err := store.SumBuckets(Selector{
+		TenantID: 1,
+		Start:    window,
+		End:      window + 4*int64(WindowSize/time.Second),
+		Signal:   SignalServiceEdge,
+	}, GroupByService|GroupByName)
+	if err != nil {
+		t.Fatalf("SumBuckets: %v", err)
+	}
+	got := make(map[uint32]uint64, len(sums))
+	for _, r := range sums {
+		if r.ServiceID != 10 {
+			t.Fatalf("row %+v carries a service the selector excluded", r)
+		}
+		if r.WindowStart != 0 {
+			t.Errorf("row %+v carries a window start without GroupByWindow", r)
+		}
+		got[r.NameID] += r.Count
+	}
+	if len(got) != 2 {
+		t.Fatalf("grouped rows = %v, want one per callee", got)
+	}
+	// Both windows of the first edge collapse into its single group row.
+	if got[20] != 6 || got[30] != 3 {
+		t.Fatalf("grouped counts = %v, want {20: 6, 30: 3}", got)
+	}
+}

--- a/internal/aggregate/topology.go
+++ b/internal/aggregate/topology.go
@@ -241,6 +241,41 @@ type topoIdentity struct {
 
 type topoPair struct{ a, b string }
 
+// topoIdentityFor derives the projection identity of a DURABLE series.
+//
+// The fold path never reverses a dictionary ID — the reducer records the
+// identity strings alongside the delta. Startup restore has no reducer to ask,
+// so it reverses IDs here, which is safe for exactly the reason the fold path
+// could not rely on: by the time recovery runs, the durable dictionary is
+// warm. A series whose names no longer resolve is refused rather than folded
+// under an invented name.
+func (e *Engine) topoIdentityFor(key SeriesKey) (topoIdentity, bool) {
+	var kind topoKind
+	switch key.Signal {
+	case SignalTraceOp:
+		kind = topoTrace
+	case SignalServiceEdge:
+		kind = topoEdge
+	case SignalMetric:
+		kind = topoMetric
+	default:
+		return topoIdentity{}, false
+	}
+	tenant := e.nameByID(key.TenantID)
+	a := e.nameByID(key.ServiceID)
+	if tenant == "" || a == "" {
+		return topoIdentity{}, false
+	}
+	b := e.nameByID(key.NameID)
+	if b == "" && kind != topoTrace {
+		// An edge with no callee and a metric with no name are not facts.
+		// A trace series with an unresolvable operation still describes its
+		// service, so it folds as a service-only observation.
+		return topoIdentity{}, false
+	}
+	return topoIdentity{Kind: kind, Tenant: tenant, A: a, B: b}, true
+}
+
 type topoWindowState struct {
 	count      uint64
 	errors     uint64
@@ -314,12 +349,18 @@ func newTopologyProjection(cfg TopologyConfig, epoch uint64) *topologyProjection
 // fold merges one reduced Export request into the projection. revision is the
 // engine revision the deltas were applied under; a tenant's snapshot revision
 // advances only when one of its facts actually landed.
-func (p *topologyProjection) fold(now time.Time, revision uint64, ids map[SeriesWindowKey]topoIdentity, deltas DeltaMap) {
+//
+// It returns how many (series, window) deltas actually landed. The count is
+// what the startup restore reports: a row read from the store but dropped by
+// the retention cutoff or a projection cap was not restored, and saying it was
+// would make the restore counter a lie.
+func (p *topologyProjection) fold(now time.Time, revision uint64, ids map[SeriesWindowKey]topoIdentity, deltas DeltaMap) int {
 	if len(ids) == 0 {
-		return
+		return 0
 	}
 	cutoff := p.retainCutoff(now)
 
+	folded := 0
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	touched := make(map[*tenantTopology]struct{}, 1)
@@ -338,12 +379,14 @@ func (p *topologyProjection) fold(now time.Time, revision uint64, ids map[Series
 		}
 		if p.foldOne(tt, id, swk.WindowStart, d) {
 			touched[tt] = struct{}{}
+			folded++
 		}
 	}
 	for tt := range touched {
 		tt.revision = revision
 		p.pruneTenantLocked(tt, cutoff)
 	}
+	return folded
 }
 
 func (p *topologyProjection) retainCutoff(now time.Time) int64 {

--- a/internal/aggregate/topology_restore_test.go
+++ b/internal/aggregate/topology_restore_test.go
@@ -1,0 +1,141 @@
+package aggregate
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Startup restore of the finalized topology horizon (#194 finding 15).
+//
+// The property under test is narrow and load-bearing: a restart must not erase
+// the recent service map, and it must not pay for that by hydrating finalized
+// history back into the mutable shards.
+
+// restoreFixture ingests one span plus one caller/callee edge through the
+// reducer, so the durable rows carry real identities, and returns the cold
+// stack that a restart leaves behind after downtime.
+func restoreFixture(t *testing.T, downtime time.Duration) *lifecycleFixture {
+	t.Helper()
+	f := openLifecycleFixture(t, filepath.Join(t.TempDir(), "aggregate.db"), Bounds{}, nil, nil)
+	now := f.clock.Now()
+
+	r := f.eng.NewReducer(now)
+	reduceSpanAt(r, "acme", "checkout", "/pay", 0, 5000, now)
+	reduceSpanAt(r, "acme", "gateway", "/checkout", 0, 7000, now)
+	r.ReduceEdge(EdgeInput{
+		Tenant: "acme", Caller: "gateway", Callee: "checkout",
+		SpanName: "/pay", Timestamp: now, DurationMicros: 5000,
+	})
+	if _, err := f.eng.ApplyReducerErr(r); err != nil {
+		t.Fatalf("ApplyReducerErr: %v", err)
+	}
+	if snap := f.eng.TopologySnapshot("acme"); len(snap.Edges) != 1 {
+		t.Fatalf("pre-restart snapshot has no edge: %+v", snap)
+	}
+
+	f.clock.Advance(downtime)
+	cold := f.restart(Bounds{})
+	if snap := cold.eng.TopologySnapshot("acme"); !snap.Empty() {
+		t.Fatalf("a cold engine already holds topology: %+v", snap)
+	}
+	return cold
+}
+
+func TestTopologyRestoreRebuildsFinalizedHorizon(t *testing.T) {
+	// Down long enough for the window's lateness to expire — it is finalized
+	// history by the time recovery runs — but well inside a 30-minute horizon.
+	cold := restoreFixture(t, WindowSize+AllowedLateness+time.Minute)
+
+	stats, err := Recover(cold.store, cold.eng, cold.writer, cold.clock.Now(),
+		RecoverOptions{TopologyHorizon: 30 * time.Minute})
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if stats.FinalizedWindows != 1 {
+		t.Fatalf("finalized %d windows, want 1", stats.FinalizedWindows)
+	}
+	if stats.ReplayedRows != 0 {
+		t.Fatalf("replayed %d mutable rows, want 0 — the window is history", stats.ReplayedRows)
+	}
+	if stats.RestoredTopologyRows == 0 || stats.RestoredTopologyWindows == 0 {
+		t.Fatalf("nothing restored into the projection: %+v", stats)
+	}
+	if stats.RestoredTopologyTruncated {
+		t.Fatalf("restore reported truncation on three series: %+v", stats)
+	}
+
+	snap := cold.eng.TopologySnapshot("acme")
+	svc := findService(t, snap, "checkout")
+	if count, _ := totalCount(svc.Windows); count != 1 {
+		t.Errorf("restored checkout count = %d, want 1", count)
+	}
+	if len(snap.Edges) != 1 || snap.Edges[0].Caller != "gateway" || snap.Edges[0].Callee != "checkout" {
+		t.Fatalf("restored edges = %+v, want one gateway->checkout entry", snap.Edges)
+	}
+	if edgeCount, _ := totalCount(snap.Edges[0].Windows); edgeCount != 1 {
+		t.Errorf("restored edge count = %d, want 1", edgeCount)
+	}
+
+	// The whole point of the exception is that it stops at the projection.
+	// Finalized history must not have re-entered the mutable shards.
+	engSnap := cold.eng.Snapshot()
+	if count, _ := engSnap.Totals(SignalTraceOp); count != 0 {
+		t.Fatalf("shards hold %d trace points after restore; finalized history must not hydrate", count)
+	}
+	if count, _ := engSnap.Totals(SignalServiceEdge); count != 0 {
+		t.Fatalf("shards hold %d edge points after restore; finalized history must not hydrate", count)
+	}
+}
+
+func TestTopologyRestoreStopsAtTheHorizon(t *testing.T) {
+	// The window is 45 minutes old: outside the projection's own 30-minute
+	// horizon, so no configured value may drag it back into memory.
+	cold := restoreFixture(t, 45*time.Minute)
+
+	stats, err := Recover(cold.store, cold.eng, cold.writer, cold.clock.Now(),
+		RecoverOptions{TopologyHorizon: time.Hour})
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if stats.RestoredTopologyRows != 0 || stats.RestoredTopologyWindows != 0 {
+		t.Fatalf("restored %+v past the horizon", stats)
+	}
+	if snap := cold.eng.TopologySnapshot("acme"); !snap.Empty() {
+		t.Fatalf("topology restored from beyond the horizon: %+v", snap)
+	}
+}
+
+func TestTopologyRestoreDisabledByZeroHorizon(t *testing.T) {
+	cold := restoreFixture(t, WindowSize+AllowedLateness+time.Minute)
+
+	stats, err := Recover(cold.store, cold.eng, cold.writer, cold.clock.Now(), RecoverOptions{})
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if stats.RestoredTopologyRows != 0 || stats.RestoredTopologyWindows != 0 {
+		t.Fatalf("zero horizon restored %+v; it must disable the read entirely", stats)
+	}
+	if snap := cold.eng.TopologySnapshot("acme"); !snap.Empty() {
+		t.Fatalf("topology restored with the restore disabled: %+v", snap)
+	}
+}
+
+// TestTopologyRestoreReportsItsRowCap pins the honesty half of the bound: when
+// the cap cuts the horizon the caller is told rather than handed a partial
+// service map that looks complete.
+func TestTopologyRestoreReportsItsRowCap(t *testing.T) {
+	cold := restoreFixture(t, WindowSize+AllowedLateness+time.Minute)
+
+	stats, err := Recover(cold.store, cold.eng, cold.writer, cold.clock.Now(),
+		RecoverOptions{TopologyHorizon: 30 * time.Minute, TopologyMaxRows: 1})
+	if err != nil {
+		t.Fatalf("Recover: %v", err)
+	}
+	if !stats.RestoredTopologyTruncated {
+		t.Fatalf("a one-row cap over three series reported no truncation: %+v", stats)
+	}
+	if stats.RestoredTopologyRows != 1 {
+		t.Fatalf("restored %d rows under a cap of 1", stats.RestoredTopologyRows)
+	}
+}

--- a/internal/api/aggregate_reads_test.go
+++ b/internal/api/aggregate_reads_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/cache"
+	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"gorm.io/gorm"
 )
@@ -112,6 +113,29 @@ func seedAggregate(t *testing.T, e *aggregate.Engine, tenant, service string, sp
 	})
 }
 
+// seedAggregateEdge folds one caller/callee service-edge series into the
+// engine's current window. The caller is the series SERVICE and the callee is
+// its NAME — the identity the reducer writes for a cross-service call.
+func seedAggregateEdge(t *testing.T, e *aggregate.Engine, tenant, caller, callee string, spans int, micros float64) {
+	t.Helper()
+	tenantID, _ := e.TenantID(tenant)
+	key := aggregate.SeriesKey{
+		TenantID:    tenantID,
+		ServiceID:   e.Cache().Intern(tenantID, aggregate.KindService, caller),
+		NameID:      e.Cache().Intern(tenantID, aggregate.KindOperation, callee),
+		Signal:      aggregate.SignalServiceEdge,
+		StatusClass: aggregate.StatusOK,
+		Variant:     aggregate.SpanKindClient,
+	}
+	d := &aggregate.AggregateDelta{}
+	for i := 0; i < spans; i++ {
+		d.ObserveSpan(micros, false, true)
+	}
+	e.ApplyCommitted(aggregate.DeltaMap{
+		{Key: key, WindowStart: aggregate.WindowStart(time.Now())}: d,
+	})
+}
+
 // seedLegacy inserts equivalent raw rows so the legacy path has something to
 // aggregate.
 func seedLegacy(t *testing.T, s *Server, tenant, service string, spans int, micros int64) {
@@ -208,11 +232,15 @@ func TestServiceMapContractLegacyVsAggregate(t *testing.T) {
 	_, aggBody := getJSON(t, agg.handleGetServiceMapMetrics, "/api/metrics/service-map", tenant)
 
 	assertFieldCompatible(t, "service-map", legacyBody, aggBody)
-	if aggBody["coverage"] != string(aggregate.CoverageSampled) {
-		t.Errorf("service-map coverage = %v, want %q", aggBody["coverage"], aggregate.CoverageSampled)
+	// Nodes and edges now come from one engine query over one tenant and one
+	// range (#194 finding 15). The response used to say "sampled" only to
+	// cover for edges supplemented from GraphRAG; with the side-channel gone
+	// the engine's own coverage stands, and a full response carries no caveat.
+	if aggBody["coverage"] != string(aggregate.CoverageFull) {
+		t.Errorf("service-map coverage = %v, want %q", aggBody["coverage"], aggregate.CoverageFull)
 	}
-	if note, _ := aggBody["coverage_note"].(string); note == "" {
-		t.Error("sampled service-map carries no coverage note")
+	if note, _ := aggBody["coverage_note"].(string); note != "" {
+		t.Errorf("full service-map carries a coverage caveat: %q", note)
 	}
 }
 
@@ -336,5 +364,49 @@ func jsonKind(v any) string {
 		return "object"
 	default:
 		return "null"
+	}
+}
+
+// TestServiceMapAggregateEdgesAreEngineSourced is #194 finding 15 at the wire:
+// the aggregate service map carries the engine's own service-edge series and
+// nothing from GraphRAG, whose topology store has a different range and a
+// different retention rule. GraphRAG itself is untouched — the system-graph
+// endpoint still reads it — so the assertion is about which store the
+// AGGREGATE response is built from.
+func TestServiceMapAggregateEdgesAreEngineSourced(t *testing.T) {
+	const tenant = "default"
+	agg, _, engine := aggregateTestServer(t, true)
+
+	g := graphrag.New(nil, nil, nil, graphrag.DefaultConfig())
+	agg.SetGraphRAG(g)
+	// A CALLS edge that exists ONLY in GraphRAG. Before finding 15 it would
+	// have been supplemented straight into the response.
+	g.ObserveSpanTopology(tenant, "trace-1", "span-parent", "", "ghost-caller")
+	g.ObserveSpanTopology(tenant, "trace-1", "span-child", "span-parent", "ghost-callee")
+
+	seedAggregate(t, engine, tenant, "checkout", 6, 2000)
+	seedAggregate(t, engine, tenant, "gateway", 6, 1000)
+	seedAggregateEdge(t, engine, tenant, "gateway", "checkout", 4, 1500)
+
+	_, body := getJSON(t, agg.handleGetServiceMapMetrics, "/api/metrics/service-map", tenant)
+	edges, ok := body["edges"].([]any)
+	if !ok {
+		t.Fatalf("service-map response carries no edges array: %v", body)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("edges = %v, want exactly the engine's gateway->checkout edge", edges)
+	}
+	edge, _ := edges[0].(map[string]any)
+	if edge["source"] != "gateway" || edge["target"] != "checkout" {
+		t.Fatalf("edge = %v, want gateway->checkout", edge)
+	}
+	if count, _ := edge["call_count"].(float64); count != 4 {
+		t.Errorf("edge call_count = %v, want 4", edge["call_count"])
+	}
+
+	// The GraphRAG edge is still in GraphRAG — this is a source change, not a
+	// deletion — it simply no longer reaches the aggregate response.
+	if len(g.AllServiceEdges(storage.WithTenantContext(context.Background(), tenant))) == 0 {
+		t.Fatal("the test never created a GraphRAG edge, so it proves nothing")
 	}
 }

--- a/internal/api/metrics_handlers.go
+++ b/internal/api/metrics_handlers.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"log/slog"
 	"math"
@@ -248,12 +247,12 @@ func (s *Server) handleGetServiceMapMetrics(w http.ResponseWriter, r *http.Reque
 
 // serviceMapView produces the topology payload.
 //
-// In aggregate mode the NODES come from engine queries and are exact for
-// accepted telemetry. The EDGES do not: caller/callee identity is not part of
-// a SeriesKey, so no reducer emits a service-edge series today and the edge
-// metrics come from the GraphRAG topology store, which is fed by retained
-// exemplars. That is why the response is marked "sampled" rather than "full" —
-// the node counts are complete, the edges are not.
+// In aggregate mode BOTH halves come from one engine query over one tenant and
+// one range (#194 finding 15). Edges used to be supplemented from the GraphRAG
+// topology store — a different range, a different retention rule, exemplar-fed
+// counts — and the response said "sampled" to cover for it. The service-edge
+// series the reducer emits made that side-channel unnecessary, so the coverage
+// the engine reports is the coverage the response carries.
 func (s *Server) serviceMapView(r *http.Request, start, end time.Time) (views.ServiceMapMetrics, error) {
 	if !s.aggregateReads() {
 		metrics, err := s.repo.GetServiceMapMetrics(r.Context(), start, end)
@@ -270,31 +269,7 @@ func (s *Server) serviceMapView(r *http.Request, start, end time.Time) (views.Se
 	if err != nil {
 		return views.ServiceMapMetrics{}, err
 	}
-	return views.ServiceMapMetricsFromAggregate(res, s.topologyEdges(r.Context()), aggregate.CoverageSampled), nil
-}
-
-// topologyEdges reads caller/callee edges out of the GraphRAG service store.
-// The edges themselves are observed for every span before any retention gate,
-// but their call counts and latencies come from retained spans only.
-func (s *Server) topologyEdges(ctx context.Context) []views.ServiceMapEdge {
-	if s.graphRAG == nil {
-		return nil
-	}
-	all := s.graphRAG.AllServiceEdges(ctx)
-	edges := make([]views.ServiceMapEdge, 0, len(all))
-	for _, e := range all {
-		if e.Type != "CALLS" {
-			continue
-		}
-		edges = append(edges, views.ServiceMapEdge{
-			Source:       e.FromID,
-			Target:       e.ToID,
-			CallCount:    e.CallCount,
-			AvgLatencyMs: e.AvgMs,
-			ErrorRate:    e.ErrorRate,
-		})
-	}
-	return edges
+	return views.ServiceMapMetricsFromAggregate(res), nil
 }
 
 // handleGetMetricBuckets handles GET /api/metrics

--- a/internal/api/views/views.go
+++ b/internal/api/views/views.go
@@ -428,9 +428,13 @@ func DashboardStatsFromAggregate(r *aggregate.DashboardResult) DashboardStats {
 }
 
 // ServiceMapMetricsFromAggregate converts an engine topology query into the
-// topology view. Edges are passed in by the caller because caller/callee
-// identity is not aggregate data — see the handler.
-func ServiceMapMetricsFromAggregate(r *aggregate.TopologyResult, edges []ServiceMapEdge, coverage aggregate.Coverage) ServiceMapMetrics {
+// topology view.
+//
+// Nodes AND edges come from the one result: they were read from one tenant,
+// one range and one ownership snapshot, and the coverage the engine reported
+// describes both. Nothing is supplemented from a second store here — that
+// supplementation is #194 finding 15.
+func ServiceMapMetricsFromAggregate(r *aggregate.TopologyResult) ServiceMapMetrics {
 	if r == nil {
 		return ServiceMapMetrics{Nodes: []ServiceMapNode{}, Edges: []ServiceMapEdge{}}
 	}
@@ -443,14 +447,21 @@ func ServiceMapMetricsFromAggregate(r *aggregate.TopologyResult, edges []Service
 			AvgLatencyMs: n.AvgLatencyMs,
 		}
 	}
-	if edges == nil {
-		edges = []ServiceMapEdge{}
+	edges := make([]ServiceMapEdge, len(r.Edges))
+	for i, e := range r.Edges {
+		edges[i] = ServiceMapEdge{
+			Source:       e.Source,
+			Target:       e.Target,
+			CallCount:    e.CallCount,
+			AvgLatencyMs: e.AvgLatencyMs,
+			ErrorRate:    e.ErrorRate,
+		}
 	}
 	return ServiceMapMetrics{
 		Nodes:        nodes,
 		Edges:        edges,
-		Coverage:     string(coverage),
-		CoverageNote: coverage.Note(),
+		Coverage:     string(r.Coverage),
+		CoverageNote: r.Coverage.Note(),
 		Epoch:        r.Epoch,
 		Revision:     r.Revision,
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/joho/godotenv"
 )
@@ -364,6 +365,15 @@ type Config struct {
 	AggregateCommitMaxWaiters       int
 	AggregateCommitMaxPendingDeltas int
 
+	// AggregateTopologyRestoreHorizon is how much FINALIZED history the
+	// engine's topology projection is rebuilt from at startup (#194 finding
+	// 15). Without it a restart erases the recent service map until new
+	// telemetry re-derives one. Accepts a Go duration ("30m", "1h"); 0
+	// disables the restore. Clamped to 24h, and internally to the projection's
+	// own retention horizon — reading a window the projection would prune on
+	// arrival is startup cost with nothing to show for it.
+	AggregateTopologyRestoreHorizon time.Duration
+
 	// AggregateFinalizeIntervalSec is how often the writer looks for windows
 	// whose lateness horizon has expired.
 	AggregateFinalizeIntervalSec int
@@ -617,6 +627,7 @@ func Load(customPath string) (*Config, error) {
 		AggregateCommitMaxWaiters:       getEnvInt("AGGREGATE_COMMIT_MAX_WAITERS", 512),
 		AggregateCommitMaxPendingDeltas: getEnvInt("AGGREGATE_COMMIT_MAX_PENDING_DELTAS", 200000),
 		AggregateFinalizeIntervalSec:    getEnvInt("AGGREGATE_FINALIZE_INTERVAL_SEC", 30),
+		AggregateTopologyRestoreHorizon: getEnvDuration("AGGREGATE_TOPOLOGY_RESTORE_HORIZON", 30*time.Minute),
 
 		// Identity lifecycle (#200)
 		AggregateGCEnabled:             getEnvBool("AGGREGATE_GC_ENABLED", true),
@@ -786,6 +797,18 @@ func splitCSV(v string) []string {
 		return nil
 	}
 	return out
+}
+
+// getEnvDuration parses a Go duration ("30m", "1h30m"). An unparseable value
+// takes the fallback, matching getEnvInt: a typo must not silently disable a
+// bounded-cost knob by reading as zero.
+func getEnvDuration(key string, fallback time.Duration) time.Duration {
+	if v, exists := os.LookupEnv(key); exists {
+		if d, err := time.ParseDuration(strings.TrimSpace(v)); err == nil {
+			return d
+		}
+	}
+	return fallback
 }
 
 func getEnvBool(key string, fallback bool) bool {
@@ -1047,6 +1070,12 @@ func (c *Config) Validate() error {
 		if c.AggregateCommitMaxPendingBytes < c.AggregateCommitMaxBytes {
 			return fmt.Errorf("AGGREGATE_COMMIT_MAX_PENDING_BYTES (%d) must be >= AGGREGATE_COMMIT_MAX_BYTES (%d)",
 				c.AggregateCommitMaxPendingBytes, c.AggregateCommitMaxBytes)
+		}
+		// The topology restore is a startup cost paid before readiness. A
+		// negative horizon is a typo, and an unbounded one is a stalled boot.
+		if c.AggregateTopologyRestoreHorizon < 0 || c.AggregateTopologyRestoreHorizon > 24*time.Hour {
+			return fmt.Errorf("AGGREGATE_TOPOLOGY_RESTORE_HORIZON must be between 0 and 24h, got %s",
+				c.AggregateTopologyRestoreHorizon)
 		}
 	}
 

--- a/internal/realtime/aggregate_publisher.go
+++ b/internal/realtime/aggregate_publisher.go
@@ -19,9 +19,6 @@ type EnginePublisher struct {
 	engine *aggregate.Engine
 	// window is how far back the coalesced payload reaches.
 	window time.Duration
-	// edges supplies caller/callee topology, which is not aggregate data.
-	// nil is allowed and yields a node-only topology.
-	edges func(ctx context.Context) []storage.ServiceMapEdge
 	// tenant scopes the queries when the caller's context carries none. Since
 	// the handshake gate pins one tenant per socket, ctx normally decides; this
 	// stays the fallback for an unauthenticated (development) deployment.
@@ -37,7 +34,11 @@ type EnginePublisherConfig struct {
 	Window time.Duration
 	// Tenant scopes every query. Empty takes storage.DefaultTenantID.
 	Tenant string
-	// Edges supplies topology edges. Optional.
+	// Edges is IGNORED since #194 finding 15: topology edges come from the
+	// engine's own service-edge series, read in the same query as the nodes.
+	// The field remains so existing wiring compiles.
+	//
+	// Deprecated: supply nothing; QueryTopology carries the edges.
 	Edges func(ctx context.Context) []storage.ServiceMapEdge
 }
 
@@ -56,7 +57,6 @@ func NewEnginePublisher(cfg EnginePublisherConfig) *EnginePublisher {
 	return &EnginePublisher{
 		engine: cfg.Engine,
 		window: cfg.Window,
-		edges:  cfg.Edges,
 		tenant: cfg.Tenant,
 	}
 }
@@ -91,9 +91,11 @@ func (p *EnginePublisher) Snapshot(ctx context.Context, service string) *LiveSna
 		Revision: p.engine.Revision(),
 	}
 
-	// Topology edges are exemplar-fed, so the coalesced payload as a whole is
-	// "sampled": the counts are exact, the edges are not.
-	coverage := aggregate.CoverageSampled
+	// Nodes and edges are both engine-sourced and read over the same range
+	// (#194 finding 15), so the payload carries the engine's own coverage
+	// instead of the blanket "sampled" the exemplar-fed edge side-channel
+	// forced on it.
+	coverage := aggregate.CoverageFull
 	snap.Coverage = string(coverage)
 	snap.CoverageNote = coverage.Note()
 
@@ -140,7 +142,7 @@ func (p *EnginePublisher) Snapshot(ctx context.Context, service string) *LiveSna
 	if topo, err := p.engine.QueryTopology(q); err == nil {
 		sm := &storage.ServiceMapMetrics{
 			Nodes: make([]storage.ServiceMapNode, 0, len(topo.Nodes)),
-			Edges: []storage.ServiceMapEdge{},
+			Edges: make([]storage.ServiceMapEdge, 0, len(topo.Edges)),
 		}
 		for _, n := range topo.Nodes {
 			sm.Nodes = append(sm.Nodes, storage.ServiceMapNode{
@@ -150,10 +152,14 @@ func (p *EnginePublisher) Snapshot(ctx context.Context, service string) *LiveSna
 				AvgLatencyMs: n.AvgLatencyMs,
 			})
 		}
-		if p.edges != nil {
-			if e := p.edges(ctx); len(e) > 0 {
-				sm.Edges = e
-			}
+		for _, e := range topo.Edges {
+			sm.Edges = append(sm.Edges, storage.ServiceMapEdge{
+				Source:       e.Source,
+				Target:       e.Target,
+				CallCount:    e.CallCount,
+				AvgLatencyMs: e.AvgLatencyMs,
+				ErrorRate:    e.ErrorRate,
+			})
 		}
 		snap.ServiceMap = sm
 	} else {

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -743,7 +743,7 @@ func New() *Metrics {
 	})
 	m.AggregateRecoveryRows = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "otelcontext_aggregate_recovery_rows",
-		Help: "Rows handled by the last aggregate startup recovery, by kind (replayed|finalized_windows).",
+		Help: "Rows handled by the last aggregate startup recovery, by kind (replayed|finalized_windows|topology_restored_rows|topology_restored_windows).",
 	}, []string{"kind"})
 	m.AggregateGCRunsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "otelcontext_aggregate_gc_runs_total",

--- a/main.go
+++ b/main.go
@@ -646,15 +646,18 @@ func main() {
 
 		// Recovery runs BEFORE the writer starts accepting Exports and before
 		// readiness flips: acknowledged-but-unfinalized deltas go back into the
-		// shards, windows whose lateness expired during downtime finalize, and
-		// durable baselines are seeded.
+		// shards, windows whose lateness expired during downtime finalize,
+		// durable baselines are seeded, and the topology projection is rebuilt
+		// over AGGREGATE_TOPOLOGY_RESTORE_HORIZON so a restart does not erase
+		// the recent service map (#194 finding 15).
 		aggRecovery = aggregate.NewRecoveryGate()
-		recoveryStats, err := aggregate.Recover(aggStore, aggEngine, aggWriter, time.Now())
+		recoveryStats, err := aggregate.Recover(aggStore, aggEngine, aggWriter, time.Now(),
+			aggregate.RecoverOptions{TopologyHorizon: cfg.AggregateTopologyRestoreHorizon})
 		if err != nil {
 			fatal("❌ Aggregate store recovery failed", err, "path", cfg.AggregateDBPath)
 		}
 		aggregate.LogRecovery(recoveryStats, cfg.AggregateDBPath)
-		aggStoreMetr.RecordRecovery(recoveryStats.Duration, recoveryStats.ReplayedRows, recoveryStats.FinalizedWindows)
+		aggStoreMetr.RecordRecovery(recoveryStats)
 
 		aggEngine.SetApplier(aggWriter)
 		aggWriter.Start()


### PR DESCRIPTION
Closes #194 finding 15 (map #195).

## The finding

> `QueryTopology` returns no aggregate edges. API responses supplement edges from GraphRAG, outside the same range/ownership contract. Recovery replays mutable delta rows only, so recent finalized topology is not restored after restart.

## What changed

**Edges come from the engine, in the node query.**
`Engine.QueryTopology` now visits `SignalTraceOp` and `SignalServiceEdge` through **one** `plan()` call — one tenant, one range, one ownership snapshot. The store half is SQL `GROUP BY` on both sides: one row per service for the nodes, one row per `(caller, callee)` for the edges, so neither half can be truncated by a row cap. A `Services` filter now selects a **subgraph** — an edge survives only when both ends do, so the result never carries an edge hanging off a node the response omits.

Supporting change: `SumBuckets` gains `GroupByName` (and `SumRow.NameID`). A `NameID`'s namespace is the signal's, so the flag is only meaningful under a single-signal selector, and that is the only way it is used.

**The GraphRAG edge side-channel is gone from aggregate responses.**
`GET /api/metrics/service-map` and the WebSocket `live_snapshot` took nodes from the engine and edges from the GraphRAG service store — a different range, a different retention rule, exemplar-fed counts — and marked the whole response `sampled` to cover for it. Both now carry the engine's edges and the engine's own coverage (`full`). GraphRAG is untouched: `/api/graph` still reads it, and in aggregate mode its topology is already replaced per revision from `TopologySnapshot`.

**Bounded finalized-horizon restore at startup.**
`aggregate.Recover` takes a `RecoverOptions` and, when `TopologyHorizon > 0`, rebuilds the topology projection from finalized bucket rows inside that horizon (`Store.ReadFinalizedSince`, newest window first) plus the mutable delta rows it just replayed. This is the **only** exception to "finalized history never hydrates", and it stops short of the shards — it writes to the projection only, so no finalized window can re-enter the mutable set through it.

Three bounds: the configured horizon, a row cap (`RecoverOptions.TopologyMaxRows`, default 20,000, clamped to `MaxReadRows`), and the projection's own retention cutoff. Recovery therefore reports what the fold **accepted**, not what the store returned:
`restored_topology_rows`, `restored_topology_windows`, `restored_topology_truncated` on the recovery log line, and `otelcontext_aggregate_recovery_rows{kind="topology_restored_rows"|"topology_restored_windows"}`. A truncated restore logs a warning — the topology is real but incomplete at its oldest end.

New knob: `AGGREGATE_TOPOLOGY_RESTORE_HORIZON` (Go duration, default `30m`, `0` disables, validated `0..24h`, clamped internally to `TopologySnapshot.Horizon`).

## Tests

New:
- `TestQueryTopologyEdgesShareTheNodeQuery` — memory-owned and store-owned halves add rather than one winning; another tenant's edge over the same window does not leak.
- `TestQueryTopologyServiceFilterKeepsTheGraphClosed` — filtered topology is a subgraph.
- `TestSumBucketsGroupsByNameWithinASignal` — the SQL grouping, against SQLite.
- `TestTopologyRestoreRebuildsFinalizedHorizon` — finalize, restart, restore; services and the edge come back and the shards stay empty.
- `TestTopologyRestoreStopsAtTheHorizon`, `TestTopologyRestoreDisabledByZeroHorizon`, `TestTopologyRestoreReportsItsRowCap`.
- `TestServiceMapAggregateEdgesAreEngineSourced` — a CALLS edge that exists only in GraphRAG never reaches the aggregate response; the engine's edge does.

Changed: `TestServiceMapContractLegacyVsAggregate` asserted `sampled` coverage with a caveat note; the aggregate service map is `full` with no caveat now that the side-channel is gone.

`lifecycle_test.go`'s fixture now carries its clock across `restart()` — a restart that rewinds the wall clock cannot express downtime. No existing test advanced that clock, so nothing else moves.

## Results

```
go build ./...                                   ok
go vet ./...                                     ok
go test -race ./internal/aggregate/... ./internal/api/...   516 passed
go test ./...                                    1372 passed, 29 packages
golangci-lint run (aggregate, api, realtime, config)        7 issues — identical to the pre-change baseline, none in changed code
gofmt -l                                         clean except two files untouched by this branch (see below)
```

## Notes / judgment calls

- **Coverage flipped `sampled` → `full`** for the aggregate service map and the WS snapshot. The `sampled` note text is exemplar-specific ("derived from retained exemplars"), which is no longer true of these edges. Edge *existence* still depends on the `EdgeResolver`'s bounded LRU join, which is documented at the resolver; the counts themselves are exact for the calls it resolved.
- **`EnginePublisherConfig.Edges` is kept as a deprecated, ignored field.** `main.go` is fenced except for the aggregate-recovery block, and removing the field would require deleting its literal and the `graphRAGServiceEdges` helper there. The closure is constructed and never called. One follow-up line to delete when main.go is next touched.
- **Edges may name a service with no node** when the caller had no trace-op series in range. Dropping such an edge would be an omission; inventing a zero-count node would be fabrication. Left as-is.
- **Pre-existing, untouched:** `internal/api/log_handlers_trace_filter_test.go` and `internal/storage/tenant_sanitize_test.go` are not gofmt-clean on `origin/main`. Flagged, not fixed.
