### PR TITLE
fix: release prep — over-cap range clamp (#217), streamed sketch merge (#219), changelog backfill, prerelease flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,130 @@ commit on `main` is the canonical version identifier (`git rev-parse HEAD`).
 Per-tag pre-release notes are published on
 [GitHub Releases](https://github.com/RandomCodeSpace/otelcontext/releases).
 This file's `Unreleased` section tracks what has landed on `main` since the
-last published pre-release tag (`v0.3.0-beta.1`).
+most recently published tag.
 
 ## [Unreleased]
+
+### Added — aggregate metrics engine (production-readiness epic #194)
+
+- **Aggregate engine** (`internal/aggregate/`, opt-in via
+  `AGGREGATE_MODE=legacy|aggregate-shadow|aggregate`, default `legacy`):
+  five-minute tumbling windows reduce spans, logs, and metrics into
+  per-series deltas — SeriesKey identity through a durable dictionary,
+  scale-4 exponential latency sketch for percentiles (p99 with a reported
+  accuracy bound), OTLP histogram completeness rules (negative-bucket
+  distributions never publish a fabricated whole-distribution percentile),
+  route normalization, `AGGREGATE_METRIC_DIMS` attribute allowlist, and
+  cardinality caps with `__other__` rerouting.
+- **Durable aggregate store** (SQLite): per-series/window delta log with
+  group commit; the durable aggregate commit IS the OTLP Export ACK; crash
+  recovery replays mutable windows; fail-closed schema
+  (`AGGREGATE_ALLOW_REBUILD=true` to destroy and recreate on mismatch);
+  dictionary GC with persisted high watermarks so IDs are never reused.
+- **Read contract**: scalar totals via SQL SUM (structurally untruncatable),
+  percentiles via sketch merge, generic rows capped with an honest
+  `truncated` flag; responses carry coverage (`OtelContext-Data-Coverage`)
+  and request-basis counts named as such.
+- **Engine-sourced topology**: service-map nodes AND edges from one
+  tenant/range query under one ownership snapshot; bounded finalized-horizon
+  restore at startup; the GraphRAG edge side-channel is gone from aggregate
+  responses.
+- **Aggregate runtime readiness probes** on `/ready`: store reachability,
+  commit-failure streak, admission saturation, finalizer progress, delta-log
+  age, and disk watermark — `/live` stays process-only.
+- **Per-tenant bearer identity** (`API_TENANT_KEYS_FILE`): tenant-bound keys
+  for HTTP, WebSocket (auth subprotocol), and gRPC; only digests are held in
+  memory.
+- **Bounded exemplar retention** replacing the sampler in aggregate mode,
+  with explicit disk-budget arithmetic inside the 8 GiB envelope.
+- **Seven-day durability gate** (`test/gate/`): full-density prefill, 3 h
+  sustained 10k pts/s plus burst and kill -9 under a 2-vCPU/4G cgroup;
+  passing report committed under `docs/gates/`.
+
+### Changed
+
+- Dashboard, traffic, service-map, and WebSocket reads come from the
+  aggregate engine in aggregate mode; the UI shows coverage badges,
+  accuracy labels, and epoch-aware WebSocket state.
+- Legacy TSDB and ring buffer are not started in aggregate mode; GraphRAG
+  consumes aggregates instead of rebuilding from raw spans.
+- TypeScript pinned to 6.0.3 (inside typescript-eslint's peer range) and a
+  new `ui-build` CI job typechecks, builds, and tests the frontend on every
+  PR — frontend breakage is no longer invisible until tag time.
+- `scripts/release.sh --release` marks the GitHub release as a pre-release
+  only when the tag carries a pre-release identifier, matching GoReleaser's
+  `prerelease: auto`.
+- Dependency refresh across 15 update PRs: OTel collector/SDK group, gRPC +
+  protobuf, GORM group, React group, vite group, lucide-react 1.x,
+  Radix tabs, azure azcore, klauspost/compress, glebarez/go-sqlite,
+  prometheus client_golang, x/sync, testcontainers, pinned GitHub Actions.
+
+### Fixed
+
+- **realtime**: WebSocket hub shutdown deadlock and WaitGroup misuse —
+  graceful shutdown could hang forever against connection churn.
+- **api**: aggregate reads whose range exceeds the read-range cap are
+  clamped and declared via `OtelContext-Requested-Start` /
+  `OtelContext-Effective-Start` headers instead of failing with 500; selector
+  errors now map to 400 (#217).
+- **aggregate**: the dashboard percentile path streams sketch rows in one
+  unordered pass instead of a sorted, keyset-paged drain — wide-range
+  dashboard queries no longer take minutes (#219).
+- **ingest**: `Processed` counts completed batches, not picked-up ones;
+  DLQ capture on pipeline DB failure; per-tenant admission; exemplar
+  saturation never fails an acked Export.
+- **aggregate**: request-basis counting and complete reads; commit-failure
+  semantics (staged baselines, admission backoff); delta log pre-merged per
+  series+window with bounded finalize.
+- **storage**: legacy graph error-status matching and tenant-safe trace
+  reads.
+- **ci**: scanner versions pinned (pip, semgrep, jscpd) and dependency
+  lifecycle scripts disabled (`npm ci --ignore-scripts`) in security and
+  release workflows.
+
+## [v0.4.0-beta.1] — 2026-06-19
+
+### Changed
+
+- **Topology scaled to 100–200 services** across GraphRAG, MCP, storage, and
+  the UI, with labelled cardinality overflow.
+
+### Fixed
+
+- **release**: install syft in `release.yml` (GoReleaser SBOM step) and add
+  `workflow_dispatch` recovery so a failed tag-push run can be re-built and
+  signed against the existing immutable tag.
+
+## [v0.3.1] — 2026-06-18
+
+### Changed
+
+- `STORE_MIN_SEVERITY` defaults to `WARN` for **all** database drivers (was
+  SQLite-only): INFO/DEBUG logs still feed in-memory GraphRAG/Drain but are
+  not persisted unless explicitly configured.
+- Dependency refresh (azure group, x/sync, grpc, pgx, websocket, mssqldb,
+  compress, vitest/typescript/eslint groups, pinned actions).
+
+### Added
+
+- goreleaser release + cosign keyless signing workflow (#116): tagged
+  releases ship signed checksums and SPDX/CycloneDX SBOMs.
+- Drain miner fuzz target for Scorecard's Fuzzing check.
+
+### Fixed
+
+- **graphrag**: `SignalStore.LogClusters` bounded (TTL + per-tenant cap).
+- **ui/graphrag**: sunflower service map at scale — flow direction,
+  blast-radius rendering.
+
+## [v0.3.1-beta.1] — 2026-06-18
+
+### Changed
+
+- Service map moved to a dagre layered layout on React Flow: routed edges,
+  level-of-detail, draggable nodes; orphaned hand-rolled map helpers pruned.
+
+## [v0.3.0] — 2026-06-17
 
 ### Changed — map-centric "Service Map" UI redesign
 

--- a/internal/aggregate/query.go
+++ b/internal/aggregate/query.go
@@ -276,8 +276,9 @@ type visitFunc func(windowStart int64, key SeriesKey, d *AggregateDelta)
 //
 //	scalar totals  -> SumBuckets: the database sums, one row per group, so no
 //	                  row cap exists to truncate the answer.
-//	percentiles    -> pageStore: sketches cannot be merged in SQL, so every
-//	                  sketch-bearing row is paged to completion.
+//	percentiles    -> VisitSketches: sketches cannot be merged in SQL, but
+//	                  their merge is order-independent, so every
+//	                  sketch-bearing row is streamed once, unordered.
 //	generic rows   -> ReadBuckets: keeps its row cap and says so.
 //
 // hasStore is false when memory owns the whole range or no store is attached.
@@ -362,70 +363,40 @@ func (e *Engine) sumStore(sel Selector, by GroupBy) ([]SumRow, error) {
 	return st.SumBuckets(sel, by)
 }
 
-// pageStore visits every store-owned row matching sel, paging to COMPLETION.
+// mergeStoreSketches folds every store-owned sketch in sel's range into merge.
 //
-// The page size is the store's own row cap; the number of pages is bounded by
-// the selector's window range, which Selector.Validate already clamps to the
-// retention horizon. Truncated is the loop condition, never a result: this
-// function returns only when the store says there is nothing left.
-func (e *Engine) pageStore(sel Selector, visit visitFunc) error {
+// It is the percentile path of the #197 read contract, restructured for #219:
+// the dashboard used to drain the sketch rows through the totally-ordered,
+// keyset-paged ReadBuckets — a sort per page plus a re-scan per resume, paid
+// hundreds of times over a wide range — and resolved every page's series
+// identities just to apply a service filter. A sketch merge is commutative
+// and associative, so VisitSketches streams the rows once in table order,
+// and the filter memoizes ONE dictionary lookup per distinct service ID.
+func (e *Engine) mergeStoreSketches(sel Selector, filter map[string]struct{}, merge func(*Sketch)) error {
 	st := e.Store()
 	if st == nil {
 		return nil
 	}
-	for {
-		page, err := st.ReadBuckets(sel)
-		if err != nil {
-			return err
-		}
-		if err := e.visitPage(st, page.Buckets, visit); err != nil {
-			return err
-		}
-		if !page.Truncated {
-			return nil
-		}
-		// A store that reports "more rows" without advancing the cursor would
-		// spin this loop forever. Refuse rather than hang a dashboard.
-		if !sel.After.zero() && !sel.After.After(page.Next.WindowStart, page.Next.SeriesID, page.Next.Source) {
-			return fmt.Errorf("aggregate: paged read did not advance past %d/%d", sel.After.WindowStart, sel.After.SeriesID)
-		}
-		sel.After = page.Next
+	sel.Signal = SignalTraceOp
+	sel.SketchOnly = true
+	var verdict map[uint32]bool
+	if filter != nil {
+		verdict = make(map[uint32]bool, len(filter))
 	}
-}
-
-// visitPage resolves one page's series identities and visits its rows.
-func (e *Engine) visitPage(st Store, buckets []Bucket, visit visitFunc) error {
-	if len(buckets) == 0 {
+	return st.VisitSketches(sel, func(serviceID uint32, sk *Sketch) error {
+		if filter != nil {
+			ok, seen := verdict[serviceID]
+			if !seen {
+				_, ok = filter[e.serviceNameByID(serviceID)]
+				verdict[serviceID] = ok
+			}
+			if !ok {
+				return nil
+			}
+		}
+		merge(sk)
 		return nil
-	}
-	ids := make([]SeriesID, 0, len(buckets))
-	seen := make(map[SeriesID]struct{}, len(buckets))
-	for _, b := range buckets {
-		if _, ok := seen[b.SeriesID]; ok {
-			continue
-		}
-		seen[b.SeriesID] = struct{}{}
-		ids = append(ids, b.SeriesID)
-	}
-	infos, err := st.ResolveSeries(ids)
-	if err != nil {
-		return err
-	}
-	keys := make(map[SeriesID]SeriesKey, len(infos))
-	for _, info := range infos {
-		keys[info.ID] = info.Key
-	}
-	for _, b := range buckets {
-		key, ok := keys[b.SeriesID]
-		if !ok {
-			// A bucket whose identity no longer resolves cannot be attributed
-			// to a service. Counting it under an invented name would be worse
-			// than leaving it out of a per-service breakdown.
-			continue
-		}
-		visit(b.WindowStart, key, b.Delta)
-	}
-	return nil
+	})
 }
 
 // serviceName resolves a series' service through the dictionary. An
@@ -601,8 +572,8 @@ func (a *dashAccum) addSum(r SumRow) {
 //
 // The store side is read TWICE, on purpose (#197 Q1). The scalar totals come
 // from one SQL aggregation that no row cap can truncate. The p99 cannot: a
-// quantile sketch is not SUMmable, so the sketch-bearing rows are paged to
-// completion and merged in Go. Doing both through one capped read is exactly
+// quantile sketch is not SUMmable, so the sketch-bearing rows are streamed
+// once and merged in Go (#219). Doing both through one capped read is exactly
 // what made the old dashboard quietly wrong past 20,000 rows.
 func (e *Engine) QueryDashboard(q Query) (*DashboardResult, error) {
 	q.Signal = SignalUnspecified // the scan covers traces and logs in one pass
@@ -683,17 +654,7 @@ func (e *Engine) QueryDashboard(q Query) (*DashboardResult, error) {
 			}
 		}
 
-		sketchSel := sel
-		sketchSel.Signal = SignalTraceOp
-		sketchSel.SketchOnly = true
-		if err := e.pageStore(sketchSel, func(_ int64, key SeriesKey, d *AggregateDelta) {
-			if filter != nil {
-				if _, ok := filter[e.serviceName(key)]; !ok {
-					return
-				}
-			}
-			mergeSketch(d.Sketch)
-		}); err != nil {
+		if err := e.mergeStoreSketches(sel, filter, mergeSketch); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/aggregate/query_test.go
+++ b/internal/aggregate/query_test.go
@@ -94,6 +94,21 @@ func (s *stubStore) ReadBuckets(sel Selector) (BucketPage, error) {
 	return page, nil
 }
 
+func (s *stubStore) VisitSketches(sel Selector, visit func(uint32, *Sketch) error) error {
+	if _, err := sel.Validate(); err != nil {
+		return err
+	}
+	s.reads++
+	s.readRanges = append(s.readRanges, [2]int64{sel.Start, sel.End})
+	sel.SketchOnly = true
+	for _, b := range s.matching(sel) {
+		if err := visit(s.infos[b.SeriesID].ServiceID, b.Delta.Sketch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *stubStore) SumBuckets(sel Selector, by GroupBy) ([]SumRow, error) {
 	if _, err := sel.Validate(); err != nil {
 		return nil, err

--- a/internal/aggregate/read_contract_test.go
+++ b/internal/aggregate/read_contract_test.go
@@ -432,18 +432,20 @@ func TestReadsAreCompleteBeyondTheRowCap(t *testing.T) {
 }
 
 // TestPercentilePathReadsEverySketchBearingRow proves the p99 is not built from
-// the first page: the merged sketch must have observed every seeded duration,
-// across materialized buckets and un-finalized delta rows alike.
+// a truncated read: the merged sketch must have observed every seeded
+// duration, across materialized buckets and un-finalized delta rows alike.
+// Since #219 the path is mergeStoreSketches -> VisitSketches — one unordered
+// streaming pass per table — not the paged, totally-ordered ReadBuckets.
 //
-// The row cap is shrunk rather than the row count raised: what matters is that
-// the read spans more pages than one, not the absolute number, and encoding
-// 20,000 sketches through a race-instrumented SQLite costs minutes.
+// The row cap is shrunk BELOW the row count on purpose: VisitSketches
+// documents that no row cap applies, and this proves it — 500 sketch-bearing
+// rows must all be observed through a 120-row cap.
 func TestPercentilePathReadsEverySketchBearingRow(t *testing.T) {
 	restore := MaxReadRows
 	MaxReadRows = 120
 	t.Cleanup(func() { MaxReadRows = restore })
 
-	const rows = 500 // four pages plus a remainder
+	const rows = 500 // far past the shrunken row cap
 	now := mustTime(t, "2026-08-21T12:02:00Z")
 	e := testEngine(t, now)
 	store := newTestStoreAt(t, filepath.Join(t.TempDir(), "aggregate.db"), StoreConfig{})
@@ -505,25 +507,43 @@ func TestPercentilePathReadsEverySketchBearingRow(t *testing.T) {
 
 	var merged *Sketch
 	visited := 0
-	sel := Selector{TenantID: tenantID, Start: base, End: base + 3*windowSecs, Signal: SignalTraceOp, SketchOnly: true}
-	if err := e.pageStore(sel, func(_ int64, _ SeriesKey, d *AggregateDelta) {
+	sel := Selector{TenantID: tenantID, Start: base, End: base + 3*windowSecs}
+	if err := e.mergeStoreSketches(sel, nil, func(sk *Sketch) {
 		visited++
-		if d.Sketch == nil {
-			t.Error("SketchOnly read returned a row with no sketch")
+		if sk == nil {
+			t.Error("sketch stream delivered a nil sketch")
 			return
 		}
 		if merged == nil {
-			merged = NewSketchAtScaleUnchecked(d.Sketch.Scale())
+			merged = NewSketchAtScaleUnchecked(sk.Scale())
 		}
-		merged.Merge(d.Sketch)
+		merged.Merge(sk)
 	}); err != nil {
-		t.Fatalf("pageStore: %v", err)
+		t.Fatalf("mergeStoreSketches: %v", err)
 	}
 	if visited != rows-withoutSketch {
-		t.Fatalf("paged read visited %d rows, want %d sketch-bearing rows", visited, rows-withoutSketch)
+		t.Fatalf("sketch stream visited %d rows, want %d sketch-bearing rows", visited, rows-withoutSketch)
 	}
 	if merged == nil || merged.Count() != want {
 		t.Fatalf("merged sketch observed %v of %d observations", merged, want)
+	}
+
+	// The service filter is applied per distinct service ID, not per row. A
+	// filter naming the seeded service must observe everything; a filter
+	// naming an absent service must observe nothing.
+	kept := 0
+	if err := e.mergeStoreSketches(sel, map[string]struct{}{"svc": {}}, func(*Sketch) { kept++ }); err != nil {
+		t.Fatalf("mergeStoreSketches(filter=svc): %v", err)
+	}
+	if kept != rows-withoutSketch {
+		t.Fatalf("filter for the seeded service kept %d rows, want %d", kept, rows-withoutSketch)
+	}
+	dropped := 0
+	if err := e.mergeStoreSketches(sel, map[string]struct{}{"absent": {}}, func(*Sketch) { dropped++ }); err != nil {
+		t.Fatalf("mergeStoreSketches(filter=absent): %v", err)
+	}
+	if dropped != 0 {
+		t.Fatalf("filter for an absent service kept %d rows, want 0", dropped)
 	}
 }
 

--- a/internal/aggregate/store.go
+++ b/internal/aggregate/store.go
@@ -581,6 +581,21 @@ type Store interface {
 	// makes a scalar dashboard total structurally impossible to truncate.
 	SumBuckets(sel Selector, by GroupBy) ([]SumRow, error)
 
+	// VisitSketches streams every sketch-bearing row matching sel — from
+	// BOTH durable tables, like ReadBuckets — to visit, in no particular
+	// order. It is the percentile path of the #197 read contract: a quantile
+	// sketch cannot be SUMmed in SQL, but its merge is commutative and
+	// associative, so no total order and no pagination are needed — one
+	// unordered pass replaces the sorted, keyset-paged drain that made a
+	// wide dashboard range cost O(pages) sorted re-scans (#219).
+	//
+	// The selector's bounds are mandatory (Selector.Validate applies) and
+	// SketchOnly is implied. The row cap is NOT applied: it bounds RESULT
+	// sizes, and this read's result is whatever the caller folds the
+	// visited sketches into; the scan itself is bounded by the validated
+	// window span, the same bound SumBuckets relies on.
+	VisitSketches(sel Selector, visit func(serviceID uint32, sk *Sketch) error) error
+
 	// ReplayMutable returns the delta-log rows for windows at or after since —
 	// the mutable set only. Finalized history never hydrates into RAM (#160).
 	ReplayMutable(since int64) ([]DeltaRow, error)

--- a/internal/aggregate/store_sqlite.go
+++ b/internal/aggregate/store_sqlite.go
@@ -1358,6 +1358,74 @@ func (s *SQLiteStore) SumBuckets(sel Selector, by GroupBy) ([]SumRow, error) {
 	return out, rows.Err()
 }
 
+// VisitSketches implements Store. Both durable tables are streamed once, in
+// their natural PRIMARY KEY (window_start, series_id) range order — no ORDER
+// BY, no LIMIT, no keyset resume. ReadBuckets must maintain a total (window,
+// series, source) order across a UNION of both tables, which forces a sort
+// per page and a re-scan per keyset resume; a wide dashboard range paid that
+// price hundreds of times over (#219). A sketch merge is order-independent,
+// so this path pays it zero times.
+func (s *SQLiteStore) VisitSketches(sel Selector, visit func(serviceID uint32, sk *Sketch) error) error {
+	if _, err := sel.Validate(); err != nil {
+		return err
+	}
+	for _, src := range bucketSources {
+		if err := s.visitTableSketches(src.table, sel, visit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// visitTableSketches streams one table's sketch-bearing rows to visit.
+func (s *SQLiteStore) visitTableSketches(table string, sel Selector, visit func(uint32, *Sketch) error) error {
+	var (
+		sb   strings.Builder
+		args []any
+	)
+	// The table name is one of the two bucketSources literals, never input.
+	fmt.Fprintf(&sb, `SELECT s.service_id, t.sketch FROM %s t
+		JOIN aggregate_series s ON s.id = t.series_id
+		WHERE t.window_start >= ? AND t.window_start < ? AND s.tenant_id = ?
+		AND t.sketch IS NOT NULL`, table)
+	args = append(args, sel.Start, sel.End, int64(sel.TenantID))
+	if sel.Signal != SignalUnspecified {
+		sb.WriteString(` AND s.signal = ?`)
+		args = append(args, int64(sel.Signal))
+	}
+	if len(sel.SeriesIDs) > 0 {
+		sb.WriteString(` AND t.series_id IN (` + placeholders(len(sel.SeriesIDs)) + `)`)
+		for _, id := range sel.SeriesIDs {
+			args = append(args, int64(id))
+		}
+	}
+	rows, err := s.reader.Query(sb.String(), args...)
+	if err != nil {
+		return fmt.Errorf("aggregate store: visit sketches: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var (
+			service int64
+			blob    []byte
+		)
+		if err := rows.Scan(&service, &blob); err != nil {
+			return fmt.Errorf("aggregate store: visit sketches: %w", err)
+		}
+		sk, err := DecodeSketch(blob)
+		if err != nil {
+			return fmt.Errorf("aggregate store: visit sketches: decode: %w", err)
+		}
+		if err := visit(uint32(service), sk); err != nil { // #nosec G115 -- dictionary IDs are uint32
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("aggregate store: visit sketches: %w", err)
+	}
+	return nil
+}
+
 // bucketSources are the two durable tables a store-owned row can live in, in
 // scan order. aggregate_buckets holds what finalization materialized;
 // aggregate_delta_log holds what it has not incorporated yet — including a

--- a/internal/aggregate/wide_range_timing_test.go
+++ b/internal/aggregate/wide_range_timing_test.go
@@ -1,0 +1,124 @@
+package aggregate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestManualWideRangeTiming is a manual A/B measurement for #219, not a CI
+// test: it seeds a wide-range store and times the old paged sketch drain
+// (reproduced inline against ReadBuckets) against the streaming VisitSketches
+// path. Run with WIDE_RANGE_TIMING=1.
+func TestManualWideRangeTiming(t *testing.T) {
+	if os.Getenv("WIDE_RANGE_TIMING") == "" {
+		t.Skip("manual timing test; set WIDE_RANGE_TIMING=1")
+	}
+	const (
+		seriesN  = 1000
+		windowsN = 2016 // 7 days of 5-minute windows
+	)
+	now := mustTime(t, "2026-08-21T12:02:00Z")
+	e := testEngine(t, now)
+	store := newTestStoreAt(t, filepath.Join(t.TempDir(), "aggregate.db"), StoreConfig{})
+	e.SetStore(store)
+
+	tenantID, _ := e.TenantID("default")
+	windowSecs := int64(WindowSize / time.Second)
+	base := WindowStart(now) - int64(windowsN+2)*windowSecs
+
+	series := make([]SeriesRow, 0, seriesN)
+	deltas := make([]*AggregateDelta, 0, seriesN)
+	for i := 0; i < seriesN; i++ {
+		id := SeriesID(i + 1)
+		series = append(series, SeriesRow{ID: id, Key: SeriesKey{
+			TenantID:  tenantID,
+			ServiceID: e.Cache().Intern(tenantID, KindService, fmt.Sprintf("svc-%03d", i%50)),
+			NameID:    e.Cache().Intern(tenantID, KindOperation, fmt.Sprintf("op-%05d", i)),
+			Signal:    SignalTraceOp,
+			Variant:   SpanKindServer,
+		}})
+		d := &AggregateDelta{}
+		d.ObserveSpan(float64(100+i%900), false, true)
+		deltas = append(deltas, d)
+	}
+
+	tx, err := store.writer.Begin()
+	if err != nil {
+		t.Fatalf("begin seed tx: %v", err)
+	}
+	seedSeries(t, tx, series)
+	ids := make([]SeriesID, seriesN)
+	wins := make([]int64, seriesN)
+	seedStart := time.Now()
+	for w := 0; w < windowsN; w++ {
+		for i := 0; i < seriesN; i++ {
+			ids[i] = SeriesID(i + 1)
+			wins[i] = base + int64(w)*windowSecs
+		}
+		insertRows(t, tx, "aggregate_buckets", ids, wins, deltas)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit seed tx: %v", err)
+	}
+	t.Logf("seeded %d rows in %s", seriesN*windowsN, time.Since(seedStart).Round(time.Millisecond))
+
+	sel := Selector{
+		TenantID: tenantID,
+		Start:    base,
+		End:      base + int64(windowsN)*windowSecs,
+		Signal:   SignalTraceOp,
+	}
+
+	// New path: one unordered streaming pass.
+	newStart := time.Now()
+	var newMerged *Sketch
+	newRows := 0
+	if err := e.mergeStoreSketches(sel, nil, func(sk *Sketch) {
+		newRows++
+		if newMerged == nil {
+			newMerged = NewSketchAtScaleUnchecked(sk.Scale())
+		}
+		newMerged.Merge(sk)
+	}); err != nil {
+		t.Fatalf("mergeStoreSketches: %v", err)
+	}
+	newDur := time.Since(newStart)
+	t.Logf("stream path: %d rows, count=%d, %s", newRows, newMerged.Count(), newDur.Round(time.Millisecond))
+
+	// Old path: the paged, totally-ordered drain QueryDashboard used to run.
+	pagedSel := sel
+	pagedSel.SketchOnly = true
+	oldStart := time.Now()
+	var oldMerged *Sketch
+	oldRows := 0
+	for {
+		page, err := store.ReadBuckets(pagedSel)
+		if err != nil {
+			t.Fatalf("ReadBuckets: %v", err)
+		}
+		for _, b := range page.Buckets {
+			oldRows++
+			if b.Delta.Sketch == nil {
+				continue
+			}
+			if oldMerged == nil {
+				oldMerged = NewSketchAtScaleUnchecked(b.Delta.Sketch.Scale())
+			}
+			oldMerged.Merge(b.Delta.Sketch)
+		}
+		if !page.Truncated {
+			break
+		}
+		pagedSel.After = page.Next
+	}
+	oldDur := time.Since(oldStart)
+	t.Logf("paged path: %d rows, count=%d, %s", oldRows, oldMerged.Count(), oldDur.Round(time.Millisecond))
+
+	if newMerged.Count() != oldMerged.Count() {
+		t.Fatalf("paths disagree: stream=%d paged=%d", newMerged.Count(), oldMerged.Count())
+	}
+	t.Logf("speedup: %.1fx", float64(oldDur)/float64(newDur))
+}

--- a/internal/api/coverage.go
+++ b/internal/api/coverage.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"errors"
 	"net/http"
+	"time"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 )
@@ -17,4 +19,47 @@ func setCoverage(w http.ResponseWriter, c aggregate.Coverage) {
 		return
 	}
 	w.Header().Set(aggregate.CoverageHeader, string(c))
+}
+
+// Range-clamp headers (#217). When an aggregate-mode request asks for more
+// history than the engine's read-range cap allows, the handler clamps the
+// range instead of refusing the request, and these headers say so: what the
+// client asked for, and what the response actually covers.
+const (
+	// RequestedStartHeader restates the start the client requested.
+	RequestedStartHeader = "OtelContext-Requested-Start"
+	// EffectiveStartHeader carries the clamped start the response covers.
+	EffectiveStartHeader = "OtelContext-Effective-Start"
+)
+
+// clampAggregateRange bounds a requested [start, end) range to the aggregate
+// engine's read-range cap and stamps the clamp on the response, so a
+// shortened answer is never mistaken for a complete one (#217).
+//
+// The comparison mirrors the window alignment the engine applies in plan():
+// start rounds down to its window, end rounds up to the next boundary. The
+// clamped start keeps the most recent MaxReadWindowSpan of the request —
+// retention holds up to the cap plus purge lag, so "everything" queries only
+// ever lose the oldest slice, which is the slice retention is about to delete
+// anyway. Selector.Validate stays in place as the hard backstop.
+func clampAggregateRange(w http.ResponseWriter, start, end time.Time) time.Time {
+	alignedStart := aggregate.WindowStart(start)
+	alignedEnd := aggregate.WindowStart(end.Add(aggregate.WindowSize - time.Second))
+	if alignedEnd-alignedStart <= aggregate.MaxReadWindowSpan {
+		return start
+	}
+	eff := time.Unix(alignedEnd-aggregate.MaxReadWindowSpan, 0).UTC()
+	w.Header().Set(RequestedStartHeader, start.UTC().Format(time.RFC3339))
+	w.Header().Set(EffectiveStartHeader, eff.Format(time.RFC3339))
+	return eff
+}
+
+// aggregateReadStatus maps an aggregate read error to its HTTP status. A
+// selector the engine refuses is a client-shaped problem — the requested
+// range or scope was invalid — not a server fault (#217).
+func aggregateReadStatus(err error) int {
+	if errors.Is(err, aggregate.ErrSelectorUnbounded) {
+		return http.StatusBadRequest
+	}
+	return http.StatusInternalServerError
 }

--- a/internal/api/metrics_handlers.go
+++ b/internal/api/metrics_handlers.go
@@ -37,6 +37,7 @@ func (s *Server) handleGetTrafficMetrics(w http.ResponseWriter, r *http.Request)
 	// carry coverage would silently break every existing client, so coverage
 	// travels in the response header instead (#164).
 	if s.aggregateReads() {
+		start = clampAggregateRange(w, start, end)
 		res, err := s.aggregateEngine.QueryBuckets(aggregate.Query{
 			Tenant:   storage.TenantFromContext(r.Context()),
 			Start:    start,
@@ -45,7 +46,7 @@ func (s *Server) handleGetTrafficMetrics(w http.ResponseWriter, r *http.Request)
 		})
 		if err != nil {
 			slog.Error("Failed to get aggregate traffic metrics", "error", err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			http.Error(w, err.Error(), aggregateReadStatus(err))
 			return
 		}
 		setCoverage(w, res.Coverage)
@@ -132,15 +133,6 @@ func (s *Server) handleGetLatencyHeatmap(w http.ResponseWriter, r *http.Request)
 // windows never share an entry; oversized queries skip the cache (see
 // maxCacheKeyQueryLen).
 func (s *Server) handleGetDashboardStats(w http.ResponseWriter, r *http.Request) {
-	var cacheKey string
-	if len(r.URL.RawQuery) <= maxCacheKeyQueryLen {
-		cacheKey = "dashboard_stats:" + storage.TenantFromContext(r.Context()) + "?" + r.URL.RawQuery
-		if cached, ok := s.cache.Get(cacheKey); ok {
-			cached.(*cachedJSON).write(w, r, "HIT")
-			return
-		}
-	}
-
 	// Default to last 30 minutes if not specified
 	end := time.Now()
 	start := end.Add(-30 * time.Minute)
@@ -155,13 +147,28 @@ func (s *Server) handleGetDashboardStats(w http.ResponseWriter, r *http.Request)
 			end = t
 		}
 	}
+	// Clamp BEFORE the cache lookup so the clamp headers are stamped on
+	// cache hits too — the cached payload was produced from the clamped
+	// range, and the headers must say so every time it is served (#217).
+	if s.aggregateReads() {
+		start = clampAggregateRange(w, start, end)
+	}
+
+	var cacheKey string
+	if len(r.URL.RawQuery) <= maxCacheKeyQueryLen {
+		cacheKey = "dashboard_stats:" + storage.TenantFromContext(r.Context()) + "?" + r.URL.RawQuery
+		if cached, ok := s.cache.Get(cacheKey); ok {
+			cached.(*cachedJSON).write(w, r, "HIT")
+			return
+		}
+	}
 
 	serviceNames := r.URL.Query()["service_name"]
 
 	view, err := s.dashboardView(r, start, end, serviceNames)
 	if err != nil {
 		slog.Error("Failed to get dashboard stats", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), aggregateReadStatus(err))
 		return
 	}
 
@@ -213,13 +220,6 @@ func (s *Server) handleGetServiceMapMetrics(w http.ResponseWriter, r *http.Reque
 	endStr := r.URL.Query().Get("end")
 	cacheKey := "service_map:" + storage.TenantFromContext(r.Context()) + ":" + startStr + ":" + endStr
 
-	if cached, ok := s.cache.Get(cacheKey); ok {
-		w.Header().Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
-		w.Header().Set("X-Cache", "HIT")
-		_ = json.NewEncoder(w).Encode(cached)
-		return
-	}
-
 	end := time.Now()
 	start := end.Add(-30 * time.Minute)
 	if startStr != "" {
@@ -232,11 +232,24 @@ func (s *Server) handleGetServiceMapMetrics(w http.ResponseWriter, r *http.Reque
 			end = t
 		}
 	}
+	// Clamp BEFORE the cache lookup so the clamp headers are stamped on
+	// cache hits too (#217); the cache key is the raw start/end params, so
+	// every hit was produced from the same clamped range.
+	if s.aggregateReads() {
+		start = clampAggregateRange(w, start, end)
+	}
+
+	if cached, ok := s.cache.Get(cacheKey); ok {
+		w.Header().Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
+		w.Header().Set("X-Cache", "HIT")
+		_ = json.NewEncoder(w).Encode(cached)
+		return
+	}
 
 	resp, err := s.serviceMapView(r, start, end)
 	if err != nil {
 		slog.Error("Failed to get service map metrics", "error", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), aggregateReadStatus(err))
 		return
 	}
 	s.cache.Set(cacheKey, resp, cacheTTL)

--- a/internal/api/range_clamp_test.go
+++ b/internal/api/range_clamp_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+// doClampGet issues one tenant-scoped GET against a handler and returns the
+// recorder without asserting the status; clamp tests care about non-200 too.
+func doClampGet(t *testing.T, h http.HandlerFunc, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	ctx := storage.WithTenantContext(context.Background(), "default")
+	req := httptest.NewRequest(http.MethodGet, target, nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	return rr
+}
+
+func rangeQueryString(start, end time.Time) string {
+	return "?start=" + url.QueryEscape(start.Format(time.RFC3339)) +
+		"&end=" + url.QueryEscape(end.Format(time.RFC3339))
+}
+
+// TestOverCapRangeClampsInsteadOfFailing is the #217 contract: a request
+// whose range exceeds the engine's read-range cap is served from the clamped
+// range with the clamp declared in headers — not refused with a 500.
+func TestOverCapRangeClampsInsteadOfFailing(t *testing.T) {
+	s, _, e := aggregateTestServer(t, true)
+	seedAggregate(t, e, "default", "checkout", 6, 1500)
+
+	end := time.Now().UTC().Truncate(time.Second)
+	start := end.Add(-200 * time.Hour) // well past the ~168h read-range cap
+	q := rangeQueryString(start, end)
+
+	alignedEnd := aggregate.WindowStart(end.Add(aggregate.WindowSize - time.Second))
+	wantEffective := time.Unix(alignedEnd-aggregate.MaxReadWindowSpan, 0).UTC().Format(time.RFC3339)
+
+	handlers := map[string]http.HandlerFunc{
+		"dashboard":   s.handleGetDashboardStats,
+		"traffic":     s.handleGetTrafficMetrics,
+		"service-map": s.handleGetServiceMapMetrics,
+	}
+	for name, h := range handlers {
+		t.Run(name, func(t *testing.T) {
+			rr := doClampGet(t, h, "/api/metrics/"+name+q)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("over-cap range = %d, want 200: %s", rr.Code, rr.Body.String())
+			}
+			if got, want := rr.Header().Get(RequestedStartHeader), start.Format(time.RFC3339); got != want {
+				t.Errorf("%s = %q, want %q", RequestedStartHeader, got, want)
+			}
+			if got := rr.Header().Get(EffectiveStartHeader); got != wantEffective {
+				t.Errorf("%s = %q, want %q", EffectiveStartHeader, got, wantEffective)
+			}
+		})
+	}
+}
+
+// TestInCapRangeStampsNoClampHeaders proves the headers appear ONLY when a
+// clamp happened: an ordinary in-cap request carries neither.
+func TestInCapRangeStampsNoClampHeaders(t *testing.T) {
+	s, _, e := aggregateTestServer(t, true)
+	seedAggregate(t, e, "default", "checkout", 3, 900)
+
+	end := time.Now().UTC().Truncate(time.Second)
+	rr := doClampGet(t, s.handleGetTrafficMetrics,
+		"/api/metrics/traffic"+rangeQueryString(end.Add(-30*time.Minute), end))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("in-cap range = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	for _, h := range []string{RequestedStartHeader, EffectiveStartHeader} {
+		if got := rr.Header().Get(h); got != "" {
+			t.Errorf("%s = %q on an unclamped response, want absent", h, got)
+		}
+	}
+}
+
+// TestSelectorErrorIsClientError pins the backstop's status: a selector the
+// engine still refuses after clamping (here a reversed range) is the client's
+// mistake and maps to 400, not 500 (#217).
+func TestSelectorErrorIsClientError(t *testing.T) {
+	s, _, _ := aggregateTestServer(t, true)
+
+	end := time.Now().UTC().Truncate(time.Second)
+	start := end.Add(24 * time.Hour) // reversed: start after end
+	rr := doClampGet(t, s.handleGetTrafficMetrics,
+		"/api/metrics/traffic"+rangeQueryString(start, end))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("reversed range = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestClampAggregateRangeBoundary pins the clamp threshold to the byte: a
+// span of exactly MaxReadWindowSpan passes untouched; one second more clamps.
+func TestClampAggregateRangeBoundary(t *testing.T) {
+	// A window-aligned end makes the arithmetic exact.
+	end := time.Unix(aggregate.WindowStart(time.Now()), 0).UTC()
+
+	rr := httptest.NewRecorder()
+	exact := end.Add(-time.Duration(aggregate.MaxReadWindowSpan) * time.Second)
+	if got := clampAggregateRange(rr, exact, end); !got.Equal(exact) {
+		t.Fatalf("exact-cap span clamped to %v, want untouched %v", got, exact)
+	}
+	if rr.Header().Get(EffectiveStartHeader) != "" {
+		t.Fatal("exact-cap span stamped a clamp header")
+	}
+
+	rr = httptest.NewRecorder()
+	over := exact.Add(-time.Second)
+	got := clampAggregateRange(rr, over, end)
+	if !got.Equal(exact) {
+		t.Fatalf("over-cap span clamped to %v, want %v", got, exact)
+	}
+	if rr.Header().Get(RequestedStartHeader) == "" || rr.Header().Get(EffectiveStartHeader) == "" {
+		t.Fatal("over-cap span did not stamp the clamp headers")
+	}
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -93,13 +93,22 @@ if [ "$MAKE_RELEASE" = "--release" ]; then
   prev="$(git describe --tags --abbrev=0 "${VER}^" 2>/dev/null || true)"
   range="${prev:+${prev}..}${VER}"
   notes="$(git log --pretty='- %s' "$range" 2>/dev/null | grep -vE '^- release:' || true)"
-  gh release create "$VER" --prerelease --title "$VER" --notes \
-"Install (UI embedded):
+  body="Install (UI embedded):
 \`\`\`
 go install github.com/RandomCodeSpace/otelcontext@$VER
 \`\`\`
 
 ### Changes
 $notes"
-  echo "✓ created GitHub pre-release $VER"
+  # Only a tag carrying a pre-release identifier (vX.Y.Z-something) is marked
+  # as a GitHub pre-release — matching GoReleaser's `prerelease: auto`, so the
+  # early release shell and the appended artifacts never disagree. A stable
+  # tag becomes a full release and is eligible for "Latest".
+  if [[ "$VER" == *-* ]]; then
+    gh release create "$VER" --prerelease --title "$VER" --notes "$body"
+    echo "✓ created GitHub pre-release $VER"
+  else
+    gh release create "$VER" --title "$VER" --notes "$body"
+    echo "✓ created GitHub release $VER"
+  fi
 fi


### PR DESCRIPTION
Release-prep batch: the two open aggregate read-path issues plus the two release blockers identified in the readiness review.

## Changes

**fix(api): clamp over-cap aggregate read ranges instead of failing** — Fixes #217
Dashboard/traffic/service-map requests past the engine's read-range cap (605100s) returned 500. They now clamp to the most recent `MaxReadWindowSpan` and declare it via `OtelContext-Requested-Start` / `OtelContext-Effective-Start` response headers (stamped on cache hits too — the clamp runs before the response-cache lookup). `Selector.Validate` stays as the hard backstop, and selector errors that still reach it map to 400, not 500.

**perf(aggregate): stream the dashboard sketch merge in one unordered pass** — Fixes #219
The percentile path drained every sketch row through the totally-ordered, keyset-paged `ReadBuckets` (a sort per page, a re-scan per resume, plus `ResolveSeries` per page just for the service filter) — 521s over the gate's full-density 7-day range. Sketch merges are commutative, so the new `Store.VisitSketches` streams each durable table once in PRIMARY KEY range order projecting only `(service_id, sketch)`; the service filter memoizes one dictionary lookup per distinct service ID.

Local A/B at 2,016,000 sketch rows (1/6 gate density, identical merge counts on both paths): paged 34.4s → streamed 3.3s, **10.5×** — and the paged cost is superlinear in range width while the stream is linear. Reproduce: `WIDE_RANGE_TIMING=1 go test -run TestManualWideRangeTiming ./internal/aggregate/`.

**docs(changelog): backfill v0.3.0 through v0.4.0-beta.1 and the aggregate epic**
`Unreleased` still described the UI redesign that shipped in v0.3.0; four published tags had no entries. Backfilled from tag history, and `Unreleased` now covers the #194 aggregate epic, the 15-PR dependency refresh, and the fixes since v0.4.0-beta.1.

**fix(release): mark GitHub releases as pre-release only for pre-release tags**
`release.sh --release` hardcoded `--prerelease`; a stable tag cut through it would never become "Latest". Now gated on the tag carrying a pre-release identifier, matching GoReleaser's `prerelease: auto`.

## Verification

- `go vet ./...` — clean
- `go test ./...` — 1534 passed, 30 packages
- `go test -race ./internal/aggregate/` — 392 passed
- `go test -race ./internal/api/` — 147 passed
- `bash -n scripts/release.sh` — clean; shellcheck adds nothing new
- New tests: clamp boundary pinned to the byte (exact cap passes, +1s clamps), all three handlers return 200 + headers on an over-cap range, no headers in-cap, reversed range → 400; `VisitSketches` completeness across both durable tables incl. the row-cap-ignored property and per-service-ID filter memoization.

Unverified: the 521s → ~tens-of-seconds claim at full 12.1M density is extrapolated from the 2M-row A/B; the definitive number comes from the next seven-day gate run.
