### PR TITLE
fix(release): pin cosign to v2.6.5 in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,14 @@ jobs:
         # sigstore/cosign-installer v3.9.2 — provides `cosign` for the keyless
         # signing step in .goreleaser.yaml (signs: cmd: cosign).
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+        with:
+          # Pin the cosign BINARY, not just the installer action: without this
+          # the action installs the latest cosign, and cosign v3 flipped
+          # --new-bundle-format on by default, ignoring the --output-signature/
+          # --output-certificate flags .goreleaser.yaml relies on and failing
+          # the sign step (v0.4.0-beta.2 tag-push run). v2 keeps the .sig+.pem
+          # output contract Scorecard Signed-Releases is checked against.
+          cosign-release: 'v2.6.5'
 
       - name: Install syft
         # anchore/sbom-action v0.24.0 (download-syft sub-action) — puts `syft`


### PR DESCRIPTION
The v0.4.0-beta.2 tag-push release run failed at the cosign signing step: the SHA-pinned installer action still installs the **latest** cosign binary, and cosign v3 turned on `--new-bundle-format` by default — the `--output-signature`/`--output-certificate` flags in `.goreleaser.yaml` are ignored and cosign dies with `create bundle file: open : no such file or directory`. Everything before the sign step (binaries, archives, SBOMs, checksums) built clean.

Pin `cosign-release: v2.6.5` (latest maintained v2 line) so the `.sig` + `.pem` output contract stays what Scorecard Signed-Releases verifies. Same unpinned-tool drift class as the pip/semgrep/jscpd pins in 6fba24c.

After merge: recover the release via `workflow_dispatch` with `tag=v0.4.0-beta.2` — the designed recovery path (runs the current default-branch workflow against the existing immutable tag, GoReleaser `mode: append`).