### PR TITLE
feat(backup): add manifest-bound restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,67 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  backup-proof:
+    name: backup proof · ${{ matrix.mode }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [legacy, aggregate-shadow, aggregate]
+    env:
+      CGO_ENABLED: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: build exact backup-proof binary
+        run: |
+          mkdir -p "${RUNNER_TEMP}/backup-proof"
+          go build -trimpath -o "${RUNNER_TEMP}/backup-proof/otelcontext" .
+
+      - name: run manifest-bound fresh-target restore proof
+        env:
+          OTELCONTEXT_SHUTDOWN_BINARY: ${{ runner.temp }}/backup-proof/otelcontext
+          OTELCONTEXT_BACKUP_PROOF_MODE: ${{ matrix.mode }}
+          OTELCONTEXT_BACKUP_PROOF_DIR: ${{ runner.temp }}/backup-proof/artifacts
+        run: |
+          set -o pipefail
+          mkdir -p "${RUNNER_TEMP}/backup-proof/artifacts"
+          go test -tags=shutdownproof -count=1 -v -timeout=150s \
+            -run '^TestBackupRestoreModeProof$' ./test/shutdownproof 2>&1 \
+            | tee "${RUNNER_TEMP}/backup-proof/artifacts/${OTELCONTEXT_BACKUP_PROOF_MODE}-test.log"
+          jq -e --arg mode "${OTELCONTEXT_BACKUP_PROOF_MODE}" '
+            .schema_version == "otelcontext.backup-proof.v1" and
+            .mode == $mode and
+            .create.schema_version == "otelcontext.backup/v1" and
+            .create.status == "created" and
+            .restore.schema_version == "otelcontext.backup/v1" and
+            .restore.status == "restored" and
+            .restore.ready_seconds > 0 and
+            .source_fingerprint == .target_fingerprint and
+            .source_surfaces == .target_surfaces and
+            .dlq_before == .dlq_after and
+            (.source_surfaces.mcp_tools | length) == 7 and
+            (.source_surfaces.mcp_calls | length) == 7 and
+            (.assertions | length) >= 14 and
+            all(.assertions[]; .passed == true)
+          ' "${RUNNER_TEMP}/backup-proof/artifacts/${OTELCONTEXT_BACKUP_PROOF_MODE}.json"
+          test -s "${RUNNER_TEMP}/backup-proof/artifacts/${OTELCONTEXT_BACKUP_PROOF_MODE}-manifest.json"
+
+      - name: upload mode backup proof
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: backup-proof-${{ matrix.mode }}-${{ github.sha }}
+          path: ${{ runner.temp }}/backup-proof/artifacts
+          if-no-files-found: error
+          retention-days: 14
+
   database-sqlite:
     name: database proof · sqlite
     runs-on: ubuntu-24.04
@@ -240,5 +301,61 @@ jobs:
         with:
           name: database-proof-postgres-16-${{ github.sha }}
           path: ${{ runner.temp }}/database-proof/postgres-16.log
+          if-no-files-found: error
+          retention-days: 14
+
+  database-backup-proof:
+    name: database backup proof · ${{ matrix.profile }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - profile: postgres-16
+            adapter: postgres
+          - profile: mysql-8.4
+            adapter: mysql
+          - profile: sqlserver-2022
+            adapter: mssql
+    env:
+      CGO_ENABLED: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: run native capture and fresh-target restore lifecycle
+        env:
+          OTELCONTEXT_BACKUP_ADAPTER: ${{ matrix.adapter }}
+          OTELCONTEXT_NATIVE_BACKUP_PROOF_DIR: ${{ runner.temp }}/native-backup-proof
+        run: |
+          set -o pipefail
+          mkdir -p "${OTELCONTEXT_NATIVE_BACKUP_PROOF_DIR}"
+          go test -tags=integration -count=1 -v -timeout=22m \
+            -run '^TestNativeBackupRestoreLifecycle$' ./internal/backup 2>&1 \
+            | tee "${OTELCONTEXT_NATIVE_BACKUP_PROOF_DIR}/${OTELCONTEXT_BACKUP_ADAPTER}-test.log"
+          jq -e --arg adapter "${OTELCONTEXT_BACKUP_ADAPTER}" '
+            .schema_version == "otelcontext.native-backup-proof/v1" and
+            .adapter == $adapter and
+            .create.schema_version == "otelcontext.backup/v1" and
+            .create.status == "created" and
+            .restore.schema_version == "otelcontext.backup/v1" and
+            .restore.status == "restored" and
+            .source_lifecycle_fingerprint == .restored_lifecycle_fingerprint and
+            (.assertions | length) >= 8 and
+            all(.assertions[]; .passed == true)
+          ' "${OTELCONTEXT_NATIVE_BACKUP_PROOF_DIR}/${OTELCONTEXT_BACKUP_ADAPTER}.json"
+          test -s "${OTELCONTEXT_NATIVE_BACKUP_PROOF_DIR}/${OTELCONTEXT_BACKUP_ADAPTER}-manifest.json"
+
+      - name: upload native database backup proof
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: native-backup-proof-${{ matrix.profile }}-${{ github.sha }}
+          path: ${{ runner.temp }}/native-backup-proof
           if-no-files-found: error
           retention-days: 14

--- a/README.md
+++ b/README.md
@@ -158,7 +158,23 @@ If the database came from an older release that predates migration tracking, ide
 ./otelcontext migrate up
 ```
 
-The baseline command validates the database first; it does not repair or guess. Back up the main database and aggregate database file, and keep the previous signed binary until `migrate status` reports `result=ready`. Versioned production checks are available for SQLite and unpartitioned PostgreSQL 16. MySQL, SQL Server, and PostgreSQL daily partitioning keep their existing preview AutoMigrate path.
+The baseline command validates the database first; it does not repair or guess. Create a complete OtelContext backup before upgrading, and keep the previous signed binary until `migrate status` reports `result=ready`. Versioned production checks are available for SQLite and unpartitioned PostgreSQL 16. MySQL, SQL Server, and PostgreSQL daily partitioning keep their existing preview AutoMigrate path.
+
+## Back up and restore
+
+After stopping OtelContext cleanly, use the same binary and environment as the service:
+
+```bash
+otelcontext backup create --out /absolute/path/to/backups
+```
+
+The published bundle keeps the main database, any mode-required aggregate database, the dead-letter queue, generated TLS identity, and a hashed manifest together. Restore into new database and sidecar paths; the command will not overwrite the source or an existing target:
+
+```bash
+otelcontext backup restore --bundle /absolute/path/to/backups/otelcontext-backup-...
+```
+
+Restore starts the same candidate briefly, waits for `/ready`, and shuts it down again. Keep the old binary, configuration, data, and bundle until the restored deployment passes your checks. The [backup and restore runbook](docs/OPERATIONS.md#backup--restore) covers database-specific tools, fresh-target setup, validation, and rollback.
 
 ## Secure a deployment
 

--- a/backup_cli.go
+++ b/backup_cli.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/backup"
+	"github.com/RandomCodeSpace/otelcontext/internal/config"
+)
+
+const backupUsage = "usage: otelcontext backup <create --out ABSOLUTE_DIRECTORY|restore --bundle ABSOLUTE_DIRECTORY>"
+
+func maybeRunBackupCommand(args []string, stdout, stderr io.Writer) (bool, int) {
+	if len(args) == 0 || args[0] != "backup" {
+		return false, 0
+	}
+	if len(args) < 2 {
+		fmt.Fprintln(stderr, backupUsage)
+		return true, 2
+	}
+	command := args[1]
+	flags := flag.NewFlagSet("backup "+command, flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	var path *string
+	switch command {
+	case "create":
+		path = flags.String("out", "", "absolute parent directory for the published bundle")
+	case "restore":
+		path = flags.String("bundle", "", "absolute completed bundle directory")
+	default:
+		fmt.Fprintln(stderr, backupUsage)
+		return true, 2
+	}
+	if err := flags.Parse(args[2:]); err != nil || *path == "" || flags.NArg() != 0 {
+		fmt.Fprintln(stderr, backupUsage)
+		return true, 2
+	}
+	cfg, err := config.Load("")
+	if err != nil {
+		fmt.Fprintf(stderr, "backup: load configuration: %v\n", err)
+		return true, 1
+	}
+	candidate, err := backup.CurrentCandidate(Version)
+	if err != nil {
+		fmt.Fprintf(stderr, "backup: identify candidate: %v\n", err)
+		return true, 1
+	}
+	backupCfg := backupConfig(cfg)
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	switch command {
+	case "create":
+		report, err := backup.Create(context.Background(), backupCfg, backup.CreateOptions{
+			OutputDirectory: *path,
+			Candidate:       candidate,
+		})
+		if err != nil {
+			fmt.Fprintf(stderr, "backup create: %v\n", err)
+			return true, 1
+		}
+		if err := encoder.Encode(report); err != nil {
+			fmt.Fprintf(stderr, "backup create: write report: %v\n", err)
+			return true, 1
+		}
+	case "restore":
+		report, err := backup.Restore(context.Background(), backupCfg, backup.RestoreOptions{
+			BundleDirectory: *path,
+			Candidate:       candidate,
+		})
+		if err != nil {
+			fmt.Fprintf(stderr, "backup restore: %v\n", err)
+			return true, 1
+		}
+		readySeconds, err := verifyRestoredCandidate(context.Background(), cfg)
+		if err != nil {
+			fmt.Fprintf(stderr, "backup restore: candidate readiness proof: %v\n", err)
+			return true, 1
+		}
+		report.ReadySeconds = &readySeconds
+		if err := encoder.Encode(report); err != nil {
+			fmt.Fprintf(stderr, "backup restore: write report: %v\n", err)
+			return true, 1
+		}
+	}
+	return true, 0
+}
+
+func backupConfig(cfg *config.Config) backup.Config {
+	return backup.Config{
+		DBDriver:               cfg.DBDriver,
+		DBDSN:                  cfg.DBDSN,
+		DBPostgresPartitioning: cfg.DBPostgresPartitioning,
+		AggregateMode:          cfg.AggregateMode,
+		AggregateDBPath:        cfg.AggregateDBPath,
+		DLQPath:                cfg.DLQPath,
+		DataDiskPath:           cfg.DataDiskPath,
+		TLSCertFile:            cfg.TLSCertFile,
+		TLSKeyFile:             cfg.TLSKeyFile,
+		TLSAutoSelfSigned:      cfg.TLSAutoSelfsigned,
+		TLSCacheDir:            cfg.TLSCacheDir,
+	}
+}

--- a/backup_verify.go
+++ b/backup_verify.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/config"
+)
+
+const restoreReadyTimeout = 60 * time.Second
+
+type boundedProcessLog struct {
+	mu        sync.Mutex
+	data      []byte
+	remaining int
+}
+
+func (b *boundedProcessLog) Write(data []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	original := len(data)
+	if b.remaining <= 0 {
+		return original, nil
+	}
+	if len(data) > b.remaining {
+		data = data[:b.remaining]
+	}
+	b.data = append(b.data, data...)
+	b.remaining -= len(data)
+	return original, nil
+}
+
+func (b *boundedProcessLog) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(append([]byte(nil), b.data...))
+}
+
+func verifyRestoredCandidate(ctx context.Context, cfg *config.Config) (float64, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return 0, fmt.Errorf("resolve restore candidate executable: %w", err)
+	}
+	started := time.Now()
+	log := &boundedProcessLog{remaining: 256 << 10}
+	command := exec.CommandContext(ctx, executable) // #nosec G204 -- exact running binary, no operator command string.
+	command.Env = restoreCandidateEnvironment(os.Environ())
+	command.Stdout = log
+	command.Stderr = log
+	if err := command.Start(); err != nil {
+		return 0, fmt.Errorf("start restored candidate: %w", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- command.Wait() }()
+	readyClient, readyURL, err := restoredReadinessClient(cfg)
+	if err != nil {
+		stopRestoreCandidate(command, done)
+		return 0, err
+	}
+	readyCtx, cancel := context.WithTimeout(ctx, restoreReadyTimeout)
+	defer cancel()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		request, requestErr := http.NewRequestWithContext(readyCtx, http.MethodGet, readyURL, nil)
+		if requestErr != nil {
+			stopRestoreCandidate(command, done)
+			return 0, requestErr
+		}
+		response, requestErr := readyClient.Do(request)
+		if requestErr == nil {
+			_, _ = io.Copy(io.Discard, response.Body)
+			_ = response.Body.Close()
+			if response.StatusCode == http.StatusOK {
+				readySeconds := time.Since(started).Seconds()
+				if err := command.Process.Signal(os.Interrupt); err != nil {
+					stopRestoreCandidate(command, done)
+					return 0, fmt.Errorf("stop restored candidate after readiness: %w", err)
+				}
+				select {
+				case waitErr := <-done:
+					if waitErr != nil {
+						return 0, fmt.Errorf("restored candidate exited after readiness: %w\n%s", waitErr, log.String())
+					}
+					return readySeconds, nil
+				case <-time.After(40 * time.Second):
+					_ = command.Process.Kill()
+					<-done
+					return 0, errors.New("restored candidate did not complete graceful shutdown within 40 seconds")
+				}
+			}
+		}
+		select {
+		case waitErr := <-done:
+			return 0, fmt.Errorf("restored candidate exited before readiness: %w\n%s", waitErr, log.String())
+		case <-readyCtx.Done():
+			stopRestoreCandidate(command, done)
+			return 0, fmt.Errorf("restored candidate readiness timeout: %w\n%s", readyCtx.Err(), log.String())
+		case <-ticker.C:
+		}
+	}
+}
+
+func restoreCandidateEnvironment(current []string) []string {
+	overrides := map[string]string{
+		"AGGREGATE_ALLOW_REBUILD": "false",
+		"DB_AUTOMIGRATE":          "false",
+	}
+	result := make([]string, 0, len(current)+len(overrides))
+	for _, item := range current {
+		key, _, _ := strings.Cut(item, "=")
+		if _, replaced := overrides[key]; !replaced {
+			result = append(result, item)
+		}
+	}
+	for key, value := range overrides {
+		result = append(result, key+"="+value)
+	}
+	return result
+}
+
+func restoredReadinessClient(cfg *config.Config) (*http.Client, string, error) {
+	transport := &http.Transport{Proxy: nil}
+	scheme := "http"
+	port, err := strconv.Atoi(cfg.HTTPPort)
+	if err != nil || port < 1 || port > 65535 {
+		return nil, "", fmt.Errorf("invalid HTTP_PORT %q for readiness proof", cfg.HTTPPort)
+	}
+	if cfg.TLSEnabled() {
+		scheme = "https"
+		certPath := cfg.TLSCertFile
+		if certPath == "" {
+			certPath = filepath.Join(cfg.TLSCacheDir, "cert.pem")
+		}
+		certificatePEM, err := os.ReadFile(certPath) // #nosec G304 -- resolved configured certificate used by the child.
+		if err != nil {
+			return nil, "", fmt.Errorf("read restored candidate certificate: %w", err)
+		}
+		roots := x509.NewCertPool()
+		if !roots.AppendCertsFromPEM(certificatePEM) {
+			return nil, "", errors.New("restored candidate certificate file contains no certificate")
+		}
+		serverName := "127.0.0.1"
+		if block, _ := pem.Decode(certificatePEM); block != nil {
+			if certificate, parseErr := x509.ParseCertificate(block.Bytes); parseErr == nil && len(certificate.IPAddresses) == 0 && len(certificate.DNSNames) > 0 {
+				serverName = certificate.DNSNames[0]
+			}
+		}
+		transport.TLSClientConfig = &tls.Config{ // #nosec G402 -- verification is enabled against the configured certificate.
+			MinVersion: tls.VersionTLS12,
+			RootCAs:    roots,
+			ServerName: serverName,
+		}
+	}
+	return &http.Client{Timeout: time.Second, Transport: transport}, scheme + "://127.0.0.1:" + strconv.Itoa(port) + "/ready", nil
+}
+
+func stopRestoreCandidate(command *exec.Cmd, done <-chan error) {
+	if command == nil || command.Process == nil {
+		return
+	}
+	_ = command.Process.Signal(os.Interrupt)
+	select {
+	case <-done:
+		return
+	case <-time.After(2 * time.Second):
+		_ = command.Process.Kill()
+		<-done
+	}
+}

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -165,41 +165,86 @@ Phase 3b will add Postgres declarative partitioning as an opt-in adapter; at tha
 
 ## Backup & Restore
 
-### SQLite
+OtelContext creates one stopped, manifest-bound bundle. Do not back up the main database, aggregate database, DLQ, or generated TLS files independently: mixing capture points can produce a set that looks complete but cannot be recovered consistently.
 
-Online backup (does not block writers):
+This is an **offline** workflow. It does not provide online backup, point-in-time recovery, retention, encryption, or an RPO/RTO promise.
+
+### What is in a bundle
+
+| Durable owner | `legacy` | `aggregate-shadow` | `aggregate` |
+|---|---:|---:|---:|
+| Main SQLite/PostgreSQL/MySQL/SQL Server database | Yes | Yes | Yes |
+| Separate aggregate SQLite database and identity/version metadata | No | Yes | Yes |
+| Dead-letter queue JSON files | Yes | Yes | Yes |
+| Generated self-signed certificate and key | When enabled | When enabled | When enabled |
+| Candidate, configuration, migration, hash, shutdown, fingerprint, and timing manifest | Yes | Yes | Yes |
+
+Explicit `TLS_CERT_FILE` and `TLS_KEY_FILE` values are operator-owned and are not copied. Back those files up through the system that owns them.
+
+### Native database tools
+
+The commands use SQLite support built into the binary. Server databases require the matching native client on `PATH`:
+
+| Database | Required client | Captured form |
+|---|---|---|
+| SQLite | None | `VACUUM INTO`, then integrity and foreign-key checks |
+| PostgreSQL 16 | `pg_dump` and `pg_restore` 16 | Custom archive without owner or privilege statements |
+| MySQL 8.4 | `mysqldump` and `mysql` 8.4 | Single-transaction logical dump |
+| SQL Server 2022 | `sqlcmd` 18 | Full `COPY_ONLY` backup with checksum |
+
+The command stops with a clear error when a client is missing or from the wrong major version. SQL Server must be able to see the absolute bundle path at the same path inside the database host or container because the server reads and writes the backup file itself.
+
+### Create a bundle
+
+1. Record the exact binary, environment, and configuration used by the service.
+2. Stop OtelContext cleanly and wait for the process to exit. A forced or incomplete stop does not qualify.
+3. Run that same binary with the same environment and an absolute output directory:
+
+   ```bash
+   /usr/local/bin/otelcontext backup create --out /var/backups/otelcontext
+   ```
+
+4. Keep only a directory reported with `"status":"created"`. A failed capture leaves a uniquely named `.partial` directory for diagnosis; it is not restorable.
+5. Record the reported `manifest_sha256` with the copied bundle, then copy the completed directory to the operator-owned backup location.
+
+The create command refuses to run while a runtime marker is active, after an unclean stop, with a shutdown proof from another binary, or when a required owner cannot be inspected. `quiesce_seconds` and `capture_seconds` are measurements from this run, not service-level promises.
+
+### Restore to fresh targets
+
+Never restore over the source. Prepare a candidate configuration that keeps the same database adapter, aggregate mode, PostgreSQL partitioning mode, and TLS ownership mode while pointing every restored owner at a fresh target:
+
+- SQLite main and aggregate paths must not exist.
+- PostgreSQL and MySQL target databases must exist but contain no user tables.
+- The SQL Server target database must not exist.
+- `DLQ_PATH` and a generated `TLS_CACHE_DIR` must not exist.
+- Mount the completed bundle read-only where practical. Never pass a `.partial` directory.
+
+With the service still stopped, run the candidate binary in that environment:
 
 ```bash
-sqlite3 otelcontext.db ".backup /backups/otelcontext-$(date +%F).db"
-# or
-sqlite3 otelcontext.db "VACUUM INTO '/backups/otelcontext-$(date +%F).db'"
+/usr/local/bin/otelcontext backup restore \
+  --bundle /var/backups/otelcontext/otelcontext-backup-YYYYMMDDTHHMMSSZ-ID
 ```
 
-Restore:
+Before writing, restore verifies the schema, complete artifact set, sizes and hashes, mode, migration state, aggregate identity and versions, DLQ and TLS inventory, database artifact, source identities, and every fresh-target condition. It restores with automatic migrations and aggregate rebuild disabled, inspects the restored durability metadata, starts the exact candidate, waits up to 60 seconds for `/ready`, and then shuts it down cleanly.
 
-```bash
-sqlite3 /backups/otelcontext-YYYY-MM-DD.db "VACUUM INTO './otelcontext.db'"
-```
+A successful report includes `"status":"restored"`, the manifest lifecycle fingerprint, measured backup age, restore time, and `ready_seconds`. The readiness drill stops the candidate; start the service normally only after checking the report.
 
-### Postgres
+If a restore fails after writing begins, discard the new target set and retry with another fresh set. Do not point the previous service at a partially populated target.
 
-Operator-owned:
+### Drill and rollback
 
-```bash
-pg_dump -Fc -d otelcontext -f /backups/otelcontext-$(date +%F).dump
-```
+For each release candidate and on the recovery cadence your operation requires:
 
-Restore:
+1. Restore the newest completed bundle to isolated fresh targets.
+2. Start the candidate and wait for `/ready`.
+3. Verify the UI and REST, all seven MCP tools, WebSocket updates, DLQ inventory/replay, migration status, and durable fingerprints relevant to your deployment.
+4. Record the bundle manifest, manifest digest, redacted command records, measured timings, and validation result.
+5. Keep the previous binary, configuration, main target, aggregate file, DLQ, generated TLS directory, and bundle until the candidate has passed.
 
-```bash
-pg_restore -d otelcontext --clean --if-exists /backups/otelcontext-YYYY-MM-DD.dump
-```
+Rollback is pointer-based: stop the candidate and switch the service back to the previous binary, configuration, and untouched target set. There are no in-place restores and no down migrations.
 
-### Cadence
-
-- Hourly purge removes rows outside the retention window. If you care about data from within the last hour, back up **before the top of the hour**.
-- Daily is fine for the platform use case (platform state is not the same as user application data).
-- Test restore quarterly against a scratch instance.
+Choose backup and drill frequency from the amount of telemetry your operation can afford to lose and the recovery time it has measured. The command reports backup age and elapsed durations; it does not turn those observations into an RPO or RTO claim.
 
 ---
 

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -1,0 +1,851 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Create captures one stopped, quiesced set of durable owners and publishes
+// the bundle only after manifest.json has been synced.
+func Create(ctx context.Context, cfg Config, options CreateOptions) (CreateReport, error) {
+	started := time.Now()
+	if err := validateConfig(cfg); err != nil {
+		return CreateReport{}, err
+	}
+	outputDir, err := absolute(options.OutputDirectory, "--out")
+	if err != nil {
+		return CreateReport{}, err
+	}
+	if err := validateCandidate(options.Candidate); err != nil {
+		return CreateReport{}, err
+	}
+	if err := validateOutputLocation(cfg, outputDir); err != nil {
+		return CreateReport{}, err
+	}
+	shutdown, err := loadShutdownProof(cfg, options.Candidate)
+	if err != nil {
+		return CreateReport{}, err
+	}
+	mainOwner, err := inspectMain(ctx, cfg)
+	if err != nil {
+		return CreateReport{}, err
+	}
+	var aggregateOwner *AggregateOwner
+	if cfg.AggregateMode != "legacy" {
+		owner, err := inspectAggregate(ctx, cfg.AggregateDBPath)
+		if err != nil {
+			return CreateReport{}, err
+		}
+		aggregateOwner = &owner
+	}
+	if err := os.MkdirAll(outputDir, 0o750); err != nil {
+		return CreateReport{}, fmt.Errorf("create backup output directory: %w", err)
+	}
+	id, err := newID()
+	if err != nil {
+		return CreateReport{}, err
+	}
+	clock := options.Now
+	if clock == nil {
+		clock = time.Now
+	}
+	stamp := clock().UTC().Format("20060102T150405Z")
+	finalPath := filepath.Join(outputDir, "otelcontext-backup-"+stamp+"-"+id)
+	stagingPath := finalPath + ".partial"
+	if err := os.Mkdir(stagingPath, 0o750); err != nil {
+		return CreateReport{}, fmt.Errorf("create unique backup staging directory: %w", err)
+	}
+
+	runner := defaultRunner(options.Runner)
+	var artifacts []Artifact
+	var commands []CommandRecord
+	mainRelative := mainArtifactName(mainOwner.Adapter)
+	mainTarget := filepath.Join(stagingPath, mainRelative)
+	integrity, err := captureMainDatabase(ctx, cfg, mainTarget, runner, &commands)
+	if err != nil {
+		return CreateReport{}, fmt.Errorf("capture main database; incomplete bundle retained at %s: %w", stagingPath, err)
+	}
+	if err := syncRegular(mainTarget); err != nil {
+		return CreateReport{}, fmt.Errorf("sync main database artifact; incomplete bundle retained at %s: %w", stagingPath, err)
+	}
+	mainOwner.ArtifactPath = filepath.ToSlash(mainRelative)
+	mainOwner.Integrity = integrity
+	mainArtifact, err := artifactFor(stagingPath, roleMain, mainRelative)
+	if err != nil {
+		return CreateReport{}, err
+	}
+	artifacts = append(artifacts, mainArtifact)
+	if mainOwner.Adapter == "sqlite" {
+		captured, err := inspectSQLiteMainArtifact(ctx, mainTarget)
+		if err != nil {
+			return CreateReport{}, fmt.Errorf("inspect captured main database: %w", err)
+		}
+		if err := compareMain(mainOwner, captured); err != nil {
+			return CreateReport{}, err
+		}
+	}
+
+	if aggregateOwner != nil {
+		const aggregateRelative = "aggregate.sqlite"
+		aggregateTarget := filepath.Join(stagingPath, aggregateRelative)
+		if err := vacuumSQLite(ctx, cfg.AggregateDBPath, aggregateTarget); err != nil {
+			return CreateReport{}, fmt.Errorf("capture aggregate database; incomplete bundle retained at %s: %w", stagingPath, err)
+		}
+		captured, err := inspectAggregate(ctx, aggregateTarget)
+		if err != nil {
+			return CreateReport{}, fmt.Errorf("inspect captured aggregate database: %w", err)
+		}
+		if err := compareAggregate(*aggregateOwner, captured); err != nil {
+			return CreateReport{}, err
+		}
+		aggregateOwner.ArtifactPath = aggregateRelative
+		aggregateOwner.Integrity = captured.Integrity
+		artifact, err := artifactFor(stagingPath, roleAggregate, aggregateRelative)
+		if err != nil {
+			return CreateReport{}, err
+		}
+		artifacts = append(artifacts, artifact)
+	}
+
+	dlqOwner, dlqArtifacts, err := captureDLQ(cfg, stagingPath)
+	if err != nil {
+		return CreateReport{}, fmt.Errorf("capture DLQ; incomplete bundle retained at %s: %w", stagingPath, err)
+	}
+	artifacts = append(artifacts, dlqArtifacts...)
+	tlsOwner, tlsArtifacts, err := captureTLS(cfg, stagingPath)
+	if err != nil {
+		return CreateReport{}, fmt.Errorf("capture generated TLS identity; incomplete bundle retained at %s: %w", stagingPath, err)
+	}
+	artifacts = append(artifacts, tlsArtifacts...)
+	sortArtifacts(artifacts)
+
+	configFingerprint, err := ConfigFingerprint(cfg)
+	if err != nil {
+		return CreateReport{}, err
+	}
+	lifecycle, err := lifecycleFingerprint(mainOwner, aggregateOwner, artifacts)
+	if err != nil {
+		return CreateReport{}, err
+	}
+	createdAt := clock().UTC()
+	manifest := Manifest{
+		SchemaVersion:        SchemaVersion,
+		BackupID:             id,
+		CreatedAt:            createdAt,
+		Candidate:            options.Candidate,
+		Mode:                 cfg.AggregateMode,
+		ConfigFingerprint:    configFingerprint,
+		Shutdown:             shutdown,
+		Main:                 mainOwner,
+		Aggregate:            aggregateOwner,
+		DLQ:                  dlqOwner,
+		TLS:                  tlsOwner,
+		LifecycleFingerprint: lifecycle,
+		Artifacts:            artifacts,
+		Commands:             commands,
+		Timings: Timings{
+			QuiesceSeconds: shutdown.CompletedAt.Sub(shutdown.StartedAt).Seconds(),
+			CaptureSeconds: time.Since(started).Seconds(),
+		},
+	}
+	if err := validateManifestStructure(manifest); err != nil {
+		return CreateReport{}, fmt.Errorf("refuse invalid generated manifest: %w", err)
+	}
+	manifestPath := filepath.Join(stagingPath, manifestName)
+	if err := writeJSONExclusive(manifestPath, manifest, 0o600); err != nil {
+		return CreateReport{}, fmt.Errorf("write manifest last: %w", err)
+	}
+	if err := syncDir(stagingPath); err != nil {
+		return CreateReport{}, fmt.Errorf("sync completed bundle: %w", err)
+	}
+	if err := os.Rename(stagingPath, finalPath); err != nil {
+		return CreateReport{}, fmt.Errorf("publish completed bundle atomically: %w", err)
+	}
+	if err := syncDir(outputDir); err != nil {
+		return CreateReport{}, fmt.Errorf("sync backup output directory: %w", err)
+	}
+	manifestDigest, _, err := hashFile(filepath.Join(finalPath, manifestName))
+	if err != nil {
+		return CreateReport{}, err
+	}
+	return CreateReport{
+		SchemaVersion:  SchemaVersion,
+		Status:         "created",
+		Bundle:         finalPath,
+		BackupID:       id,
+		ManifestSHA256: manifestDigest,
+		CaptureSeconds: manifest.Timings.CaptureSeconds,
+		QuiesceSeconds: manifest.Timings.QuiesceSeconds,
+	}, nil
+}
+
+// Restore verifies the complete bundle and every fresh-target precondition
+// before mutating any target.
+func Restore(ctx context.Context, cfg Config, options RestoreOptions) (RestoreReport, error) {
+	started := time.Now()
+	if err := validateConfig(cfg); err != nil {
+		return RestoreReport{}, err
+	}
+	bundle, err := absolute(options.BundleDirectory, "--bundle")
+	if err != nil {
+		return RestoreReport{}, err
+	}
+	if strings.HasSuffix(bundle, ".partial") {
+		return RestoreReport{}, errors.New("restore refused: incomplete .partial bundle")
+	}
+	if err := validateCandidate(options.Candidate); err != nil {
+		return RestoreReport{}, err
+	}
+	runner := defaultRunner(options.Runner)
+	manifest, err := loadAndVerifyBundle(ctx, bundle, cfg, runner)
+	if err != nil {
+		return RestoreReport{}, err
+	}
+	if err := validateFreshTargets(ctx, bundle, cfg, manifest, runner); err != nil {
+		return RestoreReport{}, err
+	}
+
+	var restoreCommands []CommandRecord
+	mainSource := filepath.Join(bundle, filepath.FromSlash(manifest.Main.ArtifactPath))
+	if err := restoreMainDatabase(ctx, manifest.Main.Adapter, mainSource, cfg.DBDSN, runner, &restoreCommands); err != nil {
+		return RestoreReport{}, fmt.Errorf("restore main database: %w", err)
+	}
+	if manifest.Aggregate != nil {
+		target, err := sqlitePath(cfg.AggregateDBPath)
+		if err != nil {
+			return RestoreReport{}, err
+		}
+		source := filepath.Join(bundle, filepath.FromSlash(manifest.Aggregate.ArtifactPath))
+		if err := publishSQLiteCopy(source, target); err != nil {
+			return RestoreReport{}, fmt.Errorf("restore aggregate database: %w", err)
+		}
+	}
+	if err := restoreDLQ(bundle, cfg.DLQPath, manifest.Artifacts); err != nil {
+		return RestoreReport{}, fmt.Errorf("restore DLQ: %w", err)
+	}
+	if manifest.TLS != nil {
+		if err := restoreTLS(bundle, cfg.TLSCacheDir, *manifest.TLS); err != nil {
+			return RestoreReport{}, fmt.Errorf("restore generated TLS identity: %w", err)
+		}
+	}
+
+	actualMain, err := inspectMain(ctx, cfg)
+	if err != nil {
+		return RestoreReport{}, fmt.Errorf("inspect restored main database: %w", err)
+	}
+	if err := compareMain(manifest.Main, actualMain); err != nil {
+		return RestoreReport{}, err
+	}
+	var actualAggregate *AggregateOwner
+	if manifest.Aggregate != nil {
+		owner, err := inspectAggregate(ctx, cfg.AggregateDBPath)
+		if err != nil {
+			return RestoreReport{}, fmt.Errorf("inspect restored aggregate database: %w", err)
+		}
+		if err := compareAggregate(*manifest.Aggregate, owner); err != nil {
+			return RestoreReport{}, err
+		}
+		actualAggregate = &owner
+	}
+	actualArtifacts, err := restoredSidecarArtifacts(cfg, manifest)
+	if err != nil {
+		return RestoreReport{}, err
+	}
+	lifecycle, err := lifecycleFingerprint(actualMain, actualAggregate, actualArtifacts)
+	if err != nil {
+		return RestoreReport{}, err
+	}
+	if lifecycle != manifest.LifecycleFingerprint {
+		return RestoreReport{}, fmt.Errorf("restored lifecycle fingerprint mismatch: got %s want %s", lifecycle, manifest.LifecycleFingerprint)
+	}
+	clock := options.Now
+	if clock == nil {
+		clock = time.Now
+	}
+	return RestoreReport{
+		SchemaVersion:        SchemaVersion,
+		Status:               "restored",
+		Bundle:               bundle,
+		BackupID:             manifest.BackupID,
+		RestoreCandidate:     options.Candidate,
+		BackupAgeSeconds:     clock().UTC().Sub(manifest.CreatedAt).Seconds(),
+		RestoreSeconds:       time.Since(started).Seconds(),
+		LifecycleFingerprint: lifecycle,
+		Commands:             restoreCommands,
+	}, nil
+}
+
+func validateConfig(cfg Config) error {
+	driver := normalizeDriver(cfg.DBDriver)
+	switch driver {
+	case "sqlite", "postgres", "mysql", "mssql":
+	default:
+		return fmt.Errorf("unsupported DB_DRIVER %q", cfg.DBDriver)
+	}
+	mode := strings.ToLower(strings.TrimSpace(cfg.AggregateMode))
+	switch mode {
+	case "legacy", "aggregate-shadow", "aggregate":
+	default:
+		return fmt.Errorf("invalid AGGREGATE_MODE %q", cfg.AggregateMode)
+	}
+	if cfg.AggregateMode != mode {
+		return fmt.Errorf("AGGREGATE_MODE must use canonical value %q", mode)
+	}
+	if mode != "legacy" && strings.TrimSpace(cfg.AggregateDBPath) == "" {
+		return errors.New("AGGREGATE_DB_PATH is required outside legacy mode")
+	}
+	if strings.TrimSpace(cfg.DLQPath) == "" || strings.TrimSpace(cfg.DataDiskPath) == "" {
+		return errors.New("DLQ_PATH and DATA_DISK_PATH must not be empty")
+	}
+	if (cfg.TLSCertFile == "") != (cfg.TLSKeyFile == "") {
+		return errors.New("TLS_CERT_FILE and TLS_KEY_FILE must both be set or both empty")
+	}
+	return nil
+}
+
+func validateCandidate(candidate Candidate) error {
+	if strings.TrimSpace(candidate.Version) == "" || strings.TrimSpace(candidate.Commit) == "" {
+		return errors.New("candidate version and commit are required")
+	}
+	if len(candidate.BinarySHA256) != 64 {
+		return errors.New("candidate binary_sha256 must be 64 hexadecimal characters")
+	}
+	if _, err := hex.DecodeString(candidate.BinarySHA256); err != nil {
+		return errors.New("candidate binary_sha256 must be hexadecimal")
+	}
+	return nil
+}
+
+func validateOutputLocation(cfg Config, output string) error {
+	dlq, err := resolved(cfg.DLQPath)
+	if err != nil {
+		return err
+	}
+	if pathWithin(output, dlq) {
+		return errors.New("backup output must not be inside DLQ_PATH")
+	}
+	if cfg.TLSAutoSelfSigned && cfg.TLSCertFile == "" {
+		tlsDir, err := resolved(cfg.TLSCacheDir)
+		if err != nil {
+			return err
+		}
+		if pathWithin(output, tlsDir) {
+			return errors.New("backup output must not be inside TLS_CACHE_DIR")
+		}
+	}
+	return nil
+}
+
+func captureDLQ(cfg Config, staging string) (DLQOwner, []Artifact, error) {
+	source, err := resolved(cfg.DLQPath)
+	if err != nil {
+		return DLQOwner{}, nil, err
+	}
+	info, err := os.Lstat(source)
+	if err != nil {
+		return DLQOwner{}, nil, err
+	}
+	if !info.IsDir() {
+		return DLQOwner{}, nil, fmt.Errorf("DLQ_PATH is not a directory: %s", source)
+	}
+	target := filepath.Join(staging, "dlq")
+	if err := os.Mkdir(target, 0o750); err != nil {
+		return DLQOwner{}, nil, err
+	}
+	entries, err := os.ReadDir(source)
+	if err != nil {
+		return DLQOwner{}, nil, err
+	}
+	var artifacts []Artifact
+	var bytes int64
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		sourcePath := filepath.Join(source, entry.Name())
+		if _, err := requireRegular(sourcePath); err != nil {
+			return DLQOwner{}, nil, fmt.Errorf("DLQ entry %s: %w", entry.Name(), err)
+		}
+		relative := filepath.ToSlash(filepath.Join("dlq", entry.Name()))
+		if err := copyRegular(sourcePath, filepath.Join(staging, filepath.FromSlash(relative)), 0o600); err != nil {
+			return DLQOwner{}, nil, err
+		}
+		artifact, err := artifactFor(staging, roleDLQ, relative)
+		if err != nil {
+			return DLQOwner{}, nil, err
+		}
+		bytes += artifact.Size
+		artifacts = append(artifacts, artifact)
+	}
+	return DLQOwner{SourceIdentity: identity(source), Count: len(artifacts), Bytes: bytes}, artifacts, nil
+}
+
+func captureTLS(cfg Config, staging string) (*TLSOwner, []Artifact, error) {
+	if cfg.TLSCertFile != "" || !cfg.TLSAutoSelfSigned {
+		return nil, nil, nil
+	}
+	source, err := resolved(cfg.TLSCacheDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	certSource := filepath.Join(source, "cert.pem")
+	keySource := filepath.Join(source, "key.pem")
+	_, certErr := requireRegular(certSource)
+	_, keyErr := requireRegular(keySource)
+	if certErr != nil || keyErr != nil {
+		return nil, nil, fmt.Errorf("generated TLS cache must contain both cert.pem and key.pem: cert=%v key=%v", certErr, keyErr)
+	}
+	if err := os.Mkdir(filepath.Join(staging, "tls"), 0o700); err != nil {
+		return nil, nil, err
+	}
+	certRelative := "tls/cert.pem"
+	keyRelative := "tls/key.pem"
+	if err := copyRegular(certSource, filepath.Join(staging, filepath.FromSlash(certRelative)), 0o600); err != nil {
+		return nil, nil, err
+	}
+	if err := copyRegular(keySource, filepath.Join(staging, filepath.FromSlash(keyRelative)), 0o600); err != nil {
+		return nil, nil, err
+	}
+	certArtifact, err := artifactFor(staging, roleTLSCert, certRelative)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyArtifact, err := artifactFor(staging, roleTLSKey, keyRelative)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &TLSOwner{SourceIdentity: identity(source), Certificate: certRelative, PrivateKey: keyRelative}, []Artifact{certArtifact, keyArtifact}, nil
+}
+
+func lifecycleFingerprint(main MainOwner, aggregate *AggregateOwner, artifacts []Artifact) (string, error) {
+	type sidecar struct {
+		Role   string `json:"role"`
+		Path   string `json:"path"`
+		Size   int64  `json:"size"`
+		SHA256 string `json:"sha256"`
+	}
+	sidecars := make([]sidecar, 0)
+	for _, artifact := range artifacts {
+		if artifact.Role == roleDLQ || artifact.Role == roleTLSCert || artifact.Role == roleTLSKey {
+			sidecars = append(sidecars, sidecar{artifact.Role, artifact.Path, artifact.Size, artifact.SHA256})
+		}
+	}
+	aggregateFingerprint := "not-required"
+	if aggregate != nil {
+		aggregateFingerprint = aggregate.LifecycleFingerprint
+	}
+	return hashJSON(struct {
+		Main      string    `json:"main"`
+		Aggregate string    `json:"aggregate"`
+		Sidecars  []sidecar `json:"sidecars"`
+	}{main.LifecycleFingerprint, aggregateFingerprint, sidecars})
+}
+
+func syncRegular(path string) error {
+	file, err := os.Open(path) // #nosec G304 -- newly captured staging artifact.
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+	return file.Sync()
+}
+
+func loadAndVerifyBundle(ctx context.Context, bundle string, cfg Config, runner CommandRunner) (Manifest, error) {
+	info, err := os.Lstat(bundle)
+	if err != nil {
+		return Manifest{}, err
+	}
+	if !info.IsDir() {
+		return Manifest{}, errors.New("--bundle must name a directory")
+	}
+	manifestPath := filepath.Join(bundle, manifestName)
+	manifestInfo, err := requireRegular(manifestPath)
+	if err != nil {
+		return Manifest{}, fmt.Errorf("read bundle manifest: %w", err)
+	}
+	if manifestInfo.Size() > 4<<20 {
+		return Manifest{}, errors.New("bundle manifest exceeds 4 MiB")
+	}
+	data, err := os.ReadFile(manifestPath) // #nosec G304 -- resolved bundle manifest.
+	if err != nil {
+		return Manifest{}, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var manifest Manifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return Manifest{}, fmt.Errorf("decode bundle manifest: %w", err)
+	}
+	if err := validateManifestStructure(manifest); err != nil {
+		return Manifest{}, err
+	}
+	wantConfig, err := ConfigFingerprint(cfg)
+	if err != nil {
+		return Manifest{}, err
+	}
+	if manifest.ConfigFingerprint != wantConfig || manifest.Mode != cfg.AggregateMode || manifest.Main.Adapter != normalizeDriver(cfg.DBDriver) {
+		return Manifest{}, errors.New("restore refused: bundle mode, adapter, or mode-critical configuration does not match the target configuration")
+	}
+	if err := verifyArtifactSet(bundle, manifest.Artifacts); err != nil {
+		return Manifest{}, err
+	}
+	if err := validateMigrationCompatibility(manifest.Main); err != nil {
+		return Manifest{}, err
+	}
+	mainPath := filepath.Join(bundle, filepath.FromSlash(manifest.Main.ArtifactPath))
+	var verifyRecords []CommandRecord
+	if err := verifyMainArtifact(ctx, manifest.Main.Adapter, mainPath, cfg.DBDSN, runner, &verifyRecords); err != nil {
+		return Manifest{}, err
+	}
+	if manifest.Main.Adapter == "sqlite" {
+		actual, err := inspectSQLiteMainArtifact(ctx, mainPath)
+		if err != nil {
+			return Manifest{}, err
+		}
+		if err := compareMain(manifest.Main, actual); err != nil {
+			return Manifest{}, err
+		}
+	}
+	if manifest.Aggregate != nil {
+		path := filepath.Join(bundle, filepath.FromSlash(manifest.Aggregate.ArtifactPath))
+		actual, err := inspectAggregate(ctx, path)
+		if err != nil {
+			return Manifest{}, err
+		}
+		if err := compareAggregate(*manifest.Aggregate, actual); err != nil {
+			return Manifest{}, err
+		}
+	}
+	computed, err := lifecycleFingerprint(manifest.Main, manifest.Aggregate, manifest.Artifacts)
+	if err != nil {
+		return Manifest{}, err
+	}
+	if computed != manifest.LifecycleFingerprint {
+		return Manifest{}, errors.New("bundle lifecycle fingerprint does not match its manifest")
+	}
+	return manifest, nil
+}
+
+func validateManifestStructure(manifest Manifest) error {
+	if manifest.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("unsupported backup schema %q", manifest.SchemaVersion)
+	}
+	if len(manifest.BackupID) != 32 {
+		return errors.New("manifest backup_id is invalid")
+	}
+	if _, err := hex.DecodeString(manifest.BackupID); err != nil {
+		return errors.New("manifest backup_id is invalid")
+	}
+	if manifest.CreatedAt.IsZero() || manifest.CreatedAt.Before(manifest.Shutdown.CompletedAt) {
+		return errors.New("manifest timestamps do not follow the shutdown boundary")
+	}
+	if err := validateCandidate(manifest.Candidate); err != nil {
+		return err
+	}
+	if manifest.Shutdown.SchemaVersion != runtimeSchemaVersion || manifest.Shutdown.Status != "success" || manifest.Shutdown.Candidate != manifest.Candidate {
+		return errors.New("manifest shutdown proof is invalid")
+	}
+	if err := validateShutdownSteps(manifest.Shutdown.Steps); err != nil {
+		return err
+	}
+	if len(manifest.ConfigFingerprint) != 64 || len(manifest.LifecycleFingerprint) != 64 {
+		return errors.New("manifest fingerprints are invalid")
+	}
+	if err := validateMigrationCompatibility(manifest.Main); err != nil {
+		return err
+	}
+	if err := validateEngineProfile(manifest.Main.Adapter, manifest.Main.EngineVersion); err != nil {
+		return err
+	}
+	aggregateRequired := manifest.Mode == "aggregate" || manifest.Mode == "aggregate-shadow"
+	if manifest.Mode != "legacy" && !aggregateRequired {
+		return fmt.Errorf("invalid manifest mode %q", manifest.Mode)
+	}
+	if aggregateRequired != (manifest.Aggregate != nil) {
+		return errors.New("manifest aggregate inventory does not match its mode")
+	}
+	if manifest.Main.SourceIdentity == "" || manifest.Main.ArtifactPath == "" || manifest.DLQ.SourceIdentity == "" || manifest.DLQ.Count < 0 || manifest.DLQ.Bytes < 0 {
+		return errors.New("manifest durable-owner metadata is incomplete")
+	}
+	roleCounts := make(map[string]int)
+	paths := make(map[string]struct{})
+	var dlqBytes int64
+	for _, artifact := range manifest.Artifacts {
+		if !safeRelative(filepath.FromSlash(artifact.Path)) || artifact.Size < 0 || len(artifact.SHA256) != 64 {
+			return fmt.Errorf("invalid artifact metadata for %q", artifact.Path)
+		}
+		if _, err := hex.DecodeString(artifact.SHA256); err != nil {
+			return fmt.Errorf("invalid artifact digest for %q", artifact.Path)
+		}
+		if _, duplicate := paths[artifact.Path]; duplicate {
+			return fmt.Errorf("duplicate artifact path %q", artifact.Path)
+		}
+		paths[artifact.Path] = struct{}{}
+		roleCounts[artifact.Role]++
+		if artifact.Role == roleDLQ {
+			dlqBytes += artifact.Size
+		}
+	}
+	if roleCounts[roleMain] != 1 || roleCounts[roleAggregate] != boolCount(aggregateRequired) || roleCounts[roleDLQ] != manifest.DLQ.Count || dlqBytes != manifest.DLQ.Bytes {
+		return errors.New("manifest artifact roles do not match durable-owner inventory")
+	}
+	if _, ok := paths[manifest.Main.ArtifactPath]; !ok {
+		return errors.New("manifest main artifact path is absent")
+	}
+	if manifest.Aggregate != nil {
+		if manifest.Aggregate.SourceIdentity == "" || manifest.Aggregate.StoreUUID == "" {
+			return errors.New("manifest aggregate metadata is incomplete")
+		}
+		if _, ok := paths[manifest.Aggregate.ArtifactPath]; !ok {
+			return errors.New("manifest aggregate artifact path is absent")
+		}
+	}
+	if manifest.TLS == nil {
+		if roleCounts[roleTLSCert] != 0 || roleCounts[roleTLSKey] != 0 {
+			return errors.New("manifest has unowned TLS artifacts")
+		}
+	} else if roleCounts[roleTLSCert] != 1 || roleCounts[roleTLSKey] != 1 || manifest.TLS.SourceIdentity == "" {
+		return errors.New("manifest must contain a complete generated TLS pair")
+	}
+	return nil
+}
+
+func verifyArtifactSet(bundle string, artifacts []Artifact) error {
+	expected := map[string]Artifact{manifestName: {Path: manifestName}}
+	for _, artifact := range artifacts {
+		expected[filepath.Clean(filepath.FromSlash(artifact.Path))] = artifact
+	}
+	seen := make(map[string]struct{})
+	err := filepath.WalkDir(bundle, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == bundle {
+			return nil
+		}
+		relative, err := filepath.Rel(bundle, path)
+		if err != nil {
+			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("bundle contains symlink %q", relative)
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !entry.Type().IsRegular() {
+			return fmt.Errorf("bundle contains non-regular file %q", relative)
+		}
+		artifact, ok := expected[relative]
+		if !ok {
+			return fmt.Errorf("bundle contains unmanifested file %q", relative)
+		}
+		seen[relative] = struct{}{}
+		if relative == manifestName {
+			return nil
+		}
+		digest, size, err := hashFile(path)
+		if err != nil {
+			return err
+		}
+		if digest != artifact.SHA256 || size != artifact.Size {
+			return fmt.Errorf("artifact %q hash or size mismatch", artifact.Path)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if len(seen) != len(expected) {
+		var missing []string
+		for path := range expected {
+			if _, ok := seen[path]; !ok {
+				missing = append(missing, path)
+			}
+		}
+		sort.Strings(missing)
+		return fmt.Errorf("bundle is missing artifacts: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func validateFreshTargets(ctx context.Context, bundle string, cfg Config, manifest Manifest, runner CommandRunner) error {
+	mainIdentity, err := mainSourceIdentity(cfg)
+	if err != nil {
+		return err
+	}
+	if mainIdentity == manifest.Main.SourceIdentity {
+		return errors.New("restore refused: main database target is the source identity")
+	}
+	if normalizeDriver(cfg.DBDriver) == "sqlite" {
+		target, err := sqlitePath(cfg.DBDSN)
+		if err != nil {
+			return err
+		}
+		if pathWithin(target, bundle) {
+			return errors.New("restore refused: main database target is inside the bundle")
+		}
+		if err := ensureSQLiteFresh(target); err != nil {
+			return err
+		}
+	} else if err := validateFreshNativeTarget(ctx, normalizeDriver(cfg.DBDriver), cfg.DBDSN, runner); err != nil {
+		return err
+	}
+	if manifest.Aggregate != nil {
+		target, err := sqlitePath(cfg.AggregateDBPath)
+		if err != nil {
+			return err
+		}
+		if identity(target) == manifest.Aggregate.SourceIdentity {
+			return errors.New("restore refused: aggregate target is the source identity")
+		}
+		if pathWithin(target, bundle) {
+			return errors.New("restore refused: aggregate target is inside the bundle")
+		}
+		if err := ensureSQLiteFresh(target); err != nil {
+			return err
+		}
+	}
+	dlq, err := resolved(cfg.DLQPath)
+	if err != nil {
+		return err
+	}
+	if identity(dlq) == manifest.DLQ.SourceIdentity {
+		return errors.New("restore refused: DLQ target is the source identity")
+	}
+	if pathWithin(dlq, bundle) {
+		return errors.New("restore refused: DLQ target is inside the bundle")
+	}
+	if _, err := os.Lstat(dlq); err == nil {
+		return fmt.Errorf("restore target is not fresh: %s already exists", dlq)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if manifest.TLS != nil {
+		tlsDir, err := resolved(cfg.TLSCacheDir)
+		if err != nil {
+			return err
+		}
+		if identity(tlsDir) == manifest.TLS.SourceIdentity {
+			return errors.New("restore refused: TLS cache target is the source identity")
+		}
+		if pathWithin(tlsDir, bundle) {
+			return errors.New("restore refused: TLS target is inside the bundle")
+		}
+		if _, err := os.Lstat(tlsDir); err == nil {
+			return fmt.Errorf("restore target is not fresh: %s already exists", tlsDir)
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func restoreDLQ(bundle, target string, artifacts []Artifact) error {
+	target, err := resolved(target)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+		return err
+	}
+	partial := target + ".restore.partial"
+	if err := os.Mkdir(partial, 0o750); err != nil {
+		return err
+	}
+	for _, artifact := range artifacts {
+		if artifact.Role != roleDLQ {
+			continue
+		}
+		name := filepath.Base(filepath.FromSlash(artifact.Path))
+		if name != filepath.FromSlash(strings.TrimPrefix(artifact.Path, "dlq/")) {
+			return fmt.Errorf("invalid DLQ artifact path %q", artifact.Path)
+		}
+		if err := copyRegular(filepath.Join(bundle, filepath.FromSlash(artifact.Path)), filepath.Join(partial, name), 0o600); err != nil {
+			return err
+		}
+	}
+	if err := syncDir(partial); err != nil {
+		return err
+	}
+	if err := os.Rename(partial, target); err != nil {
+		return err
+	}
+	if err := syncDir(filepath.Dir(target)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func restoreTLS(bundle, target string, owner TLSOwner) error {
+	target, err := resolved(target)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+		return err
+	}
+	partial := target + ".restore.partial"
+	if err := os.Mkdir(partial, 0o700); err != nil {
+		return err
+	}
+	if err := copyRegular(filepath.Join(bundle, filepath.FromSlash(owner.Certificate)), filepath.Join(partial, "cert.pem"), 0o600); err != nil {
+		return err
+	}
+	if err := copyRegular(filepath.Join(bundle, filepath.FromSlash(owner.PrivateKey)), filepath.Join(partial, "key.pem"), 0o600); err != nil {
+		return err
+	}
+	if err := syncDir(partial); err != nil {
+		return err
+	}
+	if err := os.Rename(partial, target); err != nil {
+		return err
+	}
+	if err := syncDir(filepath.Dir(target)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func restoredSidecarArtifacts(cfg Config, manifest Manifest) ([]Artifact, error) {
+	var artifacts []Artifact
+	for _, expected := range manifest.Artifacts {
+		var path string
+		switch expected.Role {
+		case roleDLQ:
+			path = filepath.Join(cfg.DLQPath, filepath.Base(filepath.FromSlash(expected.Path)))
+		case roleTLSCert:
+			path = filepath.Join(cfg.TLSCacheDir, "cert.pem")
+		case roleTLSKey:
+			path = filepath.Join(cfg.TLSCacheDir, "key.pem")
+		default:
+			continue
+		}
+		digest, size, err := hashFile(path)
+		if err != nil {
+			return nil, err
+		}
+		if digest != expected.SHA256 || size != expected.Size {
+			return nil, fmt.Errorf("restored sidecar %q does not match manifest", expected.Path)
+		}
+		artifacts = append(artifacts, expected)
+	}
+	return artifacts, nil
+}
+
+func boolCount(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -1,0 +1,451 @@
+package backup
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	schemamigrate "github.com/RandomCodeSpace/otelcontext/internal/migrate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+var testCandidate = Candidate{
+	Version:      "v-test",
+	Commit:       strings.Repeat("b", 40),
+	BinarySHA256: strings.Repeat("a", 64),
+}
+
+type fixture struct {
+	cfg      Config
+	root     string
+	shutdown ShutdownProof
+}
+
+func newFixture(t *testing.T, mode string, generatedTLS bool) fixture {
+	t.Helper()
+	root := t.TempDir()
+	data := filepath.Join(root, "data")
+	if err := os.MkdirAll(data, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	cfg := Config{
+		DBDriver:          "sqlite",
+		DBDSN:             filepath.Join(data, "main.db"),
+		AggregateMode:     mode,
+		AggregateDBPath:   filepath.Join(data, "aggregate.db"),
+		DLQPath:           filepath.Join(data, "dlq"),
+		DataDiskPath:      data,
+		TLSAutoSelfSigned: generatedTLS,
+		TLSCacheDir:       filepath.Join(data, "tls"),
+	}
+	if err := os.MkdirAll(cfg.DLQPath, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg.DLQPath, "batch_fixture.json"), []byte(`{"fixture":"durable"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	db, err := storage.NewDatabase("sqlite", cfg.DBDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := schemamigrate.Up(context.Background(), db, "sqlite"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`INSERT INTO traces
+(tenant_id,trace_id,service_name,duration,status,timestamp,created_at,updated_at,truncated,retained_span_count,observed_span_count)
+VALUES ('default','backup-fixture','checkout',42,'STATUS_CODE_ERROR',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,0,1,1)`).Error; err != nil {
+		t.Fatal(err)
+	}
+	closeGORM(db)
+	if mode != "legacy" {
+		store, err := aggregate.OpenSQLiteStore(aggregate.StoreConfig{Path: cfg.AggregateDBPath})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if generatedTLS {
+		if err := os.MkdirAll(cfg.TLSCacheDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(cfg.TLSCacheDir, "cert.pem"), []byte("fixture certificate"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(cfg.TLSCacheDir, "key.pem"), []byte("fixture private key"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	started := time.Now().UTC().Add(-2 * time.Second)
+	handle, err := BeginRuntime(cfg, testCandidate, started)
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := shutdownReportWire{
+		StartedAt:   started.Add(time.Second),
+		CompletedAt: started.Add(1500 * time.Millisecond),
+		Steps:       successfulSteps(started.Add(time.Second)),
+	}
+	proof, err := CompleteRuntime(cfg, handle, report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fixture{cfg: cfg, root: root, shutdown: proof}
+}
+
+func successfulSteps(start time.Time) []ShutdownStep {
+	steps := make([]ShutdownStep, 0, len(shutdownOwners))
+	for index, owner := range shutdownOwners {
+		stepStart := start.Add(time.Duration(index) * time.Millisecond)
+		steps = append(steps, ShutdownStep{Name: owner, StartedAt: stepStart, CompletedAt: stepStart.Add(time.Millisecond)})
+	}
+	return steps
+}
+
+func createFixtureBundle(t *testing.T, fixture fixture) (CreateReport, Manifest) {
+	t.Helper()
+	output := filepath.Join(fixture.root, "backups")
+	report, err := Create(context.Background(), fixture.cfg, CreateOptions{
+		OutputDirectory: output,
+		Candidate:       testCandidate,
+		Now:             func() time.Time { return fixture.shutdown.CompletedAt.Add(time.Second) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := readManifest(t, report.Bundle)
+	return report, manifest
+}
+
+func readManifest(t *testing.T, bundle string) Manifest {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(bundle, manifestName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}
+
+func writeManifest(t *testing.T, bundle string, manifest Manifest) {
+	t.Helper()
+	path := filepath.Join(bundle, manifestName)
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONExclusive(path, manifest, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func freshRestoreConfig(root, mode string, generatedTLS bool) Config {
+	data := filepath.Join(root, "restored")
+	return Config{
+		DBDriver:          "sqlite",
+		DBDSN:             filepath.Join(data, "main.db"),
+		AggregateMode:     mode,
+		AggregateDBPath:   filepath.Join(data, "aggregate.db"),
+		DLQPath:           filepath.Join(data, "dlq"),
+		DataDiskPath:      data,
+		TLSAutoSelfSigned: generatedTLS,
+		TLSCacheDir:       filepath.Join(data, "tls"),
+	}
+}
+
+func TestCreateAndRestoreEveryMode(t *testing.T) {
+	for _, mode := range []string{"legacy", "aggregate-shadow", "aggregate"} {
+		t.Run(mode, func(t *testing.T) {
+			fixture := newFixture(t, mode, true)
+			report, manifest := createFixtureBundle(t, fixture)
+			if strings.HasSuffix(report.Bundle, ".partial") {
+				t.Fatalf("published bundle kept partial suffix: %s", report.Bundle)
+			}
+			if manifest.SchemaVersion != SchemaVersion || manifest.Mode != mode || manifest.DLQ.Count != 1 || manifest.TLS == nil {
+				t.Fatalf("manifest inventory = %#v", manifest)
+			}
+			if (mode != "legacy") != (manifest.Aggregate != nil) {
+				t.Fatalf("aggregate inventory mismatch for %s", mode)
+			}
+			target := freshRestoreConfig(fixture.root, mode, true)
+			restored, err := Restore(context.Background(), target, RestoreOptions{
+				BundleDirectory: report.Bundle,
+				Candidate:       testCandidate,
+				Now:             func() time.Time { return manifest.CreatedAt.Add(10 * time.Second) },
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if restored.Status != "restored" || restored.LifecycleFingerprint != manifest.LifecycleFingerprint || restored.BackupAgeSeconds != 10 {
+				t.Fatalf("restore report = %#v", restored)
+			}
+			if _, err := os.Stat(filepath.Join(target.DLQPath, "batch_fixture.json")); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(filepath.Join(target.TLSCacheDir, "cert.pem")); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestCreateRefusesActiveRuntimeAndHalfTLSPair(t *testing.T) {
+	fixture := newFixture(t, "legacy", false)
+	handle, err := BeginRuntime(fixture.cfg, testCandidate, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Create(context.Background(), fixture.cfg, CreateOptions{OutputDirectory: filepath.Join(fixture.root, "active-backups"), Candidate: testCandidate})
+	if err == nil || !strings.Contains(err.Error(), "runtime is active") {
+		t.Fatalf("active-runtime error = %v", err)
+	}
+	if err := os.Remove(filepath.Join(fixture.cfg.DataDiskPath, activeMarkerName)); err != nil {
+		t.Fatal(err)
+	}
+	_ = handle
+
+	fixture = newFixture(t, "legacy", true)
+	if err := os.Remove(filepath.Join(fixture.cfg.TLSCacheDir, "key.pem")); err != nil {
+		t.Fatal(err)
+	}
+	_, err = Create(context.Background(), fixture.cfg, CreateOptions{OutputDirectory: filepath.Join(fixture.root, "half-tls-backups"), Candidate: testCandidate})
+	if err == nil || !strings.Contains(err.Error(), "both cert.pem and key.pem") {
+		t.Fatalf("half-TLS error = %v", err)
+	}
+}
+
+func TestRestoreRejectsBundleDamageBeforeTargetMutation(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, string, *Manifest)
+		want   string
+	}{
+		{
+			name: "missing artifact",
+			mutate: func(t *testing.T, bundle string, manifest *Manifest) {
+				t.Helper()
+				if err := os.Remove(filepath.Join(bundle, manifest.Main.ArtifactPath)); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "missing artifacts",
+		},
+		{
+			name: "hash mismatch",
+			mutate: func(t *testing.T, bundle string, manifest *Manifest) {
+				t.Helper()
+				path := filepath.Join(bundle, manifest.Main.ArtifactPath)
+				file, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := file.Write([]byte("tamper")); err != nil {
+					t.Fatal(err)
+				}
+				if err := file.Close(); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "hash or size mismatch",
+		},
+		{
+			name: "tampered DLQ",
+			mutate: func(t *testing.T, bundle string, _ *Manifest) {
+				t.Helper()
+				path := filepath.Join(bundle, "dlq", "batch_fixture.json")
+				file, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := file.Write([]byte("tamper")); err != nil {
+					t.Fatal(err)
+				}
+				if err := file.Close(); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "hash or size mismatch",
+		},
+		{
+			name: "unsupported migration",
+			mutate: func(t *testing.T, bundle string, manifest *Manifest) {
+				t.Helper()
+				manifest.Main.MigrationVersion = schemamigrate.CurrentVersion + 1
+				writeManifest(t, bundle, *manifest)
+			},
+			want: "unsupported main migration",
+		},
+		{
+			name: "half TLS pair",
+			mutate: func(t *testing.T, bundle string, manifest *Manifest) {
+				t.Helper()
+				for index, artifact := range manifest.Artifacts {
+					if artifact.Role == roleTLSKey {
+						manifest.Artifacts = append(manifest.Artifacts[:index], manifest.Artifacts[index+1:]...)
+						break
+					}
+				}
+				writeManifest(t, bundle, *manifest)
+			},
+			want: "complete generated TLS pair",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newFixture(t, "legacy", true)
+			report, manifest := createFixtureBundle(t, fixture)
+			test.mutate(t, report.Bundle, &manifest)
+			target := freshRestoreConfig(fixture.root, "legacy", true)
+			_, err := Restore(context.Background(), target, RestoreOptions{BundleDirectory: report.Bundle, Candidate: testCandidate})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("restore error = %v, want %q", err, test.want)
+			}
+			if _, statErr := os.Stat(target.DBDSN); !os.IsNotExist(statErr) {
+				t.Fatalf("main target mutated before rejection: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestRestoreRefusesPartialWrongModeInPlaceAndNonFreshSidecar(t *testing.T) {
+	fixture := newFixture(t, "aggregate-shadow", false)
+	report, _ := createFixtureBundle(t, fixture)
+	t.Run("partial", func(t *testing.T) {
+		partial := report.Bundle + ".partial"
+		if err := os.Rename(report.Bundle, partial); err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = os.Rename(partial, report.Bundle) }()
+		_, err := Restore(context.Background(), freshRestoreConfig(filepath.Join(fixture.root, "partial"), "aggregate-shadow", false), RestoreOptions{BundleDirectory: partial, Candidate: testCandidate})
+		if err == nil || !strings.Contains(err.Error(), "incomplete .partial") {
+			t.Fatalf("partial error = %v", err)
+		}
+	})
+	t.Run("wrong mode", func(t *testing.T) {
+		_, err := Restore(context.Background(), freshRestoreConfig(filepath.Join(fixture.root, "mode"), "legacy", false), RestoreOptions{BundleDirectory: report.Bundle, Candidate: testCandidate})
+		if err == nil || !strings.Contains(err.Error(), "does not match") {
+			t.Fatalf("wrong-mode error = %v", err)
+		}
+	})
+	t.Run("in place", func(t *testing.T) {
+		_, err := Restore(context.Background(), fixture.cfg, RestoreOptions{BundleDirectory: report.Bundle, Candidate: testCandidate})
+		if err == nil || !strings.Contains(err.Error(), "source identity") {
+			t.Fatalf("in-place error = %v", err)
+		}
+	})
+	t.Run("non-fresh DLQ", func(t *testing.T) {
+		target := freshRestoreConfig(filepath.Join(fixture.root, "nonfresh"), "aggregate-shadow", false)
+		if err := os.MkdirAll(target.DLQPath, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		_, err := Restore(context.Background(), target, RestoreOptions{BundleDirectory: report.Bundle, Candidate: testCandidate})
+		if err == nil || !strings.Contains(err.Error(), "not fresh") {
+			t.Fatalf("non-fresh error = %v", err)
+		}
+		if _, statErr := os.Stat(target.DBDSN); !os.IsNotExist(statErr) {
+			t.Fatalf("main target mutated before sidecar validation: %v", statErr)
+		}
+	})
+}
+
+func TestRestoreRejectsAggregateIdentityMismatchAfterHashValidation(t *testing.T) {
+	fixture := newFixture(t, "aggregate", false)
+	report, manifest := createFixtureBundle(t, fixture)
+	path := filepath.Join(report.Bundle, manifest.Aggregate.ArtifactPath)
+	db, err := storage.NewDatabase("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`UPDATE aggregate_meta SET value='different-store' WHERE key='store_uuid'`).Error; err != nil {
+		t.Fatal(err)
+	}
+	closeGORM(db)
+	for index := range manifest.Artifacts {
+		if manifest.Artifacts[index].Role == roleAggregate {
+			digest, size, err := hashFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			manifest.Artifacts[index].SHA256 = digest
+			manifest.Artifacts[index].Size = size
+		}
+	}
+	writeManifest(t, report.Bundle, manifest)
+	_, err = Restore(context.Background(), freshRestoreConfig(fixture.root, "aggregate", false), RestoreOptions{BundleDirectory: report.Bundle, Candidate: testCandidate})
+	if err == nil || !strings.Contains(err.Error(), "aggregate fingerprint mismatch") {
+		t.Fatalf("aggregate identity error = %v", err)
+	}
+}
+
+func TestRestoreRejectsAggregateVersionMismatchBeforeTargetMutation(t *testing.T) {
+	fixture := newFixture(t, "aggregate", false)
+	report, manifest := createFixtureBundle(t, fixture)
+	path := filepath.Join(report.Bundle, manifest.Aggregate.ArtifactPath)
+	db, err := storage.NewDatabase("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(`UPDATE aggregate_meta SET value=? WHERE key='schema_version'`, aggregate.StoreSchemaVersion+1).Error; err != nil {
+		t.Fatal(err)
+	}
+	closeGORM(db)
+	for index := range manifest.Artifacts {
+		if manifest.Artifacts[index].Role == roleAggregate {
+			digest, size, err := hashFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			manifest.Artifacts[index].SHA256 = digest
+			manifest.Artifacts[index].Size = size
+		}
+	}
+	writeManifest(t, report.Bundle, manifest)
+	target := freshRestoreConfig(fixture.root, "aggregate", false)
+	_, err = Restore(context.Background(), target, RestoreOptions{BundleDirectory: report.Bundle, Candidate: testCandidate})
+	if err == nil || !strings.Contains(err.Error(), "aggregate store state") {
+		t.Fatalf("aggregate version error = %v", err)
+	}
+	if _, statErr := os.Stat(target.DBDSN); !os.IsNotExist(statErr) {
+		t.Fatalf("main target mutated before aggregate rejection: %v", statErr)
+	}
+}
+
+type commandRunnerFunc func(context.Context, Command) (CommandResult, error)
+
+func (runner commandRunnerFunc) Run(ctx context.Context, command Command) (CommandResult, error) {
+	return runner(ctx, command)
+}
+
+func TestNativeClientFailuresAreClear(t *testing.T) {
+	t.Run("missing client", func(t *testing.T) {
+		_, err := (execRunner{}).Run(context.Background(), Command{
+			Name:    "otelcontext-native-client-does-not-exist",
+			Display: "missing native client",
+		})
+		if err == nil || !strings.Contains(err.Error(), `required client "otelcontext-native-client-does-not-exist" is missing from PATH`) {
+			t.Fatalf("missing client error = %v", err)
+		}
+	})
+
+	t.Run("wrong client version", func(t *testing.T) {
+		runner := commandRunnerFunc(func(context.Context, Command) (CommandResult, error) {
+			return CommandResult{Output: "pg_dump (PostgreSQL) 15.13", ExitCode: 0}, nil
+		})
+		var records []CommandRecord
+		err := requireVersion(context.Background(), runner, "pg_dump", []string{"--version"}, "pg_dump --version", " 16.", &records)
+		if err == nil || !strings.Contains(err.Error(), "wrong version") || !strings.Contains(err.Error(), `require output containing " 16."`) {
+			t.Fatalf("wrong version error = %v", err)
+		}
+		if len(records) != 1 || records[0].ExitCode != 0 {
+			t.Fatalf("version command records = %#v", records)
+		}
+	})
+}

--- a/internal/backup/command.go
+++ b/internal/backup/command.go
@@ -1,0 +1,152 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const maxCommandOutput = 64 << 10
+
+type execRunner struct{}
+
+func defaultRunner(runner CommandRunner) CommandRunner {
+	if runner != nil {
+		return runner
+	}
+	return execRunner{}
+}
+
+func (execRunner) Run(ctx context.Context, command Command) (CommandResult, error) {
+	started := time.Now()
+	path, err := exec.LookPath(command.Name)
+	if err != nil {
+		return CommandResult{ExitCode: -1, Duration: time.Since(started)}, fmt.Errorf("required client %q is missing from PATH", command.Name)
+	}
+	cmd := exec.CommandContext(ctx, path, command.Args...) // #nosec G204 -- fixed adapter command with parsed config arguments.
+	cmd.Env = append(os.Environ(), command.Env...)
+	var stdin *os.File
+	if command.StdinPath != "" {
+		stdin, err = os.Open(command.StdinPath) // #nosec G304 -- verified bundle artifact.
+		if err != nil {
+			return CommandResult{ExitCode: -1, Duration: time.Since(started)}, err
+		}
+		defer func() { _ = stdin.Close() }()
+		cmd.Stdin = stdin
+	}
+	var stdoutFile *os.File
+	var stdout bytes.Buffer
+	if command.StdoutPath != "" {
+		stdoutFile, err = os.OpenFile(command.StdoutPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600) // #nosec G304 -- fresh staging path.
+		if err != nil {
+			return CommandResult{ExitCode: -1, Duration: time.Since(started)}, err
+		}
+		defer func() { _ = stdoutFile.Close() }()
+		cmd.Stdout = stdoutFile
+	} else {
+		cmd.Stdout = &limitedBuffer{buffer: &stdout, remaining: maxCommandOutput}
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &limitedBuffer{buffer: &stderr, remaining: maxCommandOutput}
+	err = cmd.Run()
+	if stdoutFile != nil {
+		if syncErr := stdoutFile.Sync(); err == nil && syncErr != nil {
+			err = syncErr
+		}
+		if closeErr := stdoutFile.Close(); err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}
+	output := strings.TrimSpace(stdout.String())
+	if output == "" && err == nil {
+		output = strings.TrimSpace(stderr.String())
+	}
+	result := CommandResult{
+		Output:   sanitizeCommandText(output, command.Redactions),
+		ExitCode: exitCode(err),
+		Duration: time.Since(started),
+	}
+	if err != nil {
+		detail := sanitizeCommandText(strings.TrimSpace(stderr.String()), command.Redactions)
+		if detail == "" {
+			detail = sanitizeCommandText(err.Error(), command.Redactions)
+		}
+		if command.StdoutPath != "" {
+			_ = os.Remove(command.StdoutPath)
+		}
+		return result, fmt.Errorf("%s failed with exit %d: %s", command.Display, result.ExitCode, detail)
+	}
+	return result, nil
+}
+
+type limitedBuffer struct {
+	buffer    *bytes.Buffer
+	remaining int
+}
+
+func (w *limitedBuffer) Write(data []byte) (int, error) {
+	original := len(data)
+	if w.remaining <= 0 {
+		return original, nil
+	}
+	if len(data) > w.remaining {
+		data = data[:w.remaining]
+	}
+	_, _ = w.buffer.Write(data)
+	w.remaining -= len(data)
+	return original, nil
+}
+
+func exitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
+func sanitizeCommandText(value string, redactions []string) string {
+	for _, secret := range redactions {
+		if secret != "" {
+			value = strings.ReplaceAll(value, secret, "[redacted]")
+		}
+	}
+	return value
+}
+
+func runRecorded(ctx context.Context, runner CommandRunner, step string, command Command, records *[]CommandRecord) (CommandResult, error) {
+	result, err := runner.Run(ctx, command)
+	record := CommandRecord{
+		Step:       step,
+		Command:    command.Display,
+		DurationMS: result.Duration.Milliseconds(),
+		ExitCode:   result.ExitCode,
+		Output:     result.Output,
+	}
+	*records = append(*records, record)
+	return result, err
+}
+
+func requireVersion(ctx context.Context, runner CommandRunner, name string, args []string, display, want string, records *[]CommandRecord, redactions ...string) error {
+	result, err := runRecorded(ctx, runner, "client-version", Command{
+		Name:       name,
+		Args:       args,
+		Display:    display,
+		Redactions: redactions,
+	}, records)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(result.Output, want) {
+		return fmt.Errorf("%s has wrong version: got %q, require output containing %q", name, result.Output, want)
+	}
+	return nil
+}

--- a/internal/backup/database.go
+++ b/internal/backup/database.go
@@ -1,0 +1,466 @@
+package backup
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	schemamigrate "github.com/RandomCodeSpace/otelcontext/internal/migrate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	_ "github.com/glebarez/go-sqlite"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+var mainTables = []string{
+	"traces",
+	"spans",
+	"metric_buckets",
+	"logs",
+	"investigations",
+	"drain_templates",
+	schemamigrate.LedgerTable,
+}
+
+var aggregateOwnerTables = []string{
+	"aggregate_baseline",
+	"aggregate_buckets",
+	"aggregate_delta_log",
+	"aggregate_log_template",
+	"aggregate_series",
+	"aggregate_dict",
+	"aggregate_meta",
+}
+
+type tableCount struct {
+	Table string `json:"table"`
+	Rows  int64  `json:"rows"`
+}
+
+func mainSourceIdentity(cfg Config) (string, error) {
+	if normalizeDriver(cfg.DBDriver) == "sqlite" {
+		path, err := sqlitePath(cfg.DBDSN)
+		if err != nil {
+			return "", err
+		}
+		return identity(path), nil
+	}
+	if strings.TrimSpace(cfg.DBDSN) == "" {
+		return "", fmt.Errorf("DB_DSN is required for %s", normalizeDriver(cfg.DBDriver))
+	}
+	return identity(normalizeDriver(cfg.DBDriver) + "\x00" + cfg.DBDSN), nil
+}
+
+func sqlitePath(dsn string) (string, error) {
+	if strings.TrimSpace(dsn) == "" {
+		dsn = "OtelContext.db"
+	}
+	if dsn == ":memory:" || strings.Contains(dsn, "mode=memory") || strings.HasPrefix(dsn, "file::memory:") {
+		return "", errors.New("in-memory SQLite databases cannot be backed up")
+	}
+	plain := dsn
+	if strings.HasPrefix(dsn, "file:") {
+		parsed, err := url.Parse(dsn)
+		if err != nil {
+			return "", fmt.Errorf("parse SQLite DSN: %w", err)
+		}
+		switch {
+		case parsed.Path != "":
+			plain = parsed.Path
+		case parsed.Opaque != "":
+			plain = parsed.Opaque
+		default:
+			plain = strings.TrimPrefix(strings.SplitN(dsn, "?", 2)[0], "file:")
+		}
+	} else if index := strings.IndexByte(plain, '?'); index >= 0 {
+		plain = plain[:index]
+	}
+	if plain == "" {
+		return "", errors.New("SQLite DSN does not name a file")
+	}
+	return resolved(plain)
+}
+
+func inspectMain(ctx context.Context, cfg Config) (MainOwner, error) {
+	driver := normalizeDriver(cfg.DBDriver)
+	if driver == "sqlite" {
+		path, err := sqlitePath(cfg.DBDSN)
+		if err != nil {
+			return MainOwner{}, err
+		}
+		if _, err := requireRegular(path); err != nil {
+			return MainOwner{}, fmt.Errorf("inspect main SQLite database: %w", err)
+		}
+	}
+	db, err := storage.NewDatabase(driver, cfg.DBDSN)
+	if err != nil {
+		return MainOwner{}, fmt.Errorf("open main database for backup inspection: %w", err)
+	}
+	defer closeGORM(db)
+	return inspectMainDB(ctx, driver, cfg.DBDSN, db)
+}
+
+func inspectMainDB(ctx context.Context, driver, dsn string, db *gorm.DB) (MainOwner, error) {
+	status, err := schemamigrate.Inspect(ctx, db, driver)
+	if err != nil {
+		return MainOwner{}, fmt.Errorf("inspect main migration status: %w", err)
+	}
+	if schemamigrate.SupportsVersioned(driver) {
+		if !status.Usable() {
+			return MainOwner{}, fmt.Errorf("main migration state is %s, require exact before backup", status.State)
+		}
+	} else if status.State != schemamigrate.StateUnverified {
+		return MainOwner{}, fmt.Errorf("unexpected preview migration state %s", status.State)
+	}
+	counts, err := mainTableCounts(ctx, db)
+	if err != nil {
+		return MainOwner{}, err
+	}
+	lifecycle, err := hashJSON(struct {
+		Driver      string       `json:"driver"`
+		Migration   string       `json:"migration_fingerprint"`
+		TableCounts []tableCount `json:"table_counts"`
+	}{driver, status.Fingerprint, counts})
+	if err != nil {
+		return MainOwner{}, err
+	}
+	engineVersion, err := databaseVersion(ctx, db, driver)
+	if err != nil {
+		return MainOwner{}, err
+	}
+	if err := validateEngineProfile(driver, engineVersion); err != nil {
+		return MainOwner{}, err
+	}
+	id, err := mainSourceIdentity(Config{DBDriver: driver, DBDSN: dsn})
+	if err != nil {
+		return MainOwner{}, err
+	}
+	applied := make([]AppliedMigration, 0, len(status.Applied))
+	for _, migration := range status.Applied {
+		applied = append(applied, AppliedMigration{Version: migration.Version, Name: migration.Name, Checksum: migration.Checksum})
+	}
+	return MainOwner{
+		Adapter:              driver,
+		EngineVersion:        engineVersion,
+		SourceIdentity:       id,
+		MigrationState:       string(status.State),
+		MigrationVersion:     status.ActualVersion,
+		ExpectedMigration:    status.ExpectedVersion,
+		MigrationFingerprint: status.Fingerprint,
+		AppliedMigrations:    applied,
+		LifecycleFingerprint: lifecycle,
+	}, nil
+}
+
+func inspectSQLiteMainArtifact(ctx context.Context, path string) (MainOwner, error) {
+	if err := sqliteIntegrity(ctx, path); err != nil {
+		return MainOwner{}, err
+	}
+	db, err := gorm.Open(sqlite.Open(readOnlySQLiteDSN(path)), &gorm.Config{DisableForeignKeyConstraintWhenMigrating: true})
+	if err != nil {
+		return MainOwner{}, fmt.Errorf("open SQLite snapshot read-only: %w", err)
+	}
+	defer closeGORM(db)
+	return inspectMainDB(ctx, "sqlite", path, db)
+}
+
+func mainTableCounts(ctx context.Context, db *gorm.DB) ([]tableCount, error) {
+	counts := make([]tableCount, 0, len(mainTables))
+	for _, table := range mainTables {
+		if !db.WithContext(ctx).Migrator().HasTable(table) {
+			counts = append(counts, tableCount{Table: table})
+			continue
+		}
+		var count int64
+		if err := db.WithContext(ctx).Table(table).Count(&count).Error; err != nil {
+			return nil, fmt.Errorf("count %s: %w", table, err)
+		}
+		counts = append(counts, tableCount{Table: table, Rows: count})
+	}
+	return counts, nil
+}
+
+func databaseVersion(ctx context.Context, db *gorm.DB, driver string) (string, error) {
+	query := "SELECT sqlite_version()"
+	switch driver {
+	case "postgres":
+		query = "SHOW server_version"
+	case "mysql":
+		query = "SELECT VERSION()"
+	case "mssql":
+		query = "SELECT CONVERT(varchar(128), SERVERPROPERTY('ProductVersion'))"
+	}
+	var version string
+	if err := db.WithContext(ctx).Raw(query).Scan(&version).Error; err != nil {
+		return "", fmt.Errorf("read %s engine version: %w", driver, err)
+	}
+	return strings.TrimSpace(version), nil
+}
+
+func validateEngineProfile(driver, version string) error {
+	prefix := ""
+	switch driver {
+	case "sqlite":
+		return nil
+	case "postgres":
+		prefix = "16."
+	case "mysql":
+		prefix = "8.4."
+	case "mssql":
+		prefix = "16."
+	default:
+		return fmt.Errorf("unsupported backup adapter %q", driver)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(version), prefix) {
+		return fmt.Errorf("unsupported %s engine version %q: require %s", driver, version, prefix)
+	}
+	return nil
+}
+
+func closeGORM(db *gorm.DB) {
+	if db == nil {
+		return
+	}
+	if sqlDB, err := db.DB(); err == nil {
+		_ = sqlDB.Close()
+	}
+}
+
+func vacuumSQLite(ctx context.Context, sourceDSN, target string) error {
+	if _, err := os.Stat(target); err == nil {
+		return fmt.Errorf("SQLite snapshot target already exists: %s", target)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	db, err := sql.Open("sqlite", sourceDSN)
+	if err != nil {
+		return fmt.Errorf("open SQLite source: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	if _, err := db.ExecContext(ctx, "VACUUM INTO ?", target); err != nil {
+		_ = db.Close()
+		_ = os.Remove(target)
+		return fmt.Errorf("VACUUM INTO: %w", err)
+	}
+	if err := db.Close(); err != nil {
+		_ = os.Remove(target)
+		return fmt.Errorf("close SQLite source after VACUUM INTO: %w", err)
+	}
+	file, err := os.Open(target) // #nosec G304 -- newly captured staging artifact.
+	if err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+func readOnlySQLiteDSN(path string) string {
+	return (&url.URL{Scheme: "file", Path: path}).String() + "?mode=ro"
+}
+
+func sqliteIntegrity(ctx context.Context, path string) error {
+	if _, err := requireRegular(path); err != nil {
+		return err
+	}
+	db, err := sql.Open("sqlite", readOnlySQLiteDSN(path))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	rows, err := db.QueryContext(ctx, "PRAGMA integrity_check")
+	if err != nil {
+		return fmt.Errorf("SQLite integrity_check: %w", err)
+	}
+	var results []string
+	for rows.Next() {
+		var result string
+		if err := rows.Scan(&result); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		results = append(results, result)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if len(results) != 1 || results[0] != "ok" {
+		return fmt.Errorf("SQLite integrity_check returned %q", results)
+	}
+	foreignKeys, err := db.QueryContext(ctx, "PRAGMA foreign_key_check")
+	if err != nil {
+		return fmt.Errorf("SQLite foreign_key_check: %w", err)
+	}
+	defer func() { _ = foreignKeys.Close() }()
+	if foreignKeys.Next() {
+		return errors.New("SQLite foreign_key_check returned violations")
+	}
+	return foreignKeys.Err()
+}
+
+func inspectAggregate(ctx context.Context, path string) (AggregateOwner, error) {
+	inspection, err := aggregate.InspectSQLiteStore(path)
+	if err != nil {
+		return AggregateOwner{}, err
+	}
+	if !inspection.Usable() {
+		return AggregateOwner{}, fmt.Errorf("aggregate store state is %s, require exact before backup: %s", inspection.State, inspection.Detail)
+	}
+	absolutePath, err := sqlitePath(path)
+	if err != nil {
+		return AggregateOwner{}, err
+	}
+	if err := sqliteIntegrity(ctx, absolutePath); err != nil {
+		return AggregateOwner{}, err
+	}
+	db, err := sql.Open("sqlite", readOnlySQLiteDSN(absolutePath))
+	if err != nil {
+		return AggregateOwner{}, err
+	}
+	defer func() { _ = db.Close() }()
+	counts := make([]tableCount, 0, len(aggregateOwnerTables))
+	for _, table := range aggregateOwnerTables {
+		var count int64
+		if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+table).Scan(&count); err != nil { // #nosec G202 -- fixed table allowlist.
+			return AggregateOwner{}, fmt.Errorf("count %s: %w", table, err)
+		}
+		counts = append(counts, tableCount{Table: table, Rows: count})
+	}
+	meta := make(map[string]string)
+	rows, err := db.QueryContext(ctx, "SELECT key, value FROM aggregate_meta ORDER BY key")
+	if err != nil {
+		return AggregateOwner{}, err
+	}
+	for rows.Next() {
+		var key, value string
+		if err := rows.Scan(&key, &value); err != nil {
+			_ = rows.Close()
+			return AggregateOwner{}, err
+		}
+		meta[key] = value
+	}
+	if err := rows.Close(); err != nil {
+		return AggregateOwner{}, err
+	}
+	keys := make([]string, 0, len(meta))
+	for key := range meta {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	type metaEntry struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	}
+	metaEntries := make([]metaEntry, 0, len(keys))
+	for _, key := range keys {
+		metaEntries = append(metaEntries, metaEntry{key, meta[key]})
+	}
+	lifecycle, err := hashJSON(struct {
+		Tables []tableCount `json:"tables"`
+		Meta   []metaEntry  `json:"meta"`
+	}{counts, metaEntries})
+	if err != nil {
+		return AggregateOwner{}, err
+	}
+	dictWatermark, err := strconv.ParseUint(meta[aggregate.MetaDictWatermark], 10, 64)
+	if err != nil {
+		return AggregateOwner{}, fmt.Errorf("invalid aggregate dictionary watermark: %w", err)
+	}
+	seriesWatermark, err := strconv.ParseUint(meta[aggregate.MetaSeriesWatermark], 10, 64)
+	if err != nil {
+		return AggregateOwner{}, fmt.Errorf("invalid aggregate series watermark: %w", err)
+	}
+	return AggregateOwner{
+		SourceIdentity:       identity(absolutePath),
+		StoreUUID:            inspection.StoreUUID,
+		SchemaVersion:        inspection.ActualSchemaVersion,
+		SeriesKeyVersion:     inspection.ActualSeriesVersion,
+		SketchCodecVersion:   inspection.ActualSketchVersion,
+		DictHighWatermark:    dictWatermark,
+		SeriesHighWatermark:  seriesWatermark,
+		LifecycleFingerprint: lifecycle,
+		Integrity:            "PRAGMA integrity_check=ok; PRAGMA foreign_key_check=0 rows",
+	}, nil
+}
+
+func compareMain(expected, actual MainOwner) error {
+	if expected.Adapter != actual.Adapter || expected.MigrationState != actual.MigrationState || expected.MigrationVersion != actual.MigrationVersion || expected.ExpectedMigration != actual.ExpectedMigration || expected.MigrationFingerprint != actual.MigrationFingerprint || expected.LifecycleFingerprint != actual.LifecycleFingerprint {
+		return fmt.Errorf("restored main database fingerprint mismatch: expected migration=%s/%d lifecycle=%s, got migration=%s/%d lifecycle=%s",
+			expected.MigrationState, expected.MigrationVersion, expected.LifecycleFingerprint,
+			actual.MigrationState, actual.MigrationVersion, actual.LifecycleFingerprint)
+	}
+	return nil
+}
+
+func compareAggregate(expected, actual AggregateOwner) error {
+	if expected.StoreUUID != actual.StoreUUID || expected.SchemaVersion != actual.SchemaVersion || expected.SeriesKeyVersion != actual.SeriesKeyVersion || expected.SketchCodecVersion != actual.SketchCodecVersion || expected.DictHighWatermark != actual.DictHighWatermark || expected.SeriesHighWatermark != actual.SeriesHighWatermark || expected.LifecycleFingerprint != actual.LifecycleFingerprint {
+		return fmt.Errorf("restored aggregate fingerprint mismatch: expected uuid=%s schema=%d series=%d codec=%d lifecycle=%s, got uuid=%s schema=%d series=%d codec=%d lifecycle=%s",
+			expected.StoreUUID, expected.SchemaVersion, expected.SeriesKeyVersion, expected.SketchCodecVersion, expected.LifecycleFingerprint,
+			actual.StoreUUID, actual.SchemaVersion, actual.SeriesKeyVersion, actual.SketchCodecVersion, actual.LifecycleFingerprint)
+	}
+	return nil
+}
+
+func validateMigrationCompatibility(main MainOwner) error {
+	switch main.Adapter {
+	case "sqlite", "postgres":
+		if main.MigrationState != string(schemamigrate.StateExact) || main.MigrationVersion != schemamigrate.CurrentVersion || main.ExpectedMigration != schemamigrate.CurrentVersion {
+			return fmt.Errorf("unsupported main migration state=%s actual=%d expected=%d", main.MigrationState, main.MigrationVersion, main.ExpectedMigration)
+		}
+	case "mysql", "mssql":
+		if main.MigrationState != string(schemamigrate.StateUnverified) || main.MigrationVersion != 0 {
+			return fmt.Errorf("unsupported preview migration state=%s actual=%d", main.MigrationState, main.MigrationVersion)
+		}
+	default:
+		return fmt.Errorf("unsupported backup adapter %q", main.Adapter)
+	}
+	return nil
+}
+
+func ensureSQLiteFresh(path string) error {
+	for _, candidate := range []string{path, path + "-wal", path + "-shm"} {
+		if _, err := os.Lstat(candidate); err == nil {
+			return fmt.Errorf("restore target is not fresh: %s already exists", candidate)
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func publishSQLiteCopy(source, target string) error {
+	if err := ensureSQLiteFresh(target); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+		return err
+	}
+	partial := target + ".restore.partial"
+	if _, err := os.Lstat(partial); err == nil {
+		return fmt.Errorf("restore staging path already exists: %s", partial)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := copyRegular(source, partial, 0o600); err != nil {
+		return err
+	}
+	if err := sqliteIntegrity(context.Background(), partial); err != nil {
+		_ = os.Remove(partial)
+		return err
+	}
+	if err := os.Rename(partial, target); err != nil {
+		_ = os.Remove(partial)
+		return err
+	}
+	return syncDir(filepath.Dir(target))
+}

--- a/internal/backup/files.go
+++ b/internal/backup/files.go
@@ -1,0 +1,232 @@
+package backup
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func newID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate identifier: %w", err)
+	}
+	return hex.EncodeToString(raw[:]), nil
+}
+
+func hashBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func hashJSON(value any) (string, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return hashBytes(data), nil
+}
+
+func hashFile(path string) (string, int64, error) {
+	f, err := os.Open(path) // #nosec G304 -- path is resolved and validated by the caller.
+	if err != nil {
+		return "", 0, err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	n, err := io.Copy(h, f)
+	if err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(h.Sum(nil)), n, nil
+}
+
+func identity(value string) string {
+	return "sha256:" + hashBytes([]byte(value))
+}
+
+func absolute(path, label string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("%s must not be empty", label)
+	}
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("%s must be an absolute path: %q", label, path)
+	}
+	return filepath.Clean(path), nil
+}
+
+func resolved(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", errors.New("path must not be empty")
+	}
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(absolutePath), nil
+}
+
+func pathWithin(child, parent string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+func requireRegular(path string) (os.FileInfo, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s is not a regular file", path)
+	}
+	return info, nil
+}
+
+func copyRegular(source, target string, mode os.FileMode) error {
+	if _, err := requireRegular(source); err != nil {
+		return err
+	}
+	in, err := os.Open(source) // #nosec G304 -- source is an inspected durable owner.
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode) // #nosec G304 -- fresh staging path.
+	if err != nil {
+		return err
+	}
+	ok := false
+	defer func() {
+		_ = out.Close()
+		if !ok {
+			_ = os.Remove(target)
+		}
+	}()
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	if err := out.Sync(); err != nil {
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	ok = true
+	return nil
+}
+
+func writeJSONExclusive(path string, value any, mode os.FileMode) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode) // #nosec G304 -- caller supplies a fresh staging path.
+	if err != nil {
+		return err
+	}
+	ok := false
+	defer func() {
+		_ = f.Close()
+		if !ok {
+			_ = os.Remove(path)
+		}
+	}()
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	ok = true
+	return nil
+}
+
+func writeJSONAtomic(path string, value any, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(dir, ".otelcontext-write-*.partial")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	ok := false
+	defer func() {
+		_ = temp.Close()
+		if !ok {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if err := temp.Chmod(mode); err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(temp)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		return err
+	}
+	if err := temp.Sync(); err != nil {
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return err
+	}
+	if err := syncDir(dir); err != nil {
+		return err
+	}
+	ok = true
+	return nil
+}
+
+func syncDir(path string) error {
+	dir, err := os.Open(path) // #nosec G304 -- caller supplies a resolved directory.
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+	return dir.Sync()
+}
+
+func artifactFor(root, role, relative string) (Artifact, error) {
+	path := filepath.Join(root, filepath.FromSlash(relative))
+	digest, size, err := hashFile(path)
+	if err != nil {
+		return Artifact{}, err
+	}
+	return Artifact{Role: role, Path: filepath.ToSlash(relative), Size: size, SHA256: digest}, nil
+}
+
+func sortArtifacts(artifacts []Artifact) {
+	sort.Slice(artifacts, func(i, j int) bool {
+		if artifacts[i].Role == artifacts[j].Role {
+			return artifacts[i].Path < artifacts[j].Path
+		}
+		return artifacts[i].Role < artifacts[j].Role
+	})
+}
+
+func safeRelative(path string) bool {
+	if path == "" || filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return false
+	}
+	return path != ".." && !strings.HasPrefix(path, ".."+string(filepath.Separator))
+}

--- a/internal/backup/native.go
+++ b/internal/backup/native.go
@@ -1,0 +1,582 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	mysqlcfg "github.com/go-sql-driver/mysql"
+	"github.com/microsoft/go-mssqldb/msdsn"
+)
+
+func mainArtifactName(driver string) string {
+	switch driver {
+	case "sqlite":
+		return "main.sqlite"
+	case "postgres":
+		return "main.postgres.dump"
+	case "mysql":
+		return "main.mysql.sql"
+	case "mssql":
+		return "main.sqlserver.bak"
+	default:
+		return "main.database"
+	}
+}
+
+func captureMainDatabase(ctx context.Context, cfg Config, target string, runner CommandRunner, records *[]CommandRecord) (string, error) {
+	driver := normalizeDriver(cfg.DBDriver)
+	switch driver {
+	case "sqlite":
+		if err := vacuumSQLite(ctx, cfg.DBDSN, target); err != nil {
+			return "", err
+		}
+		if err := sqliteIntegrity(ctx, target); err != nil {
+			return "", err
+		}
+		return "PRAGMA integrity_check=ok; PRAGMA foreign_key_check=0 rows", nil
+	case "postgres":
+		return capturePostgres(ctx, cfg.DBDSN, target, runner, records)
+	case "mysql":
+		return captureMySQL(ctx, cfg.DBDSN, target, runner, records)
+	case "mssql":
+		return captureMSSQL(ctx, cfg.DBDSN, target, runner, records)
+	default:
+		return "", fmt.Errorf("unsupported backup adapter %q", driver)
+	}
+}
+
+func restoreMainDatabase(ctx context.Context, driver, source, targetDSN string, runner CommandRunner, records *[]CommandRecord) error {
+	switch driver {
+	case "sqlite":
+		target, err := sqlitePath(targetDSN)
+		if err != nil {
+			return err
+		}
+		return publishSQLiteCopy(source, target)
+	case "postgres":
+		if err := ensureFreshServerDatabase(ctx, driver, targetDSN); err != nil {
+			return err
+		}
+		return restorePostgres(ctx, source, targetDSN, runner, records)
+	case "mysql":
+		if err := ensureFreshServerDatabase(ctx, driver, targetDSN); err != nil {
+			return err
+		}
+		return restoreMySQL(ctx, source, targetDSN, runner, records)
+	case "mssql":
+		return restoreMSSQL(ctx, source, targetDSN, runner, records)
+	default:
+		return fmt.Errorf("unsupported restore adapter %q", driver)
+	}
+}
+
+func verifyMainArtifact(ctx context.Context, driver, source, targetDSN string, runner CommandRunner, records *[]CommandRecord) error {
+	switch driver {
+	case "sqlite":
+		return sqliteIntegrity(ctx, source)
+	case "postgres":
+		if err := requireVersion(ctx, runner, "pg_restore", []string{"--version"}, "pg_restore --version", " 16.", records, targetDSN); err != nil {
+			return err
+		}
+		_, err := runRecorded(ctx, runner, "verify-bundle-main", Command{
+			Name:       "pg_restore",
+			Args:       []string{"--list", source},
+			Display:    "pg_restore --list <bundle>/main.postgres.dump",
+			Redactions: []string{targetDSN},
+		}, records)
+		return err
+	case "mysql":
+		if _, err := requireRegular(source); err != nil {
+			return err
+		}
+		file, err := os.Open(source) // #nosec G304 -- verified bundle artifact.
+		if err != nil {
+			return err
+		}
+		defer func() { _ = file.Close() }()
+		data := make([]byte, 1<<20)
+		read, err := file.Read(data)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return err
+		}
+		data = data[:read]
+		if len(data) == 0 || (!strings.Contains(string(data), "CREATE TABLE") && !strings.Contains(string(data), "INSERT INTO")) {
+			return errors.New("MySQL bundle artifact is not a recognizable logical dump")
+		}
+		return nil
+	case "mssql":
+		cfg, err := parseMSSQLDSN(targetDSN)
+		if err != nil {
+			return err
+		}
+		if err := requireVersion(ctx, runner, "sqlcmd", []string{"-?"}, "sqlcmd -?", "Version 18.", records, cfg.Password, targetDSN); err != nil {
+			return err
+		}
+		base, redactions := sqlcmdBase(cfg)
+		query := fmt.Sprintf("SET NOCOUNT ON; RESTORE VERIFYONLY FROM DISK = N'%s' WITH CHECKSUM;", mssqlLiteral(source))
+		_, err = runRecorded(ctx, runner, "verify-bundle-main", Command{
+			Name:       "sqlcmd",
+			Args:       append(append([]string{}, base...), "-Q", query),
+			Display:    "sqlcmd <server> -d master -Q RESTORE VERIFYONLY WITH CHECKSUM",
+			Redactions: append(redactions, targetDSN),
+		}, records)
+		return err
+	default:
+		return fmt.Errorf("unsupported backup adapter %q", driver)
+	}
+}
+
+func validateFreshNativeTarget(ctx context.Context, driver, dsn string, runner CommandRunner) error {
+	if driver != "mssql" {
+		return ensureFreshServerDatabase(ctx, driver, dsn)
+	}
+	cfg, err := parseMSSQLDSN(dsn)
+	if err != nil {
+		return err
+	}
+	base, redactions := sqlcmdBase(cfg)
+	query := fmt.Sprintf("SET NOCOUNT ON; SELECT CONVERT(varchar(128),SERVERPROPERTY('ProductVersion')) + '|' + CASE WHEN DB_ID(N'%s') IS NULL THEN 'missing' ELSE 'exists' END;", mssqlLiteral(cfg.Database))
+	var records []CommandRecord
+	result, err := runRecorded(ctx, runner, "validate-fresh-target", Command{
+		Name:       "sqlcmd",
+		Args:       append(append([]string{}, base...), "-W", "-h", "-1", "-Q", query),
+		Display:    "sqlcmd <server> -d master -Q validate fresh target",
+		Redactions: append(redactions, dsn),
+	}, &records)
+	if err != nil {
+		return err
+	}
+	for _, line := range strings.Split(result.Output, "\n") {
+		parts := strings.Split(strings.TrimSpace(line), "|")
+		if len(parts) != 2 {
+			continue
+		}
+		if err := validateEngineProfile("mssql", strings.TrimSpace(parts[0])); err != nil {
+			return err
+		}
+		if strings.TrimSpace(parts[1]) != "missing" {
+			return fmt.Errorf("restore target is not fresh: SQL Server database %q already exists", cfg.Database)
+		}
+		return nil
+	}
+	return errors.New("SQL Server fresh-target query returned no engine version or database state")
+}
+
+func capturePostgres(ctx context.Context, dsn, target string, runner CommandRunner, records *[]CommandRecord) (string, error) {
+	if err := requireVersion(ctx, runner, "pg_dump", []string{"--version"}, "pg_dump --version", " 16.", records, dsn); err != nil {
+		return "", err
+	}
+	if err := requireVersion(ctx, runner, "pg_restore", []string{"--version"}, "pg_restore --version", " 16.", records, dsn); err != nil {
+		return "", err
+	}
+	_, err := runRecorded(ctx, runner, "capture-main", Command{
+		Name: "pg_dump",
+		Args: []string{
+			"--format=custom",
+			"--no-owner",
+			"--no-privileges",
+			"--file=" + target,
+			"--dbname=" + dsn,
+		},
+		Display:    "pg_dump --format=custom --no-owner --no-privileges --file=<bundle>/main.postgres.dump --dbname=[redacted]",
+		Redactions: []string{dsn},
+	}, records)
+	if err != nil {
+		return "", err
+	}
+	if _, err := requireRegular(target); err != nil {
+		return "", fmt.Errorf("pg_dump did not create its artifact: %w", err)
+	}
+	_, err = runRecorded(ctx, runner, "integrity-main", Command{
+		Name:       "pg_restore",
+		Args:       []string{"--list", target},
+		Display:    "pg_restore --list <bundle>/main.postgres.dump",
+		Redactions: []string{dsn},
+	}, records)
+	if err != nil {
+		return "", err
+	}
+	return "PostgreSQL 16 custom archive parsed by pg_restore --list", nil
+}
+
+func restorePostgres(ctx context.Context, source, dsn string, runner CommandRunner, records *[]CommandRecord) error {
+	if err := requireVersion(ctx, runner, "pg_restore", []string{"--version"}, "pg_restore --version", " 16.", records, dsn); err != nil {
+		return err
+	}
+	_, err := runRecorded(ctx, runner, "restore-main", Command{
+		Name: "pg_restore",
+		Args: []string{
+			"--exit-on-error",
+			"--no-owner",
+			"--no-privileges",
+			"--dbname=" + dsn,
+			source,
+		},
+		Display:    "pg_restore --exit-on-error --no-owner --no-privileges --dbname=[redacted] <bundle>/main.postgres.dump",
+		Redactions: []string{dsn},
+	}, records)
+	return err
+}
+
+func parseMySQLDSN(dsn string) (*mysqlcfg.Config, error) {
+	parsed, err := mysqlcfg.ParseDSN(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("parse MySQL DB_DSN: %w", err)
+	}
+	if parsed.DBName == "" {
+		return nil, errors.New("MySQL DB_DSN must name a database")
+	}
+	if parsed.Net == "" {
+		parsed.Net = "tcp"
+	}
+	if parsed.Addr == "" {
+		parsed.Addr = "127.0.0.1:3306"
+	}
+	return parsed, nil
+}
+
+func mysqlArgs(cfg *mysqlcfg.Config) ([]string, []string, error) {
+	args := []string{"--user=" + cfg.User}
+	switch cfg.Net {
+	case "tcp", "tcp4", "tcp6":
+		host, port, err := net.SplitHostPort(cfg.Addr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("parse MySQL address %q: %w", cfg.Addr, err)
+		}
+		args = append(args, "--host="+host, "--port="+port, "--protocol=TCP")
+	case "unix":
+		args = append(args, "--socket="+cfg.Addr, "--protocol=SOCKET")
+	default:
+		return nil, nil, fmt.Errorf("unsupported MySQL network %q", cfg.Net)
+	}
+	switch strings.ToLower(cfg.TLSConfig) {
+	case "", "false", "preferred":
+		// Native client default remains unchanged.
+	case "true":
+		args = append(args, "--ssl-mode=REQUIRED")
+	case "skip-verify":
+		args = append(args, "--ssl-mode=REQUIRED")
+	default:
+		return nil, nil, fmt.Errorf("native MySQL backup cannot resolve custom TLS config %q", cfg.TLSConfig)
+	}
+	env := []string{}
+	if cfg.Passwd != "" {
+		env = append(env, "MYSQL_PWD="+cfg.Passwd)
+	}
+	return args, env, nil
+}
+
+func captureMySQL(ctx context.Context, dsn, target string, runner CommandRunner, records *[]CommandRecord) (string, error) {
+	cfg, err := parseMySQLDSN(dsn)
+	if err != nil {
+		return "", err
+	}
+	if err := requireVersion(ctx, runner, "mysqldump", []string{"--version"}, "mysqldump --version", "Ver 8.4.", records, cfg.Passwd, dsn); err != nil {
+		return "", err
+	}
+	args, env, err := mysqlArgs(cfg)
+	if err != nil {
+		return "", err
+	}
+	args = append(args,
+		"--single-transaction",
+		"--quick",
+		"--hex-blob",
+		"--no-tablespaces",
+		"--skip-comments",
+		cfg.DBName,
+	)
+	_, err = runRecorded(ctx, runner, "capture-main", Command{
+		Name:       "mysqldump",
+		Args:       args,
+		Env:        env,
+		StdoutPath: target,
+		Display:    "mysqldump --single-transaction --quick --hex-blob --no-tablespaces <database> > <bundle>/main.mysql.sql",
+		Redactions: []string{cfg.Passwd, dsn},
+	}, records)
+	if err != nil {
+		return "", err
+	}
+	info, err := requireRegular(target)
+	if err != nil {
+		return "", err
+	}
+	if info.Size() == 0 {
+		return "", errors.New("mysqldump produced an empty artifact")
+	}
+	return "MySQL 8.4 logical dump captured; successful fresh-target import is the integrity proof", nil
+}
+
+func restoreMySQL(ctx context.Context, source, dsn string, runner CommandRunner, records *[]CommandRecord) error {
+	cfg, err := parseMySQLDSN(dsn)
+	if err != nil {
+		return err
+	}
+	if err := requireVersion(ctx, runner, "mysql", []string{"--version"}, "mysql --version", "Ver 8.4.", records, cfg.Passwd, dsn); err != nil {
+		return err
+	}
+	args, env, err := mysqlArgs(cfg)
+	if err != nil {
+		return err
+	}
+	args = append(args, "--binary-mode", cfg.DBName)
+	_, err = runRecorded(ctx, runner, "restore-main", Command{
+		Name:       "mysql",
+		Args:       args,
+		Env:        env,
+		StdinPath:  source,
+		Display:    "mysql --binary-mode <database> < <bundle>/main.mysql.sql",
+		Redactions: []string{cfg.Passwd, dsn},
+	}, records)
+	return err
+}
+
+func ensureFreshServerDatabase(ctx context.Context, driver, dsn string) error {
+	db, err := storage.NewDatabase(driver, dsn)
+	if err != nil {
+		return fmt.Errorf("open fresh restore target: %w", err)
+	}
+	defer closeGORM(db)
+	version, err := databaseVersion(ctx, db, driver)
+	if err != nil {
+		return err
+	}
+	if err := validateEngineProfile(driver, version); err != nil {
+		return err
+	}
+	query := ""
+	switch driver {
+	case "postgres":
+		query = "SELECT COUNT(*) FROM information_schema.tables WHERE table_type='BASE TABLE' AND table_schema NOT IN ('pg_catalog','information_schema')"
+	case "mysql":
+		query = "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE()"
+	default:
+		return fmt.Errorf("fresh server database check is unsupported for %s", driver)
+	}
+	var count int64
+	if err := db.WithContext(ctx).Raw(query).Scan(&count).Error; err != nil {
+		return fmt.Errorf("inspect fresh restore target: %w", err)
+	}
+	if count != 0 {
+		return fmt.Errorf("restore target is not fresh: found %d user tables", count)
+	}
+	return nil
+}
+
+func parseMSSQLDSN(dsn string) (msdsn.Config, error) {
+	parsed, err := msdsn.Parse(dsn)
+	if err != nil {
+		return msdsn.Config{}, fmt.Errorf("parse SQL Server DB_DSN: %w", err)
+	}
+	if parsed.Host == "" || parsed.Database == "" {
+		return msdsn.Config{}, errors.New("SQL Server DB_DSN must name a host and database")
+	}
+	if parsed.Port == 0 {
+		parsed.Port = 1433
+	}
+	return parsed, nil
+}
+
+func sqlcmdBase(cfg msdsn.Config) ([]string, []string) {
+	server := cfg.Host + "," + strconv.FormatUint(cfg.Port, 10)
+	args := []string{"-S", server, "-d", "master", "-b", "-r", "1"}
+	if cfg.User != "" {
+		args = append(args, "-U", cfg.User, "-P", cfg.Password)
+	} else {
+		args = append(args, "-E")
+	}
+	if cfg.TrustServerCertificate {
+		args = append(args, "-C")
+	}
+	return args, []string{cfg.Password}
+}
+
+func captureMSSQL(ctx context.Context, dsn, target string, runner CommandRunner, records *[]CommandRecord) (string, error) {
+	cfg, err := parseMSSQLDSN(dsn)
+	if err != nil {
+		return "", err
+	}
+	if err := requireVersion(ctx, runner, "sqlcmd", []string{"-?"}, "sqlcmd -?", "Version 18.", records, cfg.Password, dsn); err != nil {
+		return "", err
+	}
+	base, redactions := sqlcmdBase(cfg)
+	backupSQL := fmt.Sprintf("SET NOCOUNT ON; BACKUP DATABASE %s TO DISK = N'%s' WITH COPY_ONLY, CHECKSUM, INIT;", mssqlIdentifier(cfg.Database), mssqlLiteral(target))
+	_, err = runRecorded(ctx, runner, "capture-main", Command{
+		Name:       "sqlcmd",
+		Args:       append(append([]string{}, base...), "-Q", backupSQL),
+		Display:    "sqlcmd <server> -d master -Q BACKUP DATABASE <database> WITH COPY_ONLY,CHECKSUM,INIT",
+		Redactions: append(redactions, dsn),
+	}, records)
+	if err != nil {
+		return "", err
+	}
+	if _, err := requireRegular(target); err != nil {
+		return "", fmt.Errorf("SQL Server backup artifact is not visible at %s; mount the absolute --out directory into SQL Server: %w", target, err)
+	}
+	verifySQL := fmt.Sprintf("SET NOCOUNT ON; RESTORE VERIFYONLY FROM DISK = N'%s' WITH CHECKSUM;", mssqlLiteral(target))
+	_, err = runRecorded(ctx, runner, "integrity-main", Command{
+		Name:       "sqlcmd",
+		Args:       append(append([]string{}, base...), "-Q", verifySQL),
+		Display:    "sqlcmd <server> -d master -Q RESTORE VERIFYONLY WITH CHECKSUM",
+		Redactions: append(redactions, dsn),
+	}, records)
+	if err != nil {
+		return "", err
+	}
+	return "SQL Server full COPY_ONLY backup verified by RESTORE VERIFYONLY WITH CHECKSUM", nil
+}
+
+type mssqlBackupFile struct {
+	Logical string
+	Kind    string
+}
+
+func restoreMSSQL(ctx context.Context, source, dsn string, runner CommandRunner, records *[]CommandRecord) error {
+	cfg, err := parseMSSQLDSN(dsn)
+	if err != nil {
+		return err
+	}
+	if err := requireVersion(ctx, runner, "sqlcmd", []string{"-?"}, "sqlcmd -?", "Version 18.", records, cfg.Password, dsn); err != nil {
+		return err
+	}
+	base, redactions := sqlcmdBase(cfg)
+	checkSQL := fmt.Sprintf("SET NOCOUNT ON; SELECT CASE WHEN DB_ID(N'%s') IS NULL THEN 'missing' ELSE 'exists' END;", mssqlLiteral(cfg.Database))
+	check, err := runRecorded(ctx, runner, "validate-fresh-target", Command{
+		Name:       "sqlcmd",
+		Args:       append(append([]string{}, base...), "-W", "-h", "-1", "-Q", checkSQL),
+		Display:    "sqlcmd <server> -d master -Q validate fresh target",
+		Redactions: append(redactions, dsn),
+	}, records)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(check.Output, "missing") || strings.Contains(check.Output, "exists") {
+		return fmt.Errorf("restore target is not fresh: SQL Server database %q already exists", cfg.Database)
+	}
+	fileListSQL := fmt.Sprintf("SET NOCOUNT ON; RESTORE FILELISTONLY FROM DISK = N'%s';", mssqlLiteral(source))
+	fileList, err := runRecorded(ctx, runner, "inspect-backup-files", Command{
+		Name:       "sqlcmd",
+		Args:       append(append([]string{}, base...), "-W", "-h", "-1", "-s", "|", "-Q", fileListSQL),
+		Display:    "sqlcmd <server> -d master -Q RESTORE FILELISTONLY",
+		Redactions: append(redactions, dsn),
+	}, records)
+	if err != nil {
+		return err
+	}
+	files, err := parseMSSQLFileList(fileList.Output)
+	if err != nil {
+		return err
+	}
+	pathsSQL := "SET NOCOUNT ON; SELECT CONVERT(nvarchar(4000),SERVERPROPERTY('InstanceDefaultDataPath')) + '|' + CONVERT(nvarchar(4000),SERVERPROPERTY('InstanceDefaultLogPath'));"
+	paths, err := runRecorded(ctx, runner, "inspect-server-paths", Command{
+		Name:       "sqlcmd",
+		Args:       append(append([]string{}, base...), "-W", "-h", "-1", "-Q", pathsSQL),
+		Display:    "sqlcmd <server> -d master -Q inspect default data paths",
+		Redactions: append(redactions, dsn),
+	}, records)
+	if err != nil {
+		return err
+	}
+	dataDir, logDir, err := parseMSSQLDefaultPaths(paths.Output)
+	if err != nil {
+		return err
+	}
+	moves := make([]string, 0, len(files))
+	dataIndex, logIndex := 0, 0
+	for _, file := range files {
+		directory := dataDir
+		extension := ".ndf"
+		index := dataIndex
+		if file.Kind == "L" {
+			directory = logDir
+			extension = ".ldf"
+			index = logIndex
+			logIndex++
+		} else {
+			if dataIndex == 0 {
+				extension = ".mdf"
+			}
+			dataIndex++
+		}
+		physical := filepath.Join(directory, fmt.Sprintf("%s_%d%s", safeMSSQLFileName(cfg.Database), index, extension))
+		moves = append(moves, fmt.Sprintf("MOVE N'%s' TO N'%s'", mssqlLiteral(file.Logical), mssqlLiteral(physical)))
+	}
+	restoreSQL := fmt.Sprintf("SET NOCOUNT ON; RESTORE DATABASE %s FROM DISK = N'%s' WITH CHECKSUM, RECOVERY, %s;", mssqlIdentifier(cfg.Database), mssqlLiteral(source), strings.Join(moves, ", "))
+	_, err = runRecorded(ctx, runner, "restore-main", Command{
+		Name:       "sqlcmd",
+		Args:       append(append([]string{}, base...), "-Q", restoreSQL),
+		Display:    "sqlcmd <server> -d master -Q RESTORE DATABASE <fresh-target> WITH MOVE,CHECKSUM,RECOVERY",
+		Redactions: append(redactions, dsn),
+	}, records)
+	if err != nil {
+		return err
+	}
+	checkDBSQL := fmt.Sprintf("SET NOCOUNT ON; DBCC CHECKDB (%s) WITH NO_INFOMSGS;", mssqlIdentifier(cfg.Database))
+	_, err = runRecorded(ctx, runner, "integrity-restored-main", Command{
+		Name:       "sqlcmd",
+		Args:       append(append([]string{}, base...), "-Q", checkDBSQL),
+		Display:    "sqlcmd <server> -d master -Q DBCC CHECKDB <fresh-target>",
+		Redactions: append(redactions, dsn),
+	}, records)
+	return err
+}
+
+func parseMSSQLFileList(output string) ([]mssqlBackupFile, error) {
+	var files []mssqlBackupFile
+	for _, line := range strings.Split(output, "\n") {
+		parts := strings.Split(line, "|")
+		if len(parts) < 3 {
+			continue
+		}
+		logical := strings.TrimSpace(parts[0])
+		kind := strings.TrimSpace(parts[2])
+		if logical != "" && (kind == "D" || kind == "L") {
+			files = append(files, mssqlBackupFile{Logical: logical, Kind: kind})
+		}
+	}
+	if len(files) == 0 {
+		return nil, errors.New("RESTORE FILELISTONLY returned no data or log files")
+	}
+	return files, nil
+}
+
+func parseMSSQLDefaultPaths(output string) (string, string, error) {
+	for _, line := range strings.Split(output, "\n") {
+		parts := strings.Split(strings.TrimSpace(line), "|")
+		if len(parts) == 2 && strings.TrimSpace(parts[0]) != "" && strings.TrimSpace(parts[1]) != "" {
+			return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
+		}
+	}
+	return "", "", errors.New("SQL Server did not report default data and log paths")
+}
+
+func mssqlIdentifier(value string) string {
+	return "[" + strings.ReplaceAll(value, "]", "]]") + "]"
+}
+
+func mssqlLiteral(value string) string {
+	return strings.ReplaceAll(value, "'", "''")
+}
+
+func safeMSSQLFileName(value string) string {
+	var builder strings.Builder
+	for _, char := range value {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') || char == '-' || char == '_' {
+			builder.WriteRune(char)
+		} else {
+			builder.WriteByte('_')
+		}
+	}
+	if builder.Len() == 0 {
+		return "otelcontext_restore"
+	}
+	return builder.String()
+}

--- a/internal/backup/native_integration_test.go
+++ b/internal/backup/native_integration_test.go
@@ -1,0 +1,394 @@
+//go:build integration && !windows
+
+package backup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/migrate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+type nativeFixture struct {
+	adapter   string
+	container testcontainers.Container
+	id        string
+	root      string
+	sourceDSN string
+	targetDSN string
+	internal  map[string]string
+}
+
+type containerRunner struct {
+	fixture *nativeFixture
+}
+
+func (runner containerRunner) Run(ctx context.Context, command Command) (CommandResult, error) {
+	if err := runner.fixture.chmodShared(ctx); err != nil {
+		return CommandResult{ExitCode: -1}, err
+	}
+	client := command.Name
+	if runner.fixture.adapter == "mssql" && command.Name == "sqlcmd" {
+		client = "/opt/mssql-tools18/bin/sqlcmd"
+	}
+	args := []string{"exec", "-i"}
+	for _, value := range command.Env {
+		args = append(args, "-e", value)
+	}
+	args = append(args, runner.fixture.id, client)
+	clientArgs := append([]string(nil), command.Args...)
+	switch runner.fixture.adapter {
+	case "postgres":
+		for index, argument := range clientArgs {
+			if strings.HasPrefix(argument, "--dbname=") {
+				external := strings.TrimPrefix(argument, "--dbname=")
+				clientArgs[index] = "--dbname=" + runner.fixture.internal[external]
+			}
+		}
+	case "mysql":
+		for index, argument := range clientArgs {
+			switch {
+			case strings.HasPrefix(argument, "--host="):
+				clientArgs[index] = "--host=127.0.0.1"
+			case strings.HasPrefix(argument, "--port="):
+				clientArgs[index] = "--port=3306"
+			}
+		}
+	case "mssql":
+		for index := 0; index+1 < len(clientArgs); index++ {
+			if clientArgs[index] == "-S" {
+				clientArgs[index+1] = "127.0.0.1,1433"
+			}
+		}
+	}
+	args = append(args, clientArgs...)
+	redactions := append([]string(nil), command.Redactions...)
+	for external, internal := range runner.fixture.internal {
+		redactions = append(redactions, external, internal)
+	}
+	wrapped := command
+	wrapped.Name = "docker"
+	wrapped.Args = args
+	wrapped.Env = nil
+	wrapped.Redactions = redactions
+	result, err := (execRunner{}).Run(ctx, wrapped)
+	chmodErr := runner.fixture.chmodShared(ctx)
+	if err != nil {
+		return result, err
+	}
+	if chmodErr != nil {
+		return result, chmodErr
+	}
+	return result, nil
+}
+
+func (fixture *nativeFixture) chmodShared(ctx context.Context) error {
+	command := Command{
+		Name:    "docker",
+		Args:    []string{"exec", "-u", "0", fixture.id, "chmod", "-R", "a+rwX", fixture.root},
+		Display: "docker exec <database> chmod shared backup fixture",
+	}
+	_, err := (execRunner{}).Run(ctx, command)
+	return err
+}
+
+func startNativeFixture(t *testing.T, adapter string) *nativeFixture {
+	t.Helper()
+	ctx := context.Background()
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	request := testcontainers.ContainerRequest{
+		ExposedPorts: []string{},
+		Binds:        []string{root + ":" + root},
+	}
+	switch adapter {
+	case "postgres":
+		request.Image = "postgres:16-alpine"
+		request.Env = map[string]string{"POSTGRES_USER": "otel", "POSTGRES_PASSWORD": "otel", "POSTGRES_DB": "postgres"}
+		request.ExposedPorts = []string{"5432/tcp"}
+		request.WaitingFor = wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(2 * time.Minute)
+	case "mysql":
+		request.Image = "mysql:8.4"
+		request.Env = map[string]string{"MYSQL_ROOT_PASSWORD": "OtelContext-248"}
+		request.ExposedPorts = []string{"3306/tcp"}
+		request.WaitingFor = wait.ForLog("ready for connections").WithStartupTimeout(3 * time.Minute)
+	case "mssql":
+		request.Image = "mcr.microsoft.com/mssql/server:2022-latest"
+		request.Env = map[string]string{
+			"ACCEPT_EULA":           "Y",
+			"MSSQL_SA_PASSWORD":     "OtelContext!248Proof",
+			"MSSQL_PID":             "Developer",
+			"MSSQL_MEMORY_LIMIT_MB": "2048",
+		}
+		request.ExposedPorts = []string{"1433/tcp"}
+		request.WaitingFor = wait.ForLog("SQL Server is now ready for client connections").WithStartupTimeout(4 * time.Minute)
+	default:
+		t.Fatalf("unsupported adapter %q", adapter)
+	}
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{ContainerRequest: request, Started: true})
+	if err != nil {
+		t.Fatalf("start %s container: %v", adapter, err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+	id := container.GetContainerID()
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	portID := request.ExposedPorts[0]
+	mapped, err := container.MappedPort(ctx, portID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture := &nativeFixture{adapter: adapter, container: container, id: id, root: root, internal: make(map[string]string)}
+	switch adapter {
+	case "postgres":
+		admin := fmt.Sprintf("postgres://otel:otel@%s:%s/postgres?sslmode=disable", host, mapped.Port())
+		createDatabases(t, adapter, admin, []string{"otel_source", "otel_target"})
+		fixture.sourceDSN = fmt.Sprintf("postgres://otel:otel@%s:%s/otel_source?sslmode=disable", host, mapped.Port())
+		fixture.targetDSN = fmt.Sprintf("postgres://otel:otel@%s:%s/otel_target?sslmode=disable", host, mapped.Port())
+		fixture.internal[fixture.sourceDSN] = "postgres://otel:otel@127.0.0.1:5432/otel_source?sslmode=disable"
+		fixture.internal[fixture.targetDSN] = "postgres://otel:otel@127.0.0.1:5432/otel_target?sslmode=disable"
+	case "mysql":
+		admin := fmt.Sprintf("root:OtelContext-248@tcp(%s:%s)/mysql?charset=utf8mb4&parseTime=True&loc=UTC", host, mapped.Port())
+		createDatabases(t, adapter, admin, []string{"otel_source", "otel_target"})
+		fixture.sourceDSN = fmt.Sprintf("root:OtelContext-248@tcp(%s:%s)/otel_source?charset=utf8mb4&parseTime=True&loc=UTC", host, mapped.Port())
+		fixture.targetDSN = fmt.Sprintf("root:OtelContext-248@tcp(%s:%s)/otel_target?charset=utf8mb4&parseTime=True&loc=UTC", host, mapped.Port())
+	case "mssql":
+		adminURL := &url.URL{Scheme: "sqlserver", User: url.UserPassword("sa", "OtelContext!248Proof"), Host: host + ":" + mapped.Port()}
+		adminQuery := adminURL.Query()
+		adminQuery.Set("database", "master")
+		adminQuery.Set("encrypt", "disable")
+		adminQuery.Set("TrustServerCertificate", "true")
+		adminURL.RawQuery = adminQuery.Encode()
+		createDatabases(t, adapter, adminURL.String(), []string{"otel_source"})
+		sourceURL := *adminURL
+		sourceQuery := sourceURL.Query()
+		sourceQuery.Set("database", "otel_source")
+		sourceURL.RawQuery = sourceQuery.Encode()
+		targetURL := *adminURL
+		targetQuery := targetURL.Query()
+		targetQuery.Set("database", "otel_target")
+		targetURL.RawQuery = targetQuery.Encode()
+		fixture.sourceDSN = sourceURL.String()
+		fixture.targetDSN = targetURL.String()
+	}
+	return fixture
+}
+
+func createDatabases(t *testing.T, adapter, dsn string, names []string) {
+	t.Helper()
+	db, err := storage.NewDatabase(adapter, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeGORM(db)
+	for _, name := range names {
+		statement := "CREATE DATABASE " + name
+		if adapter == "mysql" {
+			statement += " CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+		}
+		if err := db.Exec(statement).Error; err != nil { //nolint:gosec // fixed test database identifiers.
+			t.Fatalf("create %s database %s: %v", adapter, name, err)
+		}
+	}
+}
+
+func prepareNativeSource(t *testing.T, fixture *nativeFixture) {
+	t.Helper()
+	db, err := storage.NewDatabase(fixture.adapter, fixture.sourceDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeGORM(db)
+	if migrate.SupportsVersioned(fixture.adapter) {
+		if _, err := migrate.Up(context.Background(), db, fixture.adapter); err != nil {
+			t.Fatal(err)
+		}
+	} else if err := migrate.AutoMigrate(db, fixture.adapter, storage.MigrateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	trace := storage.Trace{
+		TenantID: "default", TraceID: "native-backup-fixture", ServiceName: "checkout",
+		Duration: 42, Status: storage.StatusCodeError, Timestamp: now,
+	}
+	if err := db.Create(&trace).Error; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func nativeConfig(root, adapter, dsn, suffix string) Config {
+	data := filepath.Join(root, suffix)
+	return Config{
+		DBDriver:        adapter,
+		DBDSN:           dsn,
+		AggregateMode:   "legacy",
+		AggregateDBPath: filepath.Join(data, "aggregate.db"),
+		DLQPath:         filepath.Join(data, "dlq"),
+		DataDiskPath:    data,
+		TLSCacheDir:     filepath.Join(data, "tls"),
+	}
+}
+
+func writeNativeShutdownProof(t *testing.T, cfg Config, candidate Candidate) {
+	t.Helper()
+	if err := os.MkdirAll(cfg.DLQPath, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfg.DLQPath, "batch_native.json"), []byte(`{"fixture":"native"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now().UTC().Add(-time.Second)
+	handle, err := BeginRuntime(cfg, candidate, started)
+	if err != nil {
+		t.Fatal(err)
+	}
+	steps := make([]ShutdownStep, 0, len(shutdownOwners))
+	for index, owner := range shutdownOwners {
+		stepStart := started.Add(time.Duration(index) * time.Millisecond)
+		steps = append(steps, ShutdownStep{Name: owner, StartedAt: stepStart, CompletedAt: stepStart.Add(time.Millisecond)})
+	}
+	report := shutdownReportWire{StartedAt: started, CompletedAt: started.Add(100 * time.Millisecond), Steps: steps}
+	if _, err := CompleteRuntime(cfg, handle, report); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type nativeProof struct {
+	SchemaVersion     string        `json:"schema_version"`
+	Adapter           string        `json:"adapter"`
+	CandidateSHA      string        `json:"candidate_sha,omitempty"`
+	EngineVersion     string        `json:"engine_version"`
+	MigrationState    string        `json:"migration_state"`
+	SourceLifecycle   string        `json:"source_lifecycle_fingerprint"`
+	RestoredLifecycle string        `json:"restored_lifecycle_fingerprint"`
+	Create            CreateReport  `json:"create"`
+	Restore           RestoreReport `json:"restore"`
+	ManifestSHA256    string        `json:"manifest_sha256"`
+	Assertions        []struct {
+		Name   string `json:"name"`
+		Passed bool   `json:"passed"`
+	} `json:"assertions"`
+}
+
+func TestNativeBackupRestoreLifecycle(t *testing.T) {
+	adapter := os.Getenv("OTELCONTEXT_BACKUP_ADAPTER")
+	if adapter != "postgres" && adapter != "mysql" && adapter != "mssql" {
+		t.Fatalf("OTELCONTEXT_BACKUP_ADAPTER must be postgres, mysql, or mssql; got %q", adapter)
+	}
+	fixture := startNativeFixture(t, adapter)
+	prepareNativeSource(t, fixture)
+	candidate, err := CurrentCandidate("integration-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceCfg := nativeConfig(fixture.root, adapter, fixture.sourceDSN, "source")
+	writeNativeShutdownProof(t, sourceCfg, candidate)
+	runner := containerRunner{fixture: fixture}
+	create, err := Create(context.Background(), sourceCfg, CreateOptions{
+		OutputDirectory: filepath.Join(fixture.root, "backups"),
+		Candidate:       candidate,
+		Runner:          runner,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestData, err := os.ReadFile(filepath.Join(create.Bundle, manifestName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	targetCfg := nativeConfig(fixture.root, adapter, fixture.targetDSN, "target")
+	restore, err := Restore(context.Background(), targetCfg, RestoreOptions{
+		BundleDirectory: create.Bundle,
+		Candidate:       candidate,
+		Runner:          runner,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored, err := inspectMain(context.Background(), targetCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := compareMain(manifest.Main, restored); err != nil {
+		t.Fatal(err)
+	}
+	targetDB, err := storage.NewDatabase(adapter, fixture.targetDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restoredFixtureRows int64
+	if err := targetDB.Table("traces").Where("trace_id = ?", "native-backup-fixture").Count(&restoredFixtureRows).Error; err != nil {
+		closeGORM(targetDB)
+		t.Fatal(err)
+	}
+	closeGORM(targetDB)
+	prefix := map[string]string{"postgres": "16.", "mysql": "8.4.", "mssql": "16."}[adapter]
+	checks := []struct {
+		Name   string `json:"name"`
+		Passed bool   `json:"passed"`
+	}{
+		{"manifest_schema_v1", manifest.SchemaVersion == SchemaVersion},
+		{"candidate_binary_bound", manifest.Candidate == candidate},
+		{"adapter_bound", manifest.Main.Adapter == adapter},
+		{"engine_version_frozen", strings.HasPrefix(manifest.Main.EngineVersion, prefix)},
+		{"native_commands_recorded", len(manifest.Commands) >= 2},
+		{"fresh_restore_completed", restore.Status == "restored"},
+		{"migration_status_equal", manifest.Main.MigrationState == restored.MigrationState && manifest.Main.MigrationVersion == restored.MigrationVersion},
+		{"lifecycle_fingerprint_equal", manifest.Main.LifecycleFingerprint == restored.LifecycleFingerprint},
+		{"fixture_row_restored", restoredFixtureRows == 1},
+		{"bundle_lifecycle_equal", manifest.LifecycleFingerprint == restore.LifecycleFingerprint},
+	}
+	for _, check := range checks {
+		if !check.Passed {
+			t.Fatalf("native backup assertion failed: %s", check.Name)
+		}
+	}
+	digest := hashBytes(manifestData)
+	proof := nativeProof{
+		SchemaVersion:     "otelcontext.native-backup-proof/v1",
+		Adapter:           adapter,
+		CandidateSHA:      os.Getenv("GITHUB_SHA"),
+		EngineVersion:     manifest.Main.EngineVersion,
+		MigrationState:    manifest.Main.MigrationState,
+		SourceLifecycle:   manifest.Main.LifecycleFingerprint,
+		RestoredLifecycle: restored.LifecycleFingerprint,
+		Create:            create,
+		Restore:           restore,
+		ManifestSHA256:    digest,
+		Assertions:        checks,
+	}
+	proofDir := os.Getenv("OTELCONTEXT_NATIVE_BACKUP_PROOF_DIR")
+	if proofDir != "" {
+		if err := os.MkdirAll(proofDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		data, err := json.MarshalIndent(proof, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(proofDir, adapter+".json"), append(data, '\n'), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(proofDir, adapter+"-manifest.json"), manifestData, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/internal/backup/native_integration_test.go
+++ b/internal/backup/native_integration_test.go
@@ -190,20 +190,29 @@ func startNativeFixture(t *testing.T, adapter string) *nativeFixture {
 
 func createDatabases(t *testing.T, adapter, dsn string, names []string) {
 	t.Helper()
-	db, err := storage.NewDatabase(adapter, dsn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer closeGORM(db)
-	for _, name := range names {
-		statement := "CREATE DATABASE " + name
-		if adapter == "mysql" {
-			statement += " CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+	var lastErr error
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		db, err := storage.NewDatabase(adapter, dsn)
+		if err != nil {
+			closeGORM(db)
+			lastErr = err
+			time.Sleep(250 * time.Millisecond)
+			continue
 		}
-		if err := db.Exec(statement).Error; err != nil { //nolint:gosec // fixed test database identifiers.
-			t.Fatalf("create %s database %s: %v", adapter, name, err)
+		defer closeGORM(db)
+		for _, name := range names {
+			statement := "CREATE DATABASE " + name
+			if adapter == "mysql" {
+				statement += " CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+			}
+			if err := db.Exec(statement).Error; err != nil { //nolint:gosec // fixed test database identifiers.
+				t.Fatalf("create %s database %s: %v", adapter, name, err)
+			}
 		}
+		return
 	}
+	t.Fatalf("wait for %s database authentication: %v", adapter, lastErr)
 }
 
 func prepareNativeSource(t *testing.T, fixture *nativeFixture) {

--- a/internal/backup/native_integration_test.go
+++ b/internal/backup/native_integration_test.go
@@ -123,7 +123,7 @@ func startNativeFixture(t *testing.T, adapter string) *nativeFixture {
 		request.Image = "mysql:8.4"
 		request.Env = map[string]string{"MYSQL_ROOT_PASSWORD": "OtelContext-248"}
 		request.ExposedPorts = []string{"3306/tcp"}
-		request.WaitingFor = wait.ForLog("ready for connections").WithStartupTimeout(3 * time.Minute)
+		request.WaitingFor = wait.ForLog("ready for connections").WithOccurrence(2).WithStartupTimeout(3 * time.Minute)
 	case "mssql":
 		request.Image = "mcr.microsoft.com/mssql/server:2022-latest"
 		request.Env = map[string]string{

--- a/internal/backup/runtime.go
+++ b/internal/backup/runtime.go
@@ -1,0 +1,305 @@
+package backup
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+const (
+	runtimeSchemaVersion = "otelcontext.runtime-proof/v1"
+	activeMarkerName     = ".otelcontext-runtime-active.json"
+	shutdownMarkerName   = ".otelcontext-shutdown-success.json"
+)
+
+var shutdownOwners = []string{
+	"otlp_admission",
+	"http",
+	"pprof",
+	"realtime",
+	"ai",
+	"ingest_pipeline",
+	"aggregate_writer",
+	"tsdb",
+	"graphrag",
+	"service_graph",
+	"dlq",
+	"disk_watchdog",
+	"retention",
+	"partitions",
+	"tracer",
+	"database_health",
+	"boot_workers",
+	"aggregate_store",
+	"main_database",
+}
+
+type activeRuntime struct {
+	SchemaVersion     string    `json:"schema_version"`
+	Status            string    `json:"status"`
+	RuntimeID         string    `json:"runtime_id"`
+	ConfigFingerprint string    `json:"config_fingerprint"`
+	Candidate         Candidate `json:"candidate"`
+	StartedAt         time.Time `json:"started_at"`
+}
+
+type shutdownReportWire struct {
+	StartedAt   time.Time      `json:"started_at"`
+	CompletedAt time.Time      `json:"completed_at"`
+	Steps       []ShutdownStep `json:"steps"`
+}
+
+// CurrentCandidate hashes the running executable and reads the VCS revision
+// stamped by the Go toolchain.
+func CurrentCandidate(version string) (Candidate, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return Candidate{}, fmt.Errorf("resolve current executable: %w", err)
+	}
+	digest, _, err := hashFile(executable)
+	if err != nil {
+		return Candidate{}, fmt.Errorf("hash current executable: %w", err)
+	}
+	commit := "unknown"
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" && strings.TrimSpace(setting.Value) != "" {
+				commit = setting.Value
+				break
+			}
+		}
+	}
+	return Candidate{Version: version, Commit: commit, BinarySHA256: digest}, nil
+}
+
+// ConfigFingerprint binds settings which must not change across restore. Paths
+// and database identities are intentionally separate so fresh targets are
+// possible.
+func ConfigFingerprint(cfg Config) (string, error) {
+	tlsMode := "none"
+	switch {
+	case cfg.TLSCertFile != "" || cfg.TLSKeyFile != "":
+		tlsMode = "operator-owned"
+	case cfg.TLSAutoSelfSigned:
+		tlsMode = "generated-self-signed"
+	}
+	return hashJSON(struct {
+		Driver       string `json:"driver"`
+		Partitioning string `json:"postgres_partitioning"`
+		Mode         string `json:"aggregate_mode"`
+		TLSMode      string `json:"tls_mode"`
+	}{
+		Driver:       normalizeDriver(cfg.DBDriver),
+		Partitioning: strings.ToLower(strings.TrimSpace(cfg.DBPostgresPartitioning)),
+		Mode:         strings.ToLower(strings.TrimSpace(cfg.AggregateMode)),
+		TLSMode:      tlsMode,
+	})
+}
+
+func runtimeFingerprint(cfg Config) (string, error) {
+	base, err := ConfigFingerprint(cfg)
+	if err != nil {
+		return "", err
+	}
+	mainID, err := mainSourceIdentity(cfg)
+	if err != nil {
+		return "", err
+	}
+	aggregateID := "not-required"
+	if strings.ToLower(cfg.AggregateMode) != "legacy" {
+		path, err := resolved(cfg.AggregateDBPath)
+		if err != nil {
+			return "", err
+		}
+		aggregateID = identity(path)
+	}
+	dlqPath, err := resolved(cfg.DLQPath)
+	if err != nil {
+		return "", err
+	}
+	tlsID := "not-captured"
+	if cfg.TLSAutoSelfSigned && cfg.TLSCertFile == "" && cfg.TLSKeyFile == "" {
+		path, err := resolved(cfg.TLSCacheDir)
+		if err != nil {
+			return "", err
+		}
+		tlsID = identity(path)
+	}
+	return hashJSON(struct {
+		Config    string `json:"config_fingerprint"`
+		Main      string `json:"main_identity"`
+		Aggregate string `json:"aggregate_identity"`
+		DLQ       string `json:"dlq_identity"`
+		TLS       string `json:"tls_identity"`
+	}{base, mainID, aggregateID, identity(dlqPath), tlsID})
+}
+
+// BeginRuntime invalidates any earlier clean-shutdown proof and writes the
+// active marker before durable owners are opened.
+func BeginRuntime(cfg Config, candidate Candidate, now time.Time) (RuntimeHandle, error) {
+	dataDir, err := resolved(cfg.DataDiskPath)
+	if err != nil {
+		return RuntimeHandle{}, fmt.Errorf("resolve DATA_DISK_PATH: %w", err)
+	}
+	fingerprint, err := runtimeFingerprint(cfg)
+	if err != nil {
+		return RuntimeHandle{}, fmt.Errorf("runtime config fingerprint: %w", err)
+	}
+	id, err := newID()
+	if err != nil {
+		return RuntimeHandle{}, err
+	}
+	now = now.UTC()
+	marker := activeRuntime{
+		SchemaVersion:     runtimeSchemaVersion,
+		Status:            "active",
+		RuntimeID:         id,
+		ConfigFingerprint: fingerprint,
+		Candidate:         candidate,
+		StartedAt:         now,
+	}
+	if err := writeJSONAtomic(filepath.Join(dataDir, activeMarkerName), marker, 0o600); err != nil {
+		return RuntimeHandle{}, fmt.Errorf("write active runtime marker: %w", err)
+	}
+	if err := os.Remove(filepath.Join(dataDir, shutdownMarkerName)); err != nil && !os.IsNotExist(err) {
+		return RuntimeHandle{}, fmt.Errorf("invalidate prior shutdown proof: %w", err)
+	}
+	if err := syncDir(dataDir); err != nil {
+		return RuntimeHandle{}, fmt.Errorf("sync runtime marker directory: %w", err)
+	}
+	return RuntimeHandle{ID: id, ConfigFingerprint: fingerprint, Candidate: candidate, StartedAt: now}, nil
+}
+
+// CompleteRuntime converts the active marker into a successful shutdown proof.
+// report must JSON-encode with started_at, completed_at, and steps fields.
+func CompleteRuntime(cfg Config, handle RuntimeHandle, report any) (ShutdownProof, error) {
+	dataDir, err := resolved(cfg.DataDiskPath)
+	if err != nil {
+		return ShutdownProof{}, err
+	}
+	activePath := filepath.Join(dataDir, activeMarkerName)
+	activeData, err := os.ReadFile(activePath) // #nosec G304 -- fixed marker under resolved data directory.
+	if err != nil {
+		return ShutdownProof{}, fmt.Errorf("read active runtime marker: %w", err)
+	}
+	var active activeRuntime
+	if err := json.Unmarshal(activeData, &active); err != nil {
+		return ShutdownProof{}, fmt.Errorf("decode active runtime marker: %w", err)
+	}
+	if active.SchemaVersion != runtimeSchemaVersion || active.Status != "active" || active.RuntimeID != handle.ID || active.ConfigFingerprint != handle.ConfigFingerprint || active.Candidate != handle.Candidate {
+		return ShutdownProof{}, errors.New("active runtime marker does not match this process")
+	}
+	wireData, err := json.Marshal(report)
+	if err != nil {
+		return ShutdownProof{}, fmt.Errorf("encode shutdown report: %w", err)
+	}
+	var wire shutdownReportWire
+	if err := json.Unmarshal(wireData, &wire); err != nil {
+		return ShutdownProof{}, fmt.Errorf("decode shutdown report: %w", err)
+	}
+	if err := validateShutdownSteps(wire.Steps); err != nil {
+		return ShutdownProof{}, err
+	}
+	if wire.StartedAt.IsZero() || wire.CompletedAt.Before(wire.StartedAt) {
+		return ShutdownProof{}, errors.New("shutdown report has invalid timestamps")
+	}
+	proof := ShutdownProof{
+		SchemaVersion:     runtimeSchemaVersion,
+		Status:            "success",
+		RuntimeID:         handle.ID,
+		ConfigFingerprint: handle.ConfigFingerprint,
+		Candidate:         handle.Candidate,
+		StartedAt:         wire.StartedAt.UTC(),
+		CompletedAt:       wire.CompletedAt.UTC(),
+		Steps:             wire.Steps,
+	}
+	if err := writeJSONAtomic(filepath.Join(dataDir, shutdownMarkerName), proof, 0o600); err != nil {
+		return ShutdownProof{}, fmt.Errorf("write shutdown proof: %w", err)
+	}
+	if err := os.Remove(activePath); err != nil {
+		return ShutdownProof{}, fmt.Errorf("remove active runtime marker: %w", err)
+	}
+	if err := syncDir(dataDir); err != nil {
+		return ShutdownProof{}, fmt.Errorf("sync shutdown proof directory: %w", err)
+	}
+	return proof, nil
+}
+
+func loadShutdownProof(cfg Config, candidate Candidate) (ShutdownProof, error) {
+	dataDir, err := resolved(cfg.DataDiskPath)
+	if err != nil {
+		return ShutdownProof{}, err
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, activeMarkerName)); err == nil {
+		return ShutdownProof{}, errors.New("backup refused: an OtelContext runtime is active or did not complete a clean shutdown")
+	} else if !os.IsNotExist(err) {
+		return ShutdownProof{}, fmt.Errorf("inspect active runtime marker: %w", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dataDir, shutdownMarkerName)) // #nosec G304 -- fixed marker under resolved data directory.
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ShutdownProof{}, errors.New("backup refused: no successful shutdown proof exists; start this binary and stop it cleanly first")
+		}
+		return ShutdownProof{}, err
+	}
+	var proof ShutdownProof
+	if err := json.Unmarshal(data, &proof); err != nil {
+		return ShutdownProof{}, fmt.Errorf("decode shutdown proof: %w", err)
+	}
+	wantFingerprint, err := runtimeFingerprint(cfg)
+	if err != nil {
+		return ShutdownProof{}, err
+	}
+	if proof.SchemaVersion != runtimeSchemaVersion || proof.Status != "success" || proof.ConfigFingerprint != wantFingerprint {
+		return ShutdownProof{}, errors.New("backup refused: shutdown proof does not match the configured durable owners")
+	}
+	if proof.Candidate != candidate {
+		return ShutdownProof{}, errors.New("backup refused: shutdown proof was produced by a different candidate binary")
+	}
+	if err := validateShutdownSteps(proof.Steps); err != nil {
+		return ShutdownProof{}, fmt.Errorf("backup refused: %w", err)
+	}
+	if proof.StartedAt.IsZero() || proof.CompletedAt.Before(proof.StartedAt) || proof.CompletedAt.After(time.Now().UTC().Add(time.Minute)) {
+		return ShutdownProof{}, errors.New("backup refused: shutdown proof timestamps are invalid")
+	}
+	return proof, nil
+}
+
+func validateShutdownSteps(steps []ShutdownStep) error {
+	if len(steps) != len(shutdownOwners) {
+		return fmt.Errorf("shutdown proof completed %d owners, want %d", len(steps), len(shutdownOwners))
+	}
+	for index, want := range shutdownOwners {
+		step := steps[index]
+		if step.Name != want {
+			return fmt.Errorf("shutdown owner %d is %q, want %q", index, step.Name, want)
+		}
+		if step.Error != "" {
+			return fmt.Errorf("shutdown owner %s failed: %s", step.Name, step.Error)
+		}
+		if step.StartedAt.IsZero() || step.CompletedAt.Before(step.StartedAt) {
+			return fmt.Errorf("shutdown owner %s has invalid timestamps", step.Name)
+		}
+	}
+	return nil
+}
+
+func normalizeDriver(driver string) string {
+	switch strings.ToLower(strings.TrimSpace(driver)) {
+	case "", "sqlite":
+		return "sqlite"
+	case "postgresql", "postgres":
+		return "postgres"
+	case "sqlserver", "mssql":
+		return "mssql"
+	case "mysql":
+		return "mysql"
+	default:
+		return strings.ToLower(strings.TrimSpace(driver))
+	}
+}

--- a/internal/backup/types.go
+++ b/internal/backup/types.go
@@ -1,0 +1,244 @@
+// Package backup owns OtelContext's offline, manifest-bound backup bundle.
+package backup
+
+import (
+	"context"
+	"io"
+	"time"
+)
+
+const (
+	// SchemaVersion is the only bundle schema this binary writes.
+	SchemaVersion = "otelcontext.backup/v1"
+	manifestName  = "manifest.json"
+
+	roleMain      = "main-database"
+	roleAggregate = "aggregate-database"
+	roleDLQ       = "dlq"
+	roleTLSCert   = "tls-certificate"
+	roleTLSKey    = "tls-private-key"
+)
+
+// Config is the mode-critical and durable-owner subset of application config.
+// It intentionally contains no API keys or other credentials beyond the main
+// database DSN required by native database clients at execution time. The DSN
+// is never serialized into a bundle or command log.
+type Config struct {
+	DBDriver               string
+	DBDSN                  string
+	DBPostgresPartitioning string
+	AggregateMode          string
+	AggregateDBPath        string
+	DLQPath                string
+	DataDiskPath           string
+	TLSCertFile            string
+	TLSKeyFile             string
+	TLSAutoSelfSigned      bool
+	TLSCacheDir            string
+}
+
+// Candidate identifies the exact executable which created or restored a
+// bundle. Commit can be "unknown" for an unstamped local build; the binary
+// digest remains authoritative.
+type Candidate struct {
+	Version      string `json:"version"`
+	Commit       string `json:"commit"`
+	BinarySHA256 string `json:"binary_sha256"`
+}
+
+// ShutdownStep is one completed owner in the successful quiescence proof.
+type ShutdownStep struct {
+	Name        string    `json:"name"`
+	StartedAt   time.Time `json:"started_at"`
+	CompletedAt time.Time `json:"completed_at"`
+	Error       string    `json:"error,omitempty"`
+}
+
+// ShutdownProof is written only after the service has stopped all durable
+// owners and closed both databases.
+type ShutdownProof struct {
+	SchemaVersion     string         `json:"schema_version"`
+	Status            string         `json:"status"`
+	RuntimeID         string         `json:"runtime_id"`
+	ConfigFingerprint string         `json:"config_fingerprint"`
+	Candidate         Candidate      `json:"candidate"`
+	StartedAt         time.Time      `json:"started_at"`
+	CompletedAt       time.Time      `json:"completed_at"`
+	Steps             []ShutdownStep `json:"steps"`
+}
+
+// Artifact binds one bundle-relative regular file to its role and digest.
+type Artifact struct {
+	Role   string `json:"role"`
+	Path   string `json:"path"`
+	Size   int64  `json:"size"`
+	SHA256 string `json:"sha256"`
+}
+
+// AppliedMigration records the ordered ledger without timestamps, which are
+// not compatibility inputs.
+type AppliedMigration struct {
+	Version  int    `json:"version"`
+	Name     string `json:"name"`
+	Checksum string `json:"checksum"`
+}
+
+// MainOwner is the captured relational durability domain.
+type MainOwner struct {
+	Adapter              string             `json:"adapter"`
+	EngineVersion        string             `json:"engine_version"`
+	SourceIdentity       string             `json:"source_identity"`
+	MigrationState       string             `json:"migration_state"`
+	MigrationVersion     int                `json:"migration_version"`
+	ExpectedMigration    int                `json:"expected_migration_version"`
+	MigrationFingerprint string             `json:"migration_fingerprint"`
+	AppliedMigrations    []AppliedMigration `json:"applied_migrations,omitempty"`
+	LifecycleFingerprint string             `json:"lifecycle_fingerprint"`
+	ArtifactPath         string             `json:"artifact_path"`
+	Integrity            string             `json:"integrity"`
+}
+
+// AggregateOwner binds the separate aggregate SQLite durability domain.
+type AggregateOwner struct {
+	SourceIdentity       string `json:"source_identity"`
+	StoreUUID            string `json:"store_uuid"`
+	SchemaVersion        int    `json:"schema_version"`
+	SeriesKeyVersion     int    `json:"series_key_version"`
+	SketchCodecVersion   int    `json:"sketch_codec_version"`
+	DictHighWatermark    uint64 `json:"dict_id_high_watermark"`
+	SeriesHighWatermark  uint64 `json:"series_id_high_watermark"`
+	LifecycleFingerprint string `json:"lifecycle_fingerprint"`
+	ArtifactPath         string `json:"artifact_path"`
+	Integrity            string `json:"integrity"`
+}
+
+// DLQOwner records the stopped dead-letter queue inventory.
+type DLQOwner struct {
+	SourceIdentity string `json:"source_identity"`
+	Count          int    `json:"count"`
+	Bytes          int64  `json:"bytes"`
+}
+
+// TLSOwner records the generated self-signed identity only. Explicit
+// operator-owned TLS files are never copied into a bundle.
+type TLSOwner struct {
+	SourceIdentity string `json:"source_identity"`
+	Certificate    string `json:"certificate"`
+	PrivateKey     string `json:"private_key"`
+}
+
+// CommandRecord is a secret-free execution record for a native adapter.
+type CommandRecord struct {
+	Step       string `json:"step"`
+	Command    string `json:"command"`
+	DurationMS int64  `json:"duration_ms"`
+	ExitCode   int    `json:"exit_code"`
+	Output     string `json:"output,omitempty"`
+}
+
+// Timings are measured durations, not RPO or RTO promises.
+type Timings struct {
+	QuiesceSeconds float64 `json:"quiesce_seconds"`
+	CaptureSeconds float64 `json:"capture_seconds"`
+}
+
+// Manifest is written last, after every captured artifact is closed, synced,
+// inspected, and hashed.
+type Manifest struct {
+	SchemaVersion        string          `json:"schema_version"`
+	BackupID             string          `json:"backup_id"`
+	CreatedAt            time.Time       `json:"created_at"`
+	Candidate            Candidate       `json:"candidate"`
+	Mode                 string          `json:"mode"`
+	ConfigFingerprint    string          `json:"config_fingerprint"`
+	Shutdown             ShutdownProof   `json:"shutdown"`
+	Main                 MainOwner       `json:"main"`
+	Aggregate            *AggregateOwner `json:"aggregate,omitempty"`
+	DLQ                  DLQOwner        `json:"dlq"`
+	TLS                  *TLSOwner       `json:"tls,omitempty"`
+	LifecycleFingerprint string          `json:"lifecycle_fingerprint"`
+	Artifacts            []Artifact      `json:"artifacts"`
+	Commands             []CommandRecord `json:"commands,omitempty"`
+	Timings              Timings         `json:"timings"`
+}
+
+// CreateOptions supplies the explicit destination and test seams.
+type CreateOptions struct {
+	OutputDirectory string
+	Candidate       Candidate
+	Runner          CommandRunner
+	Now             func() time.Time
+}
+
+// RestoreOptions supplies the immutable bundle and native command runner.
+type RestoreOptions struct {
+	BundleDirectory string
+	Candidate       Candidate
+	Runner          CommandRunner
+	Now             func() time.Time
+}
+
+// CreateReport is printed by the one-shot create command.
+type CreateReport struct {
+	SchemaVersion  string  `json:"schema_version"`
+	Status         string  `json:"status"`
+	Bundle         string  `json:"bundle"`
+	BackupID       string  `json:"backup_id"`
+	ManifestSHA256 string  `json:"manifest_sha256"`
+	CaptureSeconds float64 `json:"capture_seconds"`
+	QuiesceSeconds float64 `json:"quiesce_seconds"`
+}
+
+// RestoreReport is printed after a fresh target has been populated and
+// inspected. ReadySeconds is filled by the process-level restore drill, not
+// guessed by the storage command.
+type RestoreReport struct {
+	SchemaVersion        string          `json:"schema_version"`
+	Status               string          `json:"status"`
+	Bundle               string          `json:"bundle"`
+	BackupID             string          `json:"backup_id"`
+	RestoreCandidate     Candidate       `json:"restore_candidate"`
+	BackupAgeSeconds     float64         `json:"backup_age_at_restore_seconds"`
+	RestoreSeconds       float64         `json:"restore_seconds"`
+	ReadySeconds         *float64        `json:"ready_seconds,omitempty"`
+	LifecycleFingerprint string          `json:"lifecycle_fingerprint"`
+	Commands             []CommandRecord `json:"commands,omitempty"`
+}
+
+// Command describes one native client invocation. Display must contain no
+// secret; Redactions are removed from captured errors before they leave this
+// package.
+type Command struct {
+	Name       string
+	Args       []string
+	Env        []string
+	StdinPath  string
+	StdoutPath string
+	Display    string
+	Redactions []string
+}
+
+// CommandResult is the bounded observable result of a native command.
+type CommandResult struct {
+	Output   string
+	ExitCode int
+	Duration time.Duration
+}
+
+// CommandRunner executes pinned native database clients.
+type CommandRunner interface {
+	Run(context.Context, Command) (CommandResult, error)
+}
+
+// RuntimeHandle binds the active marker to the process that wrote it.
+type RuntimeHandle struct {
+	ID                string
+	ConfigFingerprint string
+	Candidate         Candidate
+	StartedAt         time.Time
+}
+
+// outputWriter is the subset used by command tests and the CLI adapter.
+type outputWriter interface {
+	io.Writer
+}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/RandomCodeSpace/otelcontext/internal/ai"
 	"github.com/RandomCodeSpace/otelcontext/internal/api"
 	"github.com/RandomCodeSpace/otelcontext/internal/authn"
+	"github.com/RandomCodeSpace/otelcontext/internal/backup"
 	"github.com/RandomCodeSpace/otelcontext/internal/config"
 	"github.com/RandomCodeSpace/otelcontext/internal/graph"
 	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
@@ -119,6 +120,9 @@ func fatal(msg string, err error, kv ...any) {
 }
 
 func main() {
+	if handled, code := maybeRunBackupCommand(os.Args[1:], os.Stdout, os.Stderr); handled {
+		os.Exit(code)
+	}
 	if handled, code := maybeRunMigrationCommand(os.Args[1:], os.Stdout, os.Stderr); handled {
 		os.Exit(code)
 	}
@@ -158,6 +162,14 @@ func main() {
 	cfg.GuardSelfInstrumentation()
 	if err := cfg.ValidateDBForEnv(); err != nil {
 		fatal("DB/Env validation", err)
+	}
+	runtimeCandidate, err := backup.CurrentCandidate(Version)
+	if err != nil {
+		fatal("identify runtime candidate", err)
+	}
+	runtimeHandle, err := backup.BeginRuntime(backupConfig(cfg), runtimeCandidate, time.Now())
+	if err != nil {
+		fatal("write active runtime marker", err)
 	}
 	// Authenticated tenant identity (#194 blockers 7 + 8). Loaded once, at
 	// startup: swapping the key file is an explicit restart, never a live
@@ -1585,6 +1597,9 @@ func main() {
 			"version", Version,
 			"proof", string(proof),
 		)
+	}
+	if _, err := backup.CompleteRuntime(backupConfig(cfg), runtimeHandle, report); err != nil {
+		fatal("shutdown proof persistence failed", err)
 	}
 
 	slog.Info("shutdown_complete",

--- a/test/browser/browser_test.go
+++ b/test/browser/browser_test.go
@@ -128,6 +128,8 @@ func (a *appProcess) environment() []string {
 		"AUTH_TRUST_EXTERNAL":             "false",
 		"DB_DRIVER":                       "sqlite",
 		"DB_DSN":                          filepath.Join(a.dir, "otelcontext.db"),
+		"DATA_DISK_BUDGET_MB":             "1000000",
+		"DATA_DISK_PATH":                  a.dir,
 		"DLQ_PATH":                        filepath.Join(a.dir, "dlq"),
 		"GRPC_PORT":                       strconv.Itoa(a.grpcPort),
 		"HTTP_PORT":                       strconv.Itoa(a.httpPort),

--- a/test/shutdownproof/backup_restore_proof_test.go
+++ b/test/shutdownproof/backup_restore_proof_test.go
@@ -1,0 +1,486 @@
+//go:build shutdownproof && !windows
+
+package shutdownproof_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/backup"
+	"github.com/coder/websocket"
+)
+
+type oneShotResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+	Duration time.Duration
+}
+
+func runOneShot(t *testing.T, app *appProcess, args ...string) oneShotResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	command := exec.CommandContext(ctx, app.binary, args...)
+	command.Dir = app.dir
+	command.Env = app.environment()
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	started := time.Now()
+	err := command.Run()
+	result := oneShotResult{Stdout: stdout.String(), Stderr: stderr.String(), Duration: time.Since(started)}
+	if err == nil {
+		return result
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("%s timed out: %v\n%s", strings.Join(args, " "), ctx.Err(), stderr.String())
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("%s failed: %v\n%s", strings.Join(args, " "), err, stderr.String())
+	}
+	result.ExitCode = exitErr.ExitCode()
+	return result
+}
+
+func migrateExact(t *testing.T, app *appProcess) {
+	t.Helper()
+	result := runOneShot(t, app, "migrate", "up")
+	if result.ExitCode != 0 || !strings.Contains(result.Stdout, "result=ready") {
+		t.Fatalf("migrate up exit=%d stdout=%s stderr=%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+	app.autoMigrate = "false"
+}
+
+type mcpSurface struct {
+	Succeeded       bool `json:"succeeded"`
+	MentionsFixture bool `json:"mentions_fixture"`
+}
+
+type surfaceFingerprint struct {
+	REST      map[string]string     `json:"rest_sha256"`
+	MCPTools  []string              `json:"mcp_tools"`
+	MCPCalls  map[string]mcpSurface `json:"mcp_calls"`
+	WebSocket string                `json:"websocket_sha256"`
+}
+
+func collectSurfaceFingerprint(t *testing.T, app *appProcess) surfaceFingerprint {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		fingerprint, err := trySurfaceFingerprint(app)
+		if err == nil {
+			return fingerprint
+		}
+		lastErr = err
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("surface fingerprint did not stabilize: %v\n%s", lastErr, app.log.String())
+	return surfaceFingerprint{}
+}
+
+func trySurfaceFingerprint(app *appProcess) (surfaceFingerprint, error) {
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", app.httpPort)
+	fingerprint := surfaceFingerprint{
+		REST:     make(map[string]string),
+		MCPCalls: make(map[string]mcpSurface),
+	}
+	for _, path := range []string{"/api/traces?limit=50", "/api/logs?limit=50", "/api/metadata/services"} {
+		body, err := getBody(baseURL + path)
+		if err != nil {
+			return surfaceFingerprint{}, err
+		}
+		if (strings.Contains(path, "traces") || strings.Contains(path, "logs")) && !strings.Contains(string(body), "shutdown-proof") && !strings.Contains(string(body), traceFixtureID) && !strings.Contains(string(body), logFixtureBody) {
+			return surfaceFingerprint{}, fmt.Errorf("REST %s does not contain the fixture", path)
+		}
+		canonical, err := canonicalJSON(body)
+		if err != nil {
+			return surfaceFingerprint{}, fmt.Errorf("canonicalize REST %s: %w", path, err)
+		}
+		fingerprint.REST[path] = digestBytes(canonical)
+	}
+	tools, err := listMCPTools(baseURL + "/mcp")
+	if err != nil {
+		return surfaceFingerprint{}, err
+	}
+	fingerprint.MCPTools = tools
+	if len(tools) != 7 {
+		return surfaceFingerprint{}, fmt.Errorf("MCP tools=%v, want seven", tools)
+	}
+	calls := []struct {
+		name string
+		args map[string]any
+	}{
+		{"get_anomaly_timeline", nil},
+		{"get_service_map", nil},
+		{"get_service_health", map[string]any{"service_name": "shutdown-proof"}},
+		{"root_cause_analysis", map[string]any{"service": "shutdown-proof"}},
+		{"impact_analysis", map[string]any{"service": "shutdown-proof"}},
+		{"trace_graph", map[string]any{"trace_id": traceFixtureID}},
+		{"search_logs", map[string]any{"service": "shutdown-proof", "query": "payment failed"}},
+	}
+	for _, call := range calls {
+		text, succeeded, err := callMCPTool(baseURL+"/mcp", call.name, call.args)
+		if err != nil {
+			return surfaceFingerprint{}, err
+		}
+		if !succeeded {
+			return surfaceFingerprint{}, fmt.Errorf("MCP tool %s returned an error: %s", call.name, text)
+		}
+		fingerprint.MCPCalls[call.name] = mcpSurface{
+			Succeeded:       true,
+			MentionsFixture: strings.Contains(text, "shutdown-proof") || strings.Contains(text, traceFixtureID) || strings.Contains(text, logFixtureBody),
+		}
+	}
+	webSocketBody, err := readWebSocketSnapshot(baseURL + "/ws/events")
+	if err != nil {
+		return surfaceFingerprint{}, err
+	}
+	if !strings.Contains(string(webSocketBody), "shutdown-proof") && !strings.Contains(string(webSocketBody), traceFixtureID) {
+		return surfaceFingerprint{}, errors.New("WebSocket snapshot does not contain the fixture")
+	}
+	canonical, err := canonicalJSON(webSocketBody)
+	if err != nil {
+		return surfaceFingerprint{}, err
+	}
+	fingerprint.WebSocket = digestBytes(canonical)
+	return fingerprint, nil
+}
+
+func getBody(url string) ([]byte, error) {
+	client := &http.Client{Timeout: 3 * time.Second, Transport: &http.Transport{Proxy: nil}}
+	response, err := client.Get(url) //nolint:gosec // exact loopback proof endpoint.
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, 4<<20))
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s status=%d body=%s", url, response.StatusCode, body)
+	}
+	return body, nil
+}
+
+func listMCPTools(endpoint string) ([]string, error) {
+	body, err := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+	if err != nil {
+		return nil, err
+	}
+	response, err := http.Post(endpoint, "application/json", bytes.NewReader(body)) //nolint:gosec // exact loopback proof endpoint.
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	var envelope struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+		Error any `json:"error"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&envelope); err != nil {
+		return nil, err
+	}
+	if envelope.Error != nil {
+		return nil, fmt.Errorf("tools/list error: %v", envelope.Error)
+	}
+	names := make([]string, 0, len(envelope.Result.Tools))
+	for _, tool := range envelope.Result.Tools {
+		names = append(names, tool.Name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func callMCPTool(endpoint, name string, arguments map[string]any) (string, bool, error) {
+	if arguments == nil {
+		arguments = map[string]any{}
+	}
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": name, "arguments": arguments},
+	})
+	if err != nil {
+		return "", false, err
+	}
+	response, err := http.Post(endpoint, "application/json", bytes.NewReader(body)) //nolint:gosec // exact loopback proof endpoint.
+	if err != nil {
+		return "", false, err
+	}
+	defer response.Body.Close()
+	var envelope struct {
+		Result struct {
+			IsError bool `json:"isError"`
+			Content []struct {
+				Text     string `json:"text"`
+				Resource *struct {
+					Text string `json:"text"`
+				} `json:"resource,omitempty"`
+			} `json:"content"`
+		} `json:"result"`
+		Error any `json:"error"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&envelope); err != nil {
+		return "", false, err
+	}
+	if envelope.Error != nil {
+		return fmt.Sprint(envelope.Error), false, nil
+	}
+	var text strings.Builder
+	for _, content := range envelope.Result.Content {
+		text.WriteString(content.Text)
+		if content.Resource != nil {
+			text.WriteString(content.Resource.Text)
+		}
+	}
+	return text.String(), !envelope.Result.IsError && text.Len() > 0, nil
+}
+
+func readWebSocketSnapshot(httpURL string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	connection, response, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(httpURL, "http"), nil)
+	if response != nil && response.Body != nil {
+		_ = response.Body.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer connection.Close(websocket.StatusNormalClosure, "backup proof complete")
+	_, body, err := connection.Read(ctx)
+	return body, err
+}
+
+func canonicalJSON(data []byte) ([]byte, error) {
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return nil, err
+	}
+	removeVolatile(value)
+	return json.Marshal(value)
+}
+
+func removeVolatile(value any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		delete(typed, "epoch")
+		delete(typed, "revision")
+		delete(typed, "reset")
+		for _, child := range typed {
+			removeVolatile(child)
+		}
+	case []any:
+		for _, child := range typed {
+			removeVolatile(child)
+		}
+	}
+}
+
+func digestBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+type backupProofArtifact struct {
+	SchemaVersion     string               `json:"schema_version"`
+	Mode              string               `json:"mode"`
+	CandidateSHA      string               `json:"candidate_sha,omitempty"`
+	BinarySHA256      string               `json:"binary_sha256"`
+	ManifestSHA256    string               `json:"manifest_sha256"`
+	BackupID          string               `json:"backup_id"`
+	Create            backup.CreateReport  `json:"create"`
+	Restore           backup.RestoreReport `json:"restore"`
+	SourceFingerprint fingerprint          `json:"source_fingerprint"`
+	TargetFingerprint fingerprint          `json:"target_fingerprint"`
+	SourceSurfaces    surfaceFingerprint   `json:"source_surfaces"`
+	TargetSurfaces    surfaceFingerprint   `json:"target_surfaces"`
+	DLQBefore         map[string]string    `json:"dlq_before"`
+	DLQAfter          map[string]string    `json:"dlq_after"`
+	Assertions        []assertion          `json:"assertions"`
+}
+
+func TestBackupRestoreModeProof(t *testing.T) {
+	binary := os.Getenv("OTELCONTEXT_SHUTDOWN_BINARY")
+	mode := os.Getenv("OTELCONTEXT_BACKUP_PROOF_MODE")
+	if binary == "" {
+		t.Fatal("OTELCONTEXT_SHUTDOWN_BINARY is required")
+	}
+	if mode != "legacy" && mode != "aggregate-shadow" && mode != "aggregate" {
+		t.Fatalf("unsupported proof mode %q", mode)
+	}
+	source := newAppProcess(t, binary, mode)
+	t.Cleanup(func() {
+		if source.cmd != nil {
+			_, _ = source.stop()
+		}
+	})
+	migrateExact(t, source)
+	dlqBefore := seedDLQ(t, source.dlqPath)
+	if err := source.start(); err != nil {
+		t.Fatal(err)
+	}
+	readyCtx, cancelReady := context.WithTimeout(context.Background(), 20*time.Second)
+	if err := source.waitReady(readyCtx); err != nil {
+		cancelReady()
+		t.Fatalf("source readiness: %v\n%s", err, source.log.String())
+	}
+	cancelReady()
+	exportCtx, cancelExport := context.WithTimeout(context.Background(), 10*time.Second)
+	if err := sendFixtures(exportCtx, source.grpcPort); err != nil {
+		cancelExport()
+		t.Fatal(err)
+	}
+	cancelExport()
+	if exit, err := source.stop(); err != nil || exit != 0 {
+		t.Fatalf("source first shutdown exit=%d err=%v\n%s", exit, err, source.log.String())
+	}
+	if err := source.start(); err != nil {
+		t.Fatal(err)
+	}
+	recoveryCtx, cancelRecovery := context.WithTimeout(context.Background(), 20*time.Second)
+	if err := source.waitReady(recoveryCtx); err != nil {
+		cancelRecovery()
+		t.Fatalf("source recovery readiness: %v\n%s", err, source.log.String())
+	}
+	cancelRecovery()
+	sourceSurfaces := collectSurfaceFingerprint(t, source)
+	if exit, err := source.stop(); err != nil || exit != 0 {
+		t.Fatalf("source proof shutdown exit=%d err=%v\n%s", exit, err, source.log.String())
+	}
+	sourceFingerprint := readFingerprint(t, source)
+
+	backupParent := t.TempDir()
+	createCommand := runOneShot(t, source, "backup", "create", "--out", backupParent)
+	if createCommand.ExitCode != 0 {
+		t.Fatalf("backup create exit=%d stdout=%s stderr=%s", createCommand.ExitCode, createCommand.Stdout, createCommand.Stderr)
+	}
+	var createReport backup.CreateReport
+	if err := json.Unmarshal([]byte(createCommand.Stdout), &createReport); err != nil {
+		t.Fatalf("decode create report: %v (%s)", err, createCommand.Stdout)
+	}
+	manifestPath := filepath.Join(createReport.Bundle, "manifest.json")
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest backup.Manifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		t.Fatal(err)
+	}
+
+	target := newAppProcess(t, binary, mode)
+	t.Cleanup(func() {
+		if target.cmd != nil {
+			_, _ = target.stop()
+		}
+	})
+	target.autoMigrate = "false"
+	restoreCommand := runOneShot(t, target, "backup", "restore", "--bundle", createReport.Bundle)
+	if restoreCommand.ExitCode != 0 {
+		t.Fatalf("backup restore exit=%d stdout=%s stderr=%s", restoreCommand.ExitCode, restoreCommand.Stdout, restoreCommand.Stderr)
+	}
+	var restoreReport backup.RestoreReport
+	if err := json.Unmarshal([]byte(restoreCommand.Stdout), &restoreReport); err != nil {
+		t.Fatalf("decode restore report: %v (%s)", err, restoreCommand.Stdout)
+	}
+	if restoreReport.ReadySeconds == nil || *restoreReport.ReadySeconds <= 0 {
+		t.Fatalf("restore did not report measured readiness: %#v", restoreReport)
+	}
+	if err := target.start(); err != nil {
+		t.Fatal(err)
+	}
+	targetReadyCtx, cancelTargetReady := context.WithTimeout(context.Background(), 20*time.Second)
+	if err := target.waitReady(targetReadyCtx); err != nil {
+		cancelTargetReady()
+		t.Fatalf("target readiness: %v\n%s", err, target.log.String())
+	}
+	cancelTargetReady()
+	targetSurfaces := collectSurfaceFingerprint(t, target)
+	if exit, err := target.stop(); err != nil || exit != 0 {
+		t.Fatalf("target shutdown exit=%d err=%v\n%s", exit, err, target.log.String())
+	}
+	targetFingerprint := readFingerprint(t, target)
+	dlqAfter := fileInventory(t, target.dlqPath)
+
+	mainEqual := reflect.DeepEqual(sourceFingerprint, targetFingerprint)
+	dlqEqual := reflect.DeepEqual(dlqBefore, dlqAfter)
+	surfacesEqual := reflect.DeepEqual(sourceSurfaces, targetSurfaces)
+	artifact := backupProofArtifact{
+		SchemaVersion:     "otelcontext.backup-proof.v1",
+		Mode:              mode,
+		CandidateSHA:      os.Getenv("GITHUB_SHA"),
+		BinarySHA256:      sha256File(t, binary),
+		ManifestSHA256:    digestBytes(manifestData),
+		BackupID:          manifest.BackupID,
+		Create:            createReport,
+		Restore:           restoreReport,
+		SourceFingerprint: sourceFingerprint,
+		TargetFingerprint: targetFingerprint,
+		SourceSurfaces:    sourceSurfaces,
+		TargetSurfaces:    targetSurfaces,
+		DLQBefore:         dlqBefore,
+		DLQAfter:          dlqAfter,
+		Assertions: []assertion{
+			{Name: "manifest_schema_v1", Passed: manifest.SchemaVersion == backup.SchemaVersion},
+			{Name: "candidate_binary_bound", Passed: manifest.Candidate.BinarySHA256 == sha256File(t, binary)},
+			{Name: "mode_inventory_matches", Passed: manifest.Mode == mode && (mode == "legacy") == (manifest.Aggregate == nil)},
+			{Name: "clean_shutdown_bound", Passed: manifest.Shutdown.Status == "success" && len(manifest.Shutdown.Steps) == len(requiredOwners)},
+			{Name: "create_published", Passed: createReport.Status == "created" && !strings.HasSuffix(createReport.Bundle, ".partial")},
+			{Name: "fresh_restore_completed", Passed: restoreReport.Status == "restored"},
+			{Name: "readiness_measured", Passed: restoreReport.ReadySeconds != nil && *restoreReport.ReadySeconds > 0},
+			{Name: "main_and_mode_owned_state_equal", Passed: mainEqual},
+			{Name: "dlq_inventory_equal", Passed: dlqEqual},
+			{Name: "rest_surfaces_equal", Passed: reflect.DeepEqual(sourceSurfaces.REST, targetSurfaces.REST)},
+			{Name: "seven_mcp_tools_callable", Passed: len(targetSurfaces.MCPTools) == 7 && len(targetSurfaces.MCPCalls) == 7},
+			{Name: "websocket_surface_equal", Passed: sourceSurfaces.WebSocket == targetSurfaces.WebSocket},
+			{Name: "all_surfaces_equal", Passed: surfacesEqual},
+			{Name: "lifecycle_fingerprint_equal", Passed: createReport.BackupID == restoreReport.BackupID && restoreReport.LifecycleFingerprint == manifest.LifecycleFingerprint},
+		},
+	}
+	for _, check := range artifact.Assertions {
+		if !check.Passed {
+			t.Fatalf("backup proof assertion failed: %s\nsource=%#v\ntarget=%#v", check.Name, sourceSurfaces, targetSurfaces)
+		}
+	}
+	proofDir := os.Getenv("OTELCONTEXT_BACKUP_PROOF_DIR")
+	if proofDir != "" {
+		if err := os.MkdirAll(proofDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		data, err := json.MarshalIndent(artifact, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(proofDir, mode+".json"), append(data, '\n'), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(proofDir, mode+"-manifest.json"), manifestData, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		logs := "create stderr:\n" + createCommand.Stderr + "\nrestore stderr:\n" + restoreCommand.Stderr + "\nsource:\n" + source.log.String() + "\ntarget:\n" + target.log.String()
+		if err := os.WriteFile(filepath.Join(proofDir, mode+".log"), []byte(logs), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/test/shutdownproof/shutdown_proof_test.go
+++ b/test/shutdownproof/shutdown_proof_test.go
@@ -86,6 +86,7 @@ type appProcess struct {
 	mainDBPath    string
 	aggregatePath string
 	dlqPath       string
+	autoMigrate   string
 }
 
 func newAppProcess(t *testing.T, binary, mode string) *appProcess {
@@ -101,6 +102,7 @@ func newAppProcess(t *testing.T, binary, mode string) *appProcess {
 		mainDBPath:    filepath.Join(dir, "otelcontext.db"),
 		aggregatePath: filepath.Join(dir, "aggregate.db"),
 		dlqPath:       filepath.Join(dir, "dlq"),
+		autoMigrate:   "true",
 	}
 }
 
@@ -127,7 +129,7 @@ func (a *appProcess) environment() []string {
 		"APP_ENV":                    "development",
 		"DATA_DISK_BUDGET_MB":        "1000000",
 		"DATA_DISK_PATH":             a.dir,
-		"DB_AUTOMIGRATE":             "true",
+		"DB_AUTOMIGRATE":             a.autoMigrate,
 		"DB_DRIVER":                  "sqlite",
 		"DB_DSN":                     a.mainDBPath,
 		"DLQ_PATH":                   a.dlqPath,


### PR DESCRIPTION
## Summary
- add offline manifest-bound backup create and fresh-target restore commands for all three telemetry modes
- capture SQLite, PostgreSQL 16, MySQL 8.4, and SQL Server 2022 with native integrity and lifecycle checks
- bind clean shutdown, candidate, mode, migrations, aggregate state, DLQ, generated TLS, hashes, and measured timings
- prove REST, all seven MCP tools, WebSocket, DLQ, and durable fingerprints after restored readiness
- replace manual backup notes with the supported operator runbook

## Local verification
- go test -race -count=1 ./internal/backup ./internal/storage ./internal/aggregate ./internal/queue
- go test -count=1 .
- go build -trimpath .
- go vet ./internal/backup .
- actionlint .github/workflows/ci.yml
- real-process backup/restore proof: legacy, aggregate-shadow, aggregate
- compile-only hosted tags: shutdownproof and integration

The full PostgreSQL, MySQL, and SQL Server restore matrix is intentionally delegated to GitHub CI.

Closes #248