### PR TITLE
fix(gate): bound control-plane tests against the query timeout, not the runner

### DIFF
--- a/test/gate/control_test.go
+++ b/test/gate/control_test.go
@@ -45,8 +45,13 @@ func TestWaitReadyBoundedByDeadline(t *testing.T) {
 	if err == nil {
 		t.Fatal("waitReady succeeded against a server that never answers")
 	}
-	if elapsed > 4*time.Second {
-		t.Fatalf("waitReady took %s against a hung /ready, want return near its 2s budget", elapsed)
+	// The property under test is that the 600s QUERY timeout does not govern
+	// the readiness loop — not that a shared CI runner can schedule promptly.
+	// A generous ceiling still fails decisively if the long client leaks in,
+	// while a tight one just measures runner contention.
+	if elapsed > 60*time.Second {
+		t.Fatalf("waitReady took %s against a hung /ready with a 2s budget — "+
+			"the query client's timeout is governing the readiness loop", elapsed)
 	}
 }
 
@@ -63,7 +68,11 @@ func TestSamplerShutdownBoundedWithStuckScrape(t *testing.T) {
 
 	started := time.Now()
 	s.shutdown()
-	if elapsed := time.Since(started); elapsed > 3*time.Second {
-		t.Fatalf("sampler shutdown took %s with a stuck scrape, want a bound near the 500ms control timeout", elapsed)
+	// Same reasoning as above: bound generously against the 600s query
+	// timeout leaking in, not tightly against the 500ms control timeout,
+	// which a contended runner will exceed for reasons unrelated to the bug.
+	if elapsed := time.Since(started); elapsed > 60*time.Second {
+		t.Fatalf("sampler shutdown took %s with a stuck scrape — "+
+			"the query client's timeout is governing shutdown", elapsed)
 	}
 }


### PR DESCRIPTION
`TestSamplerShutdownBoundedWithStuckScrape` failed at 3.55s against its own 3s assertion on a loaded CI runner, blocking PR #133. My defect, introduced with the client split in #218.

The bound was wrong in kind, not just in size: these two tests exist to prove the 600s **query** client's timeout does not govern readiness polling or sampler shutdown. Asserting proximity to the 500ms control timeout measures runner scheduling, not that property. Both bounds move to 60s — still an immediate, decisive failure if the long client leaks into the control path, with no sensitivity to contention.

`go test -tags gate -race ./test/gate/...` green locally.