### PR TITLE
feat: prove graceful shutdown quiescence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,64 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  shutdown-proof:
+    name: shutdown proof · ${{ matrix.mode }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [legacy, aggregate-shadow, aggregate]
+    env:
+      CGO_ENABLED: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: build exact shutdown-proof binary
+        run: |
+          mkdir -p "${RUNNER_TEMP}/shutdown-proof"
+          go build -trimpath -o "${RUNNER_TEMP}/shutdown-proof/otelcontext" .
+
+      - name: run quiescence and restart proof
+        env:
+          OTELCONTEXT_SHUTDOWN_BINARY: ${{ runner.temp }}/shutdown-proof/otelcontext
+          OTELCONTEXT_SHUTDOWN_PROOF_MODE: ${{ matrix.mode }}
+          OTELCONTEXT_SHUTDOWN_PROOF_DIR: ${{ runner.temp }}/shutdown-proof/artifacts
+        run: |
+          set -o pipefail
+          mkdir -p "${RUNNER_TEMP}/shutdown-proof/artifacts"
+          go test -tags=shutdownproof -count=1 -v -timeout=90s \
+            -run '^TestShutdownModeProof$' ./test/shutdownproof 2>&1 \
+            | tee "${RUNNER_TEMP}/shutdown-proof/artifacts/${OTELCONTEXT_SHUTDOWN_PROOF_MODE}-test.log"
+          jq -e --arg mode "${OTELCONTEXT_SHUTDOWN_PROOF_MODE}" '
+            .schema_version == "otelcontext.shutdown-proof.v1" and
+            .mode == $mode and
+            .first_exit_code == 0 and
+            .restart_exit_code == 0 and
+            .pre_restart_fingerprint == .post_restart_fingerprint and
+            .dlq_before == .dlq_after and
+            (.first_shutdown.steps | length) == 19 and
+            (.restart_shutdown.steps | length) == 19 and
+            all(.first_shutdown.steps[]; (.error // "") == "") and
+            all(.restart_shutdown.steps[]; (.error // "") == "") and
+            (.assertions | length) >= 10 and
+            all(.assertions[]; .passed == true)
+          ' "${RUNNER_TEMP}/shutdown-proof/artifacts/${OTELCONTEXT_SHUTDOWN_PROOF_MODE}.json"
+
+      - name: upload mode shutdown proof
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: shutdown-proof-${{ matrix.mode }}-${{ github.sha }}
+          path: ${{ runner.temp }}/shutdown-proof/artifacts
+          if-no-files-found: error
+          retention-days: 14
+
   database-sqlite:
     name: database proof · sqlite
     runs-on: ubuntu-24.04

--- a/internal/aggregate/writer.go
+++ b/internal/aggregate/writer.go
@@ -1,6 +1,8 @@
 package aggregate
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
 	"math"
 	"sync"
@@ -233,11 +235,15 @@ type Writer struct {
 	// (#200 Q2). Running it here is what makes "no group commit interleaves
 	// with an identity delete" structural: there is one commit goroutine and
 	// the barrier IS that goroutine.
-	barriers chan *barrierRequest
-	stop     chan struct{}
-	stopOnce sync.Once
-	wg       sync.WaitGroup
-	closed   atomic.Bool
+	barriers    chan *barrierRequest
+	stop        chan struct{}
+	stopOnce    sync.Once
+	startOnce   sync.Once
+	wg          sync.WaitGroup
+	closed      atomic.Bool
+	lifecycleMu sync.Mutex
+	started     bool
+	workersDone chan struct{}
 
 	// admission counters, guarded by mu.
 	mu            sync.Mutex
@@ -289,6 +295,7 @@ func NewWriter(cfg WriterConfig) (*Writer, error) {
 		submissions: make(chan *submission, cfg.MaxWaiters),
 		barriers:    make(chan *barrierRequest),
 		stop:        make(chan struct{}),
+		workersDone: make(chan struct{}),
 	}, nil
 }
 
@@ -340,45 +347,78 @@ func (w *Writer) CollectIdentities() (GCStats, error) {
 // SaveTemplateStats writes the miner's dirty non-identity counters. Identity
 // mutations do NOT come through here — they ride the group commit — so a lost
 // batch costs a count that the next line restores.
-func (w *Writer) SaveTemplateStats() {
+func (w *Writer) SaveTemplateStats() error {
 	if w.miner == nil {
-		return
+		return nil
 	}
 	gcs, ok := w.store.(GCStore)
 	if !ok {
-		return
+		return nil
 	}
 	rows := w.miner.DrainDirtyStats()
 	if len(rows) == 0 {
-		return
+		return nil
 	}
 	if err := gcs.SaveTemplateStats(rows); err != nil {
 		slog.Warn("aggregate: template statistics write failed", "error", err, "rows", len(rows))
+		return err
 	}
+	return nil
 }
 
 // Start launches the commit loop and, unless disabled, the finalize loop.
 func (w *Writer) Start() {
-	w.wg.Add(1)
-	go w.commitLoop()
-	if w.cfg.FinalizeInterval > 0 {
+	w.startOnce.Do(func() {
+		w.lifecycleMu.Lock()
+		w.started = true
+		w.lifecycleMu.Unlock()
 		w.wg.Add(1)
-		go w.finalizeLoop()
-	}
+		go w.commitLoop()
+		if w.cfg.FinalizeInterval > 0 {
+			w.wg.Add(1)
+			go w.finalizeLoop()
+		}
+		go func() {
+			w.wg.Wait()
+			close(w.workersDone)
+		}()
+	})
 }
 
-// Stop drains the in-flight submissions, commits them, and returns once the
-// loops have exited. It is idempotent.
-func (w *Writer) Stop() {
+// Shutdown drains in-flight submissions and joins both writer loops within the
+// shared application deadline. The final template-statistics write is part of
+// the durability result rather than a best-effort log line.
+func (w *Writer) Shutdown(ctx context.Context) error {
 	w.stopOnce.Do(func() {
 		w.closed.Store(true)
 		close(w.stop)
 	})
-	w.wg.Wait()
-	// Final best-effort statistics save, after the loops are gone so nothing
-	// races the writer lock. Identity is already durable — it rode the group
-	// commits — so this only saves counters.
-	w.SaveTemplateStats()
+	w.lifecycleMu.Lock()
+	started := w.started
+	w.lifecycleMu.Unlock()
+	if started {
+		select {
+		case <-w.workersDone:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	stats := w.Stats()
+	if stats.PendingBytes != 0 || stats.PendingDeltas != 0 || stats.Waiters != 0 {
+		return fmt.Errorf("aggregate writer not drained: pending_bytes=%d pending_deltas=%d waiters=%d", stats.PendingBytes, stats.PendingDeltas, stats.Waiters)
+	}
+	if err := w.SaveTemplateStats(); err != nil {
+		return fmt.Errorf("save aggregate template statistics: %w", err)
+	}
+	return nil
+}
+
+// Stop preserves the prior internal lifecycle surface. Production shutdown
+// uses Shutdown so deadline and persistence failures reach the process result.
+func (w *Writer) Stop() {
+	if err := w.Shutdown(context.Background()); err != nil {
+		slog.Error("aggregate writer shutdown failed", "error", err)
+	}
 }
 
 // Stats returns a snapshot of the writer counters.

--- a/internal/aggregate/writer_test.go
+++ b/internal/aggregate/writer_test.go
@@ -1,6 +1,7 @@
 package aggregate
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -383,6 +384,24 @@ func TestWriterRefusesAfterStop(t *testing.T) {
 	w.Stop()
 	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 1)); !errors.Is(err, ErrStoreClosed) {
 		t.Fatalf("apply after Stop = %v, want ErrStoreClosed", err)
+	}
+}
+
+func TestWriterShutdownDrainsAndIsIdempotent(t *testing.T) {
+	clock := newClock(time.Unix(3_000_000, 0).UTC())
+	base := newTestStore(t)
+	eng := newTestEngine(t, clock, nil)
+	w := newTestWriter(t, base, eng, clock, WriterConfig{})
+	if _, err := eng.ApplyDeltasErr(deltaFor(clock.Now(), 1, 1)); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := w.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Shutdown(ctx); err != nil {
+		t.Fatalf("second shutdown: %v", err)
 	}
 }
 

--- a/internal/api/dbhealth.go
+++ b/internal/api/dbhealth.go
@@ -82,8 +82,9 @@ func (h *DBHealth) Start(ctx context.Context) {
 	go h.loop(ctx)
 }
 
-// Stop signals the poller to exit and waits briefly for it to finish.
-func (h *DBHealth) Stop() {
+// Shutdown signals the poller to exit and joins it within the application
+// shutdown deadline.
+func (h *DBHealth) Shutdown(ctx context.Context) error {
 	select {
 	case <-h.stopCh:
 		// already stopped
@@ -92,8 +93,17 @@ func (h *DBHealth) Stop() {
 	}
 	select {
 	case <-h.doneCh:
-	case <-time.After(2 * time.Second):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
+}
+
+// Stop preserves the previous two-second bounded lifecycle surface.
+func (h *DBHealth) Stop() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = h.Shutdown(ctx)
 }
 
 // Healthy reports the most recent ping result.

--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -36,6 +36,16 @@ func (s *Server) handleLive(w http.ResponseWriter, r *http.Request) {
 // the GraphRAG coordinator is running. Returns 503 with a per-check breakdown
 // on failure.
 func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
+	if s.shuttingDown.Load() {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ready":  false,
+			"checks": map[string]string{"shutdown": "in_progress"},
+		})
+		return
+	}
+
 	checks := map[string]string{
 		"database": "ok",
 		"graphrag": "ok",

--- a/internal/api/health_shutdown_test.go
+++ b/internal/api/health_shutdown_test.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestReadyFailsImmediatelyOnceShutdownBegins(t *testing.T) {
+	s := NewServer(nil, nil, nil, nil)
+	s.BeginShutdown()
+	rr := httptest.NewRecorder()
+	s.handleReady(rr, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("/ready = %d, want 503", rr.Code)
+	}
+	if body := rr.Body.String(); body == "" || !containsAll(body, `"ready":false`, `"shutdown":"in_progress"`) {
+		t.Fatalf("unexpected readiness body: %s", body)
+	}
+}
+
+func containsAll(value string, parts ...string) bool {
+	for _, part := range parts {
+		if !strings.Contains(value, part) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
@@ -72,6 +73,11 @@ type Server struct {
 	// DefaultReadinessThresholds; an explicitly-set zero struct disables
 	// every runtime probe, which is what a 0 in each env knob means.
 	readyThresholds *ReadinessThresholds
+
+	// shuttingDown flips before listener admission stops. Readiness must fail
+	// immediately so a load balancer cannot route fresh work into a process
+	// that has started its quiescence barrier.
+	shuttingDown atomic.Bool
 }
 
 // AggregateRuntime is the aggregate runtime health snapshot /ready consults.
@@ -226,6 +232,12 @@ func (s *Server) SetAggregateDBProbe(fn func(context.Context) error) {
 // any field disables that probe.
 func (s *Server) SetReadinessThresholds(t ReadinessThresholds) {
 	s.readyThresholds = &t
+}
+
+// BeginShutdown removes this instance from readiness before admission stops.
+// It is idempotent and leaves /live unchanged while the process drains.
+func (s *Server) BeginShutdown() {
+	s.shuttingDown.Store(true)
 }
 
 // RegisterRoutes registers API endpoints on the provided mux.

--- a/internal/graphrag/aggregate.go
+++ b/internal/graphrag/aggregate.go
@@ -282,11 +282,7 @@ func (g *GraphRAG) OnTemplateFact(fact aggregate.TemplateFact) {
 	if fact.Timestamp.IsZero() {
 		fact.Timestamp = time.Now()
 	}
-	select {
-	case g.eventCh <- event{tmpl: &fact}:
-	default:
-		g.recordEventDrop("log")
-	}
+	g.enqueueEvent(event{tmpl: &fact}, "log")
 }
 
 // processTemplateFact folds one template fact into its tenant's log clusters.

--- a/internal/graphrag/builder.go
+++ b/internal/graphrag/builder.go
@@ -2,6 +2,8 @@ package graphrag
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"runtime/debug"
 	"sync"
@@ -25,8 +27,10 @@ func SetPanicMetrics(m *telemetry.Metrics) { panicMetrics = m }
 
 // guardWorker is a tiny helper that recovers from panics in a worker
 // goroutine, logs the stack, and increments the metric.
-func guardWorker(name string) {
+func (g *GraphRAG) guardWorker(name string) {
 	if r := recover(); r != nil {
+		err := fmt.Errorf("graphrag worker %s panic: %v", name, r)
+		g.recordShutdownError(err)
 		slog.Error("graphrag worker panic",
 			"worker", name,
 			"panic", r,
@@ -114,6 +118,18 @@ type GraphRAG struct {
 
 	eventCh chan event
 	stopCh  chan struct{}
+
+	startOnce   sync.Once
+	stopOnce    sync.Once
+	saveOnce    sync.Once
+	lifecycleMu sync.Mutex
+	started     bool
+	workerWG    sync.WaitGroup
+	workersDone chan struct{}
+	admissionMu sync.RWMutex
+	closed      bool
+	shutdownMu  sync.Mutex
+	shutdownErr error
 
 	// Configuration
 	traceTTL          time.Duration
@@ -316,6 +332,7 @@ func New(repo *storage.Repository, tsdbAgg *tsdb.Aggregator, ringBuf *tsdb.RingB
 		drain:             NewDrain(),
 		eventCh:           make(chan event, cfg.ChannelSize),
 		stopCh:            make(chan struct{}),
+		workersDone:       make(chan struct{}),
 		traceTTL:          cfg.TraceTTL,
 		refreshEvery:      cfg.RefreshEvery,
 		snapshotEvery:     cfg.SnapshotEvery,
@@ -363,52 +380,98 @@ func New(repo *storage.Repository, tsdbAgg *tsdb.Aggregator, ringBuf *tsdb.RingB
 // Each goroutine is wrapped in a panic recovery so one misbehaving event
 // can't take down the whole subsystem.
 func (g *GraphRAG) Start(ctx context.Context) {
-	// Start event workers. Honor the configured worker count so operators
-	// can scale up under sustained high ingest; fall back to the package
-	// default when the constructor wasn't handed an override.
-	workers := g.workerCount
-	if workers <= 0 {
-		workers = defaultWorkerCount
-	}
-	for i := 0; i < workers; i++ {
+	g.startOnce.Do(func() {
+		g.lifecycleMu.Lock()
+		g.started = true
+		g.lifecycleMu.Unlock()
+
+		// Start event workers. Honor the configured worker count so operators
+		// can scale up under sustained high ingest; fall back to the package
+		// default when the constructor wasn't handed an override.
+		workers := g.workerCount
+		if workers <= 0 {
+			workers = defaultWorkerCount
+		}
+		for i := 0; i < workers; i++ {
+			g.workerWG.Add(1)
+			go func() {
+				defer g.workerWG.Done()
+				defer g.guardWorker("eventWorker")
+				g.eventWorker(ctx)
+			}()
+		}
+
+		for name, loop := range map[string]func(context.Context){
+			"refreshLoop":  g.refreshLoop,
+			"snapshotLoop": g.snapshotLoop,
+			"anomalyLoop":  g.anomalyLoop,
+		} {
+			g.workerWG.Add(1)
+			go func() {
+				defer g.workerWG.Done()
+				defer g.guardWorker(name)
+				loop(ctx)
+			}()
+		}
 		go func() {
-			defer guardWorker("eventWorker")
-			g.eventWorker(ctx)
+			g.workerWG.Wait()
+			close(g.workersDone)
 		}()
-	}
 
-	// Start background tasks
-	go func() {
-		defer guardWorker("refreshLoop")
-		g.refreshLoop(ctx)
-	}()
-	go func() {
-		defer guardWorker("snapshotLoop")
-		g.snapshotLoop(ctx)
-	}()
-	go func() {
-		defer guardWorker("anomalyLoop")
-		g.anomalyLoop(ctx)
-	}()
-
-	slog.Info("GraphRAG started",
-		"workers", workers,
-		"trace_ttl", g.traceTTL,
-		"refresh_every", g.refreshEvery,
-	)
+		slog.Info("GraphRAG started",
+			"workers", workers,
+			"trace_ttl", g.traceTTL,
+			"refresh_every", g.refreshEvery,
+		)
+	})
 }
 
-// Stop signals all goroutines to exit.
-func (g *GraphRAG) Stop() {
-	// Best-effort final Drain template persistence — losing the most recent
-	// updates on an unclean shutdown would force rebuilding from scratch.
-	if g.repo != nil && g.repo.DB() != nil && g.drain != nil {
-		if err := SaveDrainTemplates(g.repo.DB(), storage.DefaultTenantID, g.drain.Templates()); err != nil {
-			slog.Warn("GraphRAG: final drain template save failed", "error", err)
-		}
+// Shutdown closes event admission, drains accepted events, joins every worker,
+// and only then persists the final Drain template state.
+func (g *GraphRAG) Shutdown(ctx context.Context) error {
+	if g == nil {
+		return nil
 	}
-	close(g.stopCh)
-	slog.Info("GraphRAG stopped")
+	g.admissionMu.Lock()
+	g.closed = true
+	g.stopOnce.Do(func() { close(g.stopCh) })
+	g.admissionMu.Unlock()
+
+	g.lifecycleMu.Lock()
+	started := g.started
+	g.lifecycleMu.Unlock()
+	if !started {
+		return nil
+	}
+
+	select {
+	case <-g.workersDone:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	g.saveOnce.Do(func() {
+		if g.repo != nil && g.repo.DB() != nil && g.drain != nil {
+			if err := SaveDrainTemplates(g.repo.DB(), storage.DefaultTenantID, g.drain.Templates()); err != nil {
+				g.recordShutdownError(fmt.Errorf("persist final Drain templates: %w", err))
+			}
+		}
+	})
+	g.shutdownMu.Lock()
+	err := g.shutdownErr
+	g.shutdownMu.Unlock()
+	if err == nil {
+		slog.Info("GraphRAG stopped")
+	}
+	return err
+}
+
+// Stop preserves the prior internal lifecycle surface. Production shutdown
+// uses Shutdown so deadline and persistence failures reach the process result.
+func (g *GraphRAG) Stop() {
+	if err := g.Shutdown(context.Background()); err != nil {
+		slog.Error("GraphRAG shutdown failed", "error", err)
+	}
 }
 
 // EventBufferDepth returns the current number of events queued in the
@@ -447,17 +510,12 @@ func (g *GraphRAG) OnSpanIngested(span storage.Span) {
 	if tenant == "" {
 		tenant = storage.DefaultTenantID
 	}
-	select {
-	case g.eventCh <- event{span: &spanEvent{
+	g.enqueueEvent(event{span: &spanEvent{
 		Span:    span,
 		TraceID: span.TraceID,
 		Status:  status,
 		Tenant:  tenant,
-	}}:
-	default:
-		// Channel full — graph is best-effort; DB is source of truth.
-		g.recordEventDrop("span")
-	}
+	}}, "span")
 }
 
 // OnLogIngested is the callback wired into the log ingestion pipeline.
@@ -466,12 +524,7 @@ func (g *GraphRAG) OnLogIngested(log storage.Log) {
 	if tenant == "" {
 		tenant = storage.DefaultTenantID
 	}
-	select {
-	case g.eventCh <- event{log: &logEvent{Log: log, Tenant: tenant}}:
-	default:
-		// Channel full — graph is best-effort; DB is source of truth.
-		g.recordEventDrop("log")
-	}
+	g.enqueueEvent(event{log: &logEvent{Log: log, Tenant: tenant}}, "log")
 }
 
 // OnMetricIngested is the callback wired into the metric ingestion pipeline.
@@ -483,37 +536,70 @@ func (g *GraphRAG) OnMetricIngested(metric tsdb.RawMetric) {
 	if tenant == "" {
 		tenant = storage.DefaultTenantID
 	}
-	select {
-	case g.eventCh <- event{metric: &metricEvent{Metric: metric, Tenant: tenant}}:
-	default:
-		// Channel full — graph is best-effort; DB is source of truth.
-		g.recordEventDrop("metric")
-	}
+	g.enqueueEvent(event{metric: &metricEvent{Metric: metric, Tenant: tenant}}, "metric")
 }
 
 // eventWorker processes events from the channel.
 func (g *GraphRAG) eventWorker(ctx context.Context) {
 	for {
 		select {
-		case <-ctx.Done():
-			return
 		case <-g.stopCh:
+			for {
+				select {
+				case ev := <-g.eventCh:
+					g.processEvent(ev)
+				default:
+					return
+				}
+			}
+		case <-ctx.Done():
+			g.recordShutdownError(fmt.Errorf("event worker stopped before shutdown barrier: %w", ctx.Err()))
 			return
 		case ev := <-g.eventCh:
-			if ev.span != nil {
-				g.processSpan(ev.span)
-			}
-			if ev.log != nil {
-				g.processLog(ev.log)
-			}
-			if ev.metric != nil {
-				g.processMetric(ev.metric)
-			}
-			if ev.tmpl != nil {
-				g.processTemplateFact(ev.tmpl)
-			}
+			g.processEvent(ev)
 		}
 	}
+}
+
+func (g *GraphRAG) enqueueEvent(ev event, signal string) {
+	if g == nil {
+		return
+	}
+	g.admissionMu.RLock()
+	defer g.admissionMu.RUnlock()
+	if g.closed {
+		return
+	}
+	select {
+	case g.eventCh <- ev:
+	default:
+		// Channel full — graph is best-effort; DB is source of truth.
+		g.recordEventDrop(signal)
+	}
+}
+
+func (g *GraphRAG) processEvent(ev event) {
+	if ev.span != nil {
+		g.processSpan(ev.span)
+	}
+	if ev.log != nil {
+		g.processLog(ev.log)
+	}
+	if ev.metric != nil {
+		g.processMetric(ev.metric)
+	}
+	if ev.tmpl != nil {
+		g.processTemplateFact(ev.tmpl)
+	}
+}
+
+func (g *GraphRAG) recordShutdownError(err error) {
+	if err == nil {
+		return
+	}
+	g.shutdownMu.Lock()
+	g.shutdownErr = errors.Join(g.shutdownErr, err)
+	g.shutdownMu.Unlock()
 }
 
 func (g *GraphRAG) processSpan(ev *spanEvent) {

--- a/internal/graphrag/shutdown_test.go
+++ b/internal/graphrag/shutdown_test.go
@@ -1,0 +1,81 @@
+package graphrag
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+func TestShutdownDrainsFinalEventAndPersistsTemplate(t *testing.T) {
+	repo := newTestRepo(t)
+	if err := repo.DB().AutoMigrate(&DrainTemplateRow{}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := DefaultConfig()
+	cfg.WorkerCount = 1
+	cfg.ChannelSize = 8
+	cfg.RefreshEvery = time.Hour
+	cfg.SnapshotEvery = time.Hour
+	cfg.AnomalyEvery = time.Hour
+	g := New(repo, nil, nil, cfg)
+	g.Start(context.Background())
+	g.OnLogIngested(storage.Log{
+		TenantID: storage.DefaultTenantID, ServiceName: "shutdown-fixture",
+		Severity: "ERROR", Body: "payment failed for order 123", Timestamp: time.Now(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := g.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Shutdown(ctx); err != nil {
+		t.Fatalf("second shutdown: %v", err)
+	}
+
+	var count int64
+	if err := repo.DB().Model(&DrainTemplateRow{}).
+		Where("tenant_id = ?", storage.DefaultTenantID).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count == 0 {
+		t.Fatal("last accepted log template was not persisted")
+	}
+}
+
+func TestShutdownBeforeStartIsSafe(t *testing.T) {
+	g := New(nil, nil, nil, DefaultConfig())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := g.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestShutdownReturnsFinalTemplatePersistenceFailure(t *testing.T) {
+	repo := newTestRepo(t)
+	if err := repo.DB().AutoMigrate(&DrainTemplateRow{}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := DefaultConfig()
+	cfg.WorkerCount = 1
+	cfg.RefreshEvery = time.Hour
+	cfg.SnapshotEvery = time.Hour
+	cfg.AnomalyEvery = time.Hour
+	g := New(repo, nil, nil, cfg)
+	g.Start(context.Background())
+	g.OnLogIngested(storage.Log{ServiceName: "shutdown", Body: "template save must fail", Timestamp: time.Now()})
+	if err := repo.Close(); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := g.Shutdown(ctx); err == nil {
+		t.Fatal("shutdown reported success after final template persistence failed")
+	}
+}

--- a/internal/ingest/pipeline.go
+++ b/internal/ingest/pipeline.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"runtime/debug"
 	"sync"
@@ -300,6 +301,11 @@ type Pipeline struct {
 	stopCh chan struct{}
 	once   sync.Once
 	wg     sync.WaitGroup
+
+	startOnce   sync.Once
+	lifecycleMu sync.Mutex
+	started     bool
+	workersDone chan struct{}
 }
 
 // NewPipeline constructs a Pipeline with the given config, falling back
@@ -361,6 +367,7 @@ func NewPipeline(writer pipelineWriter, metrics *telemetry.Metrics, cfg Pipeline
 		queue:          make(chan *Batch, capacity),
 		tenantInFlight: make(map[string]int),
 		stopCh:         make(chan struct{}),
+		workersDone:    make(chan struct{}),
 	}
 }
 
@@ -421,22 +428,32 @@ func (p *Pipeline) TenantDropped() int64 { return p.tenantDropped.Load() }
 // Start spawns the worker pool. Safe to call once. Subsequent calls are
 // no-ops; tests rely on this for reset semantics.
 func (p *Pipeline) Start(ctx context.Context) {
-	for range p.cfg.Workers {
-		p.wg.Go(func() {
-			defer func() {
-				if r := recover(); r != nil {
-					slog.Error("ingest pipeline worker panic",
-						"panic", r,
-						"stack", string(debug.Stack()),
-					)
-					if p.metrics != nil && p.metrics.PanicsRecoveredTotal != nil {
-						p.metrics.PanicsRecoveredTotal.WithLabelValues("ingest_pipeline").Inc()
+	p.startOnce.Do(func() {
+		p.lifecycleMu.Lock()
+		p.started = true
+		p.lifecycleMu.Unlock()
+		for range p.cfg.Workers {
+			p.wg.Go(func() {
+				defer func() {
+					if r := recover(); r != nil {
+						slog.Error("ingest pipeline worker panic",
+							"panic", r,
+							"stack", string(debug.Stack()),
+						)
+						p.processFailures.Add(1)
+						if p.metrics != nil && p.metrics.PanicsRecoveredTotal != nil {
+							p.metrics.PanicsRecoveredTotal.WithLabelValues("ingest_pipeline").Inc()
+						}
 					}
-				}
-			}()
-			p.worker(ctx)
-		})
-	}
+				}()
+				p.worker(ctx)
+			})
+		}
+		go func() {
+			p.wg.Wait()
+			close(p.workersDone)
+		}()
+	})
 }
 
 // Submit enqueues a batch for asynchronous persistence. It returns a
@@ -544,13 +561,42 @@ func (p *Pipeline) releaseTenantSlot(tenant string) {
 	p.tenantMu.Unlock()
 }
 
-// Stop signals workers to exit and blocks until in-flight batches have
-// been drained from the channel. Idempotent.
-func (p *Pipeline) Stop() {
+// Shutdown signals workers to exit, drains accepted batches, and reports any
+// state that did not reach the database or durable DLQ before the deadline.
+func (p *Pipeline) Shutdown(ctx context.Context) error {
 	p.once.Do(func() {
 		close(p.stopCh)
 	})
-	p.wg.Wait()
+	p.lifecycleMu.Lock()
+	started := p.started
+	p.lifecycleMu.Unlock()
+	if !started {
+		return nil
+	}
+	select {
+	case <-p.workersDone:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	stats := p.Stats()
+	if stats.QueueDepth != 0 || stats.QueueBytes != 0 {
+		return fmt.Errorf("ingest pipeline not drained: queue_depth=%d queue_bytes=%d", stats.QueueDepth, stats.QueueBytes)
+	}
+	if stats.DLQFailed > 0 {
+		return fmt.Errorf("ingest pipeline lost %d batches after DLQ refusal", stats.DLQFailed)
+	}
+	if unprotected := stats.ProcessFailures - stats.DLQEnqueued; unprotected > 0 {
+		return fmt.Errorf("ingest pipeline has %d failed batches without durable DLQ envelopes", unprotected)
+	}
+	return nil
+}
+
+// Stop preserves the prior internal lifecycle surface. Production shutdown
+// uses Shutdown so deadline and durability failures reach the process result.
+func (p *Pipeline) Stop() {
+	if err := p.Shutdown(context.Background()); err != nil {
+		slog.Error("ingest pipeline shutdown failed", "error", err)
+	}
 }
 
 // Stats returns snapshot counters for tests and for telemetry that

--- a/internal/ingest/pipeline_test.go
+++ b/internal/ingest/pipeline_test.go
@@ -130,6 +130,55 @@ func waitFor(t *testing.T, timeout time.Duration, pred func() bool) bool {
 	return pred()
 }
 
+func TestPipelineShutdownDrainsAcceptedBatchAndIsIdempotent(t *testing.T) {
+	w := &fakeWriter{spanDelay: 25 * time.Millisecond}
+	p := NewPipeline(w, nil, PipelineConfig{Capacity: 4, Workers: 1})
+	p.Start(context.Background())
+	if _, err := p.Submit(healthyBatch()); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := p.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Shutdown(ctx); err != nil {
+		t.Fatalf("second shutdown: %v", err)
+	}
+	stats := p.Stats()
+	if stats.Processed != 1 || stats.QueueDepth != 0 || stats.QueueBytes != 0 {
+		t.Fatalf("pipeline did not quiesce: %#v", stats)
+	}
+}
+
+func TestPipelineShutdownBeforeStartIsSafe(t *testing.T) {
+	p := NewPipeline(&fakeWriter{}, nil, PipelineConfig{Capacity: 4, Workers: 1})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := p.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	p.Start(context.Background())
+	if err := p.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPipelineShutdownReturnsUndurableFailure(t *testing.T) {
+	w := &fakeWriter{traceErr: errors.New("database unavailable")}
+	p := NewPipeline(w, nil, PipelineConfig{Capacity: 4, Workers: 1})
+	p.Start(context.Background())
+	if _, err := p.Submit(healthyBatch()); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := p.Shutdown(ctx); err == nil {
+		t.Fatal("shutdown reported success for a failed batch without a DLQ")
+	}
+}
+
 // ===== Submission semantics =====
 
 func TestPipeline_NilBatch_NoOp(t *testing.T) {

--- a/internal/queue/dlq.go
+++ b/internal/queue/dlq.go
@@ -1,6 +1,7 @@
 package queue
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -25,6 +26,8 @@ type DeadLetterQueue struct {
 	stopCh   chan struct{}
 	wg       sync.WaitGroup
 	mu       sync.Mutex
+	stopOnce sync.Once
+	done     chan struct{}
 
 	// Bounds
 	maxFiles   int   // 0 = unlimited
@@ -71,6 +74,7 @@ func NewDLQWithLimits(dir string, interval time.Duration, replayFn func(data []b
 		interval:   interval,
 		replayFn:   replayFn,
 		stopCh:     make(chan struct{}),
+		done:       make(chan struct{}),
 		maxFiles:   maxFiles,
 		maxDiskMB:  maxDiskMB,
 		maxRetries: maxRetries,
@@ -292,16 +296,31 @@ func (d *DeadLetterQueue) Size() int {
 	return count
 }
 
-// Stop gracefully shuts down the replay worker.
+// Shutdown stops replay admission and joins the current replay pass within the
+// shared application deadline. Pending envelopes remain durable on disk.
+func (d *DeadLetterQueue) Shutdown(ctx context.Context) error {
+	d.stopOnce.Do(func() { close(d.stopCh) })
+	select {
+	case <-d.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Stop preserves the prior lifecycle surface for callers without a deadline.
 func (d *DeadLetterQueue) Stop() {
-	close(d.stopCh)
-	d.wg.Wait()
+	if err := d.Shutdown(context.Background()); err != nil {
+		slog.Error("DLQ shutdown failed", "error", err)
+		return
+	}
 	slog.Info("🛑 DLQ replay worker stopped")
 }
 
 // replayWorker periodically scans the DLQ directory and attempts to re-insert failed batches.
 func (d *DeadLetterQueue) replayWorker() {
 	defer d.wg.Done()
+	defer close(d.done)
 
 	ticker := time.NewTicker(d.interval)
 	defer ticker.Stop()

--- a/internal/queue/dlq_test.go
+++ b/internal/queue/dlq_test.go
@@ -1,12 +1,28 @@
 package queue
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 )
+
+func TestDLQShutdownIsIdempotent(t *testing.T) {
+	q, err := NewDLQ(t.TempDir(), time.Hour, func([]byte) error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := q.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Shutdown(ctx); err != nil {
+		t.Fatalf("second shutdown: %v", err)
+	}
+}
 
 // TestDLQ_ConcurrentEnqueue_NoFilenameCollision exercises 1000 parallel
 // Enqueue() calls and verifies each one produced its own file. This guards

--- a/internal/tsdb/aggregator.go
+++ b/internal/tsdb/aggregator.go
@@ -64,6 +64,15 @@ type Aggregator struct {
 	// Metric callbacks
 	onIngest  func() // TSDBIngestTotal.Inc()
 	onDropped func() // TSDBBatchesDropped.Inc()
+
+	startOnce   sync.Once
+	stopOnce    sync.Once
+	lifecycleMu sync.Mutex
+	started     atomic.Bool
+	runDone     chan struct{}
+	workerWG    sync.WaitGroup
+	errMu       sync.Mutex
+	shutdownErr error
 }
 
 const persistenceWorkers = 3
@@ -83,6 +92,7 @@ func NewAggregator(repo *storage.Repository, windowSize time.Duration) *Aggregat
 		seriesPerTenant: make(map[string]int),
 		stopChan:        make(chan struct{}),
 		flushChan:       make(chan []storage.MetricBucket, 500),
+		runDone:         make(chan struct{}),
 		overflowKey:     "__cardinality_overflow__",
 	}
 	a.pool.New = func() any {
@@ -126,31 +136,74 @@ func (a *Aggregator) SetMetrics(onIngest, onDropped func()) {
 
 // Start begins the aggregation background processes.
 func (a *Aggregator) Start(ctx context.Context) {
-	ticker := time.NewTicker(a.windowSize)
-	defer ticker.Stop()
+	a.startOnce.Do(func() {
+		a.lifecycleMu.Lock()
+		a.started.Store(true)
+		a.lifecycleMu.Unlock()
+		defer close(a.runDone)
 
-	slog.Info("📈 TSDB Aggregator started", "window_size", a.windowSize, "workers", persistenceWorkers)
+		ticker := time.NewTicker(a.windowSize)
+		defer ticker.Stop()
+		slog.Info("📈 TSDB Aggregator started", "window_size", a.windowSize, "workers", persistenceWorkers)
 
-	for i := 0; i < persistenceWorkers; i++ {
-		go a.persistenceWorker(ctx)
-	}
-
-	for {
-		select {
-		case <-ticker.C:
-			a.flush()
-		case <-a.stopChan:
-			a.flush() // Final flush
-			return
-		case <-ctx.Done():
-			return
+		for i := 0; i < persistenceWorkers; i++ {
+			a.workerWG.Add(1)
+			go a.persistenceWorker()
 		}
+
+	loop:
+		for {
+			select {
+			case <-ticker.C:
+				if err := a.flush(false); err != nil {
+					a.recordShutdownError(err)
+				}
+			case <-a.stopChan:
+				if err := a.flush(true); err != nil {
+					a.recordShutdownError(err)
+				}
+				break loop
+			case <-ctx.Done():
+				a.recordShutdownError(fmt.Errorf("TSDB stopped before shutdown barrier: %w", ctx.Err()))
+				if err := a.flush(true); err != nil {
+					a.recordShutdownError(err)
+				}
+				break loop
+			}
+		}
+
+		close(a.flushChan)
+		a.workerWG.Wait()
+	})
+}
+
+// Shutdown flushes the final metric window and joins every persistence worker.
+// The caller's context is the bounded quiescence deadline.
+func (a *Aggregator) Shutdown(ctx context.Context) error {
+	a.stopOnce.Do(func() { close(a.stopChan) })
+	a.lifecycleMu.Lock()
+	started := a.started.Load()
+	a.lifecycleMu.Unlock()
+	if !started {
+		return nil
+	}
+	select {
+	case <-a.runDone:
+		a.errMu.Lock()
+		err := a.shutdownErr
+		a.errMu.Unlock()
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
-// Stop stops the aggregator.
+// Stop preserves the previous internal lifecycle surface. Production shutdown
+// uses Shutdown so deadline and persistence failures reach the process result.
 func (a *Aggregator) Stop() {
-	close(a.stopChan)
+	if err := a.Shutdown(context.Background()); err != nil {
+		slog.Error("TSDB shutdown failed", "error", err)
+	}
 }
 
 // Ingest adds a raw metric point to the current aggregator window.
@@ -280,11 +333,11 @@ func (a *Aggregator) DroppedBatches() int64 {
 }
 
 // flush moves the current buckets to the flush channel and resets the in-memory map.
-func (a *Aggregator) flush() {
+func (a *Aggregator) flush(final bool) error {
 	a.mu.Lock()
 	if len(a.buckets) == 0 {
 		a.mu.Unlock()
-		return
+		return nil
 	}
 
 	batch := a.pool.Get().([]storage.MetricBucket)
@@ -297,9 +350,15 @@ func (a *Aggregator) flush() {
 	a.seriesPerTenant = make(map[string]int)
 	a.mu.Unlock()
 
+	if final {
+		a.flushChan <- batch
+		return nil
+	}
 	select {
 	case a.flushChan <- batch:
+		return nil
 	default:
+		count := len(batch)
 		dropped := a.droppedBatches.Add(1)
 		if a.onDropped != nil {
 			a.onDropped()
@@ -307,28 +366,37 @@ func (a *Aggregator) flush() {
 		slog.Warn("⚠️ TSDB flush channel full, dropping metric batch", "count", len(batch), "total_dropped", dropped)
 		batch = batch[:0]
 		a.pool.Put(batch) //nolint:staticcheck // SA6002: []T in sync.Pool is intentional; proper refactor would change channel semantics
+		return fmt.Errorf("TSDB flush channel full: dropped %d metric buckets", count)
 	}
 }
 
 // persistenceWorker drains the flush channel and writes batches to the database.
-func (a *Aggregator) persistenceWorker(ctx context.Context) {
-	for {
-		select {
-		case batch := <-a.flushChan:
-			if len(batch) == 0 {
-				a.pool.Put(batch[:0]) //nolint:staticcheck // SA6002: see flush() for rationale
-				continue
-			}
-			err := a.repo.BatchCreateMetrics(batch)
-			if err != nil {
-				slog.Error("❌ Failed to persist metric batch", "error", err, "count", len(batch))
-			} else {
-				slog.Debug("💾 TSDB persisted metric batch", "count", len(batch))
-			}
-			batch = batch[:0]
-			a.pool.Put(batch) //nolint:staticcheck // SA6002: see flush() for rationale
-		case <-ctx.Done():
-			return
+func (a *Aggregator) persistenceWorker() {
+	defer a.workerWG.Done()
+	for batch := range a.flushChan {
+		if len(batch) == 0 {
+			a.pool.Put(batch[:0]) //nolint:staticcheck // SA6002: see flush() for rationale
+			continue
 		}
+		err := a.repo.BatchCreateMetrics(batch)
+		if err != nil {
+			slog.Error("❌ Failed to persist metric batch", "error", err, "count", len(batch))
+			a.recordShutdownError(fmt.Errorf("persist metric batch: %w", err))
+		} else {
+			slog.Debug("💾 TSDB persisted metric batch", "count", len(batch))
+		}
+		batch = batch[:0]
+		a.pool.Put(batch) //nolint:staticcheck // SA6002: see flush() for rationale
 	}
+}
+
+func (a *Aggregator) recordShutdownError(err error) {
+	if err == nil {
+		return
+	}
+	a.errMu.Lock()
+	if a.shutdownErr == nil {
+		a.shutdownErr = err
+	}
+	a.errMu.Unlock()
 }

--- a/internal/tsdb/aggregator_test.go
+++ b/internal/tsdb/aggregator_test.go
@@ -163,7 +163,7 @@ func TestAggregator_FlushResetsPerTenantCounts(t *testing.T) {
 		t.Fatalf("pre-flush BucketCount=%d, want 2", got)
 	}
 
-	a.flush()
+	_ = a.flush(false)
 
 	// Post-flush, the live map is empty and per-tenant count is reset.
 	if got := a.BucketCount(); got != 0 {

--- a/internal/tsdb/shutdown_test.go
+++ b/internal/tsdb/shutdown_test.go
@@ -1,0 +1,98 @@
+package tsdb
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+func TestShutdownPersistsFinalMetricAndIsIdempotent(t *testing.T) {
+	db, err := storage.NewDatabase("sqlite", filepath.Join(t.TempDir(), "metrics.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.AutoMigrateModels(db, "sqlite"); err != nil {
+		t.Fatal(err)
+	}
+	repo := storage.NewRepositoryFromDB(db, "sqlite")
+	t.Cleanup(func() { _ = repo.Close() })
+
+	a := NewAggregator(repo, time.Hour)
+	runCtx, cancelRun := context.WithCancel(context.Background())
+	t.Cleanup(cancelRun)
+	go a.Start(runCtx)
+	deadline := time.Now().Add(time.Second)
+	for !a.started.Load() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	a.Ingest(RawMetric{
+		TenantID: storage.DefaultTenantID, ServiceName: "shutdown-fixture",
+		Name: "last_accepted_metric", Value: 42, Timestamp: time.Now(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := a.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Shutdown(ctx); err != nil {
+		t.Fatalf("second shutdown: %v", err)
+	}
+
+	var count int64
+	if err := repo.DB().Model(&storage.MetricBucket{}).
+		Where("name = ?", "last_accepted_metric").Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("persisted metric buckets = %d, want 1", count)
+	}
+}
+
+func TestShutdownBeforeStartIsSafe(t *testing.T) {
+	a := NewAggregator(nil, time.Hour)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := a.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		a.Start(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("start after shutdown did not exit")
+	}
+}
+
+func TestShutdownReturnsFinalPersistenceFailure(t *testing.T) {
+	db, err := storage.NewDatabase("sqlite", filepath.Join(t.TempDir(), "failed-metrics.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.AutoMigrateModels(db, "sqlite"); err != nil {
+		t.Fatal(err)
+	}
+	repo := storage.NewRepositoryFromDB(db, "sqlite")
+	a := NewAggregator(repo, time.Hour)
+	go a.Start(context.Background())
+	deadline := time.Now().Add(time.Second)
+	for !a.started.Load() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	a.Ingest(RawMetric{Name: "must-fail", ServiceName: "shutdown", Timestamp: time.Now(), Value: 1})
+	if err := repo.Close(); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := a.Shutdown(ctx); err == nil {
+		t.Fatal("shutdown reported success after final metric persistence failed")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -444,12 +445,17 @@ func main() {
 		return out, nil
 	}, 5*time.Minute, 30*time.Second)
 	ctxGraph, cancelGraph := context.WithCancel(context.Background())
+	var graphDone chan struct{}
 	// The legacy graph is a raw-span scanner. In aggregate mode the topology
 	// comes from the aggregate engine's snapshot and this scan is retired
 	// outright (#174) — the object stays wired so the nil-tolerant handlers
 	// keep their shape, but nothing refreshes it.
 	if cfg.AggregateMode != aggregate.ModeAggregate {
-		go svcGraph.Start(ctxGraph)
+		graphDone = make(chan struct{})
+		go func() {
+			defer close(graphDone)
+			svcGraph.Start(ctxGraph)
+		}()
 		slog.Info("🕸️  In-memory service graph started (5m window, 30s refresh)")
 	} else {
 		slog.Info("🕸️  Legacy in-memory service graph disabled (AGGREGATE_MODE=aggregate)")
@@ -709,7 +715,7 @@ func main() {
 		}
 		topologyProvider = provider
 	}
-	go graphRAG.Start(ctxGraphRAG)
+	graphRAG.Start(ctxGraphRAG)
 	slog.Info("GraphRAG started (layered graph with anomaly detection)",
 		"workers", cfg.GraphRAGWorkerCount,
 		"event_queue_size", cfg.GraphRAGEventQueueSize,
@@ -767,7 +773,11 @@ func main() {
 	go hub.Run()
 	slog.Info("🔌 WebSocket hub started", "topology_source", topologyProvider.Source())
 
-	go eventHub.Start(ctxEvents, 5*time.Second, 500*time.Millisecond)
+	eventHubDone := make(chan struct{})
+	go func() {
+		defer close(eventHubDone)
+		eventHub.Start(ctxEvents, 5*time.Second, 500*time.Millisecond)
+	}()
 	slog.Info("⚡ Event notification hub started (5s snapshots, 500ms batches)")
 
 	retention.Start(ctxRetention)
@@ -1187,9 +1197,11 @@ func main() {
 		slog.Info("🔒 gRPC reflection disabled (APP_ENV=production) — set GRPC_REFLECTION=true to re-enable")
 	}
 
+	grpcServeDone := make(chan struct{})
 	go func() {
+		defer close(grpcServeDone)
 		slog.Info("📡 gRPC OTLP receiver started", "port", cfg.GRPCPort)
-		if err := grpcServer.Serve(lis); err != nil {
+		if err := grpcServer.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 			fatal("Failed to serve gRPC", err)
 		}
 	}()
@@ -1404,7 +1416,9 @@ func main() {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
+	httpServeDone := make(chan struct{})
 	go func() {
+		defer close(httpServeDone)
 		if tlsMode != "" {
 			slog.Info("🔒 HTTPS server started", "port", cfg.HTTPPort, "mode", tlsMode)
 			if err := srv.ListenAndServeTLS(tlsCertPath, tlsKeyPath); err != nil && err != http.ErrServerClosed {
@@ -1422,104 +1436,163 @@ func main() {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 	<-stop
+	signal.Stop(stop)
 
+	apiServer.BeginShutdown()
 	slog.Info("Shutting down OtelContext V5.4...")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
 	defer cancel()
 
-	// Ordered shutdown: ingestion → HTTP → hubs/events → processing → DLQ → DB
-	// 1. Stop ingestion paths first (no new data)
-	grpcServer.GracefulStop()
-	if err := srv.Shutdown(ctx); err != nil {
-		slog.Error("HTTP server forced shutdown", "error", err)
-	}
-	if pprofSrv != nil {
-		_ = pprofSrv.Close()
+	report, shutdownErr := executeShutdown(ctx, []shutdownStep{
+		{name: "otlp_admission", run: func(stepCtx context.Context) error {
+			if err := gracefulStopAdmission(stepCtx, grpcServer.GracefulStop, grpcServer.Stop); err != nil {
+				return err
+			}
+			select {
+			case <-grpcServeDone:
+				return nil
+			case <-stepCtx.Done():
+				return stepCtx.Err()
+			}
+		}},
+		{name: "http", run: func(stepCtx context.Context) error {
+			if err := srv.Shutdown(stepCtx); err != nil {
+				return err
+			}
+			select {
+			case <-httpServeDone:
+				return nil
+			case <-stepCtx.Done():
+				return stepCtx.Err()
+			}
+		}},
+		{name: "pprof", run: func(context.Context) error {
+			if pprofSrv == nil {
+				return nil
+			}
+			if err := pprofSrv.Close(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				return err
+			}
+			return nil
+		}},
+		{name: "realtime", run: func(stepCtx context.Context) error {
+			cancelEvents()
+			eventHub.Stop()
+			hub.Stop()
+			select {
+			case <-eventHubDone:
+				return nil
+			case <-stepCtx.Done():
+				return stepCtx.Err()
+			}
+		}},
+		{name: "ai", run: func(context.Context) error {
+			// Cancel in-flight calls before joining the workers.
+			aiCancel()
+			aiService.Stop()
+			return nil
+		}},
+		{name: "ingest_pipeline", run: func(stepCtx context.Context) error {
+			if ingestPipeline == nil {
+				return nil
+			}
+			return ingestPipeline.Shutdown(stepCtx)
+		}},
+		{name: "aggregate_writer", run: func(stepCtx context.Context) error {
+			if aggWriter == nil {
+				return nil
+			}
+			return aggWriter.Shutdown(stepCtx)
+		}},
+		{name: "tsdb", run: func(stepCtx context.Context) error {
+			defer cancelTSDB()
+			if tsdbAgg == nil {
+				return nil
+			}
+			return tsdbAgg.Shutdown(stepCtx)
+		}},
+		{name: "graphrag", run: func(stepCtx context.Context) error {
+			defer cancelGraphRAG()
+			return graphRAG.Shutdown(stepCtx)
+		}},
+		{name: "service_graph", run: func(stepCtx context.Context) error {
+			cancelGraph()
+			if graphDone == nil {
+				return nil
+			}
+			select {
+			case <-graphDone:
+				return nil
+			case <-stepCtx.Done():
+				return stepCtx.Err()
+			}
+		}},
+		{name: "dlq", run: func(stepCtx context.Context) error {
+			if dlq == nil {
+				return nil
+			}
+			return dlq.Shutdown(stepCtx)
+		}},
+		{name: "disk_watchdog", run: func(context.Context) error {
+			cancelDisk()
+			diskWatchdog.Stop()
+			return nil
+		}},
+		{name: "retention", run: func(context.Context) error {
+			cancelRetention()
+			retention.Stop()
+			return nil
+		}},
+		{name: "partitions", run: func(context.Context) error {
+			cancelPartitions()
+			if partitionScheduler != nil {
+				partitionScheduler.Stop()
+			}
+			return nil
+		}},
+		{name: "tracer", run: func(stepCtx context.Context) error {
+			if shutdownTracer == nil {
+				return nil
+			}
+			return shutdownTracer(stepCtx)
+		}},
+		{name: "database_health", run: func(stepCtx context.Context) error {
+			if dbHealth == nil {
+				return nil
+			}
+			return dbHealth.Shutdown(stepCtx)
+		}},
+		{name: "boot_workers", run: func(context.Context) error {
+			appCancel()
+			bootWG.Wait()
+			return nil
+		}},
+		{name: "aggregate_store", run: func(context.Context) error {
+			if aggStore == nil {
+				return nil
+			}
+			return aggStore.Close()
+		}},
+		{name: "main_database", run: func(context.Context) error {
+			return repo.Close()
+		}},
+	})
+	proof, _ := json.Marshal(report)
+	if shutdownErr != nil {
+		fatal("shutdown_failed", shutdownErr,
+			"status", "failed",
+			"version", Version,
+			"proof", string(proof),
+		)
 	}
 
-	// 2. Stop real-time hubs and event processing
-	hub.Stop()
-	cancelEvents()
-	// Cancel in-flight LLM calls BEFORE Stop so workers don't burn the
-	// 30s LLM deadline waiting on a half-dead upstream during shutdown.
-	aiCancel()
-	aiService.Stop()
-
-	// 3. Stop processing engines (TSDB flush, graph, GraphRAG)
-	if tsdbAgg != nil {
-		tsdbAgg.Stop()
-	}
-	cancelTSDB()
-	cancelGraph()
-	graphRAG.Stop()
-	cancelGraphRAG()
-
-	// 3a. Drain async ingest pipeline. gRPC GracefulStop above guarantees
-	// no new Submits land; this blocks until workers finish in-flight
-	// batches so a graceful shutdown doesn't lose buffered ingest.
-	if ingestPipeline != nil {
-		ingestPipeline.Stop()
-	}
-
-	// 3b. Drain the aggregate group-commit writer. gRPC GracefulStop above
-	// guarantees no new Exports, so this commits whatever was still queued
-	// rather than dropping deltas an Export is still waiting on.
-	if aggWriter != nil {
-		aggWriter.Stop()
-	}
-
-	// 4. Stop DLQ (may still be replaying)
-	dlq.Stop()
-
-	// 4a. Stop retention + partition schedulers before closing DB (both issue queries).
-	cancelDisk()
-	diskWatchdog.Stop()
-	cancelRetention()
-	retention.Stop()
-	cancelPartitions()
-	if partitionScheduler != nil {
-		partitionScheduler.Stop()
-	}
-
-	// 4b. Shutdown the OTel tracer provider (flushes pending spans).
-	if shutdownTracer != nil {
-		if err := shutdownTracer(ctx); err != nil {
-			slog.Error("Failed to shutdown tracer provider", "error", err)
-		}
-	}
-
-	// 4b2. Stop DB health poller before cancelling appCtx so final state is
-	// written to the gauge before the pool closes.
-	if dbHealth != nil {
-		dbHealth.Stop()
-	}
-
-	// 4c. Cancel boot-time goroutines (hydrator, DB health poller) and wait
-	// with a bounded timeout before closing the DB — otherwise a mid-query
-	// hydrator would race with the pool closing underneath it.
-	appCancel()
-	waitDone := make(chan struct{})
-	go func() { bootWG.Wait(); close(waitDone) }()
-	select {
-	case <-waitDone:
-	case <-time.After(10 * time.Second):
-		slog.Warn("hydrator did not finish before shutdown; cancelling")
-	}
-
-	// 5. Close the databases last (everything above may still write). The
-	// aggregate store closes before the main DB: its writer has already
-	// drained, and retention — which touches both — has already stopped.
-	if aggStore != nil {
-		if err := aggStore.Close(); err != nil {
-			slog.Error("Failed to close aggregate store", "error", err)
-		}
-	}
-	if err := repo.Close(); err != nil {
-		slog.Error("Failed to close database", "error", err)
-	}
-
-	slog.Info("✅ OtelContext V5.4 shutdown complete")
+	slog.Info("shutdown_complete",
+		"status", "success",
+		"version", Version,
+		"duration_ms", report.CompletedAt.Sub(report.StartedAt).Milliseconds(),
+		"proof", string(proof),
+	)
 }
 
 // recoveryUnaryInterceptor catches panics inside any unary gRPC handler,

--- a/shutdown.go
+++ b/shutdown.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+type shutdownStep struct {
+	name string
+	run  func(context.Context) error
+}
+
+type shutdownStepResult struct {
+	Name        string    `json:"name"`
+	StartedAt   time.Time `json:"started_at"`
+	CompletedAt time.Time `json:"completed_at"`
+	Error       string    `json:"error,omitempty"`
+}
+
+type shutdownReport struct {
+	StartedAt   time.Time            `json:"started_at"`
+	CompletedAt time.Time            `json:"completed_at"`
+	Steps       []shutdownStepResult `json:"steps"`
+}
+
+const gracefulShutdownTimeout = 30 * time.Second
+
+func gracefulStopAdmission(ctx context.Context, graceful, force func()) error {
+	done := make(chan struct{})
+	go func() {
+		graceful()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		force()
+		<-done
+		return ctx.Err()
+	}
+}
+
+// executeShutdown runs the owning shutdown barriers in order. Each owner is
+// bounded by ctx even when its legacy Stop method does not accept a context.
+// An owner error is retained while later safe stops continue; a spent
+// deadline stops the sequence because the process can no longer prove that a
+// writer is quiescent.
+func executeShutdown(ctx context.Context, steps []shutdownStep) (shutdownReport, error) {
+	report := shutdownReport{
+		StartedAt: time.Now().UTC(),
+		Steps:     make([]shutdownStepResult, 0, len(steps)),
+	}
+	var failures []error
+
+	for _, step := range steps {
+		result := shutdownStepResult{Name: step.name, StartedAt: time.Now().UTC()}
+		err := runShutdownStep(ctx, step)
+		result.CompletedAt = time.Now().UTC()
+		if err != nil {
+			result.Error = err.Error()
+			failures = append(failures, fmt.Errorf("%s: %w", step.name, err))
+		}
+		report.Steps = append(report.Steps, result)
+		if ctx.Err() != nil {
+			break
+		}
+	}
+
+	report.CompletedAt = time.Now().UTC()
+	return report, errors.Join(failures...)
+}
+
+func runShutdownStep(ctx context.Context, step shutdownStep) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if step.run == nil {
+		return nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				done <- fmt.Errorf("panic: %v", recovered)
+			}
+		}()
+		done <- step.run(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/shutdown_test.go
+++ b/shutdown_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestExecuteShutdownRunsOwnersInOrder(t *testing.T) {
+	var order []string
+	steps := []shutdownStep{
+		{name: "admission", run: func(context.Context) error { order = append(order, "admission"); return nil }},
+		{name: "ingest", run: func(context.Context) error { order = append(order, "ingest"); return nil }},
+		{name: "derived", run: func(context.Context) error { order = append(order, "derived"); return nil }},
+		{name: "database", run: func(context.Context) error { order = append(order, "database"); return nil }},
+	}
+
+	report, err := executeShutdown(context.Background(), steps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"admission", "ingest", "derived", "database"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("order = %v, want %v", order, want)
+	}
+	if len(report.Steps) != len(steps) || report.CompletedAt.IsZero() {
+		t.Fatalf("incomplete report: %#v", report)
+	}
+}
+
+func TestExecuteShutdownReturnsOwnerFailureAndContinuesSafeStops(t *testing.T) {
+	wantErr := errors.New("final flush failed")
+	closed := false
+	steps := []shutdownStep{
+		{name: "tsdb", run: func(context.Context) error { return wantErr }},
+		{name: "database", run: func(context.Context) error { closed = true; return nil }},
+	}
+
+	report, err := executeShutdown(context.Background(), steps)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if !closed {
+		t.Fatal("later safe stop did not run after an owner error")
+	}
+	if report.Steps[0].Error == "" {
+		t.Fatalf("failure missing from report: %#v", report)
+	}
+}
+
+func TestExecuteShutdownBoundsBlockedOwner(t *testing.T) {
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	started := time.Now()
+	_, err := executeShutdown(ctx, []shutdownStep{{
+		name: "blocked",
+		run: func(context.Context) error {
+			<-release
+			return nil
+		},
+	}})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("bounded shutdown took %s", elapsed)
+	}
+}
+
+func TestGracefulStopAdmissionForcesOnDeadline(t *testing.T) {
+	blocked := make(chan struct{})
+	forced := false
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	err := gracefulStopAdmission(ctx, func() { <-blocked }, func() {
+		forced = true
+		close(blocked)
+	})
+	if !errors.Is(err, context.DeadlineExceeded) || !forced {
+		t.Fatalf("error=%v forced=%v, want deadline and force", err, forced)
+	}
+}

--- a/startup_schema_test.go
+++ b/startup_schema_test.go
@@ -140,7 +140,7 @@ func TestSchemaGatePrecedesEveryWorkerAndListenerInMain(t *testing.T) {
 		"startPprofServer(cfg.PprofAddr, logger)",
 		"partitionScheduler.Start(ctxPart)",
 		"go hub.Run()",
-		"go graphRAG.Start(ctxGraphRAG)",
+		"graphRAG.Start(ctxGraphRAG)",
 	} {
 		position := strings.Index(text, marker)
 		if position < 0 || position < gate {

--- a/test/shutdownproof/shutdown_proof_test.go
+++ b/test/shutdownproof/shutdown_proof_test.go
@@ -1,0 +1,618 @@
+//go:build shutdownproof && !windows
+
+package shutdownproof_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/ingest"
+	"github.com/RandomCodeSpace/otelcontext/internal/queue"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	_ "github.com/glebarez/go-sqlite"
+	collectlogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	collectmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	collecttracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	traceFixtureID = "0102030405060708090a0b0c0d0e0f10"
+	spanFixtureID  = "1112131415161718"
+	logFixtureBody = "shutdown proof payment failed for order 4242"
+	metricFixture  = "shutdown_proof_metric"
+)
+
+var requiredOwners = []string{
+	"otlp_admission", "http", "pprof", "realtime", "ai",
+	"ingest_pipeline", "aggregate_writer", "tsdb", "graphrag",
+	"service_graph", "dlq", "disk_watchdog", "retention",
+	"partitions", "tracer", "database_health", "boot_workers",
+	"aggregate_store", "main_database",
+}
+
+type lockedBuffer struct {
+	mu   sync.Mutex
+	data []byte
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	b.data = append(b.data, p...)
+	b.mu.Unlock()
+	return len(p), nil
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(append([]byte(nil), b.data...))
+}
+
+type appProcess struct {
+	binary        string
+	dir           string
+	mode          string
+	httpPort      int
+	grpcPort      int
+	log           *lockedBuffer
+	cmd           *exec.Cmd
+	done          chan error
+	mainDBPath    string
+	aggregatePath string
+	dlqPath       string
+}
+
+func newAppProcess(t *testing.T, binary, mode string) *appProcess {
+	t.Helper()
+	dir := t.TempDir()
+	return &appProcess{
+		binary:        binary,
+		dir:           dir,
+		mode:          mode,
+		httpPort:      freePort(t),
+		grpcPort:      freePort(t),
+		log:           &lockedBuffer{},
+		mainDBPath:    filepath.Join(dir, "otelcontext.db"),
+		aggregatePath: filepath.Join(dir, "aggregate.db"),
+		dlqPath:       filepath.Join(dir, "dlq"),
+	}
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+func (a *appProcess) environment() []string {
+	overrides := map[string]string{
+		"AGGREGATE_ALLOW_REBUILD":    "false",
+		"AGGREGATE_DB_PATH":          a.aggregatePath,
+		"AGGREGATE_MODE":             a.mode,
+		"API_KEY":                    "",
+		"API_TENANT_KEYS_FILE":       "",
+		"APP_ENV":                    "development",
+		"DATA_DISK_BUDGET_MB":        "1000000",
+		"DATA_DISK_PATH":             a.dir,
+		"DB_AUTOMIGRATE":             "true",
+		"DB_DRIVER":                  "sqlite",
+		"DB_DSN":                     a.mainDBPath,
+		"DLQ_PATH":                   a.dlqPath,
+		"DLQ_REPLAY_INTERVAL":        "1h",
+		"GRAPHRAG_EVENT_QUEUE_SIZE":  "64",
+		"GRAPHRAG_WORKER_COUNT":      "1",
+		"GRPC_PORT":                  strconv.Itoa(a.grpcPort),
+		"HTTP_PORT":                  strconv.Itoa(a.httpPort),
+		"INGEST_ASYNC_ENABLED":       "true",
+		"INGEST_PIPELINE_QUEUE_SIZE": "64",
+		"INGEST_PIPELINE_WORKERS":    "1",
+		"INGEST_MIN_SEVERITY":        "INFO",
+		"LOG_LEVEL":                  "INFO",
+		"PPROF_ADDR":                 "",
+		"SAMPLING_RATE":              "1.0",
+		"STORE_MIN_SEVERITY":         "INFO",
+		"TLS_AUTO_SELFSIGNED":        "false",
+		"TLS_CERT_FILE":              "",
+		"TLS_KEY_FILE":               "",
+	}
+	env := make([]string, 0, len(os.Environ())+len(overrides))
+	for _, item := range os.Environ() {
+		key, _, _ := strings.Cut(item, "=")
+		if _, replaced := overrides[key]; !replaced {
+			env = append(env, item)
+		}
+	}
+	keys := make([]string, 0, len(overrides))
+	for key := range overrides {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		env = append(env, key+"="+overrides[key])
+	}
+	return env
+}
+
+func (a *appProcess) start() error {
+	if a.cmd != nil {
+		return errors.New("application already running")
+	}
+	cmd := exec.Command(a.binary)
+	cmd.Dir = a.dir
+	cmd.Env = a.environment()
+	cmd.Stdout = a.log
+	cmd.Stderr = a.log
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	a.cmd = cmd
+	a.done = done
+	return nil
+}
+
+func (a *appProcess) stop() (int, error) {
+	cmd, done := a.cmd, a.done
+	a.cmd, a.done = nil, nil
+	if cmd == nil || cmd.Process == nil {
+		return 0, nil
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM); err != nil {
+		return -1, err
+	}
+	select {
+	case err := <-done:
+		if err == nil {
+			return 0, nil
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode(), err
+		}
+		return -1, err
+	case <-time.After(35 * time.Second):
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		<-done
+		return -1, errors.New("shutdown exceeded 35 seconds and was killed")
+	}
+}
+
+func (a *appProcess) waitReady(ctx context.Context) error {
+	client := &http.Client{Timeout: time.Second, Transport: &http.Transport{Proxy: nil}}
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
+			"http://127.0.0.1:"+strconv.Itoa(a.httpPort)+"/ready", nil)
+		resp, err := client.Do(req)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func resource(service string) *resourcepb.Resource {
+	return &resourcepb.Resource{Attributes: []*commonpb.KeyValue{{
+		Key: "service.name", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: service}},
+	}}}
+}
+
+func sendFixtures(ctx context.Context, grpcPort int) error {
+	conn, err := grpc.NewClient("127.0.0.1:"+strconv.Itoa(grpcPort),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	now := uint64(time.Now().UnixNano())
+	traceID, _ := hex.DecodeString(traceFixtureID)
+	spanID, _ := hex.DecodeString(spanFixtureID)
+
+	if _, err := collecttracepb.NewTraceServiceClient(conn).Export(ctx, &collecttracepb.ExportTraceServiceRequest{
+		ResourceSpans: []*tracepb.ResourceSpans{{
+			Resource: resource("shutdown-proof"),
+			ScopeSpans: []*tracepb.ScopeSpans{{Spans: []*tracepb.Span{{
+				TraceId: traceID, SpanId: spanID, Name: "last-accepted-trace",
+				StartTimeUnixNano: now, EndTimeUnixNano: now + uint64(time.Millisecond),
+				Status: &tracepb.Status{Code: tracepb.Status_STATUS_CODE_ERROR},
+			}}}},
+		}},
+	}); err != nil {
+		return fmt.Errorf("export trace: %w", err)
+	}
+
+	if _, err := collectlogspb.NewLogsServiceClient(conn).Export(ctx, &collectlogspb.ExportLogsServiceRequest{
+		ResourceLogs: []*logspb.ResourceLogs{{
+			Resource: resource("shutdown-proof"),
+			ScopeLogs: []*logspb.ScopeLogs{{LogRecords: []*logspb.LogRecord{{
+				TimeUnixNano: now, ObservedTimeUnixNano: now,
+				SeverityNumber: logspb.SeverityNumber_SEVERITY_NUMBER_ERROR,
+				SeverityText:   "ERROR",
+				Body:           &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: logFixtureBody}},
+				TraceId:        traceID, SpanId: spanID,
+			}}}},
+		}},
+	}); err != nil {
+		return fmt.Errorf("export log: %w", err)
+	}
+
+	if _, err := collectmetricspb.NewMetricsServiceClient(conn).Export(ctx, &collectmetricspb.ExportMetricsServiceRequest{
+		ResourceMetrics: []*metricspb.ResourceMetrics{{
+			Resource: resource("shutdown-proof"),
+			ScopeMetrics: []*metricspb.ScopeMetrics{{Metrics: []*metricspb.Metric{{
+				Name: metricFixture,
+				Data: &metricspb.Metric_Gauge{Gauge: &metricspb.Gauge{DataPoints: []*metricspb.NumberDataPoint{{
+					TimeUnixNano: now,
+					Value:        &metricspb.NumberDataPoint_AsDouble{AsDouble: 42},
+				}}}},
+			}}}},
+		}},
+	}); err != nil {
+		return fmt.Errorf("export metric: %w", err)
+	}
+	return nil
+}
+
+type fingerprint struct {
+	Traces             int64 `json:"traces"`
+	Spans              int64 `json:"spans"`
+	Logs               int64 `json:"logs"`
+	MetricBuckets      int64 `json:"metric_buckets"`
+	DrainTemplates     int64 `json:"drain_templates"`
+	AggregateDeltas    int64 `json:"aggregate_deltas"`
+	AggregateTemplates int64 `json:"aggregate_templates"`
+}
+
+func countRows(t *testing.T, db *sql.DB, query string, args ...any) int64 {
+	t.Helper()
+	var count int64
+	if err := db.QueryRow(query, args...).Scan(&count); err != nil {
+		t.Fatalf("query %q: %v", query, err)
+	}
+	return count
+}
+
+func readFingerprint(t *testing.T, app *appProcess) fingerprint {
+	t.Helper()
+	mainDB, err := sql.Open("sqlite", app.mainDBPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = mainDB.Close() }()
+	fp := fingerprint{
+		Traces: countRows(t, mainDB, "SELECT COUNT(*) FROM traces WHERE trace_id = ?", traceFixtureID),
+		Spans:  countRows(t, mainDB, "SELECT COUNT(*) FROM spans WHERE span_id = ?", spanFixtureID),
+		Logs:   countRows(t, mainDB, "SELECT COUNT(*) FROM logs WHERE body = ?", logFixtureBody),
+	}
+	if app.mode != "aggregate" {
+		fp.MetricBuckets = countRows(t, mainDB, "SELECT COUNT(*) FROM metric_buckets WHERE name = ?", metricFixture)
+	}
+	if app.mode == "legacy" {
+		fp.DrainTemplates = countRows(t, mainDB, "SELECT COUNT(*) FROM drain_templates")
+		return fp
+	}
+	aggregateDB, err := sql.Open("sqlite", app.aggregatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = aggregateDB.Close() }()
+	fp.AggregateDeltas = countRows(t, aggregateDB, "SELECT COUNT(*) FROM aggregate_delta_log")
+	fp.AggregateTemplates = countRows(t, aggregateDB, "SELECT COUNT(*) FROM aggregate_log_template")
+	return fp
+}
+
+type runtimeStep struct {
+	Name  string `json:"name"`
+	Error string `json:"error,omitempty"`
+}
+
+type runtimeReport struct {
+	StartedAt   time.Time     `json:"started_at"`
+	CompletedAt time.Time     `json:"completed_at"`
+	Steps       []runtimeStep `json:"steps"`
+}
+
+func latestShutdownReport(t *testing.T, output string) runtimeReport {
+	t.Helper()
+	var latest runtimeReport
+	found := false
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, "msg=shutdown_complete") {
+			continue
+		}
+		idx := strings.Index(line, " proof=")
+		if idx < 0 {
+			t.Fatalf("shutdown_complete missing proof: %s", line)
+		}
+		raw, err := strconv.Unquote(strings.TrimSpace(line[idx+len(" proof="):]))
+		if err != nil {
+			t.Fatalf("unquote shutdown proof: %v", err)
+		}
+		if err := json.Unmarshal([]byte(raw), &latest); err != nil {
+			t.Fatalf("decode shutdown proof: %v", err)
+		}
+		found = true
+	}
+	if !found {
+		t.Fatal("no shutdown_complete record")
+	}
+	return latest
+}
+
+func assertReport(t *testing.T, report runtimeReport) {
+	t.Helper()
+	if report.StartedAt.IsZero() || report.CompletedAt.IsZero() {
+		t.Fatalf("shutdown report lacks timestamps: %#v", report)
+	}
+	if len(report.Steps) != len(requiredOwners) {
+		t.Fatalf("shutdown owners = %d, want %d: %#v", len(report.Steps), len(requiredOwners), report.Steps)
+	}
+	for i, owner := range requiredOwners {
+		if report.Steps[i].Name != owner || report.Steps[i].Error != "" {
+			t.Fatalf("shutdown step %d = %#v, want %q without error", i, report.Steps[i], owner)
+		}
+	}
+}
+
+func fileInventory(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := make(map[string]string)
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		sum := sha256.Sum256(data)
+		out[entry.Name()] = hex.EncodeToString(sum[:])
+	}
+	return out
+}
+
+func seedDLQ(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	q, err := queue.NewDLQ(dir, time.Hour, func([]byte) error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Enqueue(ingest.DLQBatchEnvelope{
+		Type: ingest.DLQBatchType,
+		Data: ingest.DLQBatchPayload{
+			Tenant: storage.DefaultTenantID,
+			Signal: "logs",
+			Logs:   []storage.Log{{ServiceName: "shutdown-proof", Body: "pending shutdown DLQ envelope"}},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := q.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return fileInventory(t, dir)
+}
+
+func sha256File(t *testing.T, path string) string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+type assertion struct {
+	Name   string `json:"name"`
+	Passed bool   `json:"passed"`
+}
+
+type proofArtifact struct {
+	SchemaVersion   string            `json:"schema_version"`
+	Mode            string            `json:"mode"`
+	CandidateSHA    string            `json:"candidate_sha,omitempty"`
+	BinarySHA256    string            `json:"binary_sha256"`
+	FixtureIDs      map[string]string `json:"fixture_ids"`
+	FirstExitCode   int               `json:"first_exit_code"`
+	RestartExitCode int               `json:"restart_exit_code"`
+	FirstShutdown   runtimeReport     `json:"first_shutdown"`
+	RestartShutdown runtimeReport     `json:"restart_shutdown"`
+	PreRestart      fingerprint       `json:"pre_restart_fingerprint"`
+	PostRestart     fingerprint       `json:"post_restart_fingerprint"`
+	DLQBefore       map[string]string `json:"dlq_before"`
+	DLQAfter        map[string]string `json:"dlq_after"`
+	Assertions      []assertion       `json:"assertions"`
+}
+
+func TestShutdownModeProof(t *testing.T) {
+	binary := os.Getenv("OTELCONTEXT_SHUTDOWN_BINARY")
+	mode := os.Getenv("OTELCONTEXT_SHUTDOWN_PROOF_MODE")
+	if binary == "" {
+		t.Fatal("OTELCONTEXT_SHUTDOWN_BINARY is required")
+	}
+	if mode != "legacy" && mode != "aggregate-shadow" && mode != "aggregate" {
+		t.Fatalf("unsupported proof mode %q", mode)
+	}
+	app := newAppProcess(t, binary, mode)
+	t.Cleanup(func() {
+		if app.cmd != nil {
+			_, _ = app.stop()
+		}
+	})
+	dlqBefore := seedDLQ(t, app.dlqPath)
+	if len(dlqBefore) != 1 {
+		t.Fatalf("DLQ seed files = %d, want 1", len(dlqBefore))
+	}
+
+	if err := app.start(); err != nil {
+		t.Fatal(err)
+	}
+	readyCtx, cancelReady := context.WithTimeout(context.Background(), 20*time.Second)
+	if err := app.waitReady(readyCtx); err != nil {
+		cancelReady()
+		t.Fatalf("first readiness: %v\n%s", err, app.log.String())
+	}
+	cancelReady()
+	exportCtx, cancelExport := context.WithTimeout(context.Background(), 10*time.Second)
+	if err := sendFixtures(exportCtx, app.grpcPort); err != nil {
+		cancelExport()
+		t.Fatal(err)
+	}
+	cancelExport()
+	firstExit, err := app.stop()
+	if err != nil || firstExit != 0 {
+		t.Fatalf("first shutdown exit=%d err=%v\n%s", firstExit, err, app.log.String())
+	}
+	firstReport := latestShutdownReport(t, app.log.String())
+	assertReport(t, firstReport)
+	preRestart := readFingerprint(t, app)
+	if preRestart.Traces != 1 || preRestart.Spans != 1 || preRestart.Logs != 1 {
+		t.Fatalf("raw fixture fingerprint = %#v", preRestart)
+	}
+	if mode == "legacy" || mode == "aggregate-shadow" {
+		if preRestart.MetricBuckets != 1 {
+			t.Fatalf("legacy metric did not survive shutdown: %#v", preRestart)
+		}
+	}
+	if mode == "legacy" {
+		if preRestart.DrainTemplates == 0 {
+			t.Fatalf("GraphRAG template did not survive shutdown: %#v", preRestart)
+		}
+	} else if preRestart.AggregateDeltas == 0 || preRestart.AggregateTemplates == 0 {
+		t.Fatalf("aggregate window/template did not survive shutdown: %#v", preRestart)
+	}
+
+	if err := app.start(); err != nil {
+		t.Fatal(err)
+	}
+	restartReadyCtx, cancelRestartReady := context.WithTimeout(context.Background(), 20*time.Second)
+	if err := app.waitReady(restartReadyCtx); err != nil {
+		cancelRestartReady()
+		t.Fatalf("restart readiness: %v\n%s", err, app.log.String())
+	}
+	cancelRestartReady()
+	restartExit, err := app.stop()
+	if err != nil || restartExit != 0 {
+		t.Fatalf("restart shutdown exit=%d err=%v\n%s", restartExit, err, app.log.String())
+	}
+	restartReport := latestShutdownReport(t, app.log.String())
+	assertReport(t, restartReport)
+	postRestart := readFingerprint(t, app)
+	if !reflect.DeepEqual(preRestart, postRestart) {
+		t.Fatalf("restart fingerprint changed: pre=%#v post=%#v", preRestart, postRestart)
+	}
+	dlqAfter := fileInventory(t, app.dlqPath)
+	if !reflect.DeepEqual(dlqBefore, dlqAfter) {
+		t.Fatalf("DLQ inventory changed: before=%v after=%v", dlqBefore, dlqAfter)
+	}
+	output := app.log.String()
+	if got := strings.Count(output, "msg=shutdown_complete"); got != 2 {
+		t.Fatalf("shutdown_complete count = %d, want 2", got)
+	}
+	if strings.Contains(output, "msg=shutdown_failed") {
+		t.Fatal("shutdown_failed record present")
+	}
+
+	artifact := proofArtifact{
+		SchemaVersion: "otelcontext.shutdown-proof.v1",
+		Mode:          mode,
+		CandidateSHA:  os.Getenv("GITHUB_SHA"),
+		BinarySHA256:  sha256File(t, binary),
+		FixtureIDs: map[string]string{
+			"trace_id": traceFixtureID, "span_id": spanFixtureID,
+			"log_body": logFixtureBody, "metric_name": metricFixture,
+		},
+		FirstExitCode:   firstExit,
+		RestartExitCode: restartExit,
+		FirstShutdown:   firstReport,
+		RestartShutdown: restartReport,
+		PreRestart:      preRestart,
+		PostRestart:     postRestart,
+		DLQBefore:       dlqBefore,
+		DLQAfter:        dlqAfter,
+		Assertions: []assertion{
+			{Name: "first_exit_zero", Passed: firstExit == 0},
+			{Name: "restart_exit_zero", Passed: restartExit == 0},
+			{Name: "all_shutdown_owners_completed", Passed: true},
+			{Name: "last_trace_persisted", Passed: preRestart.Traces == 1},
+			{Name: "last_span_persisted", Passed: preRestart.Spans == 1},
+			{Name: "last_log_persisted", Passed: preRestart.Logs == 1},
+			{Name: "mode_owned_metric_persisted", Passed: preRestart.MetricBuckets == 1 || preRestart.AggregateDeltas > 0},
+			{Name: "mode_owned_template_persisted", Passed: preRestart.DrainTemplates > 0 || preRestart.AggregateTemplates > 0},
+			{Name: "restart_fingerprint_equal", Passed: reflect.DeepEqual(preRestart, postRestart)},
+			{Name: "dlq_inventory_equal", Passed: reflect.DeepEqual(dlqBefore, dlqAfter)},
+			{Name: "no_failure_record", Passed: !strings.Contains(output, "msg=shutdown_failed")},
+		},
+	}
+	proofDir := os.Getenv("OTELCONTEXT_SHUTDOWN_PROOF_DIR")
+	if proofDir != "" {
+		if err := os.MkdirAll(proofDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		data, err := json.MarshalIndent(artifact, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(proofDir, mode+".json"), append(data, '\n'), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(proofDir, mode+".log"), []byte(output), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #247.

## Result

- flips readiness before closing gRPC and HTTP OTLP admission
- drains accepted async ingest before aggregate, TSDB, GraphRAG, DLQ, scheduler, and database owners stop
- gives every shutdown owner one bounded deadline and propagates final persistence, join, tracer, and close failures to exit 1
- emits `shutdown_complete` only after all 19 owners succeed, with machine-readable owner timestamps
- preserves legacy, aggregate-shadow, and aggregate execution paths

## Proof

- `go test -race -count=1 ./internal/ingest ./internal/tsdb ./internal/graphrag` — 305 passed
- `go test -race -count=1 ./internal/aggregate ./internal/queue ./internal/storage` — 668 passed
- `go test -count=1 .`
- focused `go vet`, `go build -trimpath .`, `actionlint`, and diff check passed
- tagged real-process proof passed in legacy, aggregate-shadow, and aggregate: trace/span/log, mode-owned metric state, mode-owned template state, and a hashed DLQ envelope survived SIGTERM and an exact-binary restart with identical fingerprints

GitHub CI remains the repository-wide regression gate. Security hardening is intentionally unchanged.