### PR TITLE
fix(ci): pin scanner versions and disable install lifecycle scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,9 @@ jobs:
         # goreleaser compiles. `npm run build` emits into internal/ui/dist.
         run: |
           cd ui
-          npm ci
+          # --ignore-scripts: no dependency lifecycle script runs during a
+          # release install. Verified the vite build needs none.
+          npm ci --ignore-scripts
           npm run build
           test -f ../internal/ui/dist/index.html
           # vite's emptyOutDir wipes internal/ui/dist on rebuild, deleting the

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -90,7 +90,9 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install semgrep
-        run: python -m pip install --quiet --upgrade pip semgrep
+        # Pinned: a scanner that silently changes version changes the
+        # merge gate under everyone without a commit saying so.
+        run: python -m pip install --quiet "pip==26.2.1" "semgrep==1.174.0"
       - name: Run semgrep (security-audit + owasp-top-ten + golang)
         run: |
           semgrep scan \
@@ -151,7 +153,10 @@ jobs:
           # function body is ~40-80 tokens; 100 corresponds to a real
           # method body or a non-trivial code block, not import/struct
           # boilerplate that 200+ Go files share by convention.
-          npx --yes jscpd@4 \
+          # Installed with lifecycle scripts disabled and an exact version
+          # rather than resolved on demand by npx.
+          npm install --no-save --ignore-scripts jscpd@4.3.0
+          npx --no-install jscpd \
             --threshold 3 \
             --min-tokens 100 \
             --reporters consoleFull \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -62,8 +62,10 @@ cleanup() { git reset --hard --quiet "$base"; git clean -fdq -- internal/ui/dist
 trap cleanup EXIT
 
 # --- Build the UI ------------------------------------------------------------
-echo "▸ building UI (npm ci && npm run build)…"
-( cd ui && npm ci && npm run build )
+echo "▸ building UI (npm ci --ignore-scripts && npm run build)…"
+# --ignore-scripts: no dependency lifecycle script runs during a release
+# install. Verified the vite build needs none.
+( cd ui && npm ci --ignore-scripts && npm run build )
 [ -f internal/ui/dist/index.html ] || { echo "error: UI build produced no dist/index.html" >&2; exit 1; }
 touch internal/ui/dist/.gitkeep   # vite emptyOutDir wipes it; keep the placeholder
 


### PR DESCRIPTION
Main's SonarCloud gate has been ERROR since 2026-08-21 — `new_security_rating` C against a threshold of A. Every other check on main is green; this is the only red one.

Cause: four MAJOR supply-chain findings, all pre-dating this branch (created 2026-04-26, 2026-06-05, 2026-06-18) but counted as new code by main's new-code window:

| File | Rule | Issue |
|---|---|---|
| `.github/workflows/release.yml:83` | S6505 | `npm ci` runs dependency lifecycle scripts during a release build |
| `scripts/release.sh:66` | S6505 | same, in the local release path |
| `.github/workflows/security.yml:93` | S8544 | pip and semgrep installed without locked versions |
| `.github/workflows/security.yml:154` | S6505 | `npx --yes jscpd@4` resolves and runs a package on demand |

Fixes: `--ignore-scripts` on both release installs; `pip==26.2.1` and `semgrep==1.174.0` pinned; jscpd installed at exactly 4.3.0 with `--ignore-scripts`, then run via `npx --no-install`.

Verified locally before commit:
- `npm ci --ignore-scripts && npm run build` in `ui/` produces a complete dist (601.8 KB total, index.html present) — the vite build needs no lifecycle scripts.
- The rewritten jscpd invocation reports the same 3 pre-existing clones and exits 0.
- Both workflow files parse as YAML.

The semgrep and jscpd jobs execute in this PR's own CI, so the pinned versions are exercised by the gate itself. No application code touched.