### PR TITLE
feat: unify live topology providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,50 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  topology-proof:
+    name: topology proof · ${{ matrix.mode }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [legacy, aggregate-shadow, aggregate]
+    env:
+      CGO_ENABLED: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: run cross-consumer topology proof
+        env:
+          OTELCONTEXT_TOPOLOGY_PROOF_MODE: ${{ matrix.mode }}
+          OTELCONTEXT_TOPOLOGY_PROOF_DIR: ${{ runner.temp }}/topology-proof
+        run: |
+          set -o pipefail
+          mkdir -p "${OTELCONTEXT_TOPOLOGY_PROOF_DIR}"
+          go test -race -count=1 -v -run '^TestTopologyModeProof$' ./test/topologyproof 2>&1 \
+            | tee "${OTELCONTEXT_TOPOLOGY_PROOF_DIR}/${OTELCONTEXT_TOPOLOGY_PROOF_MODE}.log"
+          jq -e --arg mode "${OTELCONTEXT_TOPOLOGY_PROOF_MODE}" '
+            .schema_version == "otelcontext.topology-proof.v1" and
+            .mode == $mode and
+            (.edge_set | length) == 1 and
+            (.assertions | length) >= 10 and
+            all(.assertions[]; .passed == true)
+          ' "${OTELCONTEXT_TOPOLOGY_PROOF_DIR}/${OTELCONTEXT_TOPOLOGY_PROOF_MODE}.json"
+
+      - name: upload mode topology proof
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: topology-proof-${{ matrix.mode }}-${{ github.sha }}
+          path: ${{ runner.temp }}/topology-proof
+          if-no-files-found: error
+          retention-days: 14
+
   database-sqlite:
     name: database proof · sqlite
     runs-on: ubuntu-24.04

--- a/internal/aggregate/engine.go
+++ b/internal/aggregate/engine.go
@@ -344,7 +344,9 @@ func NewEngine(cfg EngineConfig) (*Engine, error) {
 	}
 	e.own.mutable = make(map[int64]struct{})
 	e.own.closed = make(map[int64]struct{})
-	e.own.epoch = newEpoch(cfg.Now())
+	// The query facade and the topology projection expose two encodings of
+	// this one process generation. They must never mint independent epochs.
+	e.own.epoch = strconv.FormatUint(epoch, 36)
 	var a Applier = directApplier{e}
 	e.applier.Store(&a)
 	return e, nil
@@ -387,10 +389,12 @@ func (e *Engine) TopologySnapshot(tenant string) TopologySnapshot {
 	return e.topology.Snapshot(tenant, e.now())
 }
 
-// PruneTopology drops topology windows past the retention horizon. The fold
-// path prunes the tenants it touches; this is what bounds a tenant that has
-// gone silent.
-func (e *Engine) PruneTopology() { e.topology.Prune(e.now()) }
+// PruneTopology drops topology windows past the retention horizon. A visible
+// expiry is a new full-replacement state, so it advances the same engine
+// revision used by commits and leaves an empty tenant tombstone for consumers.
+func (e *Engine) PruneTopology() {
+	e.topology.Prune(e.now(), func() uint64 { return e.revision.Add(1) })
+}
 
 // TopologyHorizon is how much finalized history the projection retains behind
 // the mutable set. Startup restore reads no further back than this: a window
@@ -548,13 +552,6 @@ func (e *Engine) evictWindowLocked(start int64) []SeriesWindowKey {
 		sh.mu.Unlock()
 	}
 	return released
-}
-
-// newEpoch derives a process generation identifier. It only has to differ from
-// the previous generation of the same process lineage, which a boot timestamp
-// in base 36 does without pulling in a UUID dependency.
-func newEpoch(now time.Time) string {
-	return strconv.FormatInt(now.UnixNano(), 36)
 }
 
 // SetApplier replaces the apply path. Phase 2 uses it to insert the

--- a/internal/aggregate/topology.go
+++ b/internal/aggregate/topology.go
@@ -559,15 +559,20 @@ func touchTimes(entry *topoEntry, d *AggregateDelta, window int64) {
 }
 
 // pruneTenantLocked drops windows behind the retention cutoff and forgets
-// entities that no longer hold any window.
-func (p *topologyProjection) pruneTenantLocked(tt *tenantTopology, cutoff int64) {
+// entities that no longer hold any window. It reports whether the visible
+// replacement changed.
+func (p *topologyProjection) pruneTenantLocked(tt *tenantTopology, cutoff int64) (changed bool) {
 	for name, e := range tt.services {
-		if pruneEntry(e, cutoff) {
+		empty, pruned := pruneEntry(e, cutoff)
+		changed = changed || pruned
+		if empty {
 			delete(tt.services, name)
 		}
 	}
 	for key, e := range tt.ops {
-		if pruneEntry(e, cutoff) {
+		empty, pruned := pruneEntry(e, cutoff)
+		changed = changed || pruned
+		if empty {
 			delete(tt.ops, key)
 			if n := tt.opsPerService[key.a]; n > 1 {
 				tt.opsPerService[key.a] = n - 1
@@ -577,38 +582,47 @@ func (p *topologyProjection) pruneTenantLocked(tt *tenantTopology, cutoff int64)
 		}
 	}
 	for key, e := range tt.edges {
-		if pruneEntry(e, cutoff) {
+		empty, pruned := pruneEntry(e, cutoff)
+		changed = changed || pruned
+		if empty {
 			delete(tt.edges, key)
 		}
 	}
 	for key, e := range tt.metrics {
-		if pruneEntry(e, cutoff) {
+		empty, pruned := pruneEntry(e, cutoff)
+		changed = changed || pruned
+		if empty {
 			delete(tt.metrics, key)
 		}
 	}
+	return changed
 }
 
 // pruneEntry drops expired windows and reports whether the entry is now empty.
-func pruneEntry(e *topoEntry, cutoff int64) bool {
+func pruneEntry(e *topoEntry, cutoff int64) (empty, changed bool) {
 	for start := range e.windows {
 		if start < cutoff {
 			delete(e.windows, start)
+			changed = true
 		}
 	}
-	return len(e.windows) == 0
+	return len(e.windows) == 0, changed
 }
 
 // Prune drops windows past the retention horizon for every tenant. The fold
 // path prunes the tenants it touches; this is what keeps a tenant that has gone
 // silent from holding its last windows forever.
-func (p *topologyProjection) Prune(now time.Time) {
+func (p *topologyProjection) Prune(now time.Time, nextRevision func() uint64) {
 	cutoff := p.retainCutoff(now)
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	for tenant, tt := range p.tenants {
-		p.pruneTenantLocked(tt, cutoff)
-		if len(tt.services) == 0 && len(tt.ops) == 0 && len(tt.edges) == 0 && len(tt.metrics) == 0 {
-			delete(p.tenants, tenant)
+	var revision uint64
+	for _, tt := range p.tenants {
+		if p.pruneTenantLocked(tt, cutoff) {
+			if revision == 0 {
+				revision = nextRevision()
+			}
+			tt.revision = revision
 		}
 	}
 }
@@ -642,10 +656,14 @@ func (p *topologyProjection) Revision(tenant string) uint64 {
 // the sketch here, so the consumer never touches engine state.
 func (p *topologyProjection) Snapshot(tenant string, now time.Time) TopologySnapshot {
 	snap := TopologySnapshot{
-		Tenant:  tenant,
-		Epoch:   p.epoch,
-		Now:     now,
-		Horizon: p.cfg.Horizon,
+		Tenant:     tenant,
+		Epoch:      p.epoch,
+		Now:        now,
+		Horizon:    p.cfg.Horizon,
+		Services:   []TopologyService{},
+		Operations: []TopologyOperation{},
+		Edges:      []SnapshotEdge{},
+		Metrics:    []TopologyMetric{},
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/aggregate/topology_test.go
+++ b/internal/aggregate/topology_test.go
@@ -1,6 +1,7 @@
 package aggregate
 
 import (
+	"strconv"
 	"testing"
 	"time"
 )
@@ -155,6 +156,61 @@ func TestTopologyPartialWindowMetadata(t *testing.T) {
 	}
 	if w.Elapsed != WindowSize {
 		t.Fatalf("closed window elapsed = %v, want %v", w.Elapsed, WindowSize)
+	}
+}
+
+func TestTopologyExpiryPublishesEmptyTombstone(t *testing.T) {
+	start := mustTime(t, "2026-08-21T12:02:00Z")
+	clock := start
+	e, err := NewEngine(EngineConfig{
+		Mode:  ModeAggregate,
+		Epoch: 12345,
+		Now:   func() time.Time { return clock },
+		Topology: TopologyConfig{
+			Horizon: 5 * time.Minute,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	r := e.NewReducer(clock)
+	reduceSpanAt(r, "acme", "checkout", "/pay", 0, 1000, clock)
+	if _, err := e.ApplyReducerErr(r); err != nil {
+		t.Fatalf("ApplyReducerErr: %v", err)
+	}
+	before := e.Revision()
+	if e.TopologySnapshot("acme").Empty() {
+		t.Fatal("fixture topology is empty before expiry")
+	}
+
+	clock = start.Add(30 * time.Minute)
+	e.PruneTopology()
+	if got := e.Revision(); got <= before {
+		t.Fatalf("engine revision did not advance on visible expiry: %d -> %d", before, got)
+	}
+	snap := e.TopologySnapshot("acme")
+	if !snap.Empty() || snap.Revision != e.Revision() {
+		t.Fatalf("expiry snapshot = %+v, want an empty replacement at revision %d", snap, e.Revision())
+	}
+	if snap.Services == nil || snap.Edges == nil {
+		t.Fatalf("empty tombstone has nil replacement slices: services=%v edges=%v", snap.Services, snap.Edges)
+	}
+	found := false
+	for _, tenant := range e.TopologyTenants() {
+		found = found || tenant == "acme"
+	}
+	if !found {
+		t.Fatal("expired tenant tombstone was removed before consumers could clear state")
+	}
+
+	stable := e.Revision()
+	e.PruneTopology()
+	if got := e.Revision(); got != stable {
+		t.Fatalf("idempotent prune moved revision: %d -> %d", stable, got)
+	}
+	if got, want := e.Epoch(), strconv.FormatUint(e.TopologyEpoch(), 36); got != want {
+		t.Fatalf("query epoch %q and topology epoch %q identify different generations", got, want)
 	}
 }
 

--- a/internal/api/graph_handler.go
+++ b/internal/api/graph_handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
 )
 
 // SystemSummary is the top-level system health summary.
@@ -57,6 +58,18 @@ type SystemGraphResponse struct {
 	System    SystemSummary `json:"system"`
 	Nodes     []GraphNode   `json:"nodes"`
 	Edges     []GraphEdge   `json:"edges"`
+
+	Source       string `json:"source,omitempty"`
+	Coverage     string `json:"coverage,omitempty"`
+	CoverageNote string `json:"coverage_note,omitempty"`
+	Epoch        string `json:"epoch,omitempty"`
+	Revision     uint64 `json:"revision,omitempty"`
+	Truncated    bool   `json:"truncated,omitempty"`
+
+	DroppedServices   uint64 `json:"dropped_services,omitempty"`
+	DroppedOperations uint64 `json:"dropped_operations,omitempty"`
+	DroppedEdges      uint64 `json:"dropped_edges,omitempty"`
+	DroppedMetrics    uint64 `json:"dropped_metrics,omitempty"`
 }
 
 var OtelContextStartTime = time.Now()
@@ -71,19 +84,32 @@ var OtelContextStartTime = time.Now()
 func (s *Server) handleGetSystemGraph(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	cacheKey := "system_graph:" + storage.TenantFromContext(ctx)
+	if s.aggregateTopology() {
+		cacheKey += ":" + s.topology.Identity(ctx).String()
+	}
 
 	if cached, ok := s.cache.Get(cacheKey); ok {
 		cached.(*cachedJSON).write(w, r, "HIT")
 		return
 	}
 
-	resp := s.buildGraphFromMemory(ctx)
-	if resp == nil {
-		// Graph not yet hydrated — fall back to DB path.
-		resp = s.buildGraphFromDB(ctx)
-		if resp == nil {
+	var resp *SystemGraphResponse
+	if s.topology != nil {
+		snapshot, err := s.topology.Snapshot(ctx, topology.Query{})
+		if err != nil {
 			http.Error(w, "failed to build system graph", http.StatusInternalServerError)
 			return
+		}
+		resp = buildGraphFromTopology(snapshot)
+	} else {
+		resp = s.buildGraphFromMemory(ctx)
+		if resp == nil {
+			// Graph not yet hydrated — fall back to DB path.
+			resp = s.buildGraphFromDB(ctx)
+			if resp == nil {
+				http.Error(w, "failed to build system graph", http.StatusInternalServerError)
+				return
+			}
 		}
 	}
 
@@ -94,6 +120,68 @@ func (s *Server) handleGetSystemGraph(w http.ResponseWriter, r *http.Request) {
 	}
 	s.cache.Set(cacheKey, cj, hotPollCacheTTL)
 	cj.write(w, r, "MISS")
+}
+
+func buildGraphFromTopology(snapshot topology.Snapshot) *SystemGraphResponse {
+	nodes := make([]GraphNode, 0, len(snapshot.Nodes))
+	var totalErrorRate, totalLatency float64
+	for _, node := range snapshot.Nodes {
+		health := node.HealthScore
+		status := node.Status
+		if status == "" {
+			health = computeHealthScore(node.ErrorRate, node.AvgLatencyMs)
+			status = healthStatus(health)
+		}
+		alerts := append([]string(nil), node.Alerts...)
+		if alerts == nil {
+			alerts = []string{}
+		}
+		nodes = append(nodes, GraphNode{
+			ID:          node.Name,
+			Type:        "service",
+			HealthScore: math.Round(health*100) / 100,
+			Status:      status,
+			Metrics: NodeMetrics{
+				RequestRateRPS: math.Round(node.RequestRateRPS*100) / 100,
+				ErrorRate:      math.Round(node.ErrorRate*1000000) / 1000000,
+				AvgLatencyMs:   math.Round(node.AvgLatencyMs*100) / 100,
+				P99LatencyMs:   math.Round(node.P99LatencyMs*100) / 100,
+				SpanCount1H:    node.SpanCount,
+			},
+			Alerts: alerts,
+		})
+		totalErrorRate += node.ErrorRate
+		totalLatency += node.AvgLatencyMs
+	}
+	edges := make([]GraphEdge, 0, len(snapshot.Edges))
+	for _, edge := range snapshot.Edges {
+		status := edge.Status
+		if status == "" {
+			status = healthStatus(computeHealthScore(edge.ErrorRate, edge.AvgLatencyMs))
+		}
+		edges = append(edges, GraphEdge{
+			Source:       edge.Source,
+			Target:       edge.Target,
+			CallCount:    edge.CallCount,
+			AvgLatencyMs: math.Round(edge.AvgLatencyMs*100) / 100,
+			ErrorRate:    math.Round(edge.ErrorRate*1000000) / 1000000,
+			Status:       status,
+		})
+	}
+	resp := buildSummaryResponse(nodes, edges, totalErrorRate, totalLatency)
+	if snapshot.Meta.Source == topology.SourceAggregate {
+		resp.Source = string(snapshot.Meta.Source)
+		resp.Coverage = snapshot.Meta.Coverage
+		resp.CoverageNote = snapshot.Meta.CoverageNote
+		resp.Epoch = snapshot.Meta.Epoch
+		resp.Revision = snapshot.Meta.Revision
+		resp.Truncated = snapshot.Meta.Truncated
+		resp.DroppedServices = snapshot.Meta.DroppedServices
+		resp.DroppedOperations = snapshot.Meta.DroppedOperations
+		resp.DroppedEdges = snapshot.Meta.DroppedEdges
+		resp.DroppedMetrics = snapshot.Meta.DroppedMetrics
+	}
+	return resp
 }
 
 // buildGraphFromMemory converts the in-memory graph snapshot to the API response.

--- a/internal/api/metrics_handlers.go
+++ b/internal/api/metrics_handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/RandomCodeSpace/otelcontext/internal/api/views"
 	"github.com/RandomCodeSpace/otelcontext/internal/httpconst"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
 )
 
 // handleGetTrafficMetrics handles GET /api/metrics/traffic
@@ -219,6 +220,9 @@ func (s *Server) handleGetServiceMapMetrics(w http.ResponseWriter, r *http.Reque
 	startStr := r.URL.Query().Get("start")
 	endStr := r.URL.Query().Get("end")
 	cacheKey := "service_map:" + storage.TenantFromContext(r.Context()) + ":" + startStr + ":" + endStr
+	if s.aggregateTopology() {
+		cacheKey += ":" + s.topology.Identity(r.Context()).String()
+	}
 
 	end := time.Now()
 	start := end.Add(-30 * time.Minute)
@@ -235,7 +239,7 @@ func (s *Server) handleGetServiceMapMetrics(w http.ResponseWriter, r *http.Reque
 	// Clamp BEFORE the cache lookup so the clamp headers are stamped on
 	// cache hits too (#217); the cache key is the raw start/end params, so
 	// every hit was produced from the same clamped range.
-	if s.aggregateReads() {
+	if s.aggregateReads() || s.aggregateTopology() {
 		start = clampAggregateRange(w, start, end)
 	}
 
@@ -267,6 +271,13 @@ func (s *Server) handleGetServiceMapMetrics(w http.ResponseWriter, r *http.Reque
 // series the reducer emits made that side-channel unnecessary, so the coverage
 // the engine reports is the coverage the response carries.
 func (s *Server) serviceMapView(r *http.Request, start, end time.Time) (views.ServiceMapMetrics, error) {
+	if s.topology != nil {
+		snapshot, err := s.topology.Snapshot(r.Context(), topology.Query{Start: start, End: end})
+		if err != nil {
+			return views.ServiceMapMetrics{}, err
+		}
+		return views.ServiceMapMetricsFromTopology(snapshot), nil
+	}
 	if !s.aggregateReads() {
 		metrics, err := s.repo.GetServiceMapMetrics(r.Context(), start, end)
 		if err != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/RandomCodeSpace/otelcontext/internal/realtime"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"github.com/RandomCodeSpace/otelcontext/internal/telemetry"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
 )
 
 // Server handles HTTP API requests.
@@ -24,6 +25,9 @@ type Server struct {
 	cache    *cache.TTLCache
 	graph    *graph.Graph       // in-memory service dependency graph (may be nil before first build)
 	graphRAG *graphrag.GraphRAG // layered GraphRAG for advanced queries
+	// topology is selected once from AGGREGATE_MODE before listeners start.
+	// It owns every service-map and system-graph read.
+	topology topology.Provider
 
 	// Saturation probes consulted by /ready. Each returns a fullness
 	// fraction in [0.0, 1.0]; nil disables the corresponding check.
@@ -150,6 +154,16 @@ func (s *Server) SetGraph(g *graph.Graph) {
 // SetGraphRAG wires the GraphRAG instance for advanced queries.
 func (s *Server) SetGraphRAG(g *graphrag.GraphRAG) {
 	s.graphRAG = g
+}
+
+// SetTopologyProvider installs the construction-time mode owner used by both
+// REST topology endpoints.
+func (s *Server) SetTopologyProvider(provider topology.Provider) {
+	s.topology = provider
+}
+
+func (s *Server) aggregateTopology() bool {
+	return s.topology != nil && s.topology.Source() == topology.SourceAggregate
 }
 
 // SetDLQSaturationProbe registers a callback returning DLQ disk fullness as

--- a/internal/api/topology_provider_test.go
+++ b/internal/api/topology_provider_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/api/views"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
+)
+
+type fakeTopologyProvider struct {
+	source   topology.Source
+	identity topology.Identity
+	snapshot topology.Snapshot
+	err      error
+}
+
+func (f *fakeTopologyProvider) Source() topology.Source { return f.source }
+
+func (f *fakeTopologyProvider) Identity(context.Context) topology.Identity { return f.identity }
+
+func (f *fakeTopologyProvider) Snapshot(context.Context, topology.Query) (topology.Snapshot, error) {
+	return f.snapshot, f.err
+}
+
+func TestAggregateTopologyProviderOwnsBothRESTGraphs(t *testing.T) {
+	provider := &fakeTopologyProvider{
+		source:   topology.SourceAggregate,
+		identity: topology.Identity{Epoch: "boot-a", Revision: 7},
+		snapshot: topology.Snapshot{
+			Nodes: []topology.Node{{Name: "gateway"}, {Name: "aggregate-payments"}},
+			Edges: []topology.Edge{{Source: "gateway", Target: "aggregate-payments", CallCount: 4}},
+			Meta: topology.Metadata{
+				Source:   topology.SourceAggregate,
+				Coverage: "full",
+				Epoch:    "boot-a",
+				Revision: 7,
+			},
+		},
+	}
+	server := NewServer(nil, nil, nil, nil)
+	server.SetTopologyProvider(provider)
+
+	serviceReq := httptest.NewRequest("GET", "/api/metrics/service-map", nil)
+	serviceRec := httptest.NewRecorder()
+	server.handleGetServiceMapMetrics(serviceRec, serviceReq)
+	if serviceRec.Code != 200 {
+		t.Fatalf("service map status = %d, body=%s", serviceRec.Code, serviceRec.Body.String())
+	}
+	var serviceMap views.ServiceMapMetrics
+	if err := json.Unmarshal(serviceRec.Body.Bytes(), &serviceMap); err != nil {
+		t.Fatalf("decode service map: %v", err)
+	}
+	if len(serviceMap.Edges) != 1 || serviceMap.Edges[0].Target != "aggregate-payments" {
+		t.Fatalf("service map mixed topology owners: %+v", serviceMap.Edges)
+	}
+	if serviceMap.Epoch != "boot-a" || serviceMap.Revision != 7 {
+		t.Fatalf("service map identity = %q/%d, want boot-a/7", serviceMap.Epoch, serviceMap.Revision)
+	}
+
+	systemReq := httptest.NewRequest("GET", "/api/system/graph", nil)
+	systemRec := httptest.NewRecorder()
+	server.handleGetSystemGraph(systemRec, systemReq)
+	if systemRec.Code != 200 {
+		t.Fatalf("system graph status = %d, body=%s", systemRec.Code, systemRec.Body.String())
+	}
+	var systemGraph SystemGraphResponse
+	if err := json.Unmarshal(systemRec.Body.Bytes(), &systemGraph); err != nil {
+		t.Fatalf("decode system graph: %v", err)
+	}
+	if len(systemGraph.Edges) != 1 || systemGraph.Edges[0].Target != "aggregate-payments" {
+		t.Fatalf("system graph mixed topology owners: %+v", systemGraph.Edges)
+	}
+	if systemGraph.Epoch != "boot-a" || systemGraph.Revision != 7 {
+		t.Fatalf("system graph identity = %q/%d, want boot-a/7", systemGraph.Epoch, systemGraph.Revision)
+	}
+}
+
+func TestAggregateTopologyCacheIdentityAndEmptyReplacement(t *testing.T) {
+	provider := &fakeTopologyProvider{
+		source:   topology.SourceAggregate,
+		identity: topology.Identity{Epoch: "boot-a", Revision: 1},
+		snapshot: topology.Snapshot{
+			Nodes: []topology.Node{{Name: "stale"}},
+			Edges: []topology.Edge{},
+			Meta:  topology.Metadata{Source: topology.SourceAggregate, Epoch: "boot-a", Revision: 1},
+		},
+	}
+	server := NewServer(nil, nil, nil, nil)
+	server.SetTopologyProvider(provider)
+	req := httptest.NewRequest("GET", "/api/system/graph", nil)
+
+	first := httptest.NewRecorder()
+	server.handleGetSystemGraph(first, req)
+	if first.Header().Get("X-Cache") != "MISS" {
+		t.Fatalf("first cache result = %q, want MISS", first.Header().Get("X-Cache"))
+	}
+
+	provider.identity.Revision = 2
+	provider.snapshot = topology.Snapshot{
+		Nodes: []topology.Node{},
+		Edges: []topology.Edge{},
+		Meta:  topology.Metadata{Source: topology.SourceAggregate, Epoch: "boot-a", Revision: 2},
+	}
+	second := httptest.NewRecorder()
+	server.handleGetSystemGraph(second, req)
+	if second.Header().Get("X-Cache") != "MISS" {
+		t.Fatalf("moved identity reused stale cache: %q", second.Header().Get("X-Cache"))
+	}
+	var got SystemGraphResponse
+	if err := json.Unmarshal(second.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode empty graph: %v", err)
+	}
+	if got.Nodes == nil || got.Edges == nil || len(got.Nodes) != 0 || len(got.Edges) != 0 {
+		t.Fatalf("empty replacement = nodes:%v edges:%v", got.Nodes, got.Edges)
+	}
+}

--- a/internal/api/views/views.go
+++ b/internal/api/views/views.go
@@ -17,6 +17,7 @@ import (
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
 )
 
 // --- Primary entity views ---
@@ -153,10 +154,17 @@ type ServiceMapMetrics struct {
 	Nodes []ServiceMapNode `json:"nodes"`
 	Edges []ServiceMapEdge `json:"edges"`
 
+	Source       string `json:"source,omitempty"`
 	Coverage     string `json:"coverage,omitempty"`
 	CoverageNote string `json:"coverage_note,omitempty"`
 	Epoch        string `json:"epoch,omitempty"`
 	Revision     uint64 `json:"revision,omitempty"`
+	Truncated    bool   `json:"truncated,omitempty"`
+
+	DroppedServices   uint64 `json:"dropped_services,omitempty"`
+	DroppedOperations uint64 `json:"dropped_operations,omitempty"`
+	DroppedEdges      uint64 `json:"dropped_edges,omitempty"`
+	DroppedMetrics    uint64 `json:"dropped_metrics,omitempty"`
 }
 
 // --- GraphRAG views ---
@@ -465,6 +473,44 @@ func ServiceMapMetricsFromAggregate(r *aggregate.TopologyResult) ServiceMapMetri
 		Epoch:        r.Epoch,
 		Revision:     r.Revision,
 	}
+}
+
+// ServiceMapMetricsFromTopology converts the mode-selected provider snapshot
+// without exposing its owning package on the HTTP wire.
+func ServiceMapMetricsFromTopology(snapshot topology.Snapshot) ServiceMapMetrics {
+	nodes := make([]ServiceMapNode, len(snapshot.Nodes))
+	for i, node := range snapshot.Nodes {
+		nodes[i] = ServiceMapNode{
+			Name:         node.Name,
+			TotalTraces:  node.TotalTraces,
+			ErrorCount:   node.ErrorCount,
+			AvgLatencyMs: node.AvgLatencyMs,
+		}
+	}
+	edges := make([]ServiceMapEdge, len(snapshot.Edges))
+	for i, edge := range snapshot.Edges {
+		edges[i] = ServiceMapEdge{
+			Source:       edge.Source,
+			Target:       edge.Target,
+			CallCount:    edge.CallCount,
+			AvgLatencyMs: edge.AvgLatencyMs,
+			ErrorRate:    edge.ErrorRate,
+		}
+	}
+	out := ServiceMapMetrics{Nodes: nodes, Edges: edges}
+	if snapshot.Meta.Source == topology.SourceAggregate {
+		out.Source = string(snapshot.Meta.Source)
+		out.Coverage = snapshot.Meta.Coverage
+		out.CoverageNote = snapshot.Meta.CoverageNote
+		out.Epoch = snapshot.Meta.Epoch
+		out.Revision = snapshot.Meta.Revision
+		out.Truncated = snapshot.Meta.Truncated
+		out.DroppedServices = snapshot.Meta.DroppedServices
+		out.DroppedOperations = snapshot.Meta.DroppedOperations
+		out.DroppedEdges = snapshot.Meta.DroppedEdges
+		out.DroppedMetrics = snapshot.Meta.DroppedMetrics
+	}
+	return out
 }
 
 // ServiceMapMetricsFromModel converts repo topology into the view form.

--- a/internal/graphrag/aggregate.go
+++ b/internal/graphrag/aggregate.go
@@ -55,18 +55,30 @@ func (g *GraphRAG) AggregateMode() bool { return g.mode == aggregate.ModeAggrega
 // aggregate modes so two template ID spaces never exist (#163).
 func (g *GraphRAG) externalTemplates() bool { return g.mode != aggregate.ModeLegacy }
 
-// SetAggregateSource wires the aggregate engine's topology projection. It is
-// only consulted in aggregate mode; wiring it in any other mode is a no-op by
-// construction, so main.go can call it unconditionally.
-func (g *GraphRAG) SetAggregateSource(src AggregateSource) { g.aggSource = src }
+// SetAggregateSource wires the aggregate engine's topology projection. Main
+// calls it before Start; the lock also keeps tests and alternate construction
+// paths from racing the refresh loop.
+func (g *GraphRAG) SetAggregateSource(src AggregateSource) {
+	g.topologyMu.Lock()
+	g.aggSource = src
+	g.topologyMu.Unlock()
+}
 
 // reconcileTopology replaces each tenant's service topology from the aggregate
 // snapshot whose revision it has not already applied. It is the aggregate-mode
 // stand-in for rebuildAllTenantsFromDB and issues no database query at all.
 func (g *GraphRAG) reconcileTopology() {
-	if !g.AggregateMode() || g.aggSource == nil {
+	if !g.AggregateMode() {
 		return
 	}
+	g.topologyMu.Lock()
+	defer g.topologyMu.Unlock()
+	if g.aggSource == nil {
+		return
+	}
+	// Expiry is itself a publishable replacement. Prune before reading the
+	// identity so this read can apply the empty tombstone immediately.
+	g.aggSource.PruneTopology()
 	epoch := g.aggSource.TopologyEpoch()
 	applied := 0
 	for _, tenant := range g.aggSource.TopologyTenants() {
@@ -87,9 +99,16 @@ func (g *GraphRAG) reconcileTopology() {
 		stores.lastTopology.Store(&snap)
 		applied++
 	}
-	g.aggSource.PruneTopology()
 	if applied > 0 {
 		slog.Debug("GraphRAG reconciled aggregate topology", "tenants", applied, "epoch", epoch)
+	}
+}
+
+// ensureTopologyCurrent makes the aggregate provider revision, rather than
+// the 60-second cleanup tick, the freshness bound for a topology read.
+func (g *GraphRAG) ensureTopologyCurrent() {
+	if g.AggregateMode() {
+		g.reconcileTopology()
 	}
 }
 

--- a/internal/graphrag/aggregate_test.go
+++ b/internal/graphrag/aggregate_test.go
@@ -174,6 +174,40 @@ func TestReconcileSkipsUnchangedRevision(t *testing.T) {
 	}
 }
 
+func TestTopologyReadReconcilesMovedAndEmptyRevision(t *testing.T) {
+	src := &fakeAggregateSource{
+		epoch: 7,
+		snaps: map[string]aggregate.TopologySnapshot{
+			storage.DefaultTenantID: oneServiceSnapshot(1, 10, 0),
+		},
+	}
+	g := aggregateGraphRAG(t, newTestRepo(t), src)
+	ctx := storage.WithTenantContext(context.Background(), storage.DefaultTenantID)
+
+	if got := g.ServiceMap(ctx, 0); len(got) != 1 || got[0].Service.Name != "checkout" {
+		t.Fatalf("first topology-dependent read did not reconcile provider state: %+v", got)
+	}
+
+	empty := aggregate.TopologySnapshot{
+		Tenant:     storage.DefaultTenantID,
+		Revision:   2,
+		Services:   []aggregate.TopologyService{},
+		Operations: []aggregate.TopologyOperation{},
+		Edges:      []aggregate.SnapshotEdge{},
+		Metrics:    []aggregate.TopologyMetric{},
+	}
+	src.snaps[storage.DefaultTenantID] = empty
+	if got := g.ServiceMap(ctx, 0); len(got) != 0 {
+		t.Fatalf("empty replacement left stale GraphRAG services: %+v", got)
+	}
+	if edges := g.AllServiceEdges(ctx); len(edges) != 0 {
+		t.Fatalf("empty replacement left stale GraphRAG edges: %+v", edges)
+	}
+	if got := src.renders.Load(); got != 2 {
+		t.Fatalf("topology reads rendered %d snapshots, want one per moved revision", got)
+	}
+}
+
 // TestReconcileHandlesEpochReset proves a restarted engine — new epoch, revision
 // counter back to a LOWER number — is applied rather than skipped as "already
 // seen".

--- a/internal/graphrag/builder.go
+++ b/internal/graphrag/builder.go
@@ -163,6 +163,10 @@ type GraphRAG struct {
 	// aggSource is the aggregate engine's topology projection, consulted only
 	// in aggregate mode.
 	aggSource AggregateSource
+	// topologyMu serializes the periodic backstop with read-through freshness.
+	// Without it, an older render could replace a newer revision under two
+	// concurrent topology-dependent reads.
+	topologyMu sync.Mutex
 }
 
 // SetMetrics wires the Prometheus registry so GraphRAG event drops are

--- a/internal/graphrag/queries.go
+++ b/internal/graphrag/queries.go
@@ -165,6 +165,7 @@ func (g *GraphRAG) ImpactAnalysis(ctx context.Context, service string, maxDepth 
 		maxDepth = 5
 	}
 
+	g.ensureTopologyCurrent()
 	stores := g.storesFor(ctx)
 
 	result := &ImpactResult{Service: service}
@@ -308,6 +309,7 @@ type CorrelatedSignalsResult struct {
 }
 
 func (g *GraphRAG) CorrelatedSignals(ctx context.Context, service string, since time.Time) *CorrelatedSignalsResult {
+	g.ensureTopologyCurrent()
 	stores := g.storesFor(ctx)
 	result := &CorrelatedSignalsResult{Service: service}
 
@@ -339,6 +341,7 @@ func (g *GraphRAG) CorrelatedSignals(ctx context.Context, service string, since 
 
 // ShortestPath finds the shortest path between two services using Dijkstra.
 func (g *GraphRAG) ShortestPath(ctx context.Context, from, to string) []string {
+	g.ensureTopologyCurrent()
 	stores := g.storesFor(ctx)
 	// Build adjacency from CALLS edges
 	stores.service.mu.RLock()
@@ -430,6 +433,7 @@ func (g *GraphRAG) AnomaliesForService(ctx context.Context, service string, sinc
 // Kept as a narrow helper so API handlers do not need to traverse the
 // tenantStores composite themselves.
 func (g *GraphRAG) AllServiceEdges(ctx context.Context) []*Edge {
+	g.ensureTopologyCurrent()
 	return g.storesFor(ctx).service.AllEdges()
 }
 
@@ -438,6 +442,7 @@ func (g *GraphRAG) AllServiceEdges(ctx context.Context) []*Edge {
 // DB scan. Used by /api/metadata/services so the dropdown matches the
 // system map exactly (both are sourced from the same store).
 func (g *GraphRAG) ServiceNames(ctx context.Context) []string {
+	g.ensureTopologyCurrent()
 	services := g.storesFor(ctx).service.AllServices()
 	names := make([]string, 0, len(services))
 	for _, svc := range services {
@@ -456,6 +461,7 @@ type ServiceMapEntry struct {
 }
 
 func (g *GraphRAG) ServiceMap(ctx context.Context, depth int) []ServiceMapEntry {
+	g.ensureTopologyCurrent()
 	stores := g.storesFor(ctx)
 	services := stores.service.AllServices()
 	result := make([]ServiceMapEntry, 0, len(services))
@@ -487,6 +493,7 @@ func (g *GraphRAG) ServiceMapAround(ctx context.Context, seed string, depth int)
 	if depth <= 0 {
 		depth = 1
 	}
+	g.ensureTopologyCurrent()
 	stores := g.storesFor(ctx)
 	if _, ok := stores.service.GetService(seed); !ok {
 		return nil

--- a/internal/mcp/robustness_test.go
+++ b/internal/mcp/robustness_test.go
@@ -271,7 +271,7 @@ func TestRobustness_TimeoutHoldsSemaphoreSlot(t *testing.T) {
 
 // TestRobustness_SSEHeartbeat_KeepsConnectionAlive verifies that the SSE
 // stream emits a `: keep-alive` comment within a short window even when
-// the periodic graph snapshot path has nothing to send (svcGraph nil).
+// the periodic graph snapshot path has nothing to send (provider nil).
 func TestRobustness_SSEHeartbeat_KeepsConnectionAlive(t *testing.T) {
 	srv := minimalServer(t)
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/RandomCodeSpace/otelcontext/internal/httpconst"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"github.com/RandomCodeSpace/otelcontext/internal/telemetry"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
 )
 
 const (
@@ -68,7 +69,7 @@ const (
 type Server struct {
 	repo          *storage.Repository
 	metrics       *telemetry.Metrics
-	svcGraph      *graph.Graph
+	topology      topology.Provider
 	graphRAG      *graphrag.GraphRAG
 	defaultTenant string
 
@@ -109,7 +110,7 @@ func New(
 	defaultTenant string,
 	repo *storage.Repository,
 	metrics *telemetry.Metrics,
-	svcGraph *graph.Graph,
+	topologyProvider topology.Provider,
 ) *Server {
 	if defaultTenant == "" {
 		defaultTenant = storage.DefaultTenantID
@@ -117,7 +118,7 @@ func New(
 	return &Server{
 		repo:          repo,
 		metrics:       metrics,
-		svcGraph:      svcGraph,
+		topology:      topologyProvider,
 		defaultTenant: defaultTenant,
 		callSlots:     make(chan struct{}, defaultMaxConcurrentCalls),
 		callTimeout:   defaultCallTimeout,
@@ -295,11 +296,12 @@ func (s *Server) handleRPC(w http.ResponseWriter, r *http.Request) {
 		if tenant == "" {
 			tenant = s.defaultTenant
 		}
+		cacheTenant := s.topologyCacheScope(r.Context(), tenant, params.Name)
 
 		// Cache fast-path: cheap, idempotent GraphRAG tools are memoized
 		// for a few seconds so polling agent clients don't cripple the
 		// in-memory store under load.
-		if cached, hit := s.cache.Get(tenant, params.Name, params.Arguments); hit {
+		if cached, hit := s.cache.Get(cacheTenant, params.Name, params.Arguments); hit {
 			s.cacheHits.Add(1)
 			result = cached
 			break
@@ -344,7 +346,7 @@ func (s *Server) handleRPC(w http.ResponseWriter, r *http.Request) {
 		}
 		s.callsServiced.Add(1)
 		if !toolResult.IsError {
-			s.cache.Set(tenant, params.Name, params.Arguments, toolResult)
+			s.cache.Set(cacheTenant, params.Name, params.Arguments, toolResult)
 		}
 		result = toolResult
 
@@ -386,6 +388,17 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	// Send initial endpoint event per MCP Streamable HTTP spec.
 	writeSSE(w, flusher, "endpoint", `{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`)
+	tenant := strings.TrimSpace(r.Header.Get(mcpTenantHeader))
+	if tenant == "" {
+		tenant = s.defaultTenant
+	}
+	ctx := storage.WithTenantContext(r.Context(), tenant)
+	lastIdentity := topology.Identity{}
+	haveIdentity := false
+	if data, identity, ok := s.topologyNotification(ctx, lastIdentity, haveIdentity); ok {
+		writeSSE(w, flusher, "message", data)
+		lastIdentity, haveIdentity = identity, true
+	}
 
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
@@ -408,26 +421,135 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 			_, _ = fmt.Fprintf(w, ": keep-alive\n\n")
 			flusher.Flush()
 		case <-ticker.C:
-			if s.svcGraph == nil {
+			if s.topology == nil {
 				continue
 			}
-			snap := s.svcGraph.Snapshot()
-			data, err := json.Marshal(snap)
-			if err != nil {
+			if s.topology.Source() == topology.SourceAggregate {
+				identity := s.topology.Identity(ctx)
+				if haveIdentity && identity.Epoch == lastIdentity.Epoch && identity.Revision == lastIdentity.Revision {
+					continue
+				}
+				if haveIdentity && identity.Epoch == lastIdentity.Epoch && identity.Revision < lastIdentity.Revision {
+					continue
+				}
+			}
+			data, identity, ok := s.topologyNotification(ctx, lastIdentity, haveIdentity)
+			if !ok {
 				continue
 			}
-			notification := map[string]any{
-				"jsonrpc": "2.0",
-				"method":  "notifications/resources/updated",
-				"params": map[string]any{
-					"uri":  "OtelContext://system/graph",
-					"data": string(data),
-				},
-			}
-			notifData, _ := json.Marshal(notification)
-			writeSSE(w, flusher, "message", string(notifData))
+			writeSSE(w, flusher, "message", data)
+			lastIdentity, haveIdentity = identity, true
 		}
 	}
+}
+
+type mcpTopologyPayload struct {
+	Nodes     map[string]*graph.ServiceNode
+	Edges     []graph.ServiceEdge
+	UpdatedAt time.Time
+
+	Source       string `json:"source,omitempty"`
+	Coverage     string `json:"coverage,omitempty"`
+	CoverageNote string `json:"coverage_note,omitempty"`
+	Epoch        string `json:"epoch,omitempty"`
+	Revision     uint64 `json:"revision,omitempty"`
+	Reset        bool   `json:"reset,omitempty"`
+	Truncated    bool   `json:"truncated,omitempty"`
+
+	DroppedServices   uint64 `json:"dropped_services,omitempty"`
+	DroppedOperations uint64 `json:"dropped_operations,omitempty"`
+	DroppedEdges      uint64 `json:"dropped_edges,omitempty"`
+	DroppedMetrics    uint64 `json:"dropped_metrics,omitempty"`
+}
+
+func (s *Server) topologyNotification(ctx context.Context, last topology.Identity, haveLast bool) (string, topology.Identity, bool) {
+	if s.topology == nil {
+		return "", topology.Identity{}, false
+	}
+	snapshot, err := s.topology.Snapshot(ctx, topology.Query{})
+	if err != nil {
+		slog.Debug("MCP topology update retained last good state", "error", err)
+		return "", topology.Identity{}, false
+	}
+	identity := snapshot.Meta.Identity()
+	if identity.Epoch == "" && s.topology.Source() == topology.SourceAggregate {
+		identity = s.topology.Identity(ctx)
+	}
+	if haveLast && identity.Epoch == last.Epoch && identity.Revision < last.Revision {
+		return "", topology.Identity{}, false
+	}
+	payload := mcpTopologyPayload{
+		Nodes:             make(map[string]*graph.ServiceNode, len(snapshot.Nodes)),
+		Edges:             make([]graph.ServiceEdge, 0, len(snapshot.Edges)),
+		UpdatedAt:         snapshot.Meta.End,
+		Source:            string(snapshot.Meta.Source),
+		Coverage:          snapshot.Meta.Coverage,
+		CoverageNote:      snapshot.Meta.CoverageNote,
+		Epoch:             identity.Epoch,
+		Revision:          identity.Revision,
+		Reset:             !haveLast || identity.Epoch != last.Epoch,
+		Truncated:         snapshot.Meta.Truncated,
+		DroppedServices:   snapshot.Meta.DroppedServices,
+		DroppedOperations: snapshot.Meta.DroppedOperations,
+		DroppedEdges:      snapshot.Meta.DroppedEdges,
+		DroppedMetrics:    snapshot.Meta.DroppedMetrics,
+	}
+	if payload.UpdatedAt.IsZero() {
+		payload.UpdatedAt = time.Now().UTC()
+	}
+	for _, node := range snapshot.Nodes {
+		alerts := append([]string(nil), node.Alerts...)
+		if alerts == nil {
+			alerts = []string{}
+		}
+		payload.Nodes[node.Name] = &graph.ServiceNode{
+			Name:           node.Name,
+			HealthScore:    node.HealthScore,
+			Status:         node.Status,
+			RequestRateRPS: node.RequestRateRPS,
+			ErrorRate:      node.ErrorRate,
+			AvgLatencyMs:   node.AvgLatencyMs,
+			P99LatencyMs:   node.P99LatencyMs,
+			SpanCount:      node.SpanCount,
+			Alerts:         alerts,
+		}
+	}
+	for _, edge := range snapshot.Edges {
+		payload.Edges = append(payload.Edges, graph.ServiceEdge{
+			Source:       edge.Source,
+			Target:       edge.Target,
+			CallCount:    edge.CallCount,
+			AvgLatencyMs: edge.AvgLatencyMs,
+			ErrorRate:    edge.ErrorRate,
+			Status:       edge.Status,
+		})
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return "", topology.Identity{}, false
+	}
+	notification := map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "notifications/resources/updated",
+		"params": map[string]any{
+			"uri":  "OtelContext://system/graph",
+			"data": string(payloadJSON),
+		},
+	}
+	notificationJSON, err := json.Marshal(notification)
+	if err != nil {
+		return "", topology.Identity{}, false
+	}
+	return string(notificationJSON), identity, true
+}
+
+func (s *Server) topologyCacheScope(ctx context.Context, tenant, tool string) string {
+	if s.topology == nil || s.topology.Source() != topology.SourceAggregate ||
+		(tool != "get_service_map" && tool != "get_service_health") {
+		return tenant
+	}
+	ctx = storage.WithTenantContext(ctx, tenant)
+	return tenant + "\x00topology=" + s.topology.Identity(ctx).String()
 }
 
 // writeSSE writes a single SSE event.

--- a/internal/mcp/tenant_isolation_test.go
+++ b/internal/mcp/tenant_isolation_test.go
@@ -1,6 +1,6 @@
 // Package mcp tests the merge-gate invariant for RAN-19/RAN-39: every
-// GraphRAG-backed MCP tool (and the legacy svcGraph-backed tools rewired
-// onto GraphRAG) must scope its response to the tenant carried by the
+// GraphRAG-backed MCP tool, including the provider-backed topology tools,
+// must scope its response to the tenant carried by the
 // X-Tenant-ID header — overlapping data ingested for two tenants under
 // the same service_name, trace_id, span_id, log template, and snapshot
 // time must never leak across tenant boundaries.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -10,6 +10,7 @@ import (
 	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
 	"github.com/RandomCodeSpace/otelcontext/internal/httpconst"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
 )
 
 const (
@@ -135,7 +136,11 @@ func (s *Server) toolHandler(ctx context.Context, name string, args map[string]a
 		"search_logs":          s.toolSearchLogs,
 	}
 	if fn, ok := dispatch[name]; ok {
-		return s.withCoverage(fn(ctx, args), toolCoverage[name])
+		result := fn(ctx, args)
+		if name == "get_service_map" || name == "get_service_health" {
+			return s.withTopologyCoverage(ctx, result)
+		}
+		return s.withCoverage(result, toolCoverage[name])
 	}
 	return errorResult(fmt.Sprintf("unknown tool: %s", name))
 }
@@ -159,8 +164,47 @@ var toolCoverage = map[string]aggregate.Coverage{
 // coverageMeta is the body metadata appended to every successful tool result
 // in aggregate mode.
 type coverageMeta struct {
-	Coverage string `json:"coverage"`
-	Note     string `json:"coverage_note,omitempty"`
+	Coverage  string `json:"coverage"`
+	Note      string `json:"coverage_note,omitempty"`
+	Source    string `json:"source,omitempty"`
+	Epoch     string `json:"epoch,omitempty"`
+	Revision  uint64 `json:"revision,omitempty"`
+	Truncated bool   `json:"truncated,omitempty"`
+
+	DroppedServices   uint64 `json:"dropped_services,omitempty"`
+	DroppedOperations uint64 `json:"dropped_operations,omitempty"`
+	DroppedEdges      uint64 `json:"dropped_edges,omitempty"`
+	DroppedMetrics    uint64 `json:"dropped_metrics,omitempty"`
+}
+
+func (s *Server) withTopologyCoverage(ctx context.Context, result ToolCallResult) ToolCallResult {
+	if s == nil || !s.aggregateMode || result.IsError || s.topology == nil || s.topology.Source() != topology.SourceAggregate {
+		return result
+	}
+	snapshot, err := s.topology.Snapshot(ctx, topology.Query{})
+	if err != nil {
+		return errorResult("topology provider unavailable")
+	}
+	coverage := snapshot.Meta.Coverage
+	if coverage == "" {
+		coverage = string(aggregate.CoverageFull)
+	}
+	data, err := json.Marshal(coverageMeta{
+		Coverage:          coverage,
+		Note:              snapshot.Meta.CoverageNote,
+		Source:            string(snapshot.Meta.Source),
+		Epoch:             snapshot.Meta.Epoch,
+		Revision:          snapshot.Meta.Revision,
+		Truncated:         snapshot.Meta.Truncated,
+		DroppedServices:   snapshot.Meta.DroppedServices,
+		DroppedOperations: snapshot.Meta.DroppedOperations,
+		DroppedEdges:      snapshot.Meta.DroppedEdges,
+		DroppedMetrics:    snapshot.Meta.DroppedMetrics,
+	})
+	if err == nil {
+		result.Content = append(result.Content, ContentItem{Type: "text", Text: string(data)})
+	}
+	return result
 }
 
 // withCoverage appends coverage metadata as an ADDITIONAL content item.

--- a/internal/mcp/topology_provider_test.go
+++ b/internal/mcp/topology_provider_test.go
@@ -1,0 +1,87 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
+)
+
+type fakeMCPTopologyProvider struct {
+	epoch    string
+	revision atomic.Uint64
+	snapshot topology.Snapshot
+	err      error
+}
+
+func (*fakeMCPTopologyProvider) Source() topology.Source { return topology.SourceAggregate }
+
+func (p *fakeMCPTopologyProvider) Identity(context.Context) topology.Identity {
+	return topology.Identity{Epoch: p.epoch, Revision: p.revision.Load()}
+}
+
+func (p *fakeMCPTopologyProvider) Snapshot(context.Context, topology.Query) (topology.Snapshot, error) {
+	if p.err != nil {
+		return topology.Snapshot{}, p.err
+	}
+	snapshot := p.snapshot
+	snapshot.Meta.Source = topology.SourceAggregate
+	snapshot.Meta.Epoch = p.epoch
+	snapshot.Meta.Revision = p.revision.Load()
+	return snapshot, nil
+}
+
+func TestMCPTopologySSEImmediatelyUsesProvider(t *testing.T) {
+	provider := &fakeMCPTopologyProvider{
+		epoch: "boot-a",
+		snapshot: topology.Snapshot{
+			Nodes: []topology.Node{{Name: "gateway"}, {Name: "aggregate-payments"}},
+			Edges: []topology.Edge{{Source: "gateway", Target: "aggregate-payments"}},
+			Meta:  topology.Metadata{Coverage: "full"},
+		},
+	}
+	provider.revision.Store(7)
+	server := New("default", nil, nil, provider)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	request := httptest.NewRequest("GET", "/mcp", nil).WithContext(ctx)
+	request.Header.Set("Last-Event-ID", "old:99")
+	recorder := httptest.NewRecorder()
+	server.handleSSE(recorder, request)
+
+	body := recorder.Body.String()
+	if !strings.Contains(body, "notifications/resources/updated") || !strings.Contains(body, "aggregate-payments") {
+		t.Fatalf("SSE did not send the current provider replacement immediately: %s", body)
+	}
+	if !strings.Contains(body, `\"epoch\":\"boot-a\"`) || !strings.Contains(body, `\"revision\":7`) || !strings.Contains(body, `\"reset\":true`) {
+		t.Fatalf("SSE replacement identity/reset missing: %s", body)
+	}
+}
+
+func TestMCPTopologyCacheScopeMovesWithProviderIdentity(t *testing.T) {
+	provider := &fakeMCPTopologyProvider{epoch: "boot-a", snapshot: topology.Snapshot{Nodes: []topology.Node{}, Edges: []topology.Edge{}}}
+	provider.revision.Store(1)
+	server := New("default", nil, nil, provider)
+	first := server.topologyCacheScope(context.Background(), "default", "get_service_map")
+	provider.revision.Store(2)
+	second := server.topologyCacheScope(context.Background(), "default", "get_service_map")
+	if first == second {
+		t.Fatalf("cache scope did not change with topology revision: %q", first)
+	}
+	if got := server.topologyCacheScope(context.Background(), "default", "trace_graph"); got != "default" {
+		t.Fatalf("non-topology tool cache scope changed: %q", got)
+	}
+}
+
+func TestMCPTopologyProviderErrorPublishesNothing(t *testing.T) {
+	provider := &fakeMCPTopologyProvider{epoch: "boot-a", err: errors.New("boom")}
+	server := New("default", nil, nil, provider)
+	if _, _, ok := server.topologyNotification(context.Background(), topology.Identity{Epoch: "boot-a", Revision: 1}, true); ok {
+		t.Fatal("provider error became an empty SSE replacement")
+	}
+}

--- a/internal/realtime/aggregate_publisher.go
+++ b/internal/realtime/aggregate_publisher.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
 )
 
 // EnginePublisher is the AggregatePublisher backed by the aggregate engine.
@@ -16,7 +17,8 @@ import (
 // seven-day history is never in a WebSocket message — a client that wants it
 // asks for it over HTTP once, not on every revision bump.
 type EnginePublisher struct {
-	engine *aggregate.Engine
+	engine   *aggregate.Engine
+	topology topology.Provider
 	// window is how far back the coalesced payload reaches.
 	window time.Duration
 	// tenant scopes the queries when the caller's context carries none. Since
@@ -29,6 +31,9 @@ type EnginePublisher struct {
 type EnginePublisherConfig struct {
 	// Engine is the aggregate query facade. Required.
 	Engine *aggregate.Engine
+	// Topology is the same mode-selected provider injected into REST, MCP and
+	// GraphRAG. It is required and must be aggregate-owned.
+	Topology topology.Provider
 	// Window is the trailing range of the coalesced payload. Zero takes 15
 	// minutes, matching the legacy snapshot window.
 	Window time.Duration
@@ -45,7 +50,7 @@ type EnginePublisherConfig struct {
 // NewEnginePublisher builds a publisher over the engine. It returns nil when no
 // engine is configured, which is what keeps the caller's wiring a one-liner.
 func NewEnginePublisher(cfg EnginePublisherConfig) *EnginePublisher {
-	if cfg.Engine == nil {
+	if cfg.Engine == nil || cfg.Topology == nil || cfg.Topology.Source() != topology.SourceAggregate {
 		return nil
 	}
 	if cfg.Window <= 0 {
@@ -55,17 +60,20 @@ func NewEnginePublisher(cfg EnginePublisherConfig) *EnginePublisher {
 		cfg.Tenant = storage.DefaultTenantID
 	}
 	return &EnginePublisher{
-		engine: cfg.Engine,
-		window: cfg.Window,
-		tenant: cfg.Tenant,
+		engine:   cfg.Engine,
+		topology: cfg.Topology,
+		window:   cfg.Window,
+		tenant:   cfg.Tenant,
 	}
 }
 
 // Epoch implements AggregatePublisher.
-func (p *EnginePublisher) Epoch() string { return p.engine.Epoch() }
+func (p *EnginePublisher) Epoch() string { return p.topology.Identity(context.Background()).Epoch }
 
 // Revision implements AggregatePublisher.
-func (p *EnginePublisher) Revision() uint64 { return p.engine.Revision() }
+func (p *EnginePublisher) Revision() uint64 {
+	return p.topology.Identity(context.Background()).Revision
+}
 
 // Snapshot implements AggregatePublisher.
 func (p *EnginePublisher) Snapshot(ctx context.Context, service string) *LiveSnapshot {
@@ -82,22 +90,39 @@ func (p *EnginePublisher) Snapshot(ctx context.Context, service string) *LiveSna
 	tenant := p.tenant
 	if storage.HasTenantContext(ctx) {
 		tenant = storage.TenantFromContext(ctx)
+	} else {
+		ctx = storage.WithTenantContext(ctx, tenant)
 	}
 	q := aggregate.Query{Tenant: tenant, Start: start, End: now, Services: services}
+	topologySnapshot, err := p.topology.Snapshot(ctx, topology.Query{Start: start, End: now, Services: services})
+	if err != nil {
+		slog.Debug("aggregate snapshot: topology provider failed", "error", err)
+		return nil
+	}
 
 	snap := &LiveSnapshot{
-		Type:     "live_snapshot",
-		Epoch:    p.engine.Epoch(),
-		Revision: p.engine.Revision(),
+		Type:              "live_snapshot",
+		Epoch:             topologySnapshot.Meta.Epoch,
+		Revision:          topologySnapshot.Meta.Revision,
+		Source:            string(topologySnapshot.Meta.Source),
+		Coverage:          topologySnapshot.Meta.Coverage,
+		CoverageNote:      topologySnapshot.Meta.CoverageNote,
+		Truncated:         topologySnapshot.Meta.Truncated,
+		DroppedServices:   topologySnapshot.Meta.DroppedServices,
+		DroppedOperations: topologySnapshot.Meta.DroppedOperations,
+		DroppedEdges:      topologySnapshot.Meta.DroppedEdges,
+		DroppedMetrics:    topologySnapshot.Meta.DroppedMetrics,
 	}
 
 	// Nodes and edges are both engine-sourced and read over the same range
 	// (#194 finding 15), so the payload carries the engine's own coverage
 	// instead of the blanket "sampled" the exemplar-fed edge side-channel
 	// forced on it.
-	coverage := aggregate.CoverageFull
-	snap.Coverage = string(coverage)
-	snap.CoverageNote = coverage.Note()
+	if snap.Coverage == "" {
+		coverage := aggregate.CoverageFull
+		snap.Coverage = string(coverage)
+		snap.CoverageNote = coverage.Note()
+	}
 
 	if dash, err := p.engine.QueryDashboard(q); err == nil {
 		snap.Dashboard = &storage.DashboardStats{
@@ -139,20 +164,20 @@ func (p *EnginePublisher) Snapshot(ctx context.Context, service string) *LiveSna
 		slog.Debug("aggregate snapshot: traffic query failed", "error", err)
 	}
 
-	if topo, err := p.engine.QueryTopology(q); err == nil {
+	{
 		sm := &storage.ServiceMapMetrics{
-			Nodes: make([]storage.ServiceMapNode, 0, len(topo.Nodes)),
-			Edges: make([]storage.ServiceMapEdge, 0, len(topo.Edges)),
+			Nodes: make([]storage.ServiceMapNode, 0, len(topologySnapshot.Nodes)),
+			Edges: make([]storage.ServiceMapEdge, 0, len(topologySnapshot.Edges)),
 		}
-		for _, n := range topo.Nodes {
+		for _, n := range topologySnapshot.Nodes {
 			sm.Nodes = append(sm.Nodes, storage.ServiceMapNode{
-				Name:         n.Service,
-				TotalTraces:  n.Count,
+				Name:         n.Name,
+				TotalTraces:  n.TotalTraces,
 				ErrorCount:   n.ErrorCount,
 				AvgLatencyMs: n.AvgLatencyMs,
 			})
 		}
-		for _, e := range topo.Edges {
+		for _, e := range topologySnapshot.Edges {
 			sm.Edges = append(sm.Edges, storage.ServiceMapEdge{
 				Source:       e.Source,
 				Target:       e.Target,
@@ -162,8 +187,6 @@ func (p *EnginePublisher) Snapshot(ctx context.Context, service string) *LiveSna
 			})
 		}
 		snap.ServiceMap = sm
-	} else {
-		slog.Debug("aggregate snapshot: topology query failed", "error", err)
 	}
 
 	// Traces stay absent: individual traces are exemplars in aggregate mode,

--- a/internal/realtime/aggregate_ws_test.go
+++ b/internal/realtime/aggregate_ws_test.go
@@ -17,6 +17,7 @@ type fakePublisher struct {
 	epoch atomic.Value // string
 	rev   atomic.Uint64
 	calls atomic.Int64
+	fail  atomic.Bool
 }
 
 func newFakePublisher(epoch string) *fakePublisher {
@@ -29,6 +30,9 @@ func (p *fakePublisher) Epoch() string    { return p.epoch.Load().(string) }
 func (p *fakePublisher) Revision() uint64 { return p.rev.Load() }
 func (p *fakePublisher) Snapshot(context.Context, string) *LiveSnapshot {
 	p.calls.Add(1)
+	if p.fail.Load() {
+		return nil
+	}
 	return &LiveSnapshot{
 		Type:     "live_snapshot",
 		Epoch:    p.Epoch(),
@@ -124,6 +128,25 @@ func TestAggregateWSTrailingEdgeDelivery(t *testing.T) {
 	}
 }
 
+func TestAggregateWSSameEpochRevisionNeverDecreases(t *testing.T) {
+	hub := NewEventHub(nil, nil, nil)
+	pub := newFakePublisher("epoch-1")
+	pub.rev.Store(6)
+	hub.SetAggregatePublisher(pub, time.Second)
+	hub.published = true
+	hub.lastEpoch = "epoch-1"
+	hub.lastRev = 7
+
+	hub.publishIfChanged()
+
+	if hub.lastRev != 7 {
+		t.Fatalf("published revision regressed to %d", hub.lastRev)
+	}
+	if pub.calls.Load() != 0 {
+		t.Fatalf("rendered %d stale replacement(s)", pub.calls.Load())
+	}
+}
+
 // TestAggregateWSPublishesOnlyOnRevisionChange: an idle engine produces no
 // data messages, however many spacing intervals elapse.
 func TestAggregateWSPublishesOnlyOnRevisionChange(t *testing.T) {
@@ -145,6 +168,82 @@ func TestAggregateWSPublishesOnlyOnRevisionChange(t *testing.T) {
 	hub.publishIfChanged()
 	if hub.lastRev != 4 {
 		t.Fatalf("lastRev = %d after a change, want 4", hub.lastRev)
+	}
+}
+
+func TestAggregateWSProviderErrorRetainsLastGoodIdentity(t *testing.T) {
+	hub := NewEventHub(nil, nil, nil)
+	pub := newFakePublisher("epoch-1")
+	hub.SetAggregatePublisher(pub, time.Hour)
+	pub.rev.Store(2)
+	pub.fail.Store(true)
+	hub.published = true
+	hub.lastEpoch = "epoch-1"
+	hub.lastRev = 1
+	client := &clientFilter{send: make(chan []byte, 1)}
+	hub.clients[nil] = client
+
+	hub.publishIfChanged()
+	if hub.lastRev != 1 {
+		t.Fatalf("provider error advanced last good revision to %d", hub.lastRev)
+	}
+	if len(client.send) != 0 {
+		t.Fatal("provider error published a replacement")
+	}
+}
+
+func TestAggregateWSReconnectRetriesObservedRevisionAfterProviderRecovery(t *testing.T) {
+	hub := NewEventHub(nil, nil, nil)
+	pub := newFakePublisher("epoch-1")
+	pub.rev.Store(2)
+	pub.fail.Store(true)
+	hub.SetAggregatePublisher(pub, 20*time.Millisecond)
+	// Observe the revision while idle, without rendering it.
+	hub.publishIfChanged()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go hub.Start(ctx, time.Hour, time.Hour)
+	server := httptest.NewServer(http.HandlerFunc(hub.HandleWebSocket))
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	conn, response, err := websocket.Dial(dialCtx, "ws"+server.URL[len("http"):], nil)
+	dialCancel()
+	if response != nil && response.Body != nil {
+		_ = response.Body.Close()
+	}
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close(websocket.StatusNormalClosure, "test")
+		cancel()
+		hub.Stop()
+		server.Close()
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for pub.calls.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if pub.calls.Load() == 0 {
+		t.Fatal("reconnect did not attempt an immediate snapshot")
+	}
+	pub.fail.Store(false)
+
+	readCtx, readCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer readCancel()
+	_, message, err := conn.Read(readCtx)
+	if err != nil {
+		t.Fatalf("read recovered snapshot: %v", err)
+	}
+	var snapshot LiveSnapshot
+	if err := json.Unmarshal(message, &snapshot); err != nil {
+		t.Fatalf("decode recovered snapshot: %v", err)
+	}
+	if snapshot.Revision != 2 {
+		t.Fatalf("recovered revision = %d, want 2", snapshot.Revision)
+	}
+	if !snapshot.Reset {
+		t.Fatal("recovered reconnect snapshot is not flagged reset")
 	}
 }
 

--- a/internal/realtime/events_ws.go
+++ b/internal/realtime/events_ws.go
@@ -35,6 +35,13 @@ type LiveSnapshot struct {
 	Reset        bool   `json:"reset,omitempty"`
 	Coverage     string `json:"coverage,omitempty"`
 	CoverageNote string `json:"coverage_note,omitempty"`
+	Source       string `json:"source,omitempty"`
+	Truncated    bool   `json:"truncated,omitempty"`
+
+	DroppedServices   uint64 `json:"dropped_services,omitempty"`
+	DroppedOperations uint64 `json:"dropped_operations,omitempty"`
+	DroppedEdges      uint64 `json:"dropped_edges,omitempty"`
+	DroppedMetrics    uint64 `json:"dropped_metrics,omitempty"`
 }
 
 // AggregatePublisher supplies revision-driven snapshots in aggregate mode. It
@@ -149,9 +156,10 @@ type EventHub struct {
 	aggPub       AggregatePublisher
 	publishFloor time.Duration
 	// lastEpoch and lastRev are what was last published to every client.
-	lastEpoch string
-	lastRev   uint64
-	published bool
+	lastEpoch  string
+	lastRev    uint64
+	published  bool
+	retryReset bool
 }
 
 // NewEventHub creates a new event notification hub.
@@ -350,7 +358,13 @@ func (h *EventHub) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Send immediate FULL snapshot so the client has data right away. In
 	// aggregate mode it carries {epoch, revision} and reset=true: a fresh
 	// client has nothing to merge into and must adopt the snapshot whole.
-	h.sendSnapshotTo(cf)
+	if !h.sendSnapshotTo(cf) && h.aggregatePublisher() != nil {
+		// A failed reconnect seed must remain retryable even when the revision
+		// was observed earlier while no clients were connected.
+		h.mu.Lock()
+		h.retryReset = true
+		h.mu.Unlock()
+	}
 
 	// Read loop: client can send {"service":"xxx"} to change filter. The
 	// tenant scope is not negotiable and is deliberately absent here.
@@ -545,20 +559,22 @@ func (h *EventHub) sendBatch(cf *clientFilter, batchType string, data any) {
 	h.deliver(cf, msg)
 }
 
-// sendSnapshotTo sends a snapshot to a single client.
-func (h *EventHub) sendSnapshotTo(cf *clientFilter) {
+// sendSnapshotTo sends a snapshot to a single client and reports whether a
+// full replacement was queued.
+func (h *EventHub) sendSnapshotTo(cf *clientFilter) bool {
 	snapshot := h.snapshotFor(scopeKey{tenant: cf.tenant, service: cf.service})
 	if snapshot == nil {
-		return
+		return false
 	}
 	if h.aggregatePublisher() != nil {
 		snapshot.Reset = true
 	}
 	msg, err := json.Marshal(snapshot)
 	if err != nil {
-		return
+		return false
 	}
 	h.deliver(cf, msg)
+	return true
 }
 
 // snapshotFor produces the payload for one scope from whichever source owns
@@ -616,34 +632,48 @@ func (h *EventHub) publishIfChanged() {
 	epoch, rev := pub.Epoch(), pub.Revision()
 
 	h.mu.Lock()
-	if h.published && h.lastEpoch == epoch && h.lastRev == rev {
+	if h.published && !h.retryReset && h.lastEpoch == epoch && h.lastRev == rev {
 		h.mu.Unlock()
 		return
 	}
-	// An epoch change means the revision counter restarted: clients cannot
-	// merge across it and are told to reset.
-	reset := h.published && h.lastEpoch != epoch
-	h.lastEpoch, h.lastRev, h.published = epoch, rev, true
+	if h.published && h.lastEpoch == epoch && rev < h.lastRev {
+		h.mu.Unlock()
+		return
+	}
+	reset := h.retryReset || (h.published && h.lastEpoch != epoch)
 	if len(h.clients) == 0 {
+		h.lastEpoch, h.lastRev, h.published = epoch, rev, true
+		h.retryReset = false
 		h.mu.Unlock()
 		return
 	}
 	groups := h.groupByScopeLocked()
 	h.mu.Unlock()
 
-	for scope, clients := range groups {
+	messages := make(map[scopeKey][]byte, len(groups))
+	for scope := range groups {
 		snap := h.snapshotFor(scope)
 		if snap == nil {
-			continue
+			// A provider error is not an empty topology. Keep the last good
+			// identity so the same revision is retried on the next tick.
+			return
 		}
 		snap.Reset = reset
 		msg, err := json.Marshal(snap)
 		if err != nil {
 			slog.Error("Event WS marshal failed", "error", err)
-			continue
+			return
 		}
+		messages[scope] = msg
+	}
+
+	h.mu.Lock()
+	h.lastEpoch, h.lastRev, h.published = epoch, rev, true
+	h.retryReset = false
+	h.mu.Unlock()
+	for scope, clients := range groups {
 		for _, cf := range clients {
-			h.deliver(cf, msg)
+			h.deliver(cf, messages[scope])
 		}
 	}
 }

--- a/internal/realtime/hub.go
+++ b/internal/realtime/hub.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/RandomCodeSpace/otelcontext/internal/authn"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
 	"github.com/coder/websocket"
 )
 
@@ -59,6 +60,13 @@ type HubBatch struct {
 	Data any    `json:"data"` // Slice of entries
 }
 
+type topologyRefresh struct {
+	Source   string `json:"source"`
+	Epoch    string `json:"epoch"`
+	Revision uint64 `json:"revision"`
+	Reset    bool   `json:"reset,omitempty"`
+}
+
 // Hub is a buffered WebSocket broadcast hub.
 //
 // Instead of broadcasting each log individually (which would freeze the UI at high throughput),
@@ -90,6 +98,13 @@ type Hub struct {
 	// re-broadcasting every event would contradict the coalesced,
 	// revision-driven publication the event hub performs (#164).
 	aggregateMode atomic.Bool
+	// topology emits one small browser wake-up for each coalesced aggregate
+	// replacement. The browser then refetches the provider-owned REST view.
+	topology          topology.Provider
+	topologyFloor     time.Duration
+	topologyEpoch     string
+	topologyRevision  uint64
+	topologyPublished bool
 
 	stopCh chan struct{}
 	// runOwner is claimed exactly once, by whichever of Run or Stop gets there
@@ -177,6 +192,17 @@ func (h *Hub) Run() {
 
 	flushTicker := time.NewTicker(h.flushInterval)
 	defer flushTicker.Stop()
+	var topologyTicker *time.Ticker
+	var topologyC <-chan time.Time
+	if h.aggregateMode.Load() && h.topology != nil && h.topology.Source() == topology.SourceAggregate {
+		floor := h.topologyFloor
+		if floor <= 0 {
+			floor = DefaultPublishFloor
+		}
+		topologyTicker = time.NewTicker(floor)
+		topologyC = topologyTicker.C
+		defer topologyTicker.Stop()
+	}
 
 	for {
 		select {
@@ -196,6 +222,19 @@ func (h *Hub) Run() {
 
 		case c := <-h.register:
 			h.clients[c] = struct{}{}
+			if msg, id, ok := h.topologyRefreshMessage(c.tenant, true); ok {
+				if h.topologyPublished && h.topologyEpoch == id.Epoch && id.Revision < h.topologyRevision {
+					id = topology.Identity{Epoch: h.topologyEpoch, Revision: h.topologyRevision}
+					msg, _ = json.Marshal(HubBatch{Type: "topology_refresh", Data: topologyRefresh{
+						Source: string(h.topology.Source()), Epoch: id.Epoch, Revision: id.Revision, Reset: true,
+					}})
+				}
+				select {
+				case c.send <- msg:
+					h.topologyEpoch, h.topologyRevision, h.topologyPublished = id.Epoch, id.Revision, true
+				default:
+				}
+			}
 			slog.Info("🔌 WebSocket client connected", "total", len(h.clients))
 			if h.onConnectionChange != nil {
 				h.onConnectionChange(len(h.clients))
@@ -235,7 +274,100 @@ func (h *Hub) Run() {
 
 		case <-flushTicker.C:
 			h.flush()
+
+		case <-topologyC:
+			h.publishTopologyRefresh()
 		}
+	}
+}
+
+// SetTopologyProvider installs the construction-time provider used only for
+// aggregate browser refresh notifications. Legacy raw batches are unchanged.
+func (h *Hub) SetTopologyProvider(provider topology.Provider, floor time.Duration) {
+	if provider == nil {
+		return
+	}
+	if floor <= 0 {
+		floor = DefaultPublishFloor
+	}
+	h.topology = provider
+	h.topologyFloor = floor
+}
+
+func (h *Hub) topologyRefreshMessage(tenant string, reset bool) ([]byte, topology.Identity, bool) {
+	if !h.aggregateMode.Load() || h.topology == nil || h.topology.Source() != topology.SourceAggregate {
+		return nil, topology.Identity{}, false
+	}
+	ctx := context.Background()
+	if tenant != "" {
+		ctx = storage.WithTenantContext(ctx, tenant)
+	}
+	snapshot, err := h.topology.Snapshot(ctx, topology.Query{})
+	if err != nil {
+		slog.Debug("topology refresh skipped: provider failed", "error", err)
+		return nil, topology.Identity{}, false
+	}
+	id := snapshot.Meta.Identity()
+	if id.Epoch == "" {
+		id = h.topology.Identity(ctx)
+	}
+	message, err := json.Marshal(HubBatch{Type: "topology_refresh", Data: topologyRefresh{
+		Source:   string(h.topology.Source()),
+		Epoch:    id.Epoch,
+		Revision: id.Revision,
+		Reset:    reset,
+	}})
+	if err != nil {
+		return nil, topology.Identity{}, false
+	}
+	return message, id, true
+}
+
+func (h *Hub) publishTopologyRefresh() {
+	if h.topology == nil || len(h.clients) == 0 {
+		return
+	}
+	id := h.topology.Identity(context.Background())
+	if h.topologyPublished && h.topologyEpoch == id.Epoch && h.topologyRevision == id.Revision {
+		return
+	}
+	if h.topologyPublished && h.topologyEpoch == id.Epoch && id.Revision < h.topologyRevision {
+		return
+	}
+	reset := h.topologyPublished && h.topologyEpoch != id.Epoch
+	message, rendered, ok := h.topologyRefreshMessage("", reset)
+	if !ok {
+		return
+	}
+	if h.topologyPublished && h.topologyEpoch == rendered.Epoch && rendered.Revision < h.topologyRevision {
+		return
+	}
+	h.topologyEpoch, h.topologyRevision, h.topologyPublished = rendered.Epoch, rendered.Revision, true
+	sent := 0
+	var slow []*client
+	for client := range h.clients {
+		select {
+		case client.send <- message:
+			sent++
+		default:
+			slow = append(slow, client)
+		}
+	}
+	for _, client := range slow {
+		delete(h.clients, client)
+		if client.closed.CompareAndSwap(false, true) {
+			close(client.send)
+		}
+		slog.Warn("Hub: slow client removed", "total", len(h.clients))
+		if h.onConnectionChange != nil {
+			h.onConnectionChange(len(h.clients))
+		}
+		if h.onSlowClientDrop != nil {
+			h.onSlowClientDrop()
+		}
+	}
+	if sent > 0 && h.onMessageSent != nil {
+		h.onMessageSent("topology_refresh")
 	}
 }
 

--- a/internal/realtime/topology_refresh_test.go
+++ b/internal/realtime/topology_refresh_test.go
@@ -1,0 +1,116 @@
+package realtime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
+	"github.com/coder/websocket"
+)
+
+type fakeRefreshProvider struct {
+	epoch atomic.Value
+	rev   atomic.Uint64
+}
+
+func newFakeRefreshProvider(epoch string) *fakeRefreshProvider {
+	provider := &fakeRefreshProvider{}
+	provider.epoch.Store(epoch)
+	return provider
+}
+
+func (*fakeRefreshProvider) Source() topology.Source { return topology.SourceAggregate }
+
+func (p *fakeRefreshProvider) Identity(context.Context) topology.Identity {
+	return topology.Identity{Epoch: p.epoch.Load().(string), Revision: p.rev.Load()}
+}
+
+func (p *fakeRefreshProvider) Snapshot(ctx context.Context, _ topology.Query) (topology.Snapshot, error) {
+	id := p.Identity(ctx)
+	return topology.Snapshot{
+		Nodes: []topology.Node{},
+		Edges: []topology.Edge{},
+		Meta:  topology.Metadata{Source: topology.SourceAggregate, Epoch: id.Epoch, Revision: id.Revision},
+	}, nil
+}
+
+func TestAggregateRawWSSendsCoalescedTopologyRefresh(t *testing.T) {
+	hub := NewHub(nil)
+	provider := newFakeRefreshProvider("boot-a")
+	provider.rev.Store(1)
+	hub.SetAggregateMode(true)
+	hub.SetTopologyProvider(provider, 30*time.Millisecond)
+	go hub.Run()
+
+	server := httptest.NewServer(http.HandlerFunc(hub.HandleWebSocket))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	conn, response, err := websocket.Dial(ctx, "ws"+server.URL[len("http"):], nil)
+	cancel()
+	if response != nil && response.Body != nil {
+		_ = response.Body.Close()
+	}
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close(websocket.StatusNormalClosure, "test")
+		hub.Stop()
+		server.Close()
+	})
+
+	first := readTopologyRefresh(t, conn, 2*time.Second)
+	if first.Epoch != "boot-a" || first.Revision != 1 || !first.Reset {
+		t.Fatalf("initial refresh = %+v, want boot-a/1 reset", first)
+	}
+
+	provider.rev.Store(2)
+	next := readTopologyRefresh(t, conn, 2*time.Second)
+	if next.Epoch != "boot-a" || next.Revision != 2 || next.Reset {
+		t.Fatalf("revision refresh = %+v, want boot-a/2 without reset", next)
+	}
+}
+
+func TestAggregateRawWSNoClientsDoesNotConsumeRevision(t *testing.T) {
+	hub := NewHub(nil)
+	provider := newFakeRefreshProvider("boot-a")
+	provider.rev.Store(9)
+	hub.SetAggregateMode(true)
+	hub.SetTopologyProvider(provider, time.Second)
+	t.Cleanup(hub.Stop)
+
+	hub.publishTopologyRefresh()
+
+	if hub.topologyPublished {
+		t.Fatal("revision was marked published with no clients")
+	}
+}
+
+func readTopologyRefresh(t *testing.T, conn *websocket.Conn, timeout time.Duration) topologyRefresh {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	_, message, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read topology refresh: %v", err)
+	}
+	var envelope struct {
+		Type string          `json:"type"`
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(message, &envelope); err != nil {
+		t.Fatalf("decode refresh envelope: %v (%s)", err, message)
+	}
+	if envelope.Type != "topology_refresh" {
+		t.Fatalf("message type = %q, want topology_refresh", envelope.Type)
+	}
+	var refresh topologyRefresh
+	if err := json.Unmarshal(envelope.Data, &refresh); err != nil {
+		t.Fatalf("decode refresh: %v", err)
+	}
+	return refresh
+}

--- a/internal/topology/aggregate.go
+++ b/internal/topology/aggregate.go
@@ -1,0 +1,223 @@
+package topology
+
+import (
+	"context"
+	"errors"
+	"math"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+// AggregateProvider is both the ordinary mode-selected provider and the
+// narrow aggregate projection source GraphRAG already consumes.
+type AggregateProvider struct {
+	engine *aggregate.Engine
+}
+
+func NewAggregateProvider(engine *aggregate.Engine) (*AggregateProvider, error) {
+	if engine == nil {
+		return nil, errors.New("aggregate topology provider requires an engine")
+	}
+	if engine.Mode() != aggregate.ModeAggregate {
+		return nil, errors.New("aggregate topology provider requires AGGREGATE_MODE=aggregate")
+	}
+	return &AggregateProvider{engine: engine}, nil
+}
+
+func (*AggregateProvider) Source() Source { return SourceAggregate }
+
+func (p *AggregateProvider) Identity(context.Context) Identity {
+	p.engine.PruneTopology()
+	return Identity{Epoch: p.engine.Epoch(), Revision: p.engine.Revision()}
+}
+
+func (p *AggregateProvider) Snapshot(ctx context.Context, q Query) (Snapshot, error) {
+	id := p.Identity(ctx)
+	tenant := storage.TenantFromContext(ctx)
+	projection := p.engine.TopologySnapshot(tenant)
+	meta := aggregateMetadata(id, projection)
+
+	if q.Start.IsZero() && q.End.IsZero() {
+		meta.Start = projection.Now.Add(-projection.Horizon)
+		meta.End = projection.Now
+		snap := fromAggregateProjection(projection)
+		snap.Meta = meta
+		filterSnapshot(&snap, q.Services)
+		finishSnapshot(&snap, nil)
+		return snap, nil
+	}
+	meta.Start, meta.End = q.Start, q.End
+
+	result, err := p.engine.QueryTopology(aggregate.Query{
+		Tenant:   tenant,
+		Start:    q.Start,
+		End:      q.End,
+		Services: append([]string(nil), q.Services...),
+	})
+	if err != nil {
+		return Snapshot{}, err
+	}
+	meta.Epoch = result.Epoch
+	meta.Revision = result.Revision
+	if result.Coverage != "" && !meta.Truncated {
+		meta.Coverage = string(result.Coverage)
+		meta.CoverageNote = result.Coverage.Note()
+	}
+	snap := Snapshot{
+		Nodes: make([]Node, 0, len(result.Nodes)),
+		Edges: make([]Edge, 0, len(result.Edges)),
+		Meta:  meta,
+	}
+	for _, node := range result.Nodes {
+		errorRate := node.ErrorRate
+		health := aggregateHealth(errorRate, node.AvgLatencyMs)
+		snap.Nodes = append(snap.Nodes, Node{
+			Name:         node.Service,
+			TotalTraces:  node.Count,
+			ErrorCount:   node.ErrorCount,
+			AvgLatencyMs: node.AvgLatencyMs,
+			ErrorRate:    errorRate,
+			SpanCount:    node.Count,
+			HealthScore:  health,
+			Status:       healthStatus(health),
+			Alerts:       alerts(errorRate, node.AvgLatencyMs),
+		})
+	}
+	for _, edge := range result.Edges {
+		snap.Edges = append(snap.Edges, Edge{
+			Source:       edge.Source,
+			Target:       edge.Target,
+			CallCount:    edge.CallCount,
+			AvgLatencyMs: edge.AvgLatencyMs,
+			ErrorRate:    edge.ErrorRate,
+			Status:       healthStatus(aggregateHealth(edge.ErrorRate, edge.AvgLatencyMs)),
+		})
+	}
+	finishSnapshot(&snap, nil)
+	return snap, nil
+}
+
+func aggregateMetadata(id Identity, projection aggregate.TopologySnapshot) Metadata {
+	coverage := aggregate.CoverageFull
+	coverageNote := coverage.Note()
+	if projection.Truncated() {
+		coverage = aggregate.CoverageSampled
+		coverageNote = "topology is incomplete because configured projection caps refused accepted facts; dropped_* counts identify the omissions"
+	}
+	return Metadata{
+		Source:            SourceAggregate,
+		Coverage:          string(coverage),
+		CoverageNote:      coverageNote,
+		Epoch:             id.Epoch,
+		Revision:          id.Revision,
+		Truncated:         projection.Truncated(),
+		DroppedServices:   projection.DroppedServices,
+		DroppedOperations: projection.DroppedOperations,
+		DroppedEdges:      projection.DroppedEdges,
+		DroppedMetrics:    projection.DroppedMetrics,
+	}
+}
+
+func fromAggregateProjection(projection aggregate.TopologySnapshot) Snapshot {
+	snap := Snapshot{
+		Nodes: make([]Node, 0, len(projection.Services)),
+		Edges: make([]Edge, 0, len(projection.Edges)),
+	}
+	for _, service := range projection.Services {
+		totals := sumWindows(service.Windows)
+		errorRate := totals.errorRate()
+		avg := totals.avgLatencyMs()
+		health := aggregateHealth(errorRate, avg)
+		snap.Nodes = append(snap.Nodes, Node{
+			Name:           service.Name,
+			TotalTraces:    saturatingInt64(totals.count),
+			ErrorCount:     saturatingInt64(totals.errors),
+			AvgLatencyMs:   avg,
+			RequestRateRPS: float64(totals.count) / 300,
+			ErrorRate:      errorRate,
+			P99LatencyMs:   totals.p99Ms,
+			SpanCount:      saturatingInt64(totals.count),
+			HealthScore:    health,
+			Status:         healthStatus(health),
+			Alerts:         alerts(errorRate, avg),
+		})
+	}
+	for _, edge := range projection.Edges {
+		totals := sumWindows(edge.Windows)
+		errorRate := totals.errorRate()
+		avg := totals.avgLatencyMs()
+		snap.Edges = append(snap.Edges, Edge{
+			Source:       edge.Caller,
+			Target:       edge.Callee,
+			CallCount:    saturatingInt64(totals.count),
+			AvgLatencyMs: avg,
+			ErrorRate:    errorRate,
+			Status:       healthStatus(aggregateHealth(errorRate, avg)),
+		})
+	}
+	return snap
+}
+
+type windowTotals struct {
+	count, errors, durationCount uint64
+	durationSumMicros, p99Ms     float64
+}
+
+func sumWindows(windows []aggregate.TopologyWindow) windowTotals {
+	var totals windowTotals
+	for _, window := range windows {
+		totals.count += window.Count
+		totals.errors += window.ErrorCount
+		totals.durationCount += window.DurationCount
+		totals.durationSumMicros += window.DurationSumMicros
+		if window.P99Micros > 0 {
+			totals.p99Ms = window.P99Micros / 1000
+		}
+	}
+	return totals
+}
+
+func (t windowTotals) errorRate() float64 {
+	if t.count == 0 {
+		return 0
+	}
+	return float64(t.errors) / float64(t.count)
+}
+
+func (t windowTotals) avgLatencyMs() float64 {
+	if t.durationCount == 0 {
+		return 0
+	}
+	return t.durationSumMicros / float64(t.durationCount) / 1000
+}
+
+func aggregateHealth(errorRate, avgLatencyMs float64) float64 {
+	latencyDeviation := math.Max(0, (avgLatencyMs-100)/100)
+	return math.Max(0, math.Min(1, 1-errorRate*5-latencyDeviation*0.1))
+}
+
+func saturatingInt64(value uint64) int64 {
+	if value > math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(value)
+}
+
+// The following methods implement graphrag.AggregateSource. Keeping that
+// projection narrow avoids teaching GraphRAG about range queries.
+func (p *AggregateProvider) TopologyEpoch() uint64 { return p.engine.TopologyEpoch() }
+
+func (p *AggregateProvider) TopologyTenants() []string { return p.engine.TopologyTenants() }
+
+func (p *AggregateProvider) TopologyRevision(tenant string) uint64 {
+	return p.engine.TopologyRevision(tenant)
+}
+
+func (p *AggregateProvider) TopologySnapshot(tenant string) aggregate.TopologySnapshot {
+	return p.engine.TopologySnapshot(tenant)
+}
+
+func (p *AggregateProvider) PruneTopology() { p.engine.PruneTopology() }
+
+var _ Provider = (*AggregateProvider)(nil)

--- a/internal/topology/legacy.go
+++ b/internal/topology/legacy.go
@@ -1,0 +1,264 @@
+package topology
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/graph"
+	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+type legacyRepository interface {
+	GetServiceMapMetrics(context.Context, time.Time, time.Time) (*storage.ServiceMapMetrics, error)
+}
+
+// LegacyProvider preserves the existing historical repository query and the
+// current GraphRAG/graph/DB preference for live topology.
+type LegacyProvider struct {
+	repo     legacyRepository
+	graph    *graph.Graph
+	graphRAG *graphrag.GraphRAG
+	now      func() time.Time
+}
+
+func NewLegacyProvider(repo legacyRepository, serviceGraph *graph.Graph, graphRAG *graphrag.GraphRAG) (*LegacyProvider, error) {
+	if repo == nil {
+		return nil, errors.New("legacy topology provider requires a repository")
+	}
+	return &LegacyProvider{repo: repo, graph: serviceGraph, graphRAG: graphRAG, now: time.Now}, nil
+}
+
+func (*LegacyProvider) Source() Source { return SourceLegacy }
+
+func (*LegacyProvider) Identity(context.Context) Identity { return Identity{} }
+
+func (p *LegacyProvider) Snapshot(ctx context.Context, q Query) (Snapshot, error) {
+	if !q.Start.IsZero() || !q.End.IsZero() {
+		return p.rangeSnapshot(ctx, q)
+	}
+	return p.liveSnapshot(ctx, q.Services)
+}
+
+func (p *LegacyProvider) rangeSnapshot(ctx context.Context, q Query) (Snapshot, error) {
+	metrics, err := p.repo.GetServiceMapMetrics(ctx, q.Start, q.End)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	snap := fromStorage(metrics)
+	snap.Meta = Metadata{Source: SourceLegacy, Start: q.Start, End: q.End}
+	filterSnapshot(&snap, q.Services)
+	return snap, nil
+}
+
+func (p *LegacyProvider) liveSnapshot(ctx context.Context, services []string) (Snapshot, error) {
+	now := p.now().UTC()
+	if p.graphRAG != nil {
+		entries := p.graphRAG.ServiceMap(ctx, 0)
+		if len(entries) > 0 {
+			snap := Snapshot{
+				Nodes: make([]Node, 0, len(entries)),
+				Edges: []Edge{},
+				Meta:  Metadata{Source: SourceLegacy, Start: now.Add(-5 * time.Minute), End: now},
+			}
+			for _, entry := range entries {
+				if entry.Service == nil {
+					continue
+				}
+				svc := entry.Service
+				snap.Nodes = append(snap.Nodes, Node{
+					Name:           svc.Name,
+					TotalTraces:    svc.CallCount,
+					ErrorCount:     svc.ErrorCount,
+					AvgLatencyMs:   svc.AvgLatency,
+					RequestRateRPS: float64(svc.CallCount) / 300,
+					ErrorRate:      svc.ErrorRate,
+					P99LatencyMs:   svc.AvgLatency * 2.5,
+					SpanCount:      svc.CallCount,
+					HealthScore:    svc.HealthScore,
+					Status:         healthStatus(svc.HealthScore),
+					Alerts:         alerts(svc.ErrorRate, svc.AvgLatency),
+				})
+			}
+			for _, edge := range p.graphRAG.AllServiceEdges(ctx) {
+				if edge == nil || edge.Type != graphrag.EdgeCalls {
+					continue
+				}
+				snap.Edges = append(snap.Edges, Edge{
+					Source:       edge.FromID,
+					Target:       edge.ToID,
+					CallCount:    edge.CallCount,
+					AvgLatencyMs: edge.AvgMs,
+					ErrorRate:    edge.ErrorRate,
+					Status:       healthStatus(legacyHealth(edge.ErrorRate, edge.AvgMs)),
+				})
+			}
+			finishSnapshot(&snap, services)
+			return snap, nil
+		}
+	}
+
+	if p.graph != nil {
+		current := p.graph.Snapshot()
+		if current != nil && !current.UpdatedAt.IsZero() && len(current.Nodes) > 0 {
+			snap := Snapshot{
+				Nodes: make([]Node, 0, len(current.Nodes)),
+				Edges: make([]Edge, 0, len(current.Edges)),
+				Meta:  Metadata{Source: SourceLegacy, Start: current.UpdatedAt.Add(-5 * time.Minute), End: current.UpdatedAt},
+			}
+			for _, node := range current.Nodes {
+				if node == nil {
+					continue
+				}
+				snap.Nodes = append(snap.Nodes, Node{
+					Name:           node.Name,
+					TotalTraces:    node.SpanCount,
+					AvgLatencyMs:   node.AvgLatencyMs,
+					RequestRateRPS: node.RequestRateRPS,
+					ErrorRate:      node.ErrorRate,
+					P99LatencyMs:   node.P99LatencyMs,
+					SpanCount:      node.SpanCount,
+					HealthScore:    node.HealthScore,
+					Status:         node.Status,
+					Alerts:         append([]string(nil), node.Alerts...),
+				})
+			}
+			for _, edge := range current.Edges {
+				snap.Edges = append(snap.Edges, Edge{
+					Source:       edge.Source,
+					Target:       edge.Target,
+					CallCount:    edge.CallCount,
+					AvgLatencyMs: edge.AvgLatencyMs,
+					ErrorRate:    edge.ErrorRate,
+					Status:       edge.Status,
+				})
+			}
+			finishSnapshot(&snap, services)
+			return snap, nil
+		}
+	}
+
+	return p.rangeSnapshot(ctx, Query{Start: now.Add(-time.Hour), End: now, Services: services})
+}
+
+func fromStorage(metrics *storage.ServiceMapMetrics) Snapshot {
+	snap := Snapshot{Nodes: []Node{}, Edges: []Edge{}}
+	if metrics == nil {
+		return snap
+	}
+	snap.Nodes = make([]Node, 0, len(metrics.Nodes))
+	for _, node := range metrics.Nodes {
+		errorRate := 0.0
+		if node.TotalTraces > 0 {
+			errorRate = float64(node.ErrorCount) / float64(node.TotalTraces)
+		}
+		health := legacyHealth(errorRate, node.AvgLatencyMs)
+		snap.Nodes = append(snap.Nodes, Node{
+			Name:           node.Name,
+			TotalTraces:    node.TotalTraces,
+			ErrorCount:     node.ErrorCount,
+			AvgLatencyMs:   node.AvgLatencyMs,
+			RequestRateRPS: float64(node.TotalTraces) / 3600,
+			ErrorRate:      errorRate,
+			P99LatencyMs:   node.AvgLatencyMs * 2.5,
+			SpanCount:      node.TotalTraces,
+			HealthScore:    health,
+			Status:         healthStatus(health),
+			Alerts:         alerts(errorRate, node.AvgLatencyMs),
+		})
+	}
+	snap.Edges = make([]Edge, 0, len(metrics.Edges))
+	for _, edge := range metrics.Edges {
+		snap.Edges = append(snap.Edges, Edge{
+			Source:       edge.Source,
+			Target:       edge.Target,
+			CallCount:    edge.CallCount,
+			AvgLatencyMs: edge.AvgLatencyMs,
+			ErrorRate:    edge.ErrorRate,
+			Status:       healthStatus(legacyHealth(edge.ErrorRate, edge.AvgLatencyMs)),
+		})
+	}
+	finishSnapshot(&snap, nil)
+	return snap
+}
+
+func finishSnapshot(snap *Snapshot, services []string) {
+	filterSnapshot(snap, services)
+	sort.Slice(snap.Nodes, func(i, j int) bool { return snap.Nodes[i].Name < snap.Nodes[j].Name })
+	sort.Slice(snap.Edges, func(i, j int) bool {
+		if snap.Edges[i].Source == snap.Edges[j].Source {
+			return snap.Edges[i].Target < snap.Edges[j].Target
+		}
+		return snap.Edges[i].Source < snap.Edges[j].Source
+	})
+	if snap.Nodes == nil {
+		snap.Nodes = []Node{}
+	}
+	if snap.Edges == nil {
+		snap.Edges = []Edge{}
+	}
+}
+
+func filterSnapshot(snap *Snapshot, services []string) {
+	if len(services) == 0 {
+		return
+	}
+	keep := make(map[string]struct{}, len(services))
+	for _, service := range services {
+		keep[service] = struct{}{}
+	}
+	nodes := snap.Nodes[:0]
+	for _, node := range snap.Nodes {
+		if _, ok := keep[node.Name]; ok {
+			nodes = append(nodes, node)
+		}
+	}
+	edges := snap.Edges[:0]
+	for _, edge := range snap.Edges {
+		_, sourceOK := keep[edge.Source]
+		_, targetOK := keep[edge.Target]
+		if sourceOK && targetOK {
+			edges = append(edges, edge)
+		}
+	}
+	snap.Nodes, snap.Edges = nodes, edges
+}
+
+func legacyHealth(errorRate, avgLatencyMs float64) float64 {
+	score := 1 - errorRate*5
+	if avgLatencyMs > 200 {
+		score -= (avgLatencyMs - 200) / 2000
+	}
+	return math.Max(0, math.Min(1, score))
+}
+
+func healthStatus(score float64) string {
+	switch {
+	case score >= 0.9:
+		return "healthy"
+	case score >= 0.7:
+		return "degraded"
+	default:
+		return "critical"
+	}
+}
+
+func alerts(errorRate, avgLatencyMs float64) []string {
+	out := []string{}
+	if errorRate > 0.05 {
+		out = append(out, "error rate above 5%")
+	}
+	if errorRate > 0.10 {
+		out = append(out, "error rate above 10% — investigate immediately")
+	}
+	if avgLatencyMs > 500 {
+		out = append(out, "avg latency above 500ms")
+	}
+	if avgLatencyMs > 1000 {
+		out = append(out, "avg latency above 1s — SLA breach risk")
+	}
+	return out
+}

--- a/internal/topology/provider.go
+++ b/internal/topology/provider.go
@@ -1,0 +1,101 @@
+// Package topology owns the mode-selected service-topology read contract.
+package topology
+
+import (
+	"context"
+	"strconv"
+	"time"
+)
+
+// Source identifies the producer that owns a snapshot.
+type Source string
+
+const (
+	SourceLegacy    Source = "legacy"
+	SourceAggregate Source = "aggregate"
+)
+
+// Identity orders full-replacement snapshots within one process generation.
+type Identity struct {
+	Epoch    string `json:"epoch,omitempty"`
+	Revision uint64 `json:"revision,omitempty"`
+}
+
+// String returns the stable cache and stream identity.
+func (i Identity) String() string {
+	if i.Epoch == "" && i.Revision == 0 {
+		return ""
+	}
+	return i.Epoch + ":" + strconv.FormatUint(i.Revision, 10)
+}
+
+// Query selects a range and an optional closed set of services. A zero range
+// asks for the provider's current live replacement.
+type Query struct {
+	Start    time.Time
+	End      time.Time
+	Services []string
+}
+
+// Metadata is additive ownership and completeness information.
+type Metadata struct {
+	Source       Source    `json:"source,omitempty"`
+	Start        time.Time `json:"start,omitempty"`
+	End          time.Time `json:"end,omitempty"`
+	Coverage     string    `json:"coverage,omitempty"`
+	CoverageNote string    `json:"coverage_note,omitempty"`
+	Epoch        string    `json:"epoch,omitempty"`
+	Revision     uint64    `json:"revision,omitempty"`
+	Truncated    bool      `json:"truncated,omitempty"`
+
+	DroppedServices   uint64 `json:"dropped_services,omitempty"`
+	DroppedOperations uint64 `json:"dropped_operations,omitempty"`
+	DroppedEdges      uint64 `json:"dropped_edges,omitempty"`
+	DroppedMetrics    uint64 `json:"dropped_metrics,omitempty"`
+}
+
+// Identity returns the ordering pair carried by this metadata.
+func (m Metadata) Identity() Identity {
+	return Identity{Epoch: m.Epoch, Revision: m.Revision}
+}
+
+// Node is the wire-neutral service projection shared by all consumers.
+type Node struct {
+	Name         string  `json:"name"`
+	TotalTraces  int64   `json:"total_traces"`
+	ErrorCount   int64   `json:"error_count"`
+	AvgLatencyMs float64 `json:"avg_latency_ms"`
+
+	RequestRateRPS float64  `json:"request_rate_rps,omitempty"`
+	ErrorRate      float64  `json:"error_rate,omitempty"`
+	P99LatencyMs   float64  `json:"p99_latency_ms,omitempty"`
+	SpanCount      int64    `json:"span_count,omitempty"`
+	HealthScore    float64  `json:"health_score,omitempty"`
+	Status         string   `json:"status,omitempty"`
+	Alerts         []string `json:"alerts,omitempty"`
+}
+
+// Edge is one directed service dependency.
+type Edge struct {
+	Source       string  `json:"source"`
+	Target       string  `json:"target"`
+	CallCount    int64   `json:"call_count"`
+	AvgLatencyMs float64 `json:"avg_latency_ms"`
+	ErrorRate    float64 `json:"error_rate"`
+	Status       string  `json:"status,omitempty"`
+}
+
+// Snapshot is always a full replacement. Nodes and Edges are never nil.
+type Snapshot struct {
+	Nodes []Node   `json:"nodes"`
+	Edges []Edge   `json:"edges"`
+	Meta  Metadata `json:"meta,omitempty"`
+}
+
+// Provider is selected once from AGGREGATE_MODE and injected into every live
+// topology consumer.
+type Provider interface {
+	Source() Source
+	Identity(context.Context) Identity
+	Snapshot(context.Context, Query) (Snapshot, error)
+}

--- a/internal/topology/provider_test.go
+++ b/internal/topology/provider_test.go
@@ -1,0 +1,119 @@
+package topology
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+type fakeLegacyRepository struct {
+	result *storage.ServiceMapMetrics
+	err    error
+}
+
+func (f fakeLegacyRepository) GetServiceMapMetrics(context.Context, time.Time, time.Time) (*storage.ServiceMapMetrics, error) {
+	return f.result, f.err
+}
+
+func TestLegacyProviderExplicitRangeUsesLegacyTopology(t *testing.T) {
+	repo := fakeLegacyRepository{result: &storage.ServiceMapMetrics{
+		Nodes: []storage.ServiceMapNode{
+			{Name: "gateway", TotalTraces: 4},
+			{Name: "legacy-payments", TotalTraces: 3},
+		},
+		Edges: []storage.ServiceMapEdge{{Source: "gateway", Target: "legacy-payments", CallCount: 3}},
+	}}
+	provider, err := NewLegacyProvider(repo, nil, nil)
+	if err != nil {
+		t.Fatalf("NewLegacyProvider: %v", err)
+	}
+
+	start := time.Unix(100, 0).UTC()
+	end := start.Add(time.Minute)
+	snapshot, err := provider.Snapshot(context.Background(), Query{Start: start, End: end})
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snapshot.Meta.Source != SourceLegacy {
+		t.Fatalf("source = %q, want %q", snapshot.Meta.Source, SourceLegacy)
+	}
+	if len(snapshot.Nodes) != 2 || len(snapshot.Edges) != 1 {
+		t.Fatalf("snapshot = %+v, want two nodes and one edge", snapshot)
+	}
+	if got := snapshot.Edges[0]; got.Source != "gateway" || got.Target != "legacy-payments" {
+		t.Fatalf("edge = %+v, want gateway -> legacy-payments", got)
+	}
+}
+
+func TestLegacyProviderReturnsNonNilEmptySlices(t *testing.T) {
+	provider, err := NewLegacyProvider(fakeLegacyRepository{result: &storage.ServiceMapMetrics{}}, nil, nil)
+	if err != nil {
+		t.Fatalf("NewLegacyProvider: %v", err)
+	}
+	snapshot, err := provider.Snapshot(context.Background(), Query{Start: time.Unix(1, 0), End: time.Unix(2, 0)})
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snapshot.Nodes == nil || snapshot.Edges == nil {
+		t.Fatalf("empty replacement contains nil slices: nodes=%v edges=%v", snapshot.Nodes, snapshot.Edges)
+	}
+}
+
+func TestAggregateProviderRequiresAggregateMode(t *testing.T) {
+	engine, err := aggregate.NewEngine(aggregate.EngineConfig{Mode: aggregate.ModeShadow})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	if _, err := NewAggregateProvider(engine); err == nil {
+		t.Fatal("NewAggregateProvider accepted a shadow engine")
+	}
+}
+
+func TestAggregateProviderLiveSnapshotCarriesActualWindow(t *testing.T) {
+	now := time.Date(2026, 8, 31, 8, 0, 0, 0, time.UTC)
+	engine, err := aggregate.NewEngine(aggregate.EngineConfig{
+		Mode: aggregate.ModeAggregate,
+		Now:  func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	provider, err := NewAggregateProvider(engine)
+	if err != nil {
+		t.Fatalf("NewAggregateProvider: %v", err)
+	}
+	snapshot, err := provider.Snapshot(context.Background(), Query{})
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if !snapshot.Meta.End.Equal(now) || !snapshot.Meta.Start.Equal(now.Add(-engine.TopologyHorizon())) {
+		t.Fatalf("live window = %s..%s, want %s..%s", snapshot.Meta.Start, snapshot.Meta.End, now.Add(-engine.TopologyHorizon()), now)
+	}
+}
+
+func TestAggregateMetadataReportsProjectionTruncation(t *testing.T) {
+	meta := aggregateMetadata(Identity{Epoch: "boot-a", Revision: 7}, aggregate.TopologySnapshot{
+		DroppedServices:   1,
+		DroppedOperations: 2,
+		DroppedEdges:      3,
+		DroppedMetrics:    4,
+	})
+	if meta.Coverage != string(aggregate.CoverageSampled) || !meta.Truncated {
+		t.Fatalf("coverage=%q truncated=%v, want sampled/true", meta.Coverage, meta.Truncated)
+	}
+	if meta.CoverageNote == "" {
+		t.Fatal("truncated topology has no coverage explanation")
+	}
+	if meta.DroppedServices != 1 || meta.DroppedOperations != 2 || meta.DroppedEdges != 3 || meta.DroppedMetrics != 4 {
+		t.Fatalf("dropped counts = %+v", meta)
+	}
+}
+
+func TestIdentityStringIsStable(t *testing.T) {
+	if got := (Identity{Epoch: "boot-a", Revision: 42}).String(); got != "boot-a:42" {
+		t.Fatalf("Identity.String() = %q, want boot-a:42", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"github.com/RandomCodeSpace/otelcontext/internal/telemetry"
 	tlsbootstrap "github.com/RandomCodeSpace/otelcontext/internal/tls"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
 	"github.com/RandomCodeSpace/otelcontext/internal/tsdb"
 	"github.com/RandomCodeSpace/otelcontext/internal/ui"
 
@@ -358,9 +359,6 @@ func main() {
 		func(msgType string) { metrics.WSMessagesSent.WithLabelValues(msgType).Inc() },
 		func() { metrics.WSSlowClientsRemoved.Inc() },
 	)
-	go hub.Run()
-	slog.Info("🔌 WebSocket hub started")
-
 	// 4b. Initialize Event Notification Hub (for live mode — pushes data snapshots)
 	eventHub := realtime.NewEventHub(
 		repo,
@@ -477,15 +475,6 @@ func main() {
 	graphRAG := graphrag.New(repo, tsdbAgg, ringBuf, graphRAGCfg)
 	graphRAG.SetMetrics(metrics)
 	ctxGraphRAG, cancelGraphRAG := context.WithCancel(context.Background())
-	go graphRAG.Start(ctxGraphRAG)
-	slog.Info("GraphRAG started (layered graph with anomaly detection)",
-		"workers", cfg.GraphRAGWorkerCount,
-		"event_queue_size", cfg.GraphRAGEventQueueSize,
-		"trace_ttl", graphRAGCfg.TraceTTL,
-		"max_spans_per_tenant", graphRAGCfg.MaxSpansPerTenant,
-		"tenant_idle_ttl", graphRAGCfg.TenantIdleTTL,
-		"mode", graphRAGCfg.Mode,
-	)
 
 	// 5. Initialize AI Service.
 	// Workers inherit aiCtx so an in-flight LLM call (30s timeout) is
@@ -495,26 +484,6 @@ func main() {
 	aiCtx, aiCancel := context.WithCancel(appCtx)
 	aiService := ai.NewService(repo)
 	aiService.SetParentContext(aiCtx)
-
-	// 6. Initialize API Server
-	apiServer := api.NewServer(repo, hub, eventHub, metrics)
-	apiServer.SetGraph(svcGraph)
-	apiServer.SetGraphRAG(graphRAG)
-
-	// 6b. Initialize MCP Server (HTTP Streamable, JSON-RPC 2.0 + SSE)
-	mcpServer := mcp.New(cfg.DefaultTenant, repo, metrics, svcGraph)
-	mcpServer.SetGraphRAG(graphRAG)
-	mcpServer.SetCallLimit(cfg.MCPMaxConcurrent)
-	mcpServer.SetCallTimeout(time.Duration(cfg.MCPCallTimeoutMs) * time.Millisecond)
-	mcpServer.SetCacheTTL(time.Duration(cfg.MCPCacheTTLMs) * time.Millisecond)
-	slog.Info("🤖 MCP server initialized",
-		"path", cfg.MCPPath,
-		"enabled", cfg.MCPEnabled,
-		"default_tenant", cfg.DefaultTenant,
-		"max_concurrent", cfg.MCPMaxConcurrent,
-		"call_timeout_ms", cfg.MCPCallTimeoutMs,
-		"cache_ttl_ms", cfg.MCPCacheTTLMs,
-	)
 
 	// 7. Initialize OTLP Ingestion (gRPC)
 	traceServer := ingest.NewTraceServer(repo, metrics, cfg)
@@ -676,14 +645,6 @@ func main() {
 		// miner of its own in either mode, so the two never disagree about a
 		// template's identity (#163).
 		aggEngine.SetTemplateFactSink(graphRAG.OnTemplateFact)
-		// Aggregate mode: GraphRAG replaces its topology from the engine's
-		// per-revision snapshot instead of rescanning the spans table (#174).
-		if cfg.AggregateMode == aggregate.ModeAggregate {
-			graphRAG.SetAggregateSource(aggEngine)
-			slog.Info("🧭 GraphRAG consuming aggregate topology snapshots (raw-span rebuild retired)",
-				"epoch", aggEngine.TopologyEpoch(),
-			)
-		}
 		slog.Info("🧮 Aggregate engine enabled",
 			"mode", cfg.AggregateMode,
 			"max_series", cfg.AggregateMaxSeries,
@@ -726,6 +687,62 @@ func main() {
 		}
 	}
 
+	// Select the topology owner once, after every possible producer exists and
+	// before any HTTP or WebSocket listener starts. Aggregate mode is strict:
+	// a missing or mode-mismatched engine is a startup error, never a silent
+	// fallback to stale raw-span topology.
+	var topologyProvider topology.Provider
+	if cfg.AggregateMode == aggregate.ModeAggregate {
+		provider, err := topology.NewAggregateProvider(aggEngine)
+		if err != nil {
+			fatal("❌ Aggregate topology provider rejected", err)
+		}
+		topologyProvider = provider
+		graphRAG.SetAggregateSource(provider)
+		slog.Info("🧭 GraphRAG consuming aggregate topology snapshots (raw-span rebuild retired)",
+			"epoch", provider.Identity(context.Background()).Epoch,
+		)
+	} else {
+		provider, err := topology.NewLegacyProvider(repo, svcGraph, graphRAG)
+		if err != nil {
+			fatal("❌ Legacy topology provider rejected", err)
+		}
+		topologyProvider = provider
+	}
+	go graphRAG.Start(ctxGraphRAG)
+	slog.Info("GraphRAG started (layered graph with anomaly detection)",
+		"workers", cfg.GraphRAGWorkerCount,
+		"event_queue_size", cfg.GraphRAGEventQueueSize,
+		"trace_ttl", graphRAGCfg.TraceTTL,
+		"max_spans_per_tenant", graphRAGCfg.MaxSpansPerTenant,
+		"tenant_idle_ttl", graphRAGCfg.TenantIdleTTL,
+		"mode", graphRAGCfg.Mode,
+		"topology_source", topologyProvider.Source(),
+	)
+
+	// 6. Initialize API Server
+	apiServer := api.NewServer(repo, hub, eventHub, metrics)
+	apiServer.SetGraph(svcGraph)
+	apiServer.SetGraphRAG(graphRAG)
+	apiServer.SetTopologyProvider(topologyProvider)
+
+	// 6b. Initialize MCP Server (HTTP Streamable, JSON-RPC 2.0 + SSE)
+	mcpServer := mcp.New(cfg.DefaultTenant, repo, metrics, topologyProvider)
+	mcpServer.SetGraphRAG(graphRAG)
+	mcpServer.SetCallLimit(cfg.MCPMaxConcurrent)
+	mcpServer.SetCallTimeout(time.Duration(cfg.MCPCallTimeoutMs) * time.Millisecond)
+	mcpServer.SetCacheTTL(time.Duration(cfg.MCPCacheTTLMs) * time.Millisecond)
+	slog.Info("🤖 MCP server initialized",
+		"path", cfg.MCPPath,
+		"enabled", cfg.MCPEnabled,
+		"default_tenant", cfg.DefaultTenant,
+		"max_concurrent", cfg.MCPMaxConcurrent,
+		"call_timeout_ms", cfg.MCPCallTimeoutMs,
+		"cache_ttl_ms", cfg.MCPCacheTTLMs,
+	)
+
+	hub.SetTopologyProvider(topologyProvider, realtime.DefaultPublishFloor)
+
 	// Aggregate READ path (#175). Only AGGREGATE_MODE=aggregate switches the
 	// dashboard, the WebSocket publisher and the MCP coverage metadata over;
 	// shadow mode writes aggregates but keeps serving the legacy reads.
@@ -736,11 +753,9 @@ func main() {
 		// revision-driven snapshot.
 		hub.SetAggregateMode(true)
 		eventHub.SetAggregatePublisher(realtime.NewEnginePublisher(realtime.EnginePublisherConfig{
-			Engine: aggEngine,
-			Tenant: cfg.DefaultTenant,
-			Edges: func(ctx context.Context) []storage.ServiceMapEdge {
-				return graphRAGServiceEdges(ctx, graphRAG)
-			},
+			Engine:   aggEngine,
+			Topology: topologyProvider,
+			Tenant:   cfg.DefaultTenant,
 		}), realtime.DefaultPublishFloor)
 		slog.Info("📊 Aggregate read path enabled",
 			"epoch", aggEngine.Epoch(),
@@ -748,6 +763,9 @@ func main() {
 			"note", "dashboard, topology and WebSocket snapshots are served from the aggregate engine",
 		)
 	}
+
+	go hub.Run()
+	slog.Info("🔌 WebSocket hub started", "topology_source", topologyProvider.Source())
 
 	go eventHub.Start(ctxEvents, 5*time.Second, 500*time.Millisecond)
 	slog.Info("⚡ Event notification hub started (5s snapshots, 500ms batches)")
@@ -1598,31 +1616,6 @@ func printBanner() {
   version: %s
 `
 	fmt.Printf(banner, Version)
-}
-
-// graphRAGServiceEdges projects the GraphRAG service store's CALLS edges into
-// the storage topology shape. Caller/callee identity is not part of an
-// aggregate SeriesKey, so the aggregate read path sources edges here — which is
-// also why any response carrying them is marked "sampled" rather than "full".
-func graphRAGServiceEdges(ctx context.Context, g *graphrag.GraphRAG) []storage.ServiceMapEdge {
-	if g == nil {
-		return nil
-	}
-	all := g.AllServiceEdges(ctx)
-	edges := make([]storage.ServiceMapEdge, 0, len(all))
-	for _, e := range all {
-		if e.Type != "CALLS" {
-			continue
-		}
-		edges = append(edges, storage.ServiceMapEdge{
-			Source:       e.FromID,
-			Target:       e.ToID,
-			CallCount:    e.CallCount,
-			AvgLatencyMs: e.AvgMs,
-			ErrorRate:    e.ErrorRate,
-		})
-	}
-	return edges
 }
 
 // fileBytes returns the size of one file, or 0 when it cannot be stat'ed.

--- a/test/topologyproof/topology_proof_test.go
+++ b/test/topologyproof/topology_proof_test.go
@@ -1,0 +1,774 @@
+package topologyproof
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/api"
+	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
+	"github.com/RandomCodeSpace/otelcontext/internal/mcp"
+	"github.com/RandomCodeSpace/otelcontext/internal/realtime"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/RandomCodeSpace/otelcontext/internal/telemetry"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
+	"github.com/coder/websocket"
+)
+
+const (
+	proofModeEnv = "OTELCONTEXT_TOPOLOGY_PROOF_MODE"
+	proofDirEnv  = "OTELCONTEXT_TOPOLOGY_PROOF_DIR"
+	proofFloor   = 25 * time.Millisecond
+)
+
+type proofEdge struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+}
+
+type proofAssertion struct {
+	Passed bool   `json:"passed"`
+	Detail string `json:"detail"`
+}
+
+type modeProof struct {
+	SchemaVersion    string                    `json:"schema_version"`
+	Mode             string                    `json:"mode"`
+	Source           string                    `json:"source"`
+	Epochs           []string                  `json:"epochs"`
+	Revisions        []uint64                  `json:"revisions"`
+	EdgeSet          []proofEdge               `json:"edge_set"`
+	EmptyReplacement string                    `json:"empty_replacement"`
+	Reconnect        string                    `json:"reconnect"`
+	Coverage         string                    `json:"coverage"`
+	Assertions       map[string]proofAssertion `json:"assertions"`
+}
+
+func newModeProof(mode string, source topology.Source) *modeProof {
+	return &modeProof{
+		SchemaVersion: "otelcontext.topology-proof.v1",
+		Mode:          mode,
+		Source:        string(source),
+		Epochs:        []string{},
+		Revisions:     []uint64{},
+		Assertions:    make(map[string]proofAssertion),
+	}
+}
+
+func (p *modeProof) check(t *testing.T, name string, passed bool, detail string) {
+	t.Helper()
+	p.Assertions[name] = proofAssertion{Passed: passed, Detail: detail}
+	if !passed {
+		t.Errorf("%s: %s", name, detail)
+	}
+}
+
+func (p *modeProof) write(t *testing.T) {
+	t.Helper()
+	dir := os.Getenv(proofDirEnv)
+	if dir == "" {
+		dir = t.TempDir()
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Errorf("create proof directory: %v", err)
+		return
+	}
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		t.Errorf("marshal proof: %v", err)
+		return
+	}
+	path := filepath.Join(dir, p.Mode+".json")
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		t.Errorf("write proof: %v", err)
+		return
+	}
+	t.Logf("topology proof: %s", path)
+}
+
+type scriptedProvider struct {
+	mu       sync.RWMutex
+	source   topology.Source
+	identity topology.Identity
+	snapshot topology.Snapshot
+	err      error
+
+	aggEpoch uint64
+	aggSnap  aggregate.TopologySnapshot
+}
+
+func (p *scriptedProvider) Source() topology.Source { return p.source }
+
+func (p *scriptedProvider) Identity(context.Context) topology.Identity {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.identity
+}
+
+func (p *scriptedProvider) Snapshot(context.Context, topology.Query) (topology.Snapshot, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.err != nil {
+		return topology.Snapshot{}, p.err
+	}
+	snapshot := p.snapshot
+	snapshot.Nodes = append([]topology.Node(nil), snapshot.Nodes...)
+	snapshot.Edges = append([]topology.Edge(nil), snapshot.Edges...)
+	return snapshot, nil
+}
+
+func (p *scriptedProvider) TopologyEpoch() uint64 {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.aggEpoch
+}
+
+func (*scriptedProvider) TopologyTenants() []string { return []string{storage.DefaultTenantID} }
+
+func (p *scriptedProvider) TopologyRevision(string) uint64 {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.aggSnap.Revision
+}
+
+func (p *scriptedProvider) TopologySnapshot(string) aggregate.TopologySnapshot {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	snapshot := p.aggSnap
+	snapshot.Services = append([]aggregate.TopologyService(nil), snapshot.Services...)
+	snapshot.Operations = append([]aggregate.TopologyOperation(nil), snapshot.Operations...)
+	snapshot.Edges = append([]aggregate.SnapshotEdge(nil), snapshot.Edges...)
+	snapshot.Metrics = append([]aggregate.TopologyMetric(nil), snapshot.Metrics...)
+	return snapshot
+}
+
+func (*scriptedProvider) PruneTopology() {}
+
+func (p *scriptedProvider) setAggregateState(epoch string, epochNumber, revision uint64, target string, empty bool, providerErr error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.identity = topology.Identity{Epoch: epoch, Revision: revision}
+	p.err = providerErr
+	p.aggEpoch = epochNumber
+	p.snapshot = topologySnapshot(p.source, epoch, revision, target, empty)
+	p.aggSnap = aggregateSnapshot(epochNumber, revision, target, empty)
+}
+
+func (p *scriptedProvider) setAggregateTruncated(epoch string, epochNumber, revision uint64, target string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.identity = topology.Identity{Epoch: epoch, Revision: revision}
+	p.err = nil
+	p.aggEpoch = epochNumber
+	p.snapshot = topologySnapshot(p.source, epoch, revision, target, false)
+	p.aggSnap = aggregateSnapshot(epochNumber, revision, target, false)
+	p.snapshot.Meta.Coverage = string(aggregate.CoverageSampled)
+	p.snapshot.Meta.CoverageNote = aggregate.CoverageSampled.Note()
+	p.snapshot.Meta.Truncated = true
+	p.snapshot.Meta.DroppedEdges = 2
+	p.aggSnap.DroppedEdges = 2
+}
+
+func (p *scriptedProvider) bumpShadowRevision(revision uint64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.aggSnap.Revision = revision
+}
+
+func topologySnapshot(source topology.Source, epoch string, revision uint64, target string, empty bool) topology.Snapshot {
+	meta := topology.Metadata{Source: source}
+	if source == topology.SourceAggregate {
+		meta.Coverage = string(aggregate.CoverageFull)
+		meta.CoverageNote = aggregate.CoverageFull.Note()
+		meta.Epoch = epoch
+		meta.Revision = revision
+	}
+	if empty {
+		return topology.Snapshot{Nodes: []topology.Node{}, Edges: []topology.Edge{}, Meta: meta}
+	}
+	return topology.Snapshot{
+		Nodes: []topology.Node{
+			{Name: "gateway", TotalTraces: 10, SpanCount: 10, HealthScore: 100, Status: "healthy"},
+			{Name: target, TotalTraces: 10, SpanCount: 10, HealthScore: 100, Status: "healthy"},
+		},
+		Edges: []topology.Edge{{Source: "gateway", Target: target, CallCount: 10, AvgLatencyMs: 4, Status: "healthy"}},
+		Meta:  meta,
+	}
+}
+
+func aggregateSnapshot(epoch, revision uint64, target string, empty bool) aggregate.TopologySnapshot {
+	now := time.Now().UTC().Truncate(aggregate.WindowSize)
+	base := aggregate.TopologySnapshot{
+		Tenant:     storage.DefaultTenantID,
+		Epoch:      epoch,
+		Revision:   revision,
+		Now:        now,
+		Services:   []aggregate.TopologyService{},
+		Operations: []aggregate.TopologyOperation{},
+		Edges:      []aggregate.SnapshotEdge{},
+		Metrics:    []aggregate.TopologyMetric{},
+	}
+	if empty {
+		return base
+	}
+	window := aggregate.TopologyWindow{
+		Start:             now,
+		End:               now.Add(aggregate.WindowSize),
+		Closed:            true,
+		Final:             true,
+		Elapsed:           aggregate.WindowSize,
+		Count:             10,
+		DurationCount:     10,
+		DurationSumMicros: 40_000,
+		P95Micros:         5_000,
+		P99Micros:         6_000,
+	}
+	base.Services = []aggregate.TopologyService{
+		{Name: "gateway", FirstSeen: now, LastSeen: window.End, Windows: []aggregate.TopologyWindow{window}},
+		{Name: target, FirstSeen: now, LastSeen: window.End, Windows: []aggregate.TopologyWindow{window}},
+	}
+	base.Edges = []aggregate.SnapshotEdge{{
+		Caller: "gateway", Callee: target, FirstSeen: now, LastSeen: window.End,
+		Windows: []aggregate.TopologyWindow{window},
+	}}
+	return base
+}
+
+type providerPublisher struct{ provider *scriptedProvider }
+
+func (p providerPublisher) Epoch() string { return p.provider.Identity(context.Background()).Epoch }
+
+func (p providerPublisher) Revision() uint64 {
+	return p.provider.Identity(context.Background()).Revision
+}
+
+func (p providerPublisher) Snapshot(ctx context.Context, _ string) *realtime.LiveSnapshot {
+	snapshot, err := p.provider.Snapshot(ctx, topology.Query{})
+	if err != nil {
+		return nil
+	}
+	nodes := make([]storage.ServiceMapNode, len(snapshot.Nodes))
+	for i, node := range snapshot.Nodes {
+		nodes[i] = storage.ServiceMapNode{Name: node.Name, TotalTraces: node.TotalTraces, ErrorCount: node.ErrorCount, AvgLatencyMs: node.AvgLatencyMs}
+	}
+	edges := make([]storage.ServiceMapEdge, len(snapshot.Edges))
+	for i, edge := range snapshot.Edges {
+		edges[i] = storage.ServiceMapEdge{Source: edge.Source, Target: edge.Target, CallCount: edge.CallCount, AvgLatencyMs: edge.AvgLatencyMs, ErrorRate: edge.ErrorRate}
+	}
+	return &realtime.LiveSnapshot{
+		Type:              "live_snapshot",
+		ServiceMap:        &storage.ServiceMapMetrics{Nodes: nodes, Edges: edges},
+		Source:            string(snapshot.Meta.Source),
+		Coverage:          snapshot.Meta.Coverage,
+		CoverageNote:      snapshot.Meta.CoverageNote,
+		Epoch:             snapshot.Meta.Epoch,
+		Revision:          snapshot.Meta.Revision,
+		Truncated:         snapshot.Meta.Truncated,
+		DroppedServices:   snapshot.Meta.DroppedServices,
+		DroppedOperations: snapshot.Meta.DroppedOperations,
+		DroppedEdges:      snapshot.Meta.DroppedEdges,
+		DroppedMetrics:    snapshot.Meta.DroppedMetrics,
+	}
+}
+
+type topologyWire struct {
+	Nodes        []json.RawMessage `json:"nodes"`
+	Edges        []proofEdge       `json:"edges"`
+	Source       string            `json:"source"`
+	Coverage     string            `json:"coverage"`
+	Epoch        string            `json:"epoch"`
+	Revision     uint64            `json:"revision"`
+	Truncated    bool              `json:"truncated"`
+	DroppedEdges uint64            `json:"dropped_edges"`
+}
+
+func TestTopologyModeProof(t *testing.T) {
+	mode := os.Getenv(proofModeEnv)
+	if mode == "" {
+		t.Skipf("%s is set by the dedicated topology-proof CI job", proofModeEnv)
+	}
+	if mode != aggregate.ModeLegacy && mode != aggregate.ModeShadow && mode != aggregate.ModeAggregate {
+		t.Fatalf("unsupported proof mode %q", mode)
+	}
+
+	source := topology.SourceLegacy
+	target := "legacy-payments"
+	forbidden := "aggregate-payments"
+	if mode == aggregate.ModeAggregate {
+		source = topology.SourceAggregate
+		target = "aggregate-payments"
+		forbidden = "legacy-payments"
+	}
+	proof := newModeProof(mode, source)
+	defer proof.write(t)
+
+	provider := &scriptedProvider{source: source}
+	if source == topology.SourceAggregate {
+		provider.setAggregateState("epoch-a", 41, 1, target, false, nil)
+		proof.Epochs = []string{"epoch-a", "epoch-b"}
+		proof.Revisions = []uint64{1, 2, 3, 4}
+		proof.Coverage = string(aggregate.CoverageFull)
+	} else {
+		provider.identity = topology.Identity{}
+		provider.snapshot = topologySnapshot(source, "", 0, target, false)
+		provider.aggEpoch = 41
+		provider.aggSnap = aggregateSnapshot(41, 1, "aggregate-payments", false)
+		proof.Coverage = "omitted (legacy-compatible)"
+	}
+	proof.EdgeSet = []proofEdge{{Source: "gateway", Target: target}}
+
+	repo := proofRepository(t)
+	seedLegacyEdge(t, repo, target)
+	graphRAG, stopGraphRAG := proofGraphRAG(t, mode, provider, target)
+	defer stopGraphRAG()
+
+	metrics := telemetry.New()
+	var rawConnections atomic.Int64
+	rawHub := realtime.NewHub(func(count int) { rawConnections.Store(int64(count)) })
+	rawHub.SetTopologyProvider(provider, proofFloor)
+	if mode == aggregate.ModeAggregate {
+		rawHub.SetAggregateMode(true)
+	}
+	go rawHub.Run()
+
+	eventHub := realtime.NewEventHub(repo, nil, nil)
+	if mode == aggregate.ModeAggregate {
+		eventHub.SetAggregatePublisher(providerPublisher{provider: provider}, proofFloor)
+	}
+	eventCtx, cancelEvents := context.WithCancel(context.Background())
+	go eventHub.Start(eventCtx, 50*time.Millisecond, 20*time.Millisecond)
+
+	apiServer := api.NewServer(repo, rawHub, eventHub, metrics)
+	apiServer.SetGraphRAG(graphRAG)
+	apiServer.SetTopologyProvider(provider)
+	mux := http.NewServeMux()
+	apiServer.RegisterRoutes(mux)
+	httpServer := httptest.NewServer(mux)
+
+	mcpServer := mcp.New(storage.DefaultTenantID, repo, metrics, provider)
+	mcpServer.SetGraphRAG(graphRAG)
+	mcpServer.SetAggregateMode(mode == aggregate.ModeAggregate)
+	mcpHTTP := httptest.NewServer(mcpServer.Handler())
+
+	t.Cleanup(func() {
+		mcpHTTP.Close()
+		httpServer.Close()
+		cancelEvents()
+		eventHub.Stop()
+		rawHub.Stop()
+	})
+
+	serviceMap := getTopology(t, httpServer.URL+"/api/metrics/service-map")
+	proof.check(t, "rest_service_map", hasOnlyEdge(serviceMap.Edges, target, forbidden), fmt.Sprintf("edges=%v", serviceMap.Edges))
+	systemGraph := getTopology(t, httpServer.URL+"/api/system/graph")
+	proof.check(t, "rest_system_graph", hasOnlyEdge(systemGraph.Edges, target, forbidden), fmt.Sprintf("edges=%v", systemGraph.Edges))
+
+	if source == topology.SourceAggregate {
+		metadataOK := serviceMap.Source == "aggregate" && serviceMap.Coverage == "full" && serviceMap.Epoch == "epoch-a" && serviceMap.Revision == 1
+		proof.check(t, "coverage_additive", metadataOK, fmt.Sprintf("source=%q coverage=%q identity=%s/%d", serviceMap.Source, serviceMap.Coverage, serviceMap.Epoch, serviceMap.Revision))
+	} else {
+		metadataOK := serviceMap.Source == "" && serviceMap.Coverage == "" && serviceMap.Epoch == "" && serviceMap.Revision == 0
+		proof.check(t, "legacy_wire_compatibility", metadataOK, fmt.Sprintf("source=%q coverage=%q identity=%s/%d", serviceMap.Source, serviceMap.Coverage, serviceMap.Epoch, serviceMap.Revision))
+		cached := getTopologyResponse(t, httpServer.URL+"/api/system/graph")
+		proof.check(t, "legacy_cache_timing", cached.Header.Get("X-Cache") == "HIT", "second legacy graph read keeps the established cache window")
+		cached.Body.Close()
+	}
+
+	graphEdges := graphRAGEdges(graphRAG)
+	proof.check(t, "graphrag", hasOnlyEdge(graphEdges, target, forbidden), fmt.Sprintf("edges=%v", graphEdges))
+
+	mapTool := callTool(t, mcpHTTP.URL, "get_service_map", nil)
+	proof.check(t, "mcp_get_service_map", strings.Contains(mapTool, target) && !strings.Contains(mapTool, forbidden), compact(mapTool))
+	healthTool := callTool(t, mcpHTTP.URL, "get_service_health", map[string]any{"service_name": target})
+	proof.check(t, "mcp_get_service_health", strings.Contains(healthTool, target) && !strings.Contains(healthTool, forbidden), compact(healthTool))
+	if source == topology.SourceAggregate {
+		proof.check(t, "mcp_coverage", strings.Contains(mapTool, `"coverage":"full"`) && strings.Contains(mapTool, `"source":"aggregate"`), compact(mapTool))
+	}
+
+	sse := immediateSSE(t, mcpServer)
+	proof.check(t, "mcp_sse", strings.Contains(sse, target) && !strings.Contains(sse, forbidden) && strings.Contains(sse, "notifications/resources/updated"), compact(sse))
+
+	eventConn := dialWS(t, httpServer.URL+"/ws/events")
+	initialEvent := readEventSnapshot(t, eventConn, 2*time.Second)
+	proof.check(t, "websocket_events", initialEvent.ServiceMap != nil && hasStorageEdge(initialEvent.ServiceMap.Edges, target, forbidden), fmt.Sprintf("snapshot=%+v", initialEvent.ServiceMap))
+	proof.check(t, "reconnect_immediate", initialEvent.Type == "live_snapshot" && (source != topology.SourceAggregate || initialEvent.Reset), fmt.Sprintf("type=%q reset=%v", initialEvent.Type, initialEvent.Reset))
+
+	rawConn := dialWS(t, httpServer.URL+"/ws")
+	waitFor(t, 2*time.Second, func() bool { return rawConnections.Load() == 1 })
+	if source == topology.SourceAggregate {
+		initialRaw := readRawRefresh(t, rawConn, 2*time.Second)
+		proof.check(t, "websocket_raw", initialRaw.Source == "aggregate" && initialRaw.Epoch == "epoch-a" && initialRaw.Revision == 1 && initialRaw.Reset, fmt.Sprintf("refresh=%+v", initialRaw))
+	} else {
+		provider.bumpShadowRevision(2)
+		time.Sleep(3 * proofFloor)
+		rawHub.Broadcast(realtime.LogEntry{ServiceName: "gateway", Body: "legacy-batch"})
+		rawType := readEnvelopeType(t, rawConn, 2*time.Second)
+		eventHub.BroadcastLog(realtime.LogEntry{ServiceName: "gateway", Body: "legacy-batch"})
+		eventType := readEnvelopeType(t, eventConn, 2*time.Second)
+		proof.check(t, "websocket_raw", rawType == "logs", fmt.Sprintf("message_type=%q", rawType))
+		proof.check(t, "shadow_revision_suppressed", mode != aggregate.ModeShadow || (rawType == "logs" && eventType == "logs"), fmt.Sprintf("raw=%q events=%q", rawType, eventType))
+		proof.EmptyReplacement = "not applicable; legacy cache and stream timing preserved"
+		proof.Reconnect = "immediate full /ws/events and MCP SSE snapshots"
+		return
+	}
+
+	// Move the aggregate identity and prove every cache/stream consumes the
+	// replacement. The stale same-epoch revision is deliberately inserted
+	// between 2 and 3; neither WebSocket may publish it.
+	provider.setAggregateState("epoch-a", 41, 2, target, false, nil)
+	nextEvent, eventRegressed := readEventUntil(t, eventConn, "epoch-a", 2, 2*time.Second)
+	nextRaw, rawRegressed := readRawUntil(t, rawConn, "epoch-a", 2, 2*time.Second)
+	proof.check(t, "same_epoch_monotonic", !eventRegressed && !rawRegressed && !nextEvent.Reset && !nextRaw.Reset, fmt.Sprintf("event=%s/%d raw=%s/%d", nextEvent.Epoch, nextEvent.Revision, nextRaw.Epoch, nextRaw.Revision))
+	cacheMove := getTopologyResponse(t, httpServer.URL+"/api/system/graph")
+	cacheBody := decodeTopology(t, cacheMove)
+	proof.check(t, "cache_identity", cacheMove.Header.Get("X-Cache") == "MISS" && hasOnlyEdge(cacheBody.Edges, target, forbidden), fmt.Sprintf("cache=%q edges=%v", cacheMove.Header.Get("X-Cache"), cacheBody.Edges))
+	cacheMove.Body.Close()
+
+	provider.setAggregateState("epoch-a", 41, 1, "stale-exemplar", false, nil)
+	time.Sleep(3 * proofFloor)
+	provider.setAggregateState("epoch-a", 41, 3, target, false, nil)
+	_, eventRegressed = readEventUntil(t, eventConn, "epoch-a", 3, 2*time.Second)
+	_, rawRegressed = readRawUntil(t, rawConn, "epoch-a", 3, 2*time.Second)
+	proof.check(t, "stale_exemplar_excluded", !eventRegressed && !rawRegressed, "same-epoch stale exemplar replacement was not published")
+
+	provider.setAggregateState("epoch-b", 42, 1, target, false, nil)
+	epochEvent, _ := readEventUntil(t, eventConn, "epoch-b", 1, 2*time.Second)
+	epochRaw, _ := readRawUntil(t, rawConn, "epoch-b", 1, 2*time.Second)
+	proof.check(t, "epoch_reset", epochEvent.Reset && epochRaw.Reset, fmt.Sprintf("event_reset=%v raw_reset=%v", epochEvent.Reset, epochRaw.Reset))
+
+	provider.setAggregateState("epoch-b", 42, 2, target, false, errors.New("proof provider unavailable"))
+	time.Sleep(3 * proofFloor)
+	errorSSE := immediateSSE(t, mcpServer)
+	provider.setAggregateState("epoch-b", 42, 2, target, false, nil)
+	recoveredEvent, _ := readEventUntil(t, eventConn, "epoch-b", 2, 2*time.Second)
+	recoveredRaw, _ := readRawUntil(t, rawConn, "epoch-b", 2, 2*time.Second)
+	retained := !strings.Contains(errorSSE, "notifications/resources/updated") && hasStorageEdge(recoveredEvent.ServiceMap.Edges, target, forbidden) && recoveredRaw.Revision == 2
+	proof.check(t, "provider_error_retains_last_good", retained, fmt.Sprintf("error_sse=%s event_revision=%d raw_revision=%d", compact(errorSSE), recoveredEvent.Revision, recoveredRaw.Revision))
+
+	provider.setAggregateTruncated("epoch-b", 42, 3, target)
+	truncatedEvent, _ := readEventUntil(t, eventConn, "epoch-b", 3, 2*time.Second)
+	_, _ = readRawUntil(t, rawConn, "epoch-b", 3, 2*time.Second)
+	truncatedREST := getTopology(t, httpServer.URL+"/api/metrics/service-map")
+	truncatedTool := callTool(t, mcpHTTP.URL, "get_service_map", nil)
+	truncationOK := truncatedEvent.Coverage == "sampled" && truncatedEvent.Truncated && truncatedEvent.DroppedEdges == 2 && truncatedREST.Coverage == "sampled" && truncatedREST.Truncated && truncatedREST.DroppedEdges == 2 && strings.Contains(truncatedTool, `"coverage":"sampled"`) && strings.Contains(truncatedTool, `"dropped_edges":2`) && strings.Contains(truncatedTool, `"truncated":true`)
+	proof.check(t, "truncation_metadata_additive", truncationOK, fmt.Sprintf("event=%q/%v/%d rest=%q/%v/%d tool=%s", truncatedEvent.Coverage, truncatedEvent.Truncated, truncatedEvent.DroppedEdges, truncatedREST.Coverage, truncatedREST.Truncated, truncatedREST.DroppedEdges, compact(truncatedTool)))
+
+	provider.setAggregateState("epoch-b", 42, 4, target, true, nil)
+	emptyEvent, _ := readEventUntil(t, eventConn, "epoch-b", 4, 2*time.Second)
+	emptyRaw, _ := readRawUntil(t, rawConn, "epoch-b", 4, 2*time.Second)
+	emptyREST := getTopology(t, httpServer.URL+"/api/system/graph")
+	emptySSE := immediateSSE(t, mcpServer)
+	emptyGraph := graphRAG.ServiceMap(context.Background(), 0)
+	emptyOK := emptyEvent.ServiceMap != nil && emptyEvent.ServiceMap.Nodes != nil && emptyEvent.ServiceMap.Edges != nil && len(emptyEvent.ServiceMap.Nodes) == 0 && len(emptyEvent.ServiceMap.Edges) == 0 && emptyRaw.Revision == 4 && emptyREST.Nodes != nil && emptyREST.Edges != nil && len(emptyREST.Nodes) == 0 && len(emptyREST.Edges) == 0 && strings.Contains(emptySSE, "notifications/resources/updated") && len(emptyGraph) == 0
+	proof.check(t, "empty_replacement", emptyOK, fmt.Sprintf("event_nodes=%d event_edges=%d rest_nodes=%d rest_edges=%d graphrag=%d", len(emptyEvent.ServiceMap.Nodes), len(emptyEvent.ServiceMap.Edges), len(emptyREST.Nodes), len(emptyREST.Edges), len(emptyGraph)))
+
+	_, failClosed := topology.NewAggregateProvider(nil)
+	proof.check(t, "aggregate_provider_fail_closed", failClosed != nil, "nil aggregate engine is rejected")
+	proof.EmptyReplacement = "epoch-b/revision-4 published nodes=[] edges=[] and cleared GraphRAG"
+	proof.Reconnect = "immediate full /ws/events, /ws refresh, and MCP SSE snapshots"
+}
+
+func proofRepository(t *testing.T) *storage.Repository {
+	t.Helper()
+	db, err := storage.NewDatabase("sqlite", filepath.Join(t.TempDir(), "topology-proof.db"))
+	if err != nil {
+		t.Fatalf("open proof database: %v", err)
+	}
+	if err := storage.AutoMigrateModels(db, "sqlite"); err != nil {
+		t.Fatalf("migrate proof database: %v", err)
+	}
+	repo := storage.NewRepositoryFromDB(db, "sqlite")
+	t.Cleanup(func() { _ = repo.Close() })
+	return repo
+}
+
+func seedLegacyEdge(t *testing.T, repo *storage.Repository, target string) {
+	t.Helper()
+	now := time.Now().UTC().Add(-time.Minute)
+	spans := []storage.Span{
+		{TenantID: storage.DefaultTenantID, TraceID: "proof-trace", SpanID: "proof-parent", ServiceName: "gateway", OperationName: "GET /", StartTime: now, EndTime: now.Add(time.Millisecond), Duration: 1_000},
+		{TenantID: storage.DefaultTenantID, TraceID: "proof-trace", SpanID: "proof-child", ParentSpanID: "proof-parent", ServiceName: target, OperationName: "GET /pay", StartTime: now.Add(time.Millisecond), EndTime: now.Add(5 * time.Millisecond), Duration: 4_000},
+	}
+	if err := repo.BatchCreateSpans(spans); err != nil {
+		t.Fatalf("seed proof spans: %v", err)
+	}
+}
+
+func proofGraphRAG(t *testing.T, mode string, provider *scriptedProvider, target string) (*graphrag.GraphRAG, func()) {
+	t.Helper()
+	cfg := graphrag.DefaultConfig()
+	cfg.Mode = mode
+	cfg.WorkerCount = 1
+	cfg.ChannelSize = 16
+	cfg.RefreshEvery = time.Hour
+	cfg.SnapshotEvery = time.Hour
+	cfg.AnomalyEvery = time.Hour
+	graphRAG := graphrag.New(nil, nil, nil, cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	if mode == aggregate.ModeAggregate {
+		graphRAG.SetAggregateSource(provider)
+	}
+	graphRAG.Start(ctx)
+	if mode != aggregate.ModeAggregate {
+		now := time.Now().UTC().Add(-time.Minute)
+		graphRAG.OnSpanIngested(storage.Span{TenantID: storage.DefaultTenantID, TraceID: "proof-trace", SpanID: "proof-parent", ServiceName: "gateway", OperationName: "GET /", StartTime: now, Duration: 1_000})
+		graphRAG.OnSpanIngested(storage.Span{TenantID: storage.DefaultTenantID, TraceID: "proof-trace", SpanID: "proof-child", ParentSpanID: "proof-parent", ServiceName: target, OperationName: "GET /pay", StartTime: now.Add(time.Millisecond), Duration: 4_000})
+		waitFor(t, 2*time.Second, func() bool { return hasOnlyEdge(graphRAGEdges(graphRAG), target, "aggregate-payments") })
+	}
+	return graphRAG, func() {
+		cancel()
+		graphRAG.Stop()
+	}
+}
+
+func getTopology(t *testing.T, url string) topologyWire {
+	t.Helper()
+	response := getTopologyResponse(t, url)
+	defer response.Body.Close()
+	return decodeTopology(t, response)
+}
+
+func getTopologyResponse(t *testing.T, url string) *http.Response {
+	t.Helper()
+	response, err := http.Get(url) //nolint:gosec // local httptest endpoint
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		response.Body.Close()
+		t.Fatalf("GET %s status %d: %s", url, response.StatusCode, body)
+	}
+	return response
+}
+
+func decodeTopology(t *testing.T, response *http.Response) topologyWire {
+	t.Helper()
+	var body topologyWire
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatalf("decode topology: %v", err)
+	}
+	return body
+}
+
+func callTool(t *testing.T, endpoint, name string, arguments map[string]any) string {
+	t.Helper()
+	if arguments == nil {
+		arguments = map[string]any{}
+	}
+	requestBody, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": name, "arguments": arguments},
+	})
+	if err != nil {
+		t.Fatalf("marshal MCP call: %v", err)
+	}
+	request, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(requestBody))
+	if err != nil {
+		t.Fatalf("new MCP request: %v", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("MCP call: %v", err)
+	}
+	defer response.Body.Close()
+	var envelope struct {
+		Result mcp.ToolCallResult `json:"result"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode MCP call: %v", err)
+	}
+	var text strings.Builder
+	for _, item := range envelope.Result.Content {
+		text.WriteString(item.Text)
+		if item.Resource != nil {
+			text.WriteString(item.Resource.Text)
+		}
+	}
+	return text.String()
+}
+
+func immediateSSE(t *testing.T, server *mcp.Server) string {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	request := httptest.NewRequest(http.MethodGet, "/mcp", nil).WithContext(ctx)
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, request)
+	return recorder.Body.String()
+}
+
+func dialWS(t *testing.T, httpURL string) *websocket.Conn {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, response, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(httpURL, "http"), nil)
+	if response != nil && response.Body != nil {
+		_ = response.Body.Close()
+	}
+	if err != nil {
+		t.Fatalf("dial %s: %v", httpURL, err)
+	}
+	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "proof complete") })
+	return conn
+}
+
+func readEventSnapshot(t *testing.T, conn *websocket.Conn, timeout time.Duration) realtime.LiveSnapshot {
+	t.Helper()
+	message := readWS(t, conn, timeout)
+	var snapshot realtime.LiveSnapshot
+	if err := json.Unmarshal(message, &snapshot); err != nil {
+		t.Fatalf("decode event snapshot: %v (%s)", err, message)
+	}
+	return snapshot
+}
+
+type rawRefresh struct {
+	Source   string `json:"source"`
+	Epoch    string `json:"epoch"`
+	Revision uint64 `json:"revision"`
+	Reset    bool   `json:"reset"`
+}
+
+func readRawRefresh(t *testing.T, conn *websocket.Conn, timeout time.Duration) rawRefresh {
+	t.Helper()
+	message := readWS(t, conn, timeout)
+	var envelope struct {
+		Type string          `json:"type"`
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(message, &envelope); err != nil {
+		t.Fatalf("decode raw envelope: %v (%s)", err, message)
+	}
+	if envelope.Type != "topology_refresh" {
+		t.Fatalf("raw message type = %q, want topology_refresh", envelope.Type)
+	}
+	var refresh rawRefresh
+	if err := json.Unmarshal(envelope.Data, &refresh); err != nil {
+		t.Fatalf("decode raw refresh: %v", err)
+	}
+	return refresh
+}
+
+func readEventUntil(t *testing.T, conn *websocket.Conn, epoch string, revision uint64, timeout time.Duration) (realtime.LiveSnapshot, bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	regressed := false
+	for time.Now().Before(deadline) {
+		snapshot := readEventSnapshot(t, conn, time.Until(deadline))
+		if snapshot.Epoch == epoch && snapshot.Revision < revision {
+			regressed = true
+		}
+		if snapshot.Epoch == epoch && snapshot.Revision == revision {
+			return snapshot, regressed
+		}
+	}
+	t.Fatalf("event stream did not reach %s/%d", epoch, revision)
+	return realtime.LiveSnapshot{}, regressed
+}
+
+func readRawUntil(t *testing.T, conn *websocket.Conn, epoch string, revision uint64, timeout time.Duration) (rawRefresh, bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	regressed := false
+	for time.Now().Before(deadline) {
+		refresh := readRawRefresh(t, conn, time.Until(deadline))
+		if refresh.Epoch == epoch && refresh.Revision < revision {
+			regressed = true
+		}
+		if refresh.Epoch == epoch && refresh.Revision == revision {
+			return refresh, regressed
+		}
+	}
+	t.Fatalf("raw stream did not reach %s/%d", epoch, revision)
+	return rawRefresh{}, regressed
+}
+
+func readEnvelopeType(t *testing.T, conn *websocket.Conn, timeout time.Duration) string {
+	t.Helper()
+	message := readWS(t, conn, timeout)
+	var envelope struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(message, &envelope); err != nil {
+		t.Fatalf("decode envelope: %v (%s)", err, message)
+	}
+	return envelope.Type
+}
+
+func readWS(t *testing.T, conn *websocket.Conn, timeout time.Duration) []byte {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	_, message, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read websocket: %v", err)
+	}
+	return message
+}
+
+func graphRAGEdges(graphRAG *graphrag.GraphRAG) []proofEdge {
+	edges := graphRAG.AllServiceEdges(context.Background())
+	out := make([]proofEdge, 0, len(edges))
+	for _, edge := range edges {
+		if edge != nil && edge.Type == graphrag.EdgeCalls {
+			out = append(out, proofEdge{Source: edge.FromID, Target: edge.ToID})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Source != out[j].Source {
+			return out[i].Source < out[j].Source
+		}
+		return out[i].Target < out[j].Target
+	})
+	return out
+}
+
+func hasOnlyEdge(edges []proofEdge, target, forbidden string) bool {
+	if len(edges) != 1 {
+		return false
+	}
+	return edges[0].Source == "gateway" && edges[0].Target == target && edges[0].Target != forbidden
+}
+
+func hasStorageEdge(edges []storage.ServiceMapEdge, target, forbidden string) bool {
+	if len(edges) != 1 {
+		return false
+	}
+	return edges[0].Source == "gateway" && edges[0].Target == target && edges[0].Target != forbidden
+}
+
+func waitFor(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition did not become true before timeout")
+}
+
+func compact(value string) string {
+	value = strings.Join(strings.Fields(value), " ")
+	if len(value) > 240 {
+		return value[:240] + "..."
+	}
+	return value
+}


### PR DESCRIPTION
## Result

Selects one mode-correct topology provider before consumers start. Legacy and aggregate-shadow preserve the legacy topology path; aggregate mode uses one engine-owned epoch/revision across REST, both WebSocket paths, MCP SSE/tools, and GraphRAG with no raw-data fallback.

The change also publishes empty expiry tombstones, keeps same-epoch revisions monotonic, retries provider failures without replacing good stream state, keys aggregate caches by provider identity, and emits additive coverage/truncation metadata.

Closes #246

## Local verification

- go test -race -count=1 ./internal/topology ./internal/aggregate ./internal/graphrag
- go test -race -count=1 ./internal/api ./internal/realtime ./internal/mcp
- go test -count=1 ./internal/ingest
- go test -count=1 .
- one race-enabled cross-consumer proof each for legacy, aggregate-shadow, and aggregate
- focused go vet and go build -trimpath .

## Hosted evidence

CI adds required topology proof jobs for all three modes. Each uploads a machine-readable artifact containing source, identity, contradictory edge set, reconnect, coverage/truncation, empty replacement, and per-consumer assertions. The existing hosted build, vet, full race suite, browser proof, database proofs, and SonarCloud remain the whole-repository regression gate.