### PR TITLE
feat(migrate): add versioned schema lifecycle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@
 # DB_DRIVER=sqlserver
 # DB_DSN=sqlserver://user:password@host:1433?database=OtelContext
 
-# DB_AUTOMIGRATE=true            # GORM AutoMigrate on startup. Set false in Postgres prod (schema out-of-band)
+# DB_AUTOMIGRATE=true            # Dev/preview AutoMigrate. For SQLite or unpartitioned Postgres prod: run `otelcontext migrate up`, then set false
 
 # ---- Database Pool ----------------------------------------------------------
 # DB_MAX_OPEN_CONNS=50           # Max concurrent DB connections (SQLite default 1; SQLite is single-writer)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,62 @@ jobs:
           path: ${{ runner.temp }}/browser-smoke/artifacts
           if-no-files-found: warn
           retention-days: 14
+
+  database-sqlite:
+    name: database proof · sqlite
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      CGO_ENABLED: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: run SQLite migration and affected-contract proof
+        run: |
+          mkdir -p "${RUNNER_TEMP}/database-proof"
+          go test -race -count=1 -v ./internal/migrate ./internal/storage ./internal/graphrag 2>&1 \
+            | tee "${RUNNER_TEMP}/database-proof/sqlite.log"
+
+      - name: upload SQLite proof
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: database-proof-sqlite-${{ github.sha }}
+          path: ${{ runner.temp }}/database-proof/sqlite.log
+          if-no-files-found: error
+          retention-days: 14
+
+  database-postgres-16:
+    name: database proof · postgres-16
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      CGO_ENABLED: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: run PostgreSQL 16 migration lifecycle proof
+        run: |
+          mkdir -p "${RUNNER_TEMP}/database-proof"
+          go test -race -count=1 -v -tags=integration -timeout=8m \
+            -run '^TestPostgres16MigrationLifecycle$' ./internal/migrate 2>&1 \
+            | tee "${RUNNER_TEMP}/database-proof/postgres-16.log"
+
+      - name: upload PostgreSQL 16 proof
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: database-proof-postgres-16-${{ github.sha }}
+          path: ${{ runner.temp }}/database-proof/postgres-16.log
+          if-no-files-found: error
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -141,6 +141,25 @@ Connect an MCP client to `http://localhost:8080/mcp` to investigate the same tel
 
 Trace-based answers say whether the supporting exemplar is complete, partial, or no longer retained. OtelContext does not present a partial trace as the whole story.
 
+## Upgrade without guessing
+
+The same binary can check and upgrade its database before it starts any receiver or background work:
+
+```bash
+./otelcontext migrate status
+./otelcontext migrate up
+```
+
+If the database came from an older release that predates migration tracking, identify it once before upgrading:
+
+```bash
+./otelcontext migrate baseline --from v0.3.1
+# or: --from v0.4.0-beta.2
+./otelcontext migrate up
+```
+
+The baseline command validates the database first; it does not repair or guess. Back up the main database and aggregate database file, and keep the previous signed binary until `migrate status` reports `result=ready`. Versioned production checks are available for SQLite and unpartitioned PostgreSQL 16. MySQL, SQL Server, and PostgreSQL daily partitioning keep their existing preview AutoMigrate path.
+
 ## Secure a deployment
 
 Set at least one authentication method before exposing OtelContext:

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -25,14 +25,14 @@ What happens:
 ### Postgres
 
 ```bash
-DB_DRIVER=postgres \
-DB_DSN="host=localhost user=otel password=otel dbname=otelcontext port=5432 sslmode=disable TimeZone=UTC" \
-DB_AUTOMIGRATE=false \
-API_KEY="$(openssl rand -hex 32)" \
-./otelcontext
+export DB_DRIVER=postgres
+export DB_DSN="host=localhost user=otel password=otel dbname=otelcontext port=5432 sslmode=disable TimeZone=UTC"
+
+./otelcontext migrate up
+DB_AUTOMIGRATE=false API_KEY="$(openssl rand -hex 32)" ./otelcontext
 ```
 
-Set `DB_AUTOMIGRATE=false` in production. AutoMigrate locks tables and has no rollback; run schema changes out-of-band (Flyway, goose, sqlc migrate, etc.).
+Set `DB_AUTOMIGRATE=false` in production after `otelcontext migrate status` reports `result=ready`. The binary owns the ordered SQLite and unpartitioned PostgreSQL 16 migrations; no separate migration tool is required. Daily PostgreSQL partitioning remains on the preview AutoMigrate path.
 
 ### TLS
 
@@ -84,7 +84,7 @@ DB_DSN="host=my-server.postgres.database.azure.com user=my-mi@tenant.onmicrosoft
 - `DB_MAX_OPEN_CONNS` — size to match your Postgres pool and expected ingest concurrency.
 - `DEFAULT_TENANT` — a non-`default` value if the deployment serves a specific tenant.
 - `OTEL_EXPORTER_OTLP_ENDPOINT` — enables self-instrumentation. Set to `localhost:4317` to dogfood into the same instance.
-- `DB_AUTOMIGRATE=false` for Postgres in production.
+- `DB_AUTOMIGRATE=false` for SQLite or unpartitioned Postgres production after the versioned migration command reports ready.
 
 ### Trust the defaults (don't tune unless you have a reason)
 - `METRIC_MAX_CARDINALITY=10000`, `METRIC_MAX_CARDINALITY_PER_TENANT=0` (unlimited per-tenant by default). For multi-tenant deployments, set the per-tenant cap to enforce fairness — a noisy tenant gets bounded before exhausting the global pool. Watch `otelcontext_tsdb_cardinality_overflow_by_tenant_total{tenant_id}` to identify offenders.
@@ -443,12 +443,14 @@ If the edge Collector applies tail-sampling, set `SAMPLING_RATE=1.0` on OtelCont
 
 ## Upgrade Path
 
-1. **Back up the DB** (see Backup & Restore above).
+1. **Stop OtelContext and back up the DB** (see Backup & Restore above). Keep the previous signed binary.
 2. **Read the CHANGELOG** for breaking changes between your current and target versions.
-3. **SQLite:** `DB_AUTOMIGRATE=true` (default) handles schema upgrades in place.
-4. **Postgres in production:** keep `DB_AUTOMIGRATE=false` and apply migrations out-of-band before starting the new binary.
-5. Roll the new binary. Watch `/ready`, `OtelContext_db_up`, and `retention_*` metrics for the first hour.
+3. Run `otelcontext migrate status` with the same `DB_*`, `AGGREGATE_MODE`, and `AGGREGATE_DB_PATH` settings as the service.
+4. If this is the first versioned upgrade, run `otelcontext migrate baseline --from v0.3.1` or `--from v0.4.0-beta.2`. The command refuses a database that does not match the named release.
+5. Run `otelcontext migrate up`, then rerun `otelcontext migrate status` and require `result=ready`.
+6. Start the new binary with `DB_AUTOMIGRATE=false`. Watch `/ready`, `OtelContext_db_up`, and `retention_*` metrics for the first hour.
+
+For automation, `migrate status` exits `0` for exact, `10` for empty, `11` for unmanaged, `12` for behind, `13` for ahead, `14` for dirty, `15` for incompatible, and `16` for an unverified preview driver. Command-usage errors exit `2`.
 
 If the new version fails to start:
-- For SQLite, restore the pre-upgrade backup with `VACUUM INTO`.
-- For Postgres, restore via `pg_restore --clean --if-exists`.
+- Stop the candidate, restore both main and aggregate stores from the pre-migration backup, and start the previous signed binary. There are no down migrations.

--- a/internal/aggregate/inspect.go
+++ b/internal/aggregate/inspect.go
@@ -1,0 +1,168 @@
+package aggregate
+
+import (
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// StoreInspection is a read-only aggregate compatibility result.
+type StoreInspection struct {
+	State                 string
+	ExpectedSchemaVersion int
+	ActualSchemaVersion   int
+	ExpectedSeriesVersion int
+	ActualSeriesVersion   int
+	ExpectedSketchVersion int
+	ActualSketchVersion   int
+	StoreUUID             string
+	MigrationResult       string
+	Detail                string
+}
+
+// Usable reports whether this binary can safely open the aggregate store.
+func (s StoreInspection) Usable() bool { return s.State == "exact" }
+
+// Description returns a stable one-line representation for operator output.
+func (s StoreInspection) Description() string {
+	actual := "none"
+	if s.ActualSchemaVersion != 0 {
+		actual = strconv.Itoa(s.ActualSchemaVersion)
+	}
+	parts := []string{
+		"state=" + s.State,
+		fmt.Sprintf("expected=%d", s.ExpectedSchemaVersion),
+		"actual=" + actual,
+		fmt.Sprintf("series_key=%d/%d", s.ActualSeriesVersion, s.ExpectedSeriesVersion),
+		fmt.Sprintf("sketch_codec=%d/%d", s.ActualSketchVersion, s.ExpectedSketchVersion),
+	}
+	if s.StoreUUID != "" {
+		parts = append(parts, "store_uuid="+s.StoreUUID)
+	}
+	if s.MigrationResult != "" {
+		parts = append(parts, "migration_result="+s.MigrationResult)
+	}
+	if s.Detail != "" {
+		parts = append(parts, "detail="+fmt.Sprintf("%q", s.Detail))
+	}
+	return strings.Join(parts, " ")
+}
+
+// InspectSQLiteStore reads aggregate tables and metadata without creating,
+// rebuilding, or changing the configured file.
+func InspectSQLiteStore(path string) (StoreInspection, error) {
+	if path == "" {
+		path = DefaultAggregateDBPath
+	}
+	inspection := StoreInspection{
+		ExpectedSchemaVersion: StoreSchemaVersion,
+		ExpectedSeriesVersion: int(SeriesKeyVersion),
+		ExpectedSketchVersion: int(SketchEncodingVersion),
+		MigrationResult:       "none",
+	}
+	if path == ":memory:" || strings.HasPrefix(path, "file::memory:") {
+		inspection.State = "empty"
+		inspection.Detail = "an in-memory aggregate store has no durable schema to inspect"
+		return inspection, nil
+	}
+	plainPath := path
+	if strings.HasPrefix(path, "file:") {
+		parsed, err := url.Parse(path)
+		if err != nil {
+			return inspection, fmt.Errorf("parse aggregate store path: %w", err)
+		}
+		plainPath = parsed.Path
+	}
+	if _, err := os.Stat(plainPath); err != nil {
+		if os.IsNotExist(err) {
+			inspection.State = "empty"
+			inspection.Detail = "aggregate store file is absent"
+			return inspection, nil
+		}
+		return inspection, fmt.Errorf("stat aggregate store: %w", err)
+	}
+	absolute, err := filepath.Abs(plainPath)
+	if err != nil {
+		return inspection, fmt.Errorf("resolve aggregate store path: %w", err)
+	}
+	readOnlyURI := (&url.URL{Scheme: "file", Path: absolute}).String() + "?mode=ro"
+	db, err := sql.Open("sqlite", readOnlyURI)
+	if err != nil {
+		return inspection, fmt.Errorf("open aggregate store read-only: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	rows, err := db.Query(`SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'aggregate_%'`)
+	if err != nil {
+		return inspection, fmt.Errorf("inspect aggregate tables: %w", err)
+	}
+	present := make(map[string]struct{})
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			_ = rows.Close()
+			return inspection, err
+		}
+		present[name] = struct{}{}
+	}
+	if err := rows.Close(); err != nil {
+		return inspection, err
+	}
+	if len(present) == 0 {
+		inspection.State = "empty"
+		inspection.Detail = "aggregate store contains no aggregate schema"
+		return inspection, nil
+	}
+	var missing []string
+	for _, table := range aggregateTables {
+		if _, ok := present[table]; !ok {
+			missing = append(missing, table)
+		}
+	}
+	if len(missing) != 0 {
+		inspection.State = "incompatible"
+		inspection.Detail = "partial aggregate schema is missing " + strings.Join(missing, ", ")
+		return inspection, nil
+	}
+	metaRows, err := db.Query(`SELECT key, value FROM aggregate_meta`)
+	if err != nil {
+		return inspection, fmt.Errorf("read aggregate metadata: %w", err)
+	}
+	meta := make(map[string]string)
+	for metaRows.Next() {
+		var key, value string
+		if err := metaRows.Scan(&key, &value); err != nil {
+			_ = metaRows.Close()
+			return inspection, err
+		}
+		meta[key] = value
+	}
+	if err := metaRows.Close(); err != nil {
+		return inspection, err
+	}
+	inspection.ActualSchemaVersion, _ = strconv.Atoi(meta["schema_version"])
+	inspection.ActualSeriesVersion, _ = strconv.Atoi(meta["series_key_version"])
+	inspection.ActualSketchVersion, _ = strconv.Atoi(meta["sketch_codec_version"])
+	inspection.StoreUUID = meta["store_uuid"]
+	if meta["schema_version"] == "" || meta["series_key_version"] == "" || meta["sketch_codec_version"] == "" || inspection.StoreUUID == "" {
+		inspection.State = "incompatible"
+		inspection.Detail = "aggregate metadata is incomplete"
+		return inspection, nil
+	}
+	if inspection.ActualSchemaVersion != inspection.ExpectedSchemaVersion {
+		inspection.State = "incompatible"
+		inspection.Detail = fmt.Sprintf("aggregate schema %d cannot be migrated losslessly to %d; run the older binary or explicitly rebuild", inspection.ActualSchemaVersion, inspection.ExpectedSchemaVersion)
+		return inspection, nil
+	}
+	if inspection.ActualSeriesVersion != inspection.ExpectedSeriesVersion || inspection.ActualSketchVersion != inspection.ExpectedSketchVersion {
+		inspection.State = "incompatible"
+		inspection.Detail = "aggregate series-key or sketch-codec version does not match this binary"
+		return inspection, nil
+	}
+	inspection.State = "exact"
+	inspection.Detail = "aggregate schema and semantic codec versions are exact"
+	return inspection, nil
+}

--- a/internal/aggregate/inspect_test.go
+++ b/internal/aggregate/inspect_test.go
@@ -1,0 +1,85 @@
+package aggregate
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInspectSQLiteStoreMissingIsReadOnly(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.db")
+	status, err := InspectSQLiteStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.State != "empty" || status.Usable() {
+		t.Fatalf("status = %#v", status)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("read-only inspection created %s: %v", path, err)
+	}
+}
+
+func TestInspectSQLiteStoreReportsExactSemanticVersions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aggregate.db")
+	store, err := OpenSQLiteStore(StoreConfig{Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	status, err := InspectSQLiteStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Usable() || status.ActualSchemaVersion != StoreSchemaVersion || status.ActualSeriesVersion != int(SeriesKeyVersion) || status.ActualSketchVersion != int(SketchEncodingVersion) || status.StoreUUID == "" {
+		t.Fatalf("status = %#v", status)
+	}
+	for _, marker := range []string{"state=exact", "series_key=1/1", "sketch_codec=1/1", "store_uuid="} {
+		if !strings.Contains(status.Description(), marker) {
+			t.Fatalf("description %q missing %q", status.Description(), marker)
+		}
+	}
+}
+
+func TestInspectSQLiteStoreRefusesUnknowableV4WithoutMutation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aggregate-v4.db")
+	store, err := OpenSQLiteStore(StoreConfig{Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE aggregate_meta SET value='4' WHERE key='schema_version'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := InspectSQLiteStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.State != "incompatible" || status.ActualSchemaVersion != 4 || !strings.Contains(status.Detail, "cannot be migrated losslessly") {
+		t.Fatalf("status = %#v", status)
+	}
+	if string(before) != string(after) {
+		t.Fatal("read-only inspection changed the v4 aggregate file")
+	}
+}

--- a/internal/graphrag/migrate.go
+++ b/internal/graphrag/migrate.go
@@ -111,12 +111,8 @@ func ensureDrainTemplatesCompositePK(db *gorm.DB) error {
 // install, so we don't have to hand-maintain a parallel CREATE TABLE.
 func ensureDrainPKSQLite(db *gorm.DB) error {
 	type pragmaCol struct {
-		Cid       int    `gorm:"column:cid"`
-		Name      string `gorm:"column:name"`
-		Type      string `gorm:"column:type"`
-		Notnull   int    `gorm:"column:notnull"`
-		DfltValue any    `gorm:"column:dflt_value"`
-		Pk        int    `gorm:"column:pk"`
+		Name string `gorm:"column:name"`
+		Pk   int    `gorm:"column:pk"`
 	}
 	var cols []pragmaCol
 	if err := db.Raw(`PRAGMA table_info('drain_templates')`).Scan(&cols).Error; err != nil {

--- a/internal/migrate/automigrate.go
+++ b/internal/migrate/automigrate.go
@@ -1,0 +1,22 @@
+package migrate
+
+import (
+	"fmt"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"gorm.io/gorm"
+)
+
+// AutoMigrate is the single development and preview-driver schema owner.
+// It deliberately does not stamp the versioned ledger: operators must validate
+// and baseline a database before changing to DB_AUTOMIGRATE=false.
+func AutoMigrate(db *gorm.DB, driver string, options storage.MigrateOptions) error {
+	if err := storage.AutoMigrateModelsWithOptions(db, driver, options); err != nil {
+		return err
+	}
+	if err := graphrag.AutoMigrateGraphRAG(db); err != nil {
+		return fmt.Errorf("migrate GraphRAG schema: %w", err)
+	}
+	return nil
+}

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -1,0 +1,341 @@
+package migrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"gorm.io/gorm"
+)
+
+func newSQLiteMigrationDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := storage.NewDatabase("sqlite", filepath.Join(t.TempDir(), "main.db"))
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("db.DB: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return db
+}
+
+func applySQLiteFixture(t *testing.T, db *gorm.DB, throughVersion int) {
+	t.Helper()
+	registry, err := registryFor("sqlite")
+	if err != nil {
+		t.Fatalf("registryFor: %v", err)
+	}
+	for _, entry := range registry[:throughVersion] {
+		for number, statement := range migrationStatements(entry.SQL) {
+			if err := db.Exec(statement).Error; err != nil {
+				t.Fatalf("fixture migration %d statement %d: %v", entry.Version, number+1, err)
+			}
+		}
+	}
+}
+
+func TestSQLiteUpEmptyAndIdempotent(t *testing.T) {
+	db := newSQLiteMigrationDB(t)
+	before, err := Inspect(context.Background(), db, "sqlite")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.State != StateEmpty || before.ExitCode() != ExitEmpty {
+		t.Fatalf("before = %#v", before)
+	}
+
+	first, err := Up(context.Background(), db, "sqlite")
+	if err != nil {
+		t.Fatalf("first Up: %v", err)
+	}
+	if first.State != StateExact || first.ActualVersion != CurrentVersion || len(first.Applied) != CurrentVersion {
+		t.Fatalf("first status = %#v", first)
+	}
+	second, err := Up(context.Background(), db, "sqlite")
+	if err != nil {
+		t.Fatalf("second Up: %v", err)
+	}
+	if second.Fingerprint != first.Fingerprint {
+		t.Fatalf("idempotent fingerprint changed: %s -> %s", first.Fingerprint, second.Fingerprint)
+	}
+	var ledgerRows int64
+	if err := db.Table(LedgerTable).Count(&ledgerRows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if ledgerRows != CurrentVersion {
+		t.Fatalf("ledger rows = %d, want %d", ledgerRows, CurrentVersion)
+	}
+}
+
+func TestSQLiteStableBaselineUpgradePreservesData(t *testing.T) {
+	db := newSQLiteMigrationDB(t)
+	applySQLiteFixture(t, db, 1)
+	if err := db.Exec(`INSERT INTO traces
+(tenant_id, trace_id, service_name, duration, status, timestamp, created_at, updated_at)
+VALUES ('default', 'trace-stable', 'checkout', 42, 'STATUS_CODE_ERROR', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`INSERT INTO investigations
+(tenant_id, id, created_at, status, severity, trigger_service)
+VALUES ('', 'inv-stable', CURRENT_TIMESTAMP, 'detected', 'warning', 'checkout')`).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`INSERT INTO drain_templates
+(tenant_id, id, tokens, count, first_seen, last_seen, sample)
+VALUES ('', 7, '["failed"]', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'failed')`).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	baseline, err := Baseline(context.Background(), db, "sqlite", "v0.3.1")
+	if err != nil {
+		t.Fatalf("Baseline: %v", err)
+	}
+	if baseline.Status.State != StateBehind || baseline.RecordedVersion != 1 {
+		t.Fatalf("baseline = %#v", baseline)
+	}
+	if baseline.BeforeFingerprint != baseline.AfterFingerprint {
+		t.Fatalf("baseline changed schema: %s -> %s", baseline.BeforeFingerprint, baseline.AfterFingerprint)
+	}
+
+	status, err := Up(context.Background(), db, "sqlite")
+	if err != nil {
+		t.Fatalf("Up: %v", err)
+	}
+	if status.State != StateExact {
+		t.Fatalf("status = %#v", status)
+	}
+	var traceCount, graphRows int64
+	if err := db.Table("traces").Where("trace_id = ?", "trace-stable").Count(&traceCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Table("investigations").Where("id = ? AND tenant_id = ?", "inv-stable", storage.DefaultTenantID).Count(&graphRows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if traceCount != 1 || graphRows != 1 {
+		t.Fatalf("preserved trace=%d graph_row=%d", traceCount, graphRows)
+	}
+	if !db.Migrator().HasColumn("traces", "truncated") || !db.Migrator().HasIndex("spans", "idx_spans_tenant_status_start") {
+		t.Fatal("upgrade did not add the current trace columns and span status index")
+	}
+}
+
+func TestSQLiteBetaBaselineIsProductSchemaNoOp(t *testing.T) {
+	db := newSQLiteMigrationDB(t)
+	applySQLiteFixture(t, db, CurrentVersion)
+	result, err := Baseline(context.Background(), db, "sqlite", "v0.4.0-beta.2")
+	if err != nil {
+		t.Fatalf("Baseline: %v", err)
+	}
+	if result.Status.State != StateExact || result.BeforeFingerprint != result.AfterFingerprint {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestSQLiteBaselineRejectsTheWrongPublishedRelease(t *testing.T) {
+	db := newSQLiteMigrationDB(t)
+	applySQLiteFixture(t, db, CurrentVersion)
+	result, err := Baseline(context.Background(), db, "sqlite", "v0.3.1")
+	var stateErr *StateError
+	if !errors.As(err, &stateErr) || result.Status.State != StateIncompatible || !strings.Contains(result.Status.Detail, "does not match frozen baseline") {
+		t.Fatalf("result=%#v err=%v", result, err)
+	}
+	if db.Migrator().HasTable(LedgerTable) {
+		t.Fatal("rejected baseline wrote a ledger")
+	}
+}
+
+func TestSQLiteStatusStatesAndExitCodes(t *testing.T) {
+	tests := []struct {
+		name     string
+		prepare  func(*testing.T, *gorm.DB)
+		state    State
+		exitCode int
+		detail   string
+	}{
+		{name: "empty", state: StateEmpty, exitCode: ExitEmpty, detail: "no OtelContext"},
+		{name: "unmanaged", prepare: func(t *testing.T, db *gorm.DB) {
+			applySQLiteFixture(t, db, 1)
+		}, state: StateUnmanaged, exitCode: ExitUnmanaged, detail: "without a migration ledger"},
+		{name: "behind", prepare: func(t *testing.T, db *gorm.DB) {
+			applySQLiteFixture(t, db, 1)
+			if _, err := Baseline(context.Background(), db, "sqlite", "v0.3.1"); err != nil {
+				t.Fatal(err)
+			}
+		}, state: StateBehind, exitCode: ExitBehind, detail: "behind"},
+		{name: "ahead", prepare: func(t *testing.T, db *gorm.DB) {
+			if _, err := Up(context.Background(), db, "sqlite"); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.Exec(`INSERT INTO otelcontext_schema_migrations
+(version,name,checksum,started_at,completed_at,dirty)
+VALUES (3,'future',?,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,0)`, strings.Repeat("a", 64)).Error; err != nil {
+				t.Fatal(err)
+			}
+		}, state: StateAhead, exitCode: ExitAhead, detail: "ahead"},
+		{name: "dirty", prepare: func(t *testing.T, db *gorm.DB) {
+			if _, err := Up(context.Background(), db, "sqlite"); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.Exec(`UPDATE otelcontext_schema_migrations SET dirty=1, completed_at=NULL WHERE version=2`).Error; err != nil {
+				t.Fatal(err)
+			}
+		}, state: StateDirty, exitCode: ExitDirty, detail: "incomplete"},
+		{name: "checksum", prepare: func(t *testing.T, db *gorm.DB) {
+			if _, err := Up(context.Background(), db, "sqlite"); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.Exec(`UPDATE otelcontext_schema_migrations SET checksum=? WHERE version=2`, strings.Repeat("b", 64)).Error; err != nil {
+				t.Fatal(err)
+			}
+		}, state: StateIncompatible, exitCode: ExitIncompatible, detail: "checksum mismatch"},
+		{name: "structure", prepare: func(t *testing.T, db *gorm.DB) {
+			if _, err := Up(context.Background(), db, "sqlite"); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.Exec(`DROP INDEX idx_spans_tenant_status_start`).Error; err != nil {
+				t.Fatal(err)
+			}
+		}, state: StateIncompatible, exitCode: ExitIncompatible, detail: "missing index"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db := newSQLiteMigrationDB(t)
+			if test.prepare != nil {
+				test.prepare(t, db)
+			}
+			first, err := Inspect(context.Background(), db, "sqlite")
+			if err != nil {
+				t.Fatal(err)
+			}
+			second, err := Inspect(context.Background(), db, "sqlite")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if first.State != test.state || first.ExitCode() != test.exitCode || !strings.Contains(first.Detail, test.detail) {
+				t.Fatalf("status = %#v", first)
+			}
+			if first.Description() != second.Description() {
+				t.Fatalf("nondeterministic status:\n%s\n%s", first.Description(), second.Description())
+			}
+		})
+	}
+}
+
+func TestSQLiteFailedMigrationRollsBackAndCanRerun(t *testing.T) {
+	db := newSQLiteMigrationDB(t)
+	registry, err := registryFor("sqlite")
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry[1].SQL += "\n-- migrate:split\nCREATE TABLE migration_probe (id integer)\n-- migrate:split\nTHIS IS NOT SQL"
+	r := &runner{registry: registry}
+	if applied, err := r.applyNext(context.Background(), db, "sqlite"); err != nil || !applied {
+		t.Fatalf("apply v1: applied=%t err=%v", applied, err)
+	}
+	if _, err := r.applyNext(context.Background(), db, "sqlite"); err == nil {
+		t.Fatal("broken v2 unexpectedly succeeded")
+	}
+	if db.Migrator().HasTable("migration_probe") {
+		t.Fatal("failed transactional migration left migration_probe behind")
+	}
+	var rows int64
+	if err := db.Table(LedgerTable).Count(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if rows != 1 {
+		t.Fatalf("ledger rows after rollback = %d, want 1", rows)
+	}
+	status, err := Up(context.Background(), db, "sqlite")
+	if err != nil || status.State != StateExact {
+		t.Fatalf("rerun status=%#v err=%v", status, err)
+	}
+}
+
+func TestSQLiteConcurrentUpUsesOneOrderedLedger(t *testing.T) {
+	db := newSQLiteMigrationDB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	const callers = 4
+	var wg sync.WaitGroup
+	errs := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			status, err := Up(ctx, db, "sqlite")
+			if err != nil {
+				errs <- err
+				return
+			}
+			if status.State != StateExact {
+				errs <- fmt.Errorf("state=%s", status.State)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	var rows int64
+	if err := db.Table(LedgerTable).Count(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if rows != CurrentVersion {
+		t.Fatalf("ledger rows = %d", rows)
+	}
+}
+
+func TestSQLiteVersionedInstallMatchesSharedAutoMigrateContract(t *testing.T) {
+	versioned := newSQLiteMigrationDB(t)
+	if _, err := Up(context.Background(), versioned, "sqlite"); err != nil {
+		t.Fatal(err)
+	}
+	versionedFingerprint, err := SchemaFingerprint(context.Background(), versioned, "sqlite", CurrentVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	automigrated := newSQLiteMigrationDB(t)
+	if err := AutoMigrate(automigrated, "sqlite", storage.MigrateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if automigrated.Migrator().HasTable(LedgerTable) {
+		t.Fatal("development AutoMigrate must not claim a versioned ledger")
+	}
+	autoFingerprint, err := SchemaFingerprint(context.Background(), automigrated, "sqlite", CurrentVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if versionedFingerprint != autoFingerprint {
+		t.Fatalf("schema parity mismatch: versioned=%s automigrate=%s", versionedFingerprint, autoFingerprint)
+	}
+}
+
+func TestRegistryAndPreviewDriverContracts(t *testing.T) {
+	registry, err := registryFor("sqlite")
+	if err != nil {
+		t.Fatal(err)
+	}
+	broken := append([]migration(nil), registry...)
+	broken[1].Version = 1
+	if err := validateRegistry(broken); err == nil {
+		t.Fatal("duplicate/gapped registry accepted")
+	}
+	status, err := Inspect(context.Background(), nil, "mysql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.State != StateUnverified || status.ExitCode() != ExitUnverified || !strings.Contains(status.Detail, "DB_AUTOMIGRATE=true") {
+		t.Fatalf("preview status = %#v", status)
+	}
+}

--- a/internal/migrate/postgres_integration_test.go
+++ b/internal/migrate/postgres_integration_test.go
@@ -1,0 +1,222 @@
+//go:build integration
+
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"gorm.io/gorm"
+)
+
+func startMigrationPostgres16(t *testing.T) (string, *gorm.DB) {
+	t.Helper()
+	ctx := context.Background()
+	container, err := postgres.Run(ctx, "postgres:16-alpine",
+		postgres.WithDatabase("otel_migrate"),
+		postgres.WithUsername("otel"),
+		postgres.WithPassword("otel"),
+		postgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		t.Fatalf("start PostgreSQL 16: %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+	dsn, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	admin, err := storage.NewDatabase("postgres", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sqlDB, err := admin.DB(); err == nil {
+		t.Cleanup(func() { _ = sqlDB.Close() })
+	}
+	return dsn, admin
+}
+
+func newPostgresMigrationDB(t *testing.T, baseDSN string, admin *gorm.DB, sequence *atomic.Int64) *gorm.DB {
+	t.Helper()
+	schema := fmt.Sprintf("migration_case_%d", sequence.Add(1))
+	if err := admin.Exec("CREATE SCHEMA " + schema).Error; err != nil { //nolint:gosec // generated identifier
+		t.Fatal(err)
+	}
+	separator := "?"
+	if strings.Contains(baseDSN, "?") {
+		separator = "&"
+	}
+	db, err := storage.NewDatabase("postgres", baseDSN+separator+"search_path="+schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sqlDB, err := db.DB(); err == nil {
+		t.Cleanup(func() { _ = sqlDB.Close() })
+	}
+	return db
+}
+
+func applyPostgresFixture(t *testing.T, db *gorm.DB, throughVersion int) {
+	t.Helper()
+	registry, err := registryFor("postgres")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range registry[:throughVersion] {
+		for number, statement := range migrationStatements(entry.SQL) {
+			if err := db.Exec(statement).Error; err != nil {
+				t.Fatalf("fixture migration %d statement %d: %v", entry.Version, number+1, err)
+			}
+		}
+	}
+}
+
+func TestPostgres16MigrationLifecycle(t *testing.T) {
+	baseDSN, admin := startMigrationPostgres16(t)
+	var sequence atomic.Int64
+	t.Run("empty install and idempotent rerun", func(t *testing.T) {
+		db := newPostgresMigrationDB(t, baseDSN, admin, &sequence)
+		first, err := Up(context.Background(), db, "postgres")
+		if err != nil {
+			t.Fatal(err)
+		}
+		second, err := Up(context.Background(), db, "postgres")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if first.State != StateExact || second.State != StateExact || first.Fingerprint != second.Fingerprint {
+			t.Fatalf("first=%#v second=%#v", first, second)
+		}
+	})
+
+	t.Run("stable baseline upgrade preserves main and GraphRAG rows", func(t *testing.T) {
+		db := newPostgresMigrationDB(t, baseDSN, admin, &sequence)
+		applyPostgresFixture(t, db, 1)
+		if err := db.Exec(`INSERT INTO traces
+(tenant_id,trace_id,service_name,duration,status,timestamp,created_at,updated_at)
+VALUES ('default','pg-stable','checkout',42,'STATUS_CODE_ERROR',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)`).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Exec(`INSERT INTO investigations
+(tenant_id,id,created_at,status,severity,trigger_service)
+VALUES ('','pg-inv',CURRENT_TIMESTAMP,'detected','warning','checkout')`).Error; err != nil {
+			t.Fatal(err)
+		}
+		baseline, err := Baseline(context.Background(), db, "postgres", "v0.3.1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if baseline.Status.State != StateBehind || baseline.BeforeFingerprint != baseline.AfterFingerprint {
+			t.Fatalf("baseline=%#v", baseline)
+		}
+		status, err := Up(context.Background(), db, "postgres")
+		if err != nil || status.State != StateExact {
+			t.Fatalf("status=%#v err=%v", status, err)
+		}
+		var traces, investigations int64
+		if err := db.Table("traces").Where("trace_id = ?", "pg-stable").Count(&traces).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Table("investigations").Where("id = ? AND tenant_id = ?", "pg-inv", storage.DefaultTenantID).Count(&investigations).Error; err != nil {
+			t.Fatal(err)
+		}
+		if traces != 1 || investigations != 1 {
+			t.Fatalf("preserved traces=%d investigations=%d", traces, investigations)
+		}
+	})
+
+	t.Run("prerelease baseline is metadata-only", func(t *testing.T) {
+		db := newPostgresMigrationDB(t, baseDSN, admin, &sequence)
+		applyPostgresFixture(t, db, CurrentVersion)
+		result, err := Baseline(context.Background(), db, "postgres", "v0.4.0-beta.2")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Status.State != StateExact || result.BeforeFingerprint != result.AfterFingerprint {
+			t.Fatalf("result=%#v", result)
+		}
+	})
+
+	t.Run("failed transaction rolls back and default registry reruns", func(t *testing.T) {
+		db := newPostgresMigrationDB(t, baseDSN, admin, &sequence)
+		registry, err := registryFor("postgres")
+		if err != nil {
+			t.Fatal(err)
+		}
+		registry[1].SQL += "\n-- migrate:split\nCREATE TABLE migration_probe (id bigint)\n-- migrate:split\nTHIS IS NOT SQL"
+		r := &runner{registry: registry}
+		if applied, err := r.applyNext(context.Background(), db, "postgres"); err != nil || !applied {
+			t.Fatalf("v1 applied=%t err=%v", applied, err)
+		}
+		if _, err := r.applyNext(context.Background(), db, "postgres"); err == nil {
+			t.Fatal("broken v2 unexpectedly succeeded")
+		}
+		if db.Migrator().HasTable("migration_probe") {
+			t.Fatal("failed transaction left migration_probe")
+		}
+		status, err := Up(context.Background(), db, "postgres")
+		if err != nil || status.State != StateExact {
+			t.Fatalf("status=%#v err=%v", status, err)
+		}
+	})
+
+	t.Run("advisory lock serializes concurrent runners", func(t *testing.T) {
+		db := newPostgresMigrationDB(t, baseDSN, admin, &sequence)
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		const callers = 4
+		var wg sync.WaitGroup
+		errs := make(chan error, callers)
+		for i := 0; i < callers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				status, err := Up(ctx, db, "postgres")
+				if err != nil {
+					errs <- err
+					return
+				}
+				if status.State != StateExact {
+					errs <- fmt.Errorf("state=%s", status.State)
+				}
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			t.Error(err)
+		}
+	})
+
+	t.Run("versioned and shared AutoMigrate structures agree", func(t *testing.T) {
+		versioned := newPostgresMigrationDB(t, baseDSN, admin, &sequence)
+		if _, err := Up(context.Background(), versioned, "postgres"); err != nil {
+			t.Fatal(err)
+		}
+		versionedFingerprint, err := SchemaFingerprint(context.Background(), versioned, "postgres", CurrentVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
+		auto := newPostgresMigrationDB(t, baseDSN, admin, &sequence)
+		if err := AutoMigrate(auto, "postgres", storage.MigrateOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		autoFingerprint, err := SchemaFingerprint(context.Background(), auto, "postgres", CurrentVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if versionedFingerprint != autoFingerprint {
+			versionedLines, _ := schemaFingerprintLines(context.Background(), versioned, "postgres", CurrentVersion)
+			autoLines, _ := schemaFingerprintLines(context.Background(), auto, "postgres", CurrentVersion)
+			t.Fatalf("schema parity mismatch: versioned=%s automigrate=%s\nversioned:\n%s\nautomigrate:\n%s",
+				versionedFingerprint, autoFingerprint, strings.Join(versionedLines, "\n"), strings.Join(autoLines, "\n"))
+		}
+	})
+}

--- a/internal/migrate/registry.go
+++ b/internal/migrate/registry.go
@@ -1,0 +1,123 @@
+// Package migrate owns OtelContext's ordered main-database schema contract.
+package migrate
+
+import (
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+const (
+	// LedgerTable is shared by main storage and GraphRAG migrations.
+	LedgerTable = "otelcontext_schema_migrations"
+	// CurrentVersion is the exact relational schema version required by this binary.
+	CurrentVersion = 2
+)
+
+//go:embed sql/*/*.sql
+var migrationSQL embed.FS
+
+type migration struct {
+	Version       int
+	Name          string
+	Transactional bool
+	SQL           string
+	Checksum      string
+}
+
+func registryFor(driver string) ([]migration, error) {
+	driver = NormalizeDriver(driver)
+	if !SupportsVersioned(driver) {
+		return nil, fmt.Errorf("versioned migrations are not verified for driver %q", driver)
+	}
+	definitions := []struct {
+		version int
+		name    string
+		file    string
+	}{
+		{1, "v0.3.1", "001_v0_3_1.sql"},
+		{2, "v0.4.0-beta.2", "002_v0_4_0_beta_2.sql"},
+	}
+	registry := make([]migration, 0, len(definitions))
+	for _, definition := range definitions {
+		path := fmt.Sprintf("sql/%s/%s", driver, definition.file)
+		content, err := migrationSQL.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read embedded migration %s: %w", path, err)
+		}
+		sum := sha256.Sum256(content)
+		registry = append(registry, migration{
+			Version:       definition.version,
+			Name:          definition.name,
+			Transactional: true,
+			SQL:           strings.TrimSpace(string(content)),
+			Checksum:      hex.EncodeToString(sum[:]),
+		})
+	}
+	if err := validateRegistry(registry); err != nil {
+		return nil, err
+	}
+	return registry, nil
+}
+
+func validateRegistry(registry []migration) error {
+	if len(registry) != CurrentVersion {
+		return fmt.Errorf("migration registry has %d entries, expected %d", len(registry), CurrentVersion)
+	}
+	seen := make(map[int]struct{}, len(registry))
+	for i, entry := range registry {
+		want := i + 1
+		if entry.Version != want {
+			return fmt.Errorf("migration registry gap: entry %d has version %d", want, entry.Version)
+		}
+		if _, duplicate := seen[entry.Version]; duplicate {
+			return fmt.Errorf("duplicate migration version %d", entry.Version)
+		}
+		seen[entry.Version] = struct{}{}
+		if strings.TrimSpace(entry.Name) == "" || strings.TrimSpace(entry.SQL) == "" || len(entry.Checksum) != 64 {
+			return fmt.Errorf("migration version %d has incomplete metadata", entry.Version)
+		}
+		if !entry.Transactional {
+			return fmt.Errorf("migration version %d is non-transactional without a resume implementation", entry.Version)
+		}
+	}
+	return nil
+}
+
+func migrationStatements(sqlText string) []string {
+	parts := strings.Split(sqlText, "-- migrate:split")
+	statements := make([]string, 0, len(parts))
+	for _, part := range parts {
+		statement := strings.TrimSpace(part)
+		if statement != "" {
+			statements = append(statements, statement)
+		}
+	}
+	return statements
+}
+
+// NormalizeDriver returns the canonical driver name used by the registry.
+func NormalizeDriver(driver string) string {
+	switch strings.ToLower(strings.TrimSpace(driver)) {
+	case "", "sqlite":
+		return "sqlite"
+	case "postgres", "postgresql":
+		return "postgres"
+	case "mssql", "sqlserver":
+		return "sqlserver"
+	default:
+		return strings.ToLower(strings.TrimSpace(driver))
+	}
+}
+
+// SupportsVersioned reports whether this driver has promoted migration definitions.
+func SupportsVersioned(driver string) bool {
+	switch NormalizeDriver(driver) {
+	case "sqlite", "postgres":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/migrate/runner.go
+++ b/internal/migrate/runner.go
@@ -1,0 +1,423 @@
+package migrate
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const postgresAdvisoryLockKey int64 = 5716286928489378676 // "OTELMIGT"
+
+// StateError carries the read-only status that made an operation fail closed.
+type StateError struct {
+	Operation string
+	Status    Status
+}
+
+func (e *StateError) Error() string {
+	action := "run `otelcontext migrate status` and inspect the reported schema"
+	switch e.Status.State {
+	case StateEmpty, StateBehind:
+		action = "run `otelcontext migrate up`"
+	case StateUnmanaged:
+		action = "run `otelcontext migrate baseline --from v0.3.1` or `--from v0.4.0-beta.2` after matching the source release"
+	case StateAhead:
+		action = "run the newer signed binary that owns this schema or restore the pre-migration backup"
+	case StateDirty:
+		action = "restore the pre-migration backup or resolve the recorded dirty migration before retrying"
+	}
+	return fmt.Sprintf("%s refused: main schema state=%s expected=%d actual=%d: %s; %s",
+		e.Operation, e.Status.State, e.Status.ExpectedVersion, e.Status.ActualVersion, e.Status.Detail, action)
+}
+
+// RequireExact performs the production startup compatibility gate.
+func RequireExact(ctx context.Context, db *gorm.DB, driver string) (Status, error) {
+	status, err := Inspect(ctx, db, driver)
+	if err != nil {
+		return status, err
+	}
+	if !status.Usable() {
+		return status, &StateError{Operation: "startup", Status: status}
+	}
+	return status, nil
+}
+
+// BaselineResult records the no-repair bridge from a published release.
+type BaselineResult struct {
+	Release           string
+	RecordedVersion   int
+	BeforeFingerprint string
+	AfterFingerprint  string
+	Status            Status
+}
+
+type runner struct {
+	registry []migration
+}
+
+func newRunner(driver string) (*runner, error) {
+	registry, err := registryFor(driver)
+	if err != nil {
+		return nil, err
+	}
+	return &runner{registry: registry}, nil
+}
+
+// Up installs an empty supported database or applies every pending migration.
+func Up(ctx context.Context, db *gorm.DB, driver string) (Status, error) {
+	driver = NormalizeDriver(driver)
+	if !SupportsVersioned(driver) {
+		status, _ := Inspect(ctx, db, driver)
+		return status, &StateError{Operation: "migrate up", Status: status}
+	}
+	r, err := newRunner(driver)
+	if err != nil {
+		return Status{}, err
+	}
+	return r.up(ctx, db, driver)
+}
+
+func (r *runner) up(ctx context.Context, db *gorm.DB, driver string) (Status, error) {
+	status, err := Inspect(ctx, db, driver)
+	if err != nil {
+		return status, err
+	}
+	switch status.State {
+	case StateExact:
+		return status, nil
+	case StateEmpty, StateBehind:
+		// Continue below.
+	default:
+		return status, &StateError{Operation: "migrate up", Status: status}
+	}
+	for {
+		applied, err := r.applyNext(ctx, db, driver)
+		if err != nil {
+			return status, err
+		}
+		status, err = Inspect(ctx, db, driver)
+		if err != nil {
+			return status, err
+		}
+		if status.State == StateExact {
+			return status, nil
+		}
+		if status.State != StateBehind || !applied {
+			return status, &StateError{Operation: "migrate up", Status: status}
+		}
+	}
+}
+
+func (r *runner) applyNext(ctx context.Context, db *gorm.DB, driver string) (bool, error) {
+	sqlDB, err := db.DB()
+	if err != nil {
+		return false, fmt.Errorf("open migration connection: %w", err)
+	}
+	applied := false
+	err = withLockedTransaction(ctx, sqlDB, driver, func(tx sqlExecutor) error {
+		if err := ensureLedger(ctx, tx, driver); err != nil {
+			return err
+		}
+		rows, err := loadRawLedger(ctx, tx)
+		if err != nil {
+			return err
+		}
+		actual, err := validateRawLedger(rows, r.registry)
+		if err != nil {
+			return err
+		}
+		if actual >= len(r.registry) {
+			return nil
+		}
+		if actual == 0 {
+			count, err := countOwnedTables(ctx, tx, driver)
+			if err != nil {
+				return err
+			}
+			if count != 0 {
+				return errors.New("migrate up refused: non-empty database has no migration ledger; run migrate baseline")
+			}
+		}
+		entry := r.registry[actual]
+		for number, statement := range migrationStatements(entry.SQL) {
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				return fmt.Errorf("migration %d (%s) statement %d: %w", entry.Version, entry.Name, number+1, err)
+			}
+		}
+		now := time.Now().UTC()
+		if err := insertLedgerRow(ctx, tx, driver, entry, now); err != nil {
+			return err
+		}
+		applied = true
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return applied, nil
+}
+
+// Baseline validates a frozen released structure and records it without repair.
+func Baseline(ctx context.Context, db *gorm.DB, driver, release string) (BaselineResult, error) {
+	driver = NormalizeDriver(driver)
+	result := BaselineResult{Release: release}
+	if !SupportsVersioned(driver) {
+		status, _ := Inspect(ctx, db, driver)
+		result.Status = status
+		return result, &StateError{Operation: "migrate baseline", Status: status}
+	}
+	baselineVersion := 0
+	switch release {
+	case "v0.3.1":
+		baselineVersion = 1
+	case "v0.4.0-beta.2":
+		baselineVersion = 2
+	default:
+		return result, fmt.Errorf("unsupported baseline %q; supported releases are v0.3.1 and v0.4.0-beta.2", release)
+	}
+	status, err := Inspect(ctx, db, driver)
+	if err != nil {
+		return result, err
+	}
+	if status.State != StateUnmanaged {
+		result.Status = status
+		return result, &StateError{Operation: "migrate baseline", Status: status}
+	}
+	if err := validateSchema(ctx, db, driver, baselineVersion); err != nil {
+		status.State = StateIncompatible
+		status.Detail = fmt.Sprintf("database does not match frozen baseline %s: %v", release, err)
+		result.Status = status
+		return result, &StateError{Operation: "migrate baseline", Status: status}
+	}
+	result.BeforeFingerprint, err = SchemaFingerprint(ctx, db, driver, baselineVersion)
+	if err != nil {
+		return result, err
+	}
+	r, err := newRunner(driver)
+	if err != nil {
+		return result, err
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		return result, err
+	}
+	err = withLockedTransaction(ctx, sqlDB, driver, func(tx sqlExecutor) error {
+		if err := ensureLedger(ctx, tx, driver); err != nil {
+			return err
+		}
+		rows, err := loadRawLedger(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if len(rows) != 0 {
+			return errors.New("migrate baseline refused: migration ledger appeared while waiting for the lock")
+		}
+		count, err := countOwnedTables(ctx, tx, driver)
+		if err != nil {
+			return err
+		}
+		if count != len(ownedTableNames) {
+			return fmt.Errorf("migrate baseline refused: found %d of %d required tables after locking", count, len(ownedTableNames))
+		}
+		now := time.Now().UTC()
+		for _, entry := range r.registry[:baselineVersion] {
+			if err := insertLedgerRow(ctx, tx, driver, entry, now); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return result, err
+	}
+	result.RecordedVersion = baselineVersion
+	result.AfterFingerprint, err = SchemaFingerprint(ctx, db, driver, baselineVersion)
+	if err != nil {
+		return result, err
+	}
+	if result.BeforeFingerprint != result.AfterFingerprint {
+		return result, errors.New("baseline changed the product schema fingerprint; ledger transaction was not metadata-only")
+	}
+	result.Status, err = Inspect(ctx, db, driver)
+	return result, err
+}
+
+type sqlExecutor interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func withLockedTransaction(ctx context.Context, db *sql.DB, driver string, fn func(sqlExecutor) error) error {
+	switch NormalizeDriver(driver) {
+	case "sqlite":
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			return fmt.Errorf("acquire sqlite migration connection: %w", err)
+		}
+		defer func() { _ = conn.Close() }()
+		if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+			return fmt.Errorf("begin sqlite immediate migration: %w", err)
+		}
+		committed := false
+		defer func() {
+			if !committed {
+				_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+			}
+		}()
+		if err := fn(conn); err != nil {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+			return fmt.Errorf("commit sqlite migration: %w", err)
+		}
+		committed = true
+		return nil
+	case "postgres":
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin postgres migration: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+		if _, err := tx.ExecContext(ctx, "SELECT pg_advisory_xact_lock($1)", postgresAdvisoryLockKey); err != nil {
+			return fmt.Errorf("acquire postgres migration lock: %w", err)
+		}
+		if err := fn(tx); err != nil {
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit postgres migration: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("transactional migrations are unverified for driver %q", driver)
+	}
+}
+
+func ensureLedger(ctx context.Context, tx sqlExecutor, driver string) error {
+	var statement string
+	if NormalizeDriver(driver) == "postgres" {
+		statement = `CREATE TABLE IF NOT EXISTS otelcontext_schema_migrations (
+version bigint PRIMARY KEY,
+name varchar(128) NOT NULL,
+checksum char(64) NOT NULL,
+started_at timestamptz NOT NULL,
+completed_at timestamptz,
+dirty boolean NOT NULL
+)`
+	} else {
+		statement = `CREATE TABLE IF NOT EXISTS otelcontext_schema_migrations (
+version integer PRIMARY KEY,
+name text NOT NULL,
+checksum text NOT NULL,
+started_at datetime NOT NULL,
+completed_at datetime,
+dirty numeric NOT NULL
+)`
+	}
+	if _, err := tx.ExecContext(ctx, statement); err != nil {
+		return fmt.Errorf("create migration ledger: %w", err)
+	}
+	return nil
+}
+
+type rawLedgerRow struct {
+	version    int
+	name       string
+	checksum   string
+	dirty      bool
+	incomplete bool
+}
+
+func loadRawLedger(ctx context.Context, tx sqlExecutor) ([]rawLedgerRow, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT version, name, checksum, dirty, completed_at IS NULL
+FROM otelcontext_schema_migrations ORDER BY version ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("read migration ledger under lock: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var result []rawLedgerRow
+	for rows.Next() {
+		var row rawLedgerRow
+		if err := rows.Scan(&row.version, &row.name, &row.checksum, &row.dirty, &row.incomplete); err != nil {
+			return nil, fmt.Errorf("scan migration ledger under lock: %w", err)
+		}
+		result = append(result, row)
+	}
+	return result, rows.Err()
+}
+
+func validateRawLedger(rows []rawLedgerRow, registry []migration) (int, error) {
+	if len(rows) > len(registry) {
+		return 0, fmt.Errorf("migration ledger is ahead: %d entries, binary knows %d", len(rows), len(registry))
+	}
+	for i, row := range rows {
+		want := registry[i]
+		if row.version != i+1 || row.version != want.Version {
+			return 0, fmt.Errorf("migration ledger gap at version %d", i+1)
+		}
+		if row.dirty || row.incomplete {
+			return 0, fmt.Errorf("migration %d is dirty or incomplete", row.version)
+		}
+		if row.name != want.Name || row.checksum != want.Checksum {
+			return 0, fmt.Errorf("migration %d metadata does not match the embedded registry", row.version)
+		}
+	}
+	return len(rows), nil
+}
+
+func countOwnedTables(ctx context.Context, tx sqlExecutor, driver string) (int, error) {
+	var count int
+	var err error
+	if NormalizeDriver(driver) == "postgres" {
+		err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM information_schema.tables
+WHERE table_schema = current_schema()
+AND table_name IN ('traces','spans','metric_buckets','logs','investigations','drain_templates')`).Scan(&count)
+	} else {
+		err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master
+WHERE type = 'table'
+AND name IN ('traces','spans','metric_buckets','logs','investigations','drain_templates')`).Scan(&count)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("count OtelContext tables: %w", err)
+	}
+	return count, nil
+}
+
+func insertLedgerRow(ctx context.Context, tx sqlExecutor, driver string, entry migration, now time.Time) error {
+	statement := `INSERT INTO otelcontext_schema_migrations
+(version, name, checksum, started_at, completed_at, dirty) VALUES (?, ?, ?, ?, ?, ?)`
+	if NormalizeDriver(driver) == "postgres" {
+		statement = `INSERT INTO otelcontext_schema_migrations
+(version, name, checksum, started_at, completed_at, dirty) VALUES ($1, $2, $3, $4, $5, $6)`
+	}
+	if _, err := tx.ExecContext(ctx, statement, entry.Version, entry.Name, entry.Checksum, now, now, false); err != nil {
+		return fmt.Errorf("record migration %d (%s): %w", entry.Version, entry.Name, err)
+	}
+	return nil
+}
+
+// Description returns a compact stable line for logs and command output.
+func (s Status) Description() string {
+	actual := fmt.Sprint(s.ActualVersion)
+	if s.ActualVersion == 0 {
+		actual = "none"
+	}
+	parts := []string{
+		"state=" + string(s.State),
+		fmt.Sprintf("expected=%d", s.ExpectedVersion),
+		"actual=" + actual,
+	}
+	if s.Fingerprint != "" {
+		parts = append(parts, "fingerprint="+s.Fingerprint)
+	}
+	if s.Detail != "" {
+		parts = append(parts, "detail="+fmt.Sprintf("%q", s.Detail))
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/migrate/sql/postgres/001_v0_3_1.sql
+++ b/internal/migrate/sql/postgres/001_v0_3_1.sql
@@ -1,0 +1,129 @@
+CREATE TABLE IF NOT EXISTS traces (
+    id bigserial PRIMARY KEY,
+    tenant_id varchar(64) NOT NULL DEFAULT 'default',
+    trace_id varchar(32) NOT NULL,
+    service_name varchar(255),
+    duration bigint,
+    status varchar(50),
+    timestamp timestamptz,
+    created_at timestamptz,
+    updated_at timestamptz,
+    deleted_at timestamptz
+)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_traces_deleted_at ON traces (deleted_at)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_traces_timestamp ON traces (timestamp)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_traces_duration ON traces (duration)
+-- migrate:split
+CREATE UNIQUE INDEX IF NOT EXISTS idx_traces_tenant_trace_id ON traces (tenant_id, trace_id)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_traces_tenant_service ON traces (tenant_id, service_name)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_traces_tenant_ts ON traces (tenant_id, timestamp)
+-- migrate:split
+CREATE TABLE IF NOT EXISTS spans (
+    id bigserial PRIMARY KEY,
+    tenant_id varchar(64) NOT NULL DEFAULT 'default',
+    trace_id varchar(32) NOT NULL,
+    span_id varchar(16) NOT NULL,
+    parent_span_id varchar(16),
+    operation_name varchar(255),
+    start_time timestamptz,
+    end_time timestamptz,
+    duration bigint,
+    service_name varchar(255),
+    status varchar(50) DEFAULT 'STATUS_CODE_UNSET',
+    attributes_json bytea
+)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_spans_status ON spans (status)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_spans_operation_name ON spans (operation_name)
+-- migrate:split
+CREATE UNIQUE INDEX IF NOT EXISTS idx_spans_tenant_trace_span ON spans (tenant_id, trace_id, span_id)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_spans_tenant_service_start ON spans (tenant_id, service_name, start_time)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_spans_tenant_trace ON spans (tenant_id, trace_id)
+-- migrate:split
+CREATE TABLE IF NOT EXISTS metric_buckets (
+    id bigserial PRIMARY KEY,
+    tenant_id varchar(64) NOT NULL DEFAULT 'default',
+    name varchar(255) NOT NULL,
+    service_name varchar(255) NOT NULL,
+    time_bucket timestamptz NOT NULL,
+    min numeric,
+    max numeric,
+    sum numeric,
+    count bigint,
+    attributes_json bytea
+)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_metric_buckets_time_bucket ON metric_buckets (time_bucket)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_metrics_tenant_service_bucket ON metric_buckets (tenant_id, service_name, time_bucket)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_metrics_tenant_name_bucket ON metric_buckets (tenant_id, name, time_bucket)
+-- migrate:split
+CREATE TABLE IF NOT EXISTS logs (
+    id bigserial PRIMARY KEY,
+    tenant_id varchar(64) NOT NULL DEFAULT 'default',
+    trace_id varchar(32),
+    span_id varchar(16),
+    severity varchar(50),
+    body text,
+    service_name varchar(255),
+    attributes_json bytea,
+    ai_insight bytea,
+    timestamp timestamptz
+)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_logs_timestamp ON logs (timestamp)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_logs_trace_id ON logs (trace_id)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_logs_tenant_severity ON logs (tenant_id, severity)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_logs_tenant_service ON logs (tenant_id, service_name)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_logs_tenant_ts ON logs (tenant_id, timestamp)
+-- migrate:split
+CREATE TABLE IF NOT EXISTS investigations (
+    tenant_id varchar(64) NOT NULL DEFAULT 'default',
+    id varchar(64) PRIMARY KEY,
+    created_at timestamptz,
+    status varchar(20),
+    severity varchar(20),
+    trigger_service varchar(255),
+    trigger_operation varchar(255),
+    error_message text,
+    root_service varchar(255),
+    root_operation varchar(255),
+    causal_chain text,
+    trace_ids text,
+    error_logs text,
+    anomalous_metrics text,
+    affected_services text,
+    span_chain text
+)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_investigations_trigger_service ON investigations (trigger_service)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_investigations_tenant_created ON investigations (tenant_id, created_at)
+-- migrate:split
+CREATE TABLE IF NOT EXISTS drain_templates (
+    tenant_id varchar(64) NOT NULL DEFAULT 'default',
+    id bigint NOT NULL,
+    tokens text NOT NULL,
+    count bigint,
+    first_seen timestamptz,
+    last_seen timestamptz,
+    sample text,
+    PRIMARY KEY (tenant_id, id)
+)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_drain_templates_last_seen ON drain_templates (last_seen)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_drain_templates_first_seen ON drain_templates (first_seen)

--- a/internal/migrate/sql/postgres/002_v0_4_0_beta_2.sql
+++ b/internal/migrate/sql/postgres/002_v0_4_0_beta_2.sql
@@ -1,0 +1,17 @@
+ALTER TABLE traces ADD COLUMN IF NOT EXISTS truncated boolean
+-- migrate:split
+ALTER TABLE traces ADD COLUMN IF NOT EXISTS retained_span_count bigint
+-- migrate:split
+ALTER TABLE traces ADD COLUMN IF NOT EXISTS observed_span_count bigint
+-- migrate:split
+DROP INDEX IF EXISTS idx_spans_status
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_spans_tenant_status_start ON spans (tenant_id, status, start_time)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_spans_start_time_brin ON spans USING BRIN (start_time)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_traces_timestamp_brin ON traces USING BRIN (timestamp)
+-- migrate:split
+UPDATE investigations SET tenant_id = 'default' WHERE tenant_id IS NULL OR tenant_id = ''
+-- migrate:split
+UPDATE drain_templates SET tenant_id = 'default' WHERE tenant_id IS NULL OR tenant_id = ''

--- a/internal/migrate/sql/sqlite/001_v0_3_1.sql
+++ b/internal/migrate/sql/sqlite/001_v0_3_1.sql
@@ -1,0 +1,129 @@
+CREATE TABLE IF NOT EXISTS traces (
+    id integer PRIMARY KEY AUTOINCREMENT,
+    tenant_id text NOT NULL DEFAULT 'default',
+    trace_id text NOT NULL,
+    service_name text,
+    duration integer,
+    status text,
+    timestamp datetime,
+    created_at datetime,
+    updated_at datetime,
+    deleted_at datetime
+)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_traces_deleted_at ON traces (deleted_at)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_traces_timestamp ON traces (timestamp)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_traces_duration ON traces (duration)
+-- migrate:split
+CREATE UNIQUE INDEX IF NOT EXISTS idx_traces_tenant_trace_id ON traces (tenant_id, trace_id)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_traces_tenant_service ON traces (tenant_id, service_name)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_traces_tenant_ts ON traces (tenant_id, timestamp)
+-- migrate:split
+CREATE TABLE IF NOT EXISTS spans (
+    id integer PRIMARY KEY AUTOINCREMENT,
+    tenant_id text NOT NULL DEFAULT 'default',
+    trace_id text NOT NULL,
+    span_id text NOT NULL,
+    parent_span_id text,
+    operation_name text,
+    start_time datetime,
+    end_time datetime,
+    duration integer,
+    service_name text,
+    status text DEFAULT 'STATUS_CODE_UNSET',
+    attributes_json blob
+)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_spans_status ON spans (status)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_spans_operation_name ON spans (operation_name)
+-- migrate:split
+CREATE UNIQUE INDEX IF NOT EXISTS idx_spans_tenant_trace_span ON spans (tenant_id, trace_id, span_id)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_spans_tenant_service_start ON spans (tenant_id, service_name, start_time)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_spans_tenant_trace ON spans (tenant_id, trace_id)
+-- migrate:split
+CREATE TABLE IF NOT EXISTS metric_buckets (
+    id integer PRIMARY KEY AUTOINCREMENT,
+    tenant_id text NOT NULL DEFAULT 'default',
+    name text NOT NULL,
+    service_name text NOT NULL,
+    time_bucket datetime NOT NULL,
+    min real,
+    max real,
+    sum real,
+    count integer,
+    attributes_json blob
+)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_metric_buckets_time_bucket ON metric_buckets (time_bucket)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_metrics_tenant_service_bucket ON metric_buckets (tenant_id, service_name, time_bucket)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_metrics_tenant_name_bucket ON metric_buckets (tenant_id, name, time_bucket)
+-- migrate:split
+CREATE TABLE IF NOT EXISTS logs (
+    id integer PRIMARY KEY AUTOINCREMENT,
+    tenant_id text NOT NULL DEFAULT 'default',
+    trace_id text,
+    span_id text,
+    severity text,
+    body text,
+    service_name text,
+    attributes_json blob,
+    ai_insight blob,
+    timestamp datetime
+)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_logs_timestamp ON logs (timestamp)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_logs_trace_id ON logs (trace_id)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_logs_tenant_severity ON logs (tenant_id, severity)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_logs_tenant_service ON logs (tenant_id, service_name)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_logs_tenant_ts ON logs (tenant_id, timestamp)
+-- migrate:split
+CREATE TABLE IF NOT EXISTS investigations (
+    tenant_id text NOT NULL DEFAULT 'default',
+    id text PRIMARY KEY,
+    created_at datetime,
+    status text,
+    severity text,
+    trigger_service text,
+    trigger_operation text,
+    error_message text,
+    root_service text,
+    root_operation text,
+    causal_chain text,
+    trace_ids text,
+    error_logs text,
+    anomalous_metrics text,
+    affected_services text,
+    span_chain text
+)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_investigations_trigger_service ON investigations (trigger_service)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_investigations_tenant_created ON investigations (tenant_id, created_at)
+-- migrate:split
+CREATE TABLE IF NOT EXISTS drain_templates (
+    tenant_id text NOT NULL DEFAULT 'default',
+    id integer,
+    tokens text NOT NULL,
+    count integer,
+    first_seen datetime,
+    last_seen datetime,
+    sample text,
+    PRIMARY KEY (tenant_id, id)
+)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_drain_templates_last_seen ON drain_templates (last_seen)
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_drain_templates_first_seen ON drain_templates (first_seen)

--- a/internal/migrate/sql/sqlite/002_v0_4_0_beta_2.sql
+++ b/internal/migrate/sql/sqlite/002_v0_4_0_beta_2.sql
@@ -1,0 +1,13 @@
+ALTER TABLE traces ADD COLUMN truncated numeric
+-- migrate:split
+ALTER TABLE traces ADD COLUMN retained_span_count integer
+-- migrate:split
+ALTER TABLE traces ADD COLUMN observed_span_count integer
+-- migrate:split
+DROP INDEX IF EXISTS idx_spans_status
+-- migrate:split
+CREATE INDEX IF NOT EXISTS idx_spans_tenant_status_start ON spans (tenant_id, status, start_time)
+-- migrate:split
+UPDATE investigations SET tenant_id = 'default' WHERE tenant_id IS NULL OR tenant_id = ''
+-- migrate:split
+UPDATE drain_templates SET tenant_id = 'default' WHERE tenant_id IS NULL OR tenant_id = ''

--- a/internal/migrate/status.go
+++ b/internal/migrate/status.go
@@ -1,0 +1,593 @@
+package migrate
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// State is the operator-visible compatibility state of the main database.
+type State string
+
+const (
+	StateEmpty        State = "empty"
+	StateUnmanaged    State = "unmanaged"
+	StateExact        State = "exact"
+	StateBehind       State = "behind"
+	StateAhead        State = "ahead"
+	StateDirty        State = "dirty"
+	StateIncompatible State = "incompatible"
+	StateUnverified   State = "unverified"
+)
+
+// Exit codes are stable so deployment scripts do not need to parse prose.
+const (
+	ExitOK           = 0
+	ExitUsage        = 2
+	ExitEmpty        = 10
+	ExitUnmanaged    = 11
+	ExitBehind       = 12
+	ExitAhead        = 13
+	ExitDirty        = 14
+	ExitIncompatible = 15
+	ExitUnverified   = 16
+)
+
+// Applied records one ledger entry without exposing the database row type.
+type Applied struct {
+	Version     int
+	Name        string
+	Checksum    string
+	StartedAt   time.Time
+	CompletedAt *time.Time
+	Dirty       bool
+}
+
+// Status is the complete read-only compatibility result for the main database.
+type Status struct {
+	Driver          string
+	State           State
+	ExpectedVersion int
+	ActualVersion   int
+	Fingerprint     string
+	Detail          string
+	Applied         []Applied
+}
+
+// Usable reports whether this binary can safely use the inspected schema.
+func (s Status) Usable() bool { return s.State == StateExact }
+
+// ExitCode maps a state to its stable command exit code.
+func (s Status) ExitCode() int {
+	switch s.State {
+	case StateExact:
+		return ExitOK
+	case StateEmpty:
+		return ExitEmpty
+	case StateUnmanaged:
+		return ExitUnmanaged
+	case StateBehind:
+		return ExitBehind
+	case StateAhead:
+		return ExitAhead
+	case StateDirty:
+		return ExitDirty
+	case StateUnverified:
+		return ExitUnverified
+	default:
+		return ExitIncompatible
+	}
+}
+
+type ledgerRow struct {
+	Version     int        `gorm:"column:version"`
+	Name        string     `gorm:"column:name"`
+	Checksum    string     `gorm:"column:checksum"`
+	StartedAt   time.Time  `gorm:"column:started_at"`
+	CompletedAt *time.Time `gorm:"column:completed_at"`
+	Dirty       bool       `gorm:"column:dirty"`
+}
+
+type indexSpec struct {
+	columns []string
+	unique  bool
+}
+
+type tableSpec struct {
+	columns []string
+	primary []string
+	indexes map[string]indexSpec
+}
+
+var ownedTableNames = []string{
+	"traces",
+	"spans",
+	"metric_buckets",
+	"logs",
+	"investigations",
+	"drain_templates",
+}
+
+func schemaSpec(version int) map[string]tableSpec {
+	traceColumns := []string{"id", "tenant_id", "trace_id", "service_name", "duration", "status", "timestamp", "created_at", "updated_at", "deleted_at"}
+	spanIndexes := map[string]indexSpec{
+		"idx_spans_operation_name":       {columns: []string{"operation_name"}},
+		"idx_spans_tenant_trace_span":    {columns: []string{"tenant_id", "trace_id", "span_id"}, unique: true},
+		"idx_spans_tenant_service_start": {columns: []string{"tenant_id", "service_name", "start_time"}},
+		"idx_spans_tenant_trace":         {columns: []string{"tenant_id", "trace_id"}},
+	}
+	if version >= 2 {
+		traceColumns = append(traceColumns[:7], append([]string{"truncated", "retained_span_count", "observed_span_count"}, traceColumns[7:]...)...)
+		spanIndexes["idx_spans_tenant_status_start"] = indexSpec{columns: []string{"tenant_id", "status", "start_time"}}
+	} else {
+		spanIndexes["idx_spans_status"] = indexSpec{columns: []string{"status"}}
+	}
+	return map[string]tableSpec{
+		"traces": {
+			columns: traceColumns,
+			primary: []string{"id"},
+			indexes: map[string]indexSpec{
+				"idx_traces_deleted_at":      {columns: []string{"deleted_at"}},
+				"idx_traces_timestamp":       {columns: []string{"timestamp"}},
+				"idx_traces_duration":        {columns: []string{"duration"}},
+				"idx_traces_tenant_trace_id": {columns: []string{"tenant_id", "trace_id"}, unique: true},
+				"idx_traces_tenant_service":  {columns: []string{"tenant_id", "service_name"}},
+				"idx_traces_tenant_ts":       {columns: []string{"tenant_id", "timestamp"}},
+			},
+		},
+		"spans": {
+			columns: []string{"id", "tenant_id", "trace_id", "span_id", "parent_span_id", "operation_name", "start_time", "end_time", "duration", "service_name", "status", "attributes_json"},
+			primary: []string{"id"},
+			indexes: spanIndexes,
+		},
+		"metric_buckets": {
+			columns: []string{"id", "tenant_id", "name", "service_name", "time_bucket", "min", "max", "sum", "count", "attributes_json"},
+			primary: []string{"id"},
+			indexes: map[string]indexSpec{
+				"idx_metric_buckets_time_bucket":    {columns: []string{"time_bucket"}},
+				"idx_metrics_tenant_service_bucket": {columns: []string{"tenant_id", "service_name", "time_bucket"}},
+				"idx_metrics_tenant_name_bucket":    {columns: []string{"tenant_id", "name", "time_bucket"}},
+			},
+		},
+		"logs": {
+			columns: []string{"id", "tenant_id", "trace_id", "span_id", "severity", "body", "service_name", "attributes_json", "ai_insight", "timestamp"},
+			primary: []string{"id"},
+			indexes: map[string]indexSpec{
+				"idx_logs_timestamp":       {columns: []string{"timestamp"}},
+				"idx_logs_trace_id":        {columns: []string{"trace_id"}},
+				"idx_logs_tenant_severity": {columns: []string{"tenant_id", "severity"}},
+				"idx_logs_tenant_service":  {columns: []string{"tenant_id", "service_name"}},
+				"idx_logs_tenant_ts":       {columns: []string{"tenant_id", "timestamp"}},
+			},
+		},
+		"investigations": {
+			columns: []string{"tenant_id", "id", "created_at", "status", "severity", "trigger_service", "trigger_operation", "error_message", "root_service", "root_operation", "causal_chain", "trace_ids", "error_logs", "anomalous_metrics", "affected_services", "span_chain"},
+			primary: []string{"id"},
+			indexes: map[string]indexSpec{
+				"idx_investigations_trigger_service": {columns: []string{"trigger_service"}},
+				"idx_investigations_tenant_created":  {columns: []string{"tenant_id", "created_at"}},
+			},
+		},
+		"drain_templates": {
+			columns: []string{"tenant_id", "id", "tokens", "count", "first_seen", "last_seen", "sample"},
+			primary: []string{"tenant_id", "id"},
+			indexes: map[string]indexSpec{
+				"idx_drain_templates_last_seen":  {columns: []string{"last_seen"}},
+				"idx_drain_templates_first_seen": {columns: []string{"first_seen"}},
+			},
+		},
+	}
+}
+
+// Inspect reads the ledger and required relational structure without mutating it.
+// A migration can commit between those two reads, so managed states are retried
+// unless the ledger still matches the snapshot used for structural validation.
+func Inspect(ctx context.Context, db *gorm.DB, driver string) (Status, error) {
+	for attempt := 0; attempt < 3; attempt++ {
+		status, err := inspectOnce(ctx, db, driver)
+		if err != nil {
+			return status, err
+		}
+		if len(status.Applied) == 0 {
+			if (status.State == StateEmpty || status.State == StateUnmanaged) && db.WithContext(ctx).Migrator().HasTable(LedgerTable) {
+				continue
+			}
+			return status, nil
+		}
+		stable, err := ledgerMatchesStatus(ctx, db, status)
+		if err != nil {
+			return status, err
+		}
+		if stable {
+			return status, nil
+		}
+	}
+	return Status{}, errors.New("migration ledger changed repeatedly during read-only inspection; retry status")
+}
+
+func inspectOnce(ctx context.Context, db *gorm.DB, driver string) (Status, error) {
+	driver = NormalizeDriver(driver)
+	status := Status{Driver: driver, ExpectedVersion: CurrentVersion}
+	if !SupportsVersioned(driver) {
+		status.State = StateUnverified
+		status.Detail = "versioned schema compatibility is unverified; keep DB_AUTOMIGRATE=true for this preview driver"
+		return status, nil
+	}
+	registry, err := registryFor(driver)
+	if err != nil {
+		return status, err
+	}
+	db = db.WithContext(ctx)
+	if !db.Migrator().HasTable(LedgerTable) {
+		count := 0
+		for _, table := range ownedTableNames {
+			if db.Migrator().HasTable(table) {
+				count++
+			}
+		}
+		status.Fingerprint, _ = SchemaFingerprint(ctx, db, driver, CurrentVersion)
+		if count == 0 {
+			status.State = StateEmpty
+			status.Detail = "no OtelContext relational schema or migration ledger is present"
+		} else {
+			status.State = StateUnmanaged
+			status.Detail = "OtelContext tables are present without a migration ledger; validate and baseline a published release"
+		}
+		return status, nil
+	}
+
+	var rows []ledgerRow
+	if err := db.Table(LedgerTable).Order("version ASC").Find(&rows).Error; err != nil {
+		return status, fmt.Errorf("read %s: %w", LedgerTable, err)
+	}
+	if len(rows) == 0 {
+		status.State = StateIncompatible
+		status.Detail = "migration ledger exists but contains no entries"
+		status.Fingerprint, _ = SchemaFingerprint(ctx, db, driver, CurrentVersion)
+		return status, nil
+	}
+	status.Applied = make([]Applied, 0, len(rows))
+	for _, row := range rows {
+		status.Applied = append(status.Applied, Applied{
+			Version: row.Version, Name: row.Name, Checksum: row.Checksum,
+			StartedAt: row.StartedAt, CompletedAt: row.CompletedAt, Dirty: row.Dirty,
+		})
+		if row.Version > status.ActualVersion {
+			status.ActualVersion = row.Version
+		}
+		if row.Dirty || row.CompletedAt == nil {
+			status.State = StateDirty
+			status.Detail = fmt.Sprintf("migration %d (%s) is incomplete", row.Version, row.Name)
+			status.Fingerprint, _ = SchemaFingerprint(ctx, db, driver, minVersion(status.ActualVersion))
+			return status, nil
+		}
+	}
+	if status.ActualVersion > CurrentVersion || len(rows) > len(registry) {
+		status.State = StateAhead
+		status.Detail = fmt.Sprintf("database version %d is ahead of binary version %d", status.ActualVersion, CurrentVersion)
+		status.Fingerprint, _ = SchemaFingerprint(ctx, db, driver, CurrentVersion)
+		return status, nil
+	}
+	for i, row := range rows {
+		if row.Version != i+1 {
+			status.State = StateIncompatible
+			status.Detail = fmt.Sprintf("migration ledger gap at version %d", i+1)
+			return status, nil
+		}
+		expected := registry[i]
+		if row.Name != expected.Name {
+			status.State = StateIncompatible
+			status.Detail = fmt.Sprintf("migration %d name mismatch: got %q, expected %q", row.Version, row.Name, expected.Name)
+			return status, nil
+		}
+		if row.Checksum != expected.Checksum {
+			status.State = StateIncompatible
+			status.Detail = fmt.Sprintf("migration %d checksum mismatch", row.Version)
+			return status, nil
+		}
+	}
+	if status.ActualVersion < CurrentVersion {
+		if err := validateSchema(ctx, db, driver, status.ActualVersion); err != nil {
+			status.State = StateIncompatible
+			status.Detail = "managed schema does not match its recorded version: " + err.Error()
+			return status, nil
+		}
+		status.State = StateBehind
+		status.Detail = fmt.Sprintf("database version %d is behind binary version %d", status.ActualVersion, CurrentVersion)
+		status.Fingerprint, _ = SchemaFingerprint(ctx, db, driver, status.ActualVersion)
+		return status, nil
+	}
+	if err := validateSchema(ctx, db, driver, CurrentVersion); err != nil {
+		status.State = StateIncompatible
+		status.Detail = "recorded schema is structurally incompatible: " + err.Error()
+		return status, nil
+	}
+	status.State = StateExact
+	status.Detail = "relational schema and embedded migration checksums are exact"
+	status.Fingerprint, err = SchemaFingerprint(ctx, db, driver, CurrentVersion)
+	if err != nil {
+		return status, err
+	}
+	return status, nil
+}
+
+func ledgerMatchesStatus(ctx context.Context, db *gorm.DB, status Status) (bool, error) {
+	var rows []ledgerRow
+	if err := db.WithContext(ctx).Table(LedgerTable).Order("version ASC").Find(&rows).Error; err != nil {
+		return false, fmt.Errorf("re-read %s: %w", LedgerTable, err)
+	}
+	if len(rows) != len(status.Applied) {
+		return false, nil
+	}
+	for i, row := range rows {
+		applied := status.Applied[i]
+		if row.Version != applied.Version || row.Name != applied.Name || row.Checksum != applied.Checksum || row.Dirty != applied.Dirty || (row.CompletedAt == nil) != (applied.CompletedAt == nil) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func minVersion(version int) int {
+	if version < 1 {
+		return 1
+	}
+	if version > CurrentVersion {
+		return CurrentVersion
+	}
+	return version
+}
+
+func validateSchema(ctx context.Context, db *gorm.DB, driver string, version int) error {
+	if version < 1 || version > CurrentVersion {
+		return fmt.Errorf("unsupported schema version %d", version)
+	}
+	db = db.WithContext(ctx)
+	spec := schemaSpec(version)
+	tables := make([]string, 0, len(spec))
+	for table := range spec {
+		tables = append(tables, table)
+	}
+	sort.Strings(tables)
+	for _, table := range tables {
+		expected := spec[table]
+		if !db.Migrator().HasTable(table) {
+			return fmt.Errorf("missing table %s", table)
+		}
+		columnTypes, err := db.Migrator().ColumnTypes(table)
+		if err != nil {
+			return fmt.Errorf("inspect columns for %s: %w", table, err)
+		}
+		actualColumns := make([]string, 0, len(columnTypes))
+		for _, column := range columnTypes {
+			actualColumns = append(actualColumns, strings.ToLower(column.Name()))
+		}
+		sort.Strings(actualColumns)
+		expectedColumns := append([]string(nil), expected.columns...)
+		sort.Strings(expectedColumns)
+		if !equalStrings(actualColumns, expectedColumns) {
+			return fmt.Errorf("table %s columns got [%s], expected [%s]", table, strings.Join(actualColumns, ","), strings.Join(expectedColumns, ","))
+		}
+		primary, err := primaryKeyColumns(ctx, db, driver, table)
+		if err != nil {
+			return err
+		}
+		if !equalStrings(primary, expected.primary) {
+			return fmt.Errorf("table %s primary key got [%s], expected [%s]", table, strings.Join(primary, ","), strings.Join(expected.primary, ","))
+		}
+		actualIndexes, err := readIndexes(ctx, db, driver, table)
+		if err != nil {
+			return fmt.Errorf("inspect indexes for %s: %w", table, err)
+		}
+		for name, want := range expected.indexes {
+			got, ok := actualIndexes[name]
+			if !ok {
+				return fmt.Errorf("table %s is missing index %s", table, name)
+			}
+			if !equalStrings(got.columns, want.columns) || got.unique != want.unique {
+				return fmt.Errorf("table %s index %s has columns [%s] unique=%t, expected [%s] unique=%t", table, name, strings.Join(got.columns, ","), got.unique, strings.Join(want.columns, ","), want.unique)
+			}
+		}
+	}
+	if version >= 2 {
+		checks := []struct {
+			table string
+			query string
+		}{
+			{table: "investigations", query: `SELECT COUNT(*) FROM investigations WHERE tenant_id IS NULL OR tenant_id = ''`},
+			{table: "drain_templates", query: `SELECT COUNT(*) FROM drain_templates WHERE tenant_id IS NULL OR tenant_id = ''`},
+		}
+		for _, check := range checks {
+			var count int64
+			if err := db.Raw(check.query).Scan(&count).Error; err != nil {
+				return fmt.Errorf("validate %s tenant backfill: %w", check.table, err)
+			}
+			if count != 0 {
+				return fmt.Errorf("table %s has %d rows without tenant_id", check.table, count)
+			}
+		}
+	}
+	return nil
+}
+
+func primaryKeyColumns(ctx context.Context, db *gorm.DB, driver, table string) ([]string, error) {
+	switch NormalizeDriver(driver) {
+	case "sqlite":
+		type pragmaColumn struct {
+			Name        string         `gorm:"column:name"`
+			Default     sql.NullString `gorm:"column:dflt_value"`
+			PrimaryRank int            `gorm:"column:pk"`
+		}
+		var columns []pragmaColumn
+		if err := db.WithContext(ctx).Raw(`SELECT name, pk FROM pragma_table_info(?)`, table).Scan(&columns).Error; err != nil {
+			return nil, fmt.Errorf("inspect primary key for %s: %w", table, err)
+		}
+		sort.Slice(columns, func(i, j int) bool { return columns[i].PrimaryRank < columns[j].PrimaryRank })
+		var primary []string
+		for _, column := range columns {
+			if column.PrimaryRank > 0 {
+				primary = append(primary, column.Name)
+			}
+		}
+		return primary, nil
+	case "postgres":
+		var primary []string
+		err := db.WithContext(ctx).Raw(`
+SELECT a.attname::text
+FROM pg_index i
+JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord) ON true
+JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum
+WHERE i.indrelid = to_regclass(?) AND i.indisprimary
+ORDER BY k.ord`, table).Scan(&primary).Error
+		if err != nil {
+			return nil, fmt.Errorf("inspect primary key for %s: %w", table, err)
+		}
+		return primary, nil
+	default:
+		return nil, fmt.Errorf("primary-key inspection is unverified for driver %q", driver)
+	}
+}
+
+// SchemaFingerprint hashes the required tables, columns, keys, and indexes.
+// It deliberately excludes optional search indexes and the migration ledger.
+func SchemaFingerprint(ctx context.Context, db *gorm.DB, driver string, version int) (string, error) {
+	lines, err := schemaFingerprintLines(ctx, db, driver, version)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(strings.Join(lines, "\n")))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func schemaFingerprintLines(ctx context.Context, db *gorm.DB, driver string, version int) ([]string, error) {
+	spec := schemaSpec(version)
+	tables := make([]string, 0, len(spec))
+	for table := range spec {
+		tables = append(tables, table)
+	}
+	sort.Strings(tables)
+	var lines []string
+	db = db.WithContext(ctx)
+	for _, table := range tables {
+		if !db.Migrator().HasTable(table) {
+			lines = append(lines, "table:"+table+":missing")
+			continue
+		}
+		columns, err := db.Migrator().ColumnTypes(table)
+		if err != nil {
+			return nil, err
+		}
+		for _, column := range columns {
+			lines = append(lines, fmt.Sprintf("column:%s:%s:%s", table, strings.ToLower(column.Name()), strings.ToLower(column.DatabaseTypeName())))
+		}
+		primary, err := primaryKeyColumns(ctx, db, driver, table)
+		if err != nil {
+			return nil, err
+		}
+		lines = append(lines, "primary:"+table+":"+strings.Join(primary, ","))
+		byName, err := readIndexes(ctx, db, driver, table)
+		if err != nil {
+			return nil, err
+		}
+		indexNames := make([]string, 0, len(spec[table].indexes))
+		for name := range spec[table].indexes {
+			indexNames = append(indexNames, name)
+		}
+		sort.Strings(indexNames)
+		for _, name := range indexNames {
+			index, ok := byName[name]
+			if !ok {
+				lines = append(lines, "index:"+table+":"+name+":missing")
+				continue
+			}
+			lines = append(lines, fmt.Sprintf("index:%s:%s:%s:%t", table, name, strings.Join(index.columns, ","), index.unique))
+		}
+	}
+	sort.Strings(lines)
+	return lines, nil
+}
+
+func readIndexes(ctx context.Context, db *gorm.DB, driver, table string) (map[string]indexSpec, error) {
+	result := make(map[string]indexSpec)
+	switch NormalizeDriver(driver) {
+	case "sqlite":
+		type indexListRow struct {
+			Name   string `gorm:"column:name"`
+			Unique int    `gorm:"column:unique"`
+		}
+		var list []indexListRow
+		if err := db.WithContext(ctx).Raw(`SELECT name, "unique" FROM pragma_index_list(?)`, table).Scan(&list).Error; err != nil {
+			return nil, err
+		}
+		for _, listed := range list {
+			type indexColumn struct {
+				Rank int    `gorm:"column:seqno"`
+				Name string `gorm:"column:name"`
+			}
+			var columns []indexColumn
+			if err := db.WithContext(ctx).Raw(`SELECT seqno, name FROM pragma_index_info(?)`, listed.Name).Scan(&columns).Error; err != nil {
+				return nil, err
+			}
+			sort.Slice(columns, func(i, j int) bool { return columns[i].Rank < columns[j].Rank })
+			names := make([]string, 0, len(columns))
+			for _, column := range columns {
+				names = append(names, column.Name)
+			}
+			result[listed.Name] = indexSpec{columns: names, unique: listed.Unique != 0}
+		}
+		return result, nil
+	case "postgres":
+		type indexColumn struct {
+			IndexName string `gorm:"column:index_name"`
+			Unique    bool   `gorm:"column:is_unique"`
+			Column    string `gorm:"column:column_name"`
+			Rank      int    `gorm:"column:column_rank"`
+		}
+		var rows []indexColumn
+		err := db.WithContext(ctx).Raw(`
+SELECT ci.relname::text AS index_name,
+       i.indisunique AS is_unique,
+       a.attname::text AS column_name,
+       k.ord::integer AS column_rank
+FROM pg_index i
+JOIN pg_class t ON t.oid = i.indrelid
+JOIN pg_namespace n ON n.oid = t.relnamespace
+JOIN pg_class ci ON ci.oid = i.indexrelid
+JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord) ON true
+JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+WHERE n.nspname = current_schema() AND t.relname = ?
+ORDER BY ci.relname, k.ord`, table).Scan(&rows).Error
+		if err != nil {
+			return nil, err
+		}
+		for _, row := range rows {
+			index := result[row.IndexName]
+			index.unique = row.Unique
+			index.columns = append(index.columns, row.Column)
+			result[row.IndexName] = index
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("index inspection is unverified for driver %q", driver)
+	}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/storage/dialect_test.go
+++ b/internal/storage/dialect_test.go
@@ -209,7 +209,7 @@ func TestAutoMigrateEnabled_EnvParsing(t *testing.T) {
 			} else {
 				t.Setenv("DB_AUTOMIGRATE", c.env)
 			}
-			got := autoMigrateEnabled()
+			got := AutoMigrateEnabled()
 			if got != c.want {
 				t.Fatalf("DB_AUTOMIGRATE=%q → %v, want %v", c.env, got, c.want)
 			}

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -78,9 +78,9 @@ func likeOpFor(driver string) string {
 // likeOp returns the case-insensitive LIKE operator for this Repository's dialect.
 func (r *Repository) likeOp() string { return likeOpFor(r.driver) }
 
-// autoMigrateEnabled reports whether GORM AutoMigrate should run on startup.
+// AutoMigrateEnabled reports whether GORM AutoMigrate should run on startup.
 // Defaults to true; set DB_AUTOMIGRATE=false to run versioned migrations externally.
-func autoMigrateEnabled() bool {
+func AutoMigrateEnabled() bool {
 	v, ok := os.LookupEnv("DB_AUTOMIGRATE")
 	if !ok {
 		return true
@@ -90,6 +90,16 @@ func autoMigrateEnabled() bool {
 		return false
 	default:
 		return true
+	}
+}
+
+// MigrateOptionsFromEnv returns the existing development AutoMigrate tuning.
+// The versioned migration owner calls this before any worker or listener starts.
+func MigrateOptionsFromEnv() MigrateOptions {
+	return MigrateOptions{
+		PostgresPartitioning:   strings.ToLower(strings.TrimSpace(os.Getenv("DB_POSTGRES_PARTITIONING"))),
+		PartitionLookaheadDays: partitionLookaheadFromEnv(),
+		Timeout:                migrateTimeoutFromEnv(),
 	}
 }
 
@@ -121,7 +131,9 @@ func (r *Repository) LogsPartitioned() bool { return r.logsPartitioned.Load() }
 // setup path (factory.go) once the partitioned schema is in place.
 func (r *Repository) MarkLogsPartitioned() { r.logsPartitioned.Store(true) }
 
-// NewRepository initializes the database connection using environment variables and migrates the schema.
+// NewRepository initializes the database connection using environment variables.
+// Schema ownership lives in internal/migrate so main storage and GraphRAG cannot
+// migrate under different startup policies.
 func NewRepository(metrics *telemetry.Metrics) (*Repository, error) {
 	driver := os.Getenv("DB_DRIVER")
 	dsn := os.Getenv("DB_DSN")
@@ -134,21 +146,6 @@ func NewRepository(metrics *telemetry.Metrics) (*Repository, error) {
 	// Resolve effective driver name
 	if driver == "" {
 		driver = "sqlite"
-	}
-
-	// Auto-migration is enabled by default. Disable via DB_AUTOMIGRATE=false when
-	// using versioned migrations in production (Postgres table locks, no rollback).
-	if autoMigrateEnabled() {
-		opts := MigrateOptions{
-			PostgresPartitioning:   strings.ToLower(strings.TrimSpace(os.Getenv("DB_POSTGRES_PARTITIONING"))),
-			PartitionLookaheadDays: partitionLookaheadFromEnv(),
-			Timeout:                migrateTimeoutFromEnv(),
-		}
-		if err := AutoMigrateModelsWithOptions(db, driver, opts); err != nil {
-			return nil, err
-		}
-	} else {
-		slog.Info("AutoMigrate skipped (DB_AUTOMIGRATE=false)")
 	}
 
 	// Register GORM Callback for DB Latency Metrics

--- a/main.go
+++ b/main.go
@@ -117,6 +117,10 @@ func fatal(msg string, err error, kv ...any) {
 }
 
 func main() {
+	if handled, code := maybeRunMigrationCommand(os.Args[1:], os.Stdout, os.Stderr); handled {
+		os.Exit(code)
+	}
+
 	versionFlag := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
 
@@ -191,6 +195,22 @@ func main() {
 
 	slog.Info("🚀 Starting OtelContext", "version", Version, "env", cfg.Env, "log_level", level)
 
+	// 1. Initialize Internal Telemetry (first — everything registers metrics against this)
+	metrics := telemetry.New()
+	slog.Info("📊 Internal telemetry initialized")
+
+	// 2. Initialize Storage
+	repo, err := storage.NewRepository(metrics)
+	if err != nil {
+		fatal("Failed to initialize repository", err)
+	}
+	if err := prepareDatabaseSchemas(appCtx, cfg, repo); err != nil {
+		_ = repo.Close()
+		fatal("Database schema compatibility gate failed", err)
+	}
+	slog.Info("💾 Storage initialized", "driver", cfg.DBDriver)
+
+	// No listener or background worker may start before the schema gate above.
 	// Pace the GC against a soft memory ceiling so RSS stays bounded under
 	// sustained ingest (honors an explicit GOMEMLIMIT; otherwise 75% of the
 	// detected cgroup/host budget). See applyMemoryLimit in memlimit.go.
@@ -202,11 +222,7 @@ func main() {
 		slog.Warn("pprof server disabled", "error", err, "addr", cfg.PprofAddr)
 	}
 
-	// 1. Initialize Internal Telemetry (first — everything registers metrics against this)
-	metrics := telemetry.New()
-	slog.Info("📊 Internal telemetry initialized")
-
-	// 1b. Initialize OTel self-instrumentation (optional)
+	// 2b. Initialize OTel self-instrumentation (optional).
 	var shutdownTracer func(context.Context) error
 	if cfg.OTelExporterEndpoint != "" {
 		tp, err := initTracerProvider(cfg.OTelExporterEndpoint)
@@ -219,14 +235,7 @@ func main() {
 		}
 	}
 
-	// 2. Initialize Storage
-	repo, err := storage.NewRepository(metrics)
-	if err != nil {
-		fatal("Failed to initialize repository", err)
-	}
-	slog.Info("💾 Storage initialized", "driver", cfg.DBDriver)
-
-	// 2a. Retention scheduler: hourly batched purge + daily maintenance
+	// 2c. Retention scheduler: hourly batched purge + daily maintenance
 	// (VACUUM ANALYZE / OPTIMIZE / PRAGMA optimize + incremental_vacuum).
 	ctxRetention, cancelRetention := context.WithCancel(context.Background())
 	retention := storage.NewRetentionScheduler(
@@ -239,7 +248,7 @@ func main() {
 	// Start() is deferred until after the aggregate store is wired in below —
 	// SetAggregateRetention must be called before the loop reads the fields.
 
-	// 2b. Partition scheduler: only when DB_POSTGRES_PARTITIONING=daily.
+	// 2d. Partition scheduler: only when DB_POSTGRES_PARTITIONING=daily.
 	// Maintains lookahead daily partitions and drops expired ones — DROP
 	// PARTITION is orders of magnitude faster than DELETE for retention.
 	var partitionScheduler *storage.PartitionScheduler
@@ -477,11 +486,6 @@ func main() {
 		"tenant_idle_ttl", graphRAGCfg.TenantIdleTTL,
 		"mode", graphRAGCfg.Mode,
 	)
-
-	// Auto-migrate GraphRAG models (Investigation, DrainTemplateRow)
-	if err := graphrag.AutoMigrateGraphRAG(repo.DB()); err != nil {
-		slog.Error("Failed to migrate GraphRAG models", "error", err)
-	}
 
 	// 5. Initialize AI Service.
 	// Workers inherit aiCtx so an in-flight LLM call (30s timeout) is

--- a/migrate_cli.go
+++ b/migrate_cli.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/config"
+	schemamigrate "github.com/RandomCodeSpace/otelcontext/internal/migrate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"gorm.io/gorm"
+)
+
+const migrationUsage = "usage: otelcontext migrate <status|up|baseline --from RELEASE>"
+
+func maybeRunMigrationCommand(args []string, stdout, stderr io.Writer) (bool, int) {
+	if len(args) == 0 || args[0] != "migrate" {
+		return false, 0
+	}
+	if len(args) < 2 {
+		fmt.Fprintln(stderr, migrationUsage)
+		return true, schemamigrate.ExitUsage
+	}
+	command := args[1]
+	baselineFrom := ""
+	switch command {
+	case "status", "up":
+		if len(args) != 2 {
+			fmt.Fprintln(stderr, migrationUsage)
+			return true, schemamigrate.ExitUsage
+		}
+	case "baseline":
+		flags := flag.NewFlagSet("migrate baseline", flag.ContinueOnError)
+		flags.SetOutput(stderr)
+		from := flags.String("from", "", "published release to validate and record")
+		if err := flags.Parse(args[2:]); err != nil || *from == "" || flags.NArg() != 0 {
+			fmt.Fprintln(stderr, migrationUsage)
+			return true, schemamigrate.ExitUsage
+		}
+		baselineFrom = *from
+	default:
+		fmt.Fprintln(stderr, migrationUsage)
+		return true, schemamigrate.ExitUsage
+	}
+	ctx := context.Background()
+	cfg, err := config.Load("")
+	if err != nil {
+		fmt.Fprintf(stderr, "migrate: load configuration: %v\n", err)
+		return true, schemamigrate.ExitUsage
+	}
+	if err := validateMigrationConfig(cfg); err != nil {
+		fmt.Fprintf(stderr, "migrate: %v\n", err)
+		return true, schemamigrate.ExitUsage
+	}
+	if command != "status" {
+		if err := versionedProfileError(cfg); err != nil {
+			fmt.Fprintf(stderr, "migrate %s: %v\n", command, err)
+			return true, schemamigrate.ExitIncompatible
+		}
+	}
+	db, err := storage.NewDatabase(cfg.DBDriver, cfg.DBDSN)
+	if err != nil {
+		fmt.Fprintf(stderr, "migrate: open main database: %v\n", err)
+		return true, schemamigrate.ExitIncompatible
+	}
+	if sqlDB, dbErr := db.DB(); dbErr == nil {
+		defer func() { _ = sqlDB.Close() }()
+	}
+
+	switch command {
+	case "status":
+		return true, printMigrationStatus(ctx, stdout, stderr, cfg, db)
+	case "up":
+		return true, runMigrationUp(ctx, stdout, stderr, cfg, db)
+	case "baseline":
+		return true, runMigrationBaseline(ctx, stdout, stderr, cfg, db, baselineFrom)
+	}
+	return true, schemamigrate.ExitUsage
+}
+
+func validateMigrationConfig(cfg *config.Config) error {
+	switch strings.ToLower(cfg.AggregateMode) {
+	case aggregate.ModeLegacy, aggregate.ModeShadow, aggregate.ModeAggregate:
+	default:
+		return fmt.Errorf("invalid AGGREGATE_MODE %q", cfg.AggregateMode)
+	}
+	if cfg.AggregateMode != aggregate.ModeLegacy && strings.TrimSpace(cfg.AggregateDBPath) == "" {
+		return fmt.Errorf("AGGREGATE_DB_PATH is required when AGGREGATE_MODE=%s", cfg.AggregateMode)
+	}
+	return nil
+}
+
+func printMigrationStatus(ctx context.Context, stdout, stderr io.Writer, cfg *config.Config, db *gorm.DB) int {
+	mainStatus, err := schemamigrate.Inspect(ctx, db, cfg.DBDriver)
+	if err != nil {
+		fmt.Fprintf(stderr, "migrate status: inspect main database: %v\n", err)
+		return schemamigrate.ExitIncompatible
+	}
+	if profileErr := versionedProfileError(cfg); profileErr != nil {
+		mainStatus.State = schemamigrate.StateIncompatible
+		mainStatus.Detail = profileErr.Error()
+	}
+	aggregateStatus, aggregateRequired, err := inspectConfiguredAggregate(cfg)
+	if err != nil {
+		fmt.Fprintf(stderr, "migrate status: inspect aggregate database: %v\n", err)
+		return schemamigrate.ExitIncompatible
+	}
+	printStatusReport(stdout, cfg, mainStatus, aggregateStatus, aggregateRequired)
+	if code := mainStatus.ExitCode(); code != schemamigrate.ExitOK {
+		return code
+	}
+	if aggregateRequired && !aggregateStatus.Usable() {
+		if aggregateStatus.State == "empty" {
+			return schemamigrate.ExitEmpty
+		}
+		return schemamigrate.ExitIncompatible
+	}
+	return schemamigrate.ExitOK
+}
+
+func runMigrationUp(ctx context.Context, stdout, stderr io.Writer, cfg *config.Config, db *gorm.DB) int {
+	if err := versionedProfileError(cfg); err != nil {
+		fmt.Fprintf(stderr, "migrate up: %v\n", err)
+		return schemamigrate.ExitIncompatible
+	}
+	mainStatus, err := schemamigrate.Up(ctx, db, cfg.DBDriver)
+	if err != nil {
+		fmt.Fprintf(stderr, "migrate up: %v\n", err)
+		if mainStatus.State != "" {
+			fmt.Fprintf(stdout, "main %s\n", mainStatus.Description())
+			var stateErr *schemamigrate.StateError
+			if errors.As(err, &stateErr) {
+				return mainStatus.ExitCode()
+			}
+		}
+		return schemamigrate.ExitIncompatible
+	}
+	aggregateStatus, aggregateRequired, err := ensureConfiguredAggregate(cfg)
+	if err != nil {
+		fmt.Fprintf(stderr, "migrate up: aggregate store: %v\n", err)
+		fmt.Fprintf(stdout, "main %s\n", mainStatus.Description())
+		if aggregateStatus.State != "" {
+			fmt.Fprintf(stdout, "aggregate %s\n", aggregateStatus.Description())
+		}
+		return schemamigrate.ExitIncompatible
+	}
+	printStatusReport(stdout, cfg, mainStatus, aggregateStatus, aggregateRequired)
+	return schemamigrate.ExitOK
+}
+
+func versionedProfileError(cfg *config.Config) error {
+	if schemamigrate.NormalizeDriver(cfg.DBDriver) == "postgres" && cfg.DBPostgresPartitioning == storage.PartitioningModeDaily {
+		return fmt.Errorf("DB_POSTGRES_PARTITIONING=daily is not promoted for versioned migrations; use the unpartitioned PostgreSQL 16 profile or keep DB_AUTOMIGRATE=true")
+	}
+	return nil
+}
+
+func runMigrationBaseline(ctx context.Context, stdout, stderr io.Writer, cfg *config.Config, db *gorm.DB, release string) int {
+	if err := versionedProfileError(cfg); err != nil {
+		fmt.Fprintf(stderr, "migrate baseline: %v\n", err)
+		return schemamigrate.ExitIncompatible
+	}
+	result, err := schemamigrate.Baseline(ctx, db, cfg.DBDriver, release)
+	if err != nil {
+		fmt.Fprintf(stderr, "migrate baseline: %v\n", err)
+		if result.Status.State != "" {
+			fmt.Fprintf(stdout, "main %s\n", result.Status.Description())
+			var stateErr *schemamigrate.StateError
+			if errors.As(err, &stateErr) {
+				return result.Status.ExitCode()
+			}
+		}
+		return schemamigrate.ExitIncompatible
+	}
+	fmt.Fprintf(stdout, "binary=%s\n", Version)
+	fmt.Fprintf(stdout, "driver=%s\n", schemamigrate.NormalizeDriver(cfg.DBDriver))
+	fmt.Fprintf(stdout, "baseline release=%s recorded=%d before_fingerprint=%s after_fingerprint=%s\n",
+		result.Release, result.RecordedVersion, result.BeforeFingerprint, result.AfterFingerprint)
+	fmt.Fprintf(stdout, "main %s\n", result.Status.Description())
+	if result.Status.State == schemamigrate.StateExact {
+		fmt.Fprintln(stdout, "result=ready")
+	} else {
+		fmt.Fprintln(stdout, "result=baseline-recorded-migrate-up-required")
+	}
+	return schemamigrate.ExitOK
+}
+
+func inspectConfiguredAggregate(cfg *config.Config) (aggregate.StoreInspection, bool, error) {
+	if cfg.AggregateMode == aggregate.ModeLegacy {
+		return aggregate.StoreInspection{State: "not-required", ExpectedSchemaVersion: aggregate.StoreSchemaVersion, MigrationResult: "not-required"}, false, nil
+	}
+	status, err := aggregate.InspectSQLiteStore(cfg.AggregateDBPath)
+	return status, true, err
+}
+
+func ensureConfiguredAggregate(cfg *config.Config) (aggregate.StoreInspection, bool, error) {
+	status, required, err := inspectConfiguredAggregate(cfg)
+	if err != nil || !required || status.Usable() {
+		return status, required, err
+	}
+	if status.State != "empty" {
+		return status, required, fmt.Errorf("state=%s: %s", status.State, status.Detail)
+	}
+	store, err := aggregate.OpenSQLiteStore(aggregate.StoreConfig{
+		Path:         cfg.AggregateDBPath,
+		AllowRebuild: false,
+	})
+	if err != nil {
+		return status, required, err
+	}
+	if err := store.Close(); err != nil {
+		return status, required, err
+	}
+	status, err = aggregate.InspectSQLiteStore(cfg.AggregateDBPath)
+	status.MigrationResult = "created-v5"
+	return status, required, err
+}
+
+func printStatusReport(stdout io.Writer, cfg *config.Config, mainStatus schemamigrate.Status, aggregateStatus aggregate.StoreInspection, aggregateRequired bool) {
+	fmt.Fprintf(stdout, "binary=%s\n", Version)
+	fmt.Fprintf(stdout, "driver=%s\n", schemamigrate.NormalizeDriver(cfg.DBDriver))
+	fmt.Fprintf(stdout, "main %s\n", mainStatus.Description())
+	if aggregateRequired {
+		fmt.Fprintf(stdout, "aggregate %s\n", aggregateStatus.Description())
+	} else {
+		fmt.Fprintf(stdout, "aggregate state=not-required expected=%d actual=none migration_result=not-required\n", aggregate.StoreSchemaVersion)
+	}
+	if mainStatus.Usable() && (!aggregateRequired || aggregateStatus.Usable()) {
+		fmt.Fprintln(stdout, "result=ready")
+	} else {
+		fmt.Fprintln(stdout, "result=action-required")
+	}
+}

--- a/migrate_cli_test.go
+++ b/migrate_cli_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/config"
+	schemamigrate "github.com/RandomCodeSpace/otelcontext/internal/migrate"
+)
+
+func configureMigrationCLI(t *testing.T, mainPath, mode, aggregatePath string) {
+	t.Helper()
+	t.Setenv("DB_DRIVER", "sqlite")
+	t.Setenv("DB_DSN", mainPath)
+	t.Setenv("AGGREGATE_MODE", mode)
+	t.Setenv("AGGREGATE_DB_PATH", aggregatePath)
+	t.Setenv("AGGREGATE_ALLOW_REBUILD", "true")
+	t.Setenv("APP_ENV", "development")
+}
+
+func runMigrationCLIForTest(t *testing.T, args ...string) (int, string, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	handled, code := maybeRunMigrationCommand(args, &stdout, &stderr)
+	if !handled {
+		t.Fatalf("command was not handled: %v", args)
+	}
+	return code, stdout.String(), stderr.String()
+}
+
+func TestMigrationCLIStatusAndUpHaveStableOperatorOutput(t *testing.T) {
+	dir := t.TempDir()
+	configureMigrationCLI(t, filepath.Join(dir, "main.db"), aggregate.ModeLegacy, filepath.Join(dir, "aggregate.db"))
+
+	code, stdout, stderr := runMigrationCLIForTest(t, "migrate", "status")
+	if code != schemamigrate.ExitEmpty || stderr != "" || !strings.Contains(stdout, "main state=empty expected=2 actual=none") || !strings.Contains(stdout, "result=action-required") {
+		t.Fatalf("empty status code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	code, stdout, stderr = runMigrationCLIForTest(t, "migrate", "up")
+	if code != 0 || stderr != "" || !strings.Contains(stdout, "main state=exact expected=2 actual=2") || !strings.Contains(stdout, "result=ready") {
+		t.Fatalf("up code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	code, stdout, stderr = runMigrationCLIForTest(t, "migrate", "status")
+	if code != 0 || stderr != "" || !strings.Contains(stdout, "aggregate state=not-required") {
+		t.Fatalf("exact status code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+}
+
+func TestMigrationCLIUpCreatesOnlyAnEmptyAggregateV5(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.db")
+	aggregatePath := filepath.Join(dir, "aggregate.db")
+	configureMigrationCLI(t, mainPath, aggregate.ModeShadow, aggregatePath)
+	code, stdout, stderr := runMigrationCLIForTest(t, "migrate", "up")
+	if code != 0 || stderr != "" || !strings.Contains(stdout, "aggregate state=exact expected=5 actual=5") || !strings.Contains(stdout, "migration_result=created-v5") {
+		t.Fatalf("up code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+
+	db, err := sql.Open("sqlite", aggregatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE aggregate_meta SET value='4' WHERE key='schema_version'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	code, stdout, stderr = runMigrationCLIForTest(t, "migrate", "up")
+	if code != schemamigrate.ExitIncompatible || !strings.Contains(stderr, "cannot be migrated losslessly") || !strings.Contains(stdout, "main state=exact") {
+		t.Fatalf("v4 up code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	db, err = sql.Open("sqlite", aggregatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var version string
+	if err := db.QueryRow(`SELECT value FROM aggregate_meta WHERE key='schema_version'`).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if version != "4" {
+		t.Fatalf("migrate up rebuilt aggregate v4 despite explicit policy: version=%s", version)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store, err := aggregate.OpenSQLiteStore(aggregate.StoreConfig{Path: aggregatePath, AllowRebuild: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	code, stdout, stderr = runMigrationCLIForTest(t, "migrate", "up")
+	if code != 0 || stderr != "" || !strings.Contains(stdout, "main state=exact") || !strings.Contains(stdout, "aggregate state=exact") {
+		t.Fatalf("partial rerun code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+}
+
+func TestMigrationCLIUsageAndNormalInvocationDispatch(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if handled, _ := maybeRunMigrationCommand([]string{"--version"}, &stdout, &stderr); handled {
+		t.Fatal("normal invocation was intercepted by migration dispatch")
+	}
+	mainPath := filepath.Join(t.TempDir(), "main.db")
+	configureMigrationCLI(t, mainPath, aggregate.ModeLegacy, "")
+	code, _, stderrText := runMigrationCLIForTest(t, "migrate", "baseline")
+	if code != schemamigrate.ExitUsage || !strings.Contains(stderrText, migrationUsage) {
+		t.Fatalf("usage code=%d stderr=%q", code, stderrText)
+	}
+	if _, err := os.Stat(mainPath); !os.IsNotExist(err) {
+		t.Fatalf("invalid command opened or created the configured database: %v", err)
+	}
+	if err := versionedProfileError(&config.Config{DBDriver: "postgres", DBPostgresPartitioning: "daily"}); err == nil || !strings.Contains(err.Error(), "not promoted") {
+		t.Fatalf("daily partition profile error = %v", err)
+	}
+}

--- a/startup_schema.go
+++ b/startup_schema.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/config"
+	schemamigrate "github.com/RandomCodeSpace/otelcontext/internal/migrate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+// prepareDatabaseSchemas is the startup quiescence gate for schema ownership.
+// The caller must invoke it before starting any worker or listener.
+func prepareDatabaseSchemas(ctx context.Context, cfg *config.Config, repo *storage.Repository) error {
+	autoMigrate := storage.AutoMigrateEnabled()
+	if autoMigrate {
+		options := storage.MigrateOptionsFromEnv()
+		if err := schemamigrate.AutoMigrate(repo.DB(), cfg.DBDriver, options); err != nil {
+			return fmt.Errorf("development AutoMigrate: %w", err)
+		}
+		if schemamigrate.NormalizeDriver(cfg.DBDriver) == "postgres" && options.PostgresPartitioning == storage.PartitioningModeDaily {
+			repo.MarkLogsPartitioned()
+		}
+		slog.Info("Development AutoMigrate completed for main storage and GraphRAG",
+			"driver", schemamigrate.NormalizeDriver(cfg.DBDriver),
+			"binary_version", Version,
+		)
+	} else if schemamigrate.SupportsVersioned(cfg.DBDriver) {
+		if err := versionedProfileError(cfg); err != nil {
+			return err
+		}
+		status, err := schemamigrate.RequireExact(ctx, repo.DB(), cfg.DBDriver)
+		slog.Info("Production schema compatibility check",
+			"driver", status.Driver,
+			"state", status.State,
+			"expected_version", status.ExpectedVersion,
+			"actual_version", status.ActualVersion,
+			"fingerprint", status.Fingerprint,
+			"binary_version", Version,
+		)
+		if err != nil {
+			return err
+		}
+	} else {
+		slog.Warn("DB_AUTOMIGRATE=false leaves schema compatibility unverified for preview driver",
+			"driver", schemamigrate.NormalizeDriver(cfg.DBDriver),
+			"binary_version", Version,
+			"action", "keep DB_AUTOMIGRATE=true until versioned definitions are promoted",
+		)
+	}
+
+	if !autoMigrate && cfg.AggregateMode != aggregate.ModeLegacy {
+		status, err := aggregate.InspectSQLiteStore(cfg.AggregateDBPath)
+		if err != nil {
+			return fmt.Errorf("inspect aggregate schema: %w", err)
+		}
+		if !status.Usable() && cfg.AggregateAllowRebuild {
+			store, rebuildErr := aggregate.OpenSQLiteStore(aggregate.StoreConfig{
+				Path:         cfg.AggregateDBPath,
+				AllowRebuild: true,
+			})
+			if rebuildErr != nil {
+				return fmt.Errorf("explicit aggregate rebuild: %w", rebuildErr)
+			}
+			if closeErr := store.Close(); closeErr != nil {
+				return fmt.Errorf("close explicitly rebuilt aggregate store: %w", closeErr)
+			}
+			status, err = aggregate.InspectSQLiteStore(cfg.AggregateDBPath)
+			if err != nil {
+				return fmt.Errorf("inspect explicitly rebuilt aggregate schema: %w", err)
+			}
+		}
+		slog.Info("Production aggregate compatibility check",
+			"state", status.State,
+			"expected_version", status.ExpectedSchemaVersion,
+			"actual_version", status.ActualSchemaVersion,
+			"series_key_version", status.ActualSeriesVersion,
+			"sketch_codec_version", status.ActualSketchVersion,
+			"store_uuid", status.StoreUUID,
+			"binary_version", Version,
+		)
+		if !status.Usable() {
+			return fmt.Errorf("startup refused: aggregate schema state=%s expected=%d actual=%d: %s; run `otelcontext migrate status` then `otelcontext migrate up`, use the older signed binary, or explicitly rebuild with AGGREGATE_ALLOW_REBUILD=true",
+				status.State, status.ExpectedSchemaVersion, status.ActualSchemaVersion, status.Detail)
+		}
+	}
+	return nil
+}

--- a/startup_schema_test.go
+++ b/startup_schema_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/config"
+	schemamigrate "github.com/RandomCodeSpace/otelcontext/internal/migrate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+func openStartupRepository(t *testing.T, path string, autoMigrate bool) *storage.Repository {
+	t.Helper()
+	t.Setenv("DB_DRIVER", "sqlite")
+	t.Setenv("DB_DSN", path)
+	if autoMigrate {
+		t.Setenv("DB_AUTOMIGRATE", "true")
+	} else {
+		t.Setenv("DB_AUTOMIGRATE", "false")
+	}
+	repo, err := storage.NewRepository(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = repo.Close() })
+	return repo
+}
+
+func sqliteSchemaObjects(t *testing.T, repo *storage.Repository) []string {
+	t.Helper()
+	var objects []string
+	if err := repo.DB().Raw(`SELECT type || ':' || name FROM sqlite_master
+WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name`).Scan(&objects).Error; err != nil {
+		t.Fatal(err)
+	}
+	return objects
+}
+
+func TestProductionStartupRefusalDoesNotWriteSchema(t *testing.T) {
+	repo := openStartupRepository(t, filepath.Join(t.TempDir(), "empty.db"), false)
+	before := sqliteSchemaObjects(t, repo)
+	cfg := &config.Config{DBDriver: "sqlite", AggregateMode: aggregate.ModeLegacy}
+	err := prepareDatabaseSchemas(context.Background(), cfg, repo)
+	if err == nil || !strings.Contains(err.Error(), "state=empty") || !strings.Contains(err.Error(), "migrate up") {
+		t.Fatalf("error = %v", err)
+	}
+	after := sqliteSchemaObjects(t, repo)
+	if !reflect.DeepEqual(before, after) {
+		t.Fatalf("schema changed on read-only refusal: before=%v after=%v", before, after)
+	}
+	if repo.DB().Migrator().HasTable(schemamigrate.LedgerTable) {
+		t.Fatal("startup refusal created the migration ledger")
+	}
+}
+
+func TestDevelopmentStartupUsesOneMainAndGraphRAGOwner(t *testing.T) {
+	repo := openStartupRepository(t, filepath.Join(t.TempDir(), "development.db"), true)
+	cfg := &config.Config{DBDriver: "sqlite", AggregateMode: aggregate.ModeLegacy}
+	if err := prepareDatabaseSchemas(context.Background(), cfg, repo); err != nil {
+		t.Fatal(err)
+	}
+	for _, table := range []string{"traces", "spans", "logs", "metric_buckets", "investigations", "drain_templates"} {
+		if !repo.DB().Migrator().HasTable(table) {
+			t.Fatalf("shared AutoMigrate missed %s", table)
+		}
+	}
+	if repo.DB().Migrator().HasTable(schemamigrate.LedgerTable) {
+		t.Fatal("development AutoMigrate claimed a versioned ledger")
+	}
+}
+
+func TestProductionStartupAcceptsExactMainAndAggregateV5(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.db")
+	db, err := storage.NewDatabase("sqlite", mainPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := schemamigrate.Up(context.Background(), db, "sqlite"); err != nil {
+		t.Fatal(err)
+	}
+	if sqlDB, err := db.DB(); err == nil {
+		_ = sqlDB.Close()
+	}
+	aggregatePath := filepath.Join(dir, "aggregate.db")
+	store, err := aggregate.OpenSQLiteStore(aggregate.StoreConfig{Path: aggregatePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := openStartupRepository(t, mainPath, false)
+	cfg := &config.Config{DBDriver: "sqlite", AggregateMode: aggregate.ModeShadow, AggregateDBPath: aggregatePath}
+	if err := prepareDatabaseSchemas(context.Background(), cfg, repo); err != nil {
+		t.Fatal(err)
+	}
+
+	aggregateDB, err := sql.Open("sqlite", aggregatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := aggregateDB.Exec(`UPDATE aggregate_meta SET value='4' WHERE key='schema_version'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := aggregateDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareDatabaseSchemas(context.Background(), cfg, repo); err == nil || !strings.Contains(err.Error(), "aggregate schema state=incompatible") {
+		t.Fatalf("v4 without explicit rebuild error = %v", err)
+	}
+	cfg.AggregateAllowRebuild = true
+	if err := prepareDatabaseSchemas(context.Background(), cfg, repo); err != nil {
+		t.Fatalf("explicit aggregate rebuild: %v", err)
+	}
+	inspection, err := aggregate.InspectSQLiteStore(aggregatePath)
+	if err != nil || !inspection.Usable() {
+		t.Fatalf("inspection=%#v err=%v", inspection, err)
+	}
+}
+
+func TestSchemaGatePrecedesEveryWorkerAndListenerInMain(t *testing.T) {
+	source, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	gate := strings.Index(text, "prepareDatabaseSchemas(appCtx, cfg, repo)")
+	if gate < 0 {
+		t.Fatal("main does not call the schema gate")
+	}
+	for _, marker := range []string{
+		"startPprofServer(cfg.PprofAddr, logger)",
+		"partitionScheduler.Start(ctxPart)",
+		"go hub.Run()",
+		"go graphRAG.Start(ctxGraphRAG)",
+	} {
+		position := strings.Index(text, marker)
+		if position < 0 || position < gate {
+			t.Fatalf("%q position=%d must follow schema gate position=%d", marker, position, gate)
+		}
+	}
+	if strings.Contains(text, "graphrag.AutoMigrateGraphRAG") {
+		t.Fatal("main still has split GraphRAG migration ownership")
+	}
+}


### PR DESCRIPTION
Closes #245

Implements the schema lifecycle resolved in #234.

## Result

- embeds ordered SQLite and PostgreSQL migrations in the Go binary
- adds `migrate status`, `migrate baseline --from`, and `migrate up`
- uses the shared `otelcontext_schema_migrations` ledger for the main and GraphRAG schemas
- validates version gaps, dirty rows, checksums, structural fingerprints, and incompatible schemas before writes
- gates normal startup before listeners and workers when `DB_AUTOMIGRATE=false`
- keeps MySQL and SQL Server in their documented preview AutoMigrate path
- inspects aggregate schema independently and only creates an empty v5 store
- preserves the explicit aggregate rebuild escape hatch on normal startup
- adds dedicated SQLite and PostgreSQL 16 GitHub CI proof jobs and uploads their logs

## Baseline proof

Source-built trees at the exact historical tag commits were used for local upgrade proof. These are not claims about signed release artifacts; #254 owns that final evidence.

- `v0.3.1` (`c597614e300f0ca68dd93ed732d41b4a6f227c2b`): baseline preserved fingerprint `7aa0fba0e24401ed9581f5ae1b4a1240e4c620e7a92e783c747e1dba152d94fa`; upgrade reached current fingerprint `ae573dd9ec50c246dd848c085d48e10a6df6cdabb3e7fd5dc982e13562b531e7`
- `v0.4.0-beta.2` (`0a3b32d95455968b0d94395fe6968aedc5833229`): baseline preserved current fingerprint `ae573dd9ec50c246dd848c085d48e10a6df6cdabb3e7fd5dc982e13562b531e7`

## Targeted local verification

- `GOTOOLCHAIN=go1.25.13 go test -race -count=1 ./internal/migrate ./internal/storage ./internal/graphrag`
- `GOTOOLCHAIN=go1.25.13 go test -count=1 .`
- `GOTOOLCHAIN=go1.25.13 go test -race -count=1 -run ^TestInspectSQLiteStore ./internal/aggregate`
- `GOTOOLCHAIN=go1.25.13 go test -race -count=1 -tags=integration -timeout=8m -run ^TestPostgres16MigrationLifecycle$ ./internal/migrate`
- `GOTOOLCHAIN=go1.25.13 go vet ./internal/migrate ./internal/aggregate ./internal/storage ./internal/graphrag .`
- `GOTOOLCHAIN=go1.25.13 go build -trimpath .`
- GitHub Actions workflow YAML parsed successfully

The full repository regression suite remains the GitHub CI gate, as required by #243.

## Compatibility and rollback

Existing query, ingestion, GraphRAG, retention, and aggregate-rebuild behavior stays present. No down migrations are invented: rollback means restore the pre-upgrade binary and database snapshot. PostgreSQL daily partitioning is refused in the versioned path until it has an explicit promoted migration; its existing AutoMigrate path remains available.

Security hardening is intentionally outside this production-readiness epic.