### PR TITLE
feat: make latency claims explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,14 @@ jobs:
           BROWSER_SMOKE_ARTIFACTS: ${{ runner.temp }}/browser-smoke/artifacts
         run: go test -tags=browser -count=1 -timeout 150s -run '^TestProtectedBrowserWorkflow$' ./test/browser
 
+      - name: verify latency wording in the embedded client
+        env:
+          OTELCONTEXT_BINARY: ${{ runner.temp }}/browser-smoke/otelcontext
+          OTELCONTEXT_BROWSER_CASE: latency
+          CHROME_BIN: google-chrome
+          BROWSER_SMOKE_ARTIFACTS: ${{ runner.temp }}/browser-smoke/artifacts
+        run: go test -tags=browser -count=1 -timeout 150s -run '^TestLatencyLabels$' ./test/browser
+
       - name: upload browser diagnostics
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
@@ -123,6 +131,53 @@ jobs:
         with:
           name: topology-proof-${{ matrix.mode }}-${{ github.sha }}
           path: ${{ runner.temp }}/topology-proof
+          if-no-files-found: error
+          retention-days: 14
+
+  latency-proof:
+    name: latency proof · ${{ matrix.mode }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [legacy, aggregate-shadow, aggregate]
+    env:
+      CGO_ENABLED: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: run contradictory-distribution latency proof
+        env:
+          OTELCONTEXT_LATENCY_PROOF_MODE: ${{ matrix.mode }}
+          OTELCONTEXT_LATENCY_PROOF_DIR: ${{ runner.temp }}/latency-proof
+        run: |
+          set -o pipefail
+          mkdir -p "${OTELCONTEXT_LATENCY_PROOF_DIR}"
+          go test -race -count=1 -v -run '^TestLatencyModeProof$' ./test/topologyproof 2>&1 \
+            | tee "${OTELCONTEXT_LATENCY_PROOF_DIR}/${OTELCONTEXT_LATENCY_PROOF_MODE}.log"
+          jq -e --arg mode "${OTELCONTEXT_LATENCY_PROOF_MODE}" '
+            .schema_version == "otelcontext.latency-contract.v1" and
+            .mode == $mode and
+            .sentinel.population == 1000 and
+            .sentinel.nearest_rank_p99_ms == 1000 and
+            .websocket_dashboard.unit == "microseconds" and
+            (.ui_labels | length) == 7 and
+            (.assertions | length) >= 11 and
+            all(.assertions[]; .passed == true)
+          ' "${OTELCONTEXT_LATENCY_PROOF_DIR}/${OTELCONTEXT_LATENCY_PROOF_MODE}.json"
+
+      - name: upload mode latency proof
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: latency-contract-${{ matrix.mode }}-${{ github.sha }}
+          path: ${{ runner.temp }}/latency-proof
           if-no-files-found: error
           retention-days: 14
 

--- a/internal/aggregate/latency_provenance_test.go
+++ b/internal/aggregate/latency_provenance_test.go
@@ -1,0 +1,34 @@
+package aggregate
+
+import (
+	"math"
+	"testing"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
+)
+
+func TestSketchLatencyProvenanceStates(t *testing.T) {
+	if got := percentileProvenanceFromSketch(nil); got.Status != latency.StatusUnavailable || got.Reason != latency.ReasonNoObservations {
+		t.Fatalf("nil sketch provenance = %+v", got)
+	}
+
+	sketch, err := NewSketchAtScale(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 99; i++ {
+		sketch.Observe(10)
+	}
+	got := percentileProvenanceFromSketch(sketch)
+	if got.Status != latency.StatusApproximate || got.Method != latency.MethodDDSketch || got.SampleCount != 99 || !got.LowSample || got.SketchScale != 2 || math.Abs(got.RelativeErrorBound-sketch.RelativeError()) > 1e-12 {
+		t.Fatalf("ordinary sketch provenance = %+v", got)
+	}
+
+	sketch.Observe(10)
+	sketch.collapsed = true
+	sketch.saturations = 3
+	got = percentileProvenanceFromSketch(sketch)
+	if !got.Degraded || !got.Collapsed || got.Saturations != 3 || got.Reason != latency.ReasonSketchCollapsedSaturated || got.LowSample {
+		t.Fatalf("degraded sketch provenance = %+v", got)
+	}
+}

--- a/internal/aggregate/query.go
+++ b/internal/aggregate/query.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"sort"
 	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 )
 
 // The engine's query facade (#164, #175).
@@ -146,6 +148,39 @@ func AccuracyFromSketch(s *Sketch) AccuracyMetadata {
 	}
 }
 
+func percentileProvenanceFromSketch(s *Sketch) *latency.Percentile {
+	if s == nil || s.Count() == 0 {
+		return &latency.Percentile{
+			Status: latency.StatusUnavailable,
+			Method: latency.MethodDDSketch,
+			Reason: latency.ReasonNoObservations,
+		}
+	}
+	collapsed := s.Collapsed()
+	saturations := s.Saturations()
+	reason := ""
+	switch {
+	case collapsed && saturations > 0:
+		reason = latency.ReasonSketchCollapsedSaturated
+	case collapsed:
+		reason = latency.ReasonSketchCollapsed
+	case saturations > 0:
+		reason = latency.ReasonSketchSaturated
+	}
+	return &latency.Percentile{
+		Status:             latency.StatusApproximate,
+		Method:             latency.MethodDDSketch,
+		SampleCount:        s.Count(),
+		LowSample:          s.Count() < latency.LowSampleThreshold,
+		SketchScale:        s.Scale(),
+		RelativeErrorBound: s.RelativeError(),
+		Degraded:           collapsed || saturations > 0,
+		Collapsed:          collapsed,
+		Saturations:        saturations,
+		Reason:             reason,
+	}
+}
+
 // Query bounds one read. Tenant, Start and End are mandatory; the rest narrow
 // the scan.
 type Query struct {
@@ -194,6 +229,8 @@ type ServiceStat struct {
 	ErrorCount        int64
 	ErrorRate         float64
 	AvgLatencyMs      float64
+	P99LatencyMicros  float64
+	LatencyProvenance latency.Provenance
 	RequestCount      int64
 	ErrorRequestCount int64
 }
@@ -217,15 +254,16 @@ type DashboardResult struct {
 	SpanErrorCount int64
 	SpanErrorRate  float64
 
-	TotalLogs        int64
-	AvgLatencyMs     float64
-	ActiveServices   int64
-	P99LatencyMicros float64
-	TopFailing       []ServiceStat
-	Accuracy         AccuracyMetadata
-	Coverage         Coverage
-	Epoch            string
-	Revision         uint64
+	TotalLogs         int64
+	AvgLatencyMs      float64
+	ActiveServices    int64
+	P99LatencyMicros  float64
+	LatencyProvenance latency.Provenance
+	TopFailing        []ServiceStat
+	Accuracy          AccuracyMetadata
+	Coverage          Coverage
+	Epoch             string
+	Revision          uint64
 }
 
 // TopologyEdge is one caller/callee edge of the topology.
@@ -372,7 +410,7 @@ func (e *Engine) sumStore(sel Selector, by GroupBy) ([]SumRow, error) {
 // identities just to apply a service filter. A sketch merge is commutative
 // and associative, so VisitSketches streams the rows once in table order,
 // and the filter memoizes ONE dictionary lookup per distinct service ID.
-func (e *Engine) mergeStoreSketches(sel Selector, filter map[string]struct{}, merge func(*Sketch)) error {
+func (e *Engine) visitStoreSketches(sel Selector, filter map[string]struct{}, visit func(uint32, *Sketch)) error {
 	st := e.Store()
 	if st == nil {
 		return nil
@@ -394,9 +432,13 @@ func (e *Engine) mergeStoreSketches(sel Selector, filter map[string]struct{}, me
 				return nil
 			}
 		}
-		merge(sk)
+		visit(serviceID, sk)
 		return nil
 	})
+}
+
+func (e *Engine) mergeStoreSketches(sel Selector, filter map[string]struct{}, merge func(*Sketch)) error {
+	return e.visitStoreSketches(sel, filter, func(_ uint32, sk *Sketch) { merge(sk) })
 }
 
 // serviceName resolves a series' service through the dictionary. An
@@ -544,6 +586,17 @@ type dashAccum struct {
 	errRequests uint64
 	durCount    uint64
 	durSum      float64
+	sketch      *Sketch
+}
+
+func (a *dashAccum) mergeSketch(s *Sketch) {
+	if s == nil {
+		return
+	}
+	if a.sketch == nil {
+		a.sketch = NewSketchAtScaleUnchecked(s.Scale())
+	}
+	a.sketch.Merge(s)
 }
 
 // addDelta folds one in-memory delta into the accumulator.
@@ -554,6 +607,7 @@ func (a *dashAccum) addDelta(d *AggregateDelta) {
 	a.errRequests += d.ErrorRequestCount
 	a.durCount += d.DurationCount
 	a.durSum += d.DurationSum
+	a.mergeSketch(d.Sketch)
 }
 
 // addSum folds one SQL aggregation row into the accumulator.
@@ -667,6 +721,7 @@ func (e *Engine) QueryDashboard(q Query) (*DashboardResult, error) {
 		TotalLogs:         asInt64(logs),
 		ActiveServices:    int64(len(services)),
 		Accuracy:          AccuracyFromSketch(merged),
+		LatencyProvenance: latency.Provenance{P99: percentileProvenanceFromSketch(merged)},
 		Coverage:          CoverageFull,
 		Epoch:             own.Epoch,
 		Revision:          own.Revision,
@@ -799,6 +854,14 @@ func (e *Engine) QueryTopology(q Query) (*TopologyResult, error) {
 			}
 			at(name).addSum(r)
 		}
+		if err := e.visitStoreSketches(sel, filter, func(serviceID uint32, sk *Sketch) {
+			name := e.serviceNameByID(serviceID)
+			if keep(name) {
+				at(name).mergeSketch(sk)
+			}
+		}); err != nil {
+			return nil, err
+		}
 
 		// One row per (caller, callee): the callee is the series NAME, so the
 		// edge grouping is GroupByService|GroupByName under a single-signal
@@ -832,6 +895,10 @@ func (e *Engine) QueryTopology(q Query) (*TopologyResult, error) {
 		}
 		if acc.durCount > 0 {
 			stat.AvgLatencyMs = acc.durSum / float64(acc.durCount) / 1000.0
+		}
+		stat.LatencyProvenance = latency.Provenance{P99: percentileProvenanceFromSketch(acc.sketch)}
+		if acc.sketch != nil {
+			stat.P99LatencyMicros = acc.sketch.Quantile(0.99)
 		}
 		out = append(out, stat)
 	}

--- a/internal/aggregate/query_test.go
+++ b/internal/aggregate/query_test.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 )
 
 // stubStore is a Store that serves a fixed set of store-owned rows. It exists
@@ -346,6 +348,10 @@ func TestQueryDashboardPercentileWithinReportedBound(t *testing.T) {
 	}
 	if res.Accuracy.RelativeErrorBound <= 0 {
 		t.Fatalf("RelativeErrorBound = %v, want > 0", res.Accuracy.RelativeErrorBound)
+	}
+	p99 := res.LatencyProvenance.P99
+	if p99 == nil || p99.Status != latency.StatusApproximate || p99.Method != latency.MethodDDSketch || p99.SampleCount != 1000 || p99.SketchScale != SketchDefaultScale || p99.Degraded {
+		t.Fatalf("latency provenance = %+v", p99)
 	}
 	want := 99000.0 // the 990th of 1000 values, in microseconds
 	rel := math.Abs(res.P99LatencyMicros-want) / want

--- a/internal/aggregate/topology.go
+++ b/internal/aggregate/topology.go
@@ -4,6 +4,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 )
 
 // Bounded per-tenant topology projection (#163, #174).
@@ -98,8 +100,9 @@ type TopologyWindow struct {
 	// zero when the entity carries no sketch (operations, edges and metrics
 	// deliberately do not, so a 2 KiB sketch is not multiplied by every
 	// operation of every service of every window).
-	P95Micros float64 `json:"p95_micros,omitempty"`
-	P99Micros float64 `json:"p99_micros,omitempty"`
+	P95Micros         float64             `json:"p95_micros,omitempty"`
+	P99Micros         float64             `json:"p99_micros,omitempty"`
+	LatencyProvenance *latency.Provenance `json:"latency_provenance,omitempty"`
 
 	// Value* carry metric samples: gauge samples plus counter deltas, which
 	// is what a rolling mean/variance baseline is computed over.
@@ -778,6 +781,9 @@ func renderWindows(e *topoEntry, now time.Time) []TopologyWindow {
 		if w.sketch != nil && w.sketch.Count() > 0 {
 			tw.P95Micros = w.sketch.Quantile(0.95)
 			tw.P99Micros = w.sketch.Quantile(0.99)
+			p95 := *percentileProvenanceFromSketch(w.sketch)
+			p99 := p95
+			tw.LatencyProvenance = &latency.Provenance{P95: &p95, P99: &p99}
 		}
 		out = append(out, tw)
 	}

--- a/internal/api/graph_handler.go
+++ b/internal/api/graph_handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"github.com/RandomCodeSpace/otelcontext/internal/topology"
 )
@@ -35,11 +36,12 @@ type GraphNode struct {
 
 // NodeMetrics holds per-service observability metrics.
 type NodeMetrics struct {
-	RequestRateRPS float64 `json:"request_rate_rps"`
-	ErrorRate      float64 `json:"error_rate"`
-	AvgLatencyMs   float64 `json:"avg_latency_ms"`
-	P99LatencyMs   float64 `json:"p99_latency_ms"`
-	SpanCount1H    int64   `json:"span_count_1h"`
+	RequestRateRPS    float64             `json:"request_rate_rps"`
+	ErrorRate         float64             `json:"error_rate"`
+	AvgLatencyMs      float64             `json:"avg_latency_ms"`
+	P99LatencyMs      float64             `json:"p99_latency_ms"`
+	LatencyProvenance *latency.Provenance `json:"latency_provenance,omitempty"`
+	SpanCount1H       int64               `json:"span_count_1h"`
 }
 
 // GraphEdge represents a call relationship between two services.
@@ -142,11 +144,12 @@ func buildGraphFromTopology(snapshot topology.Snapshot) *SystemGraphResponse {
 			HealthScore: math.Round(health*100) / 100,
 			Status:      status,
 			Metrics: NodeMetrics{
-				RequestRateRPS: math.Round(node.RequestRateRPS*100) / 100,
-				ErrorRate:      math.Round(node.ErrorRate*1000000) / 1000000,
-				AvgLatencyMs:   math.Round(node.AvgLatencyMs*100) / 100,
-				P99LatencyMs:   math.Round(node.P99LatencyMs*100) / 100,
-				SpanCount1H:    node.SpanCount,
+				RequestRateRPS:    math.Round(node.RequestRateRPS*100) / 100,
+				ErrorRate:         math.Round(node.ErrorRate*1000000) / 1000000,
+				AvgLatencyMs:      math.Round(node.AvgLatencyMs*100) / 100,
+				P99LatencyMs:      math.Round(node.P99LatencyMs*100) / 100,
+				LatencyProvenance: node.LatencyProvenance,
+				SpanCount1H:       node.SpanCount,
 			},
 			Alerts: alerts,
 		})
@@ -213,11 +216,12 @@ func (s *Server) buildGraphFromMemory(ctx context.Context) *SystemGraphResponse 
 			HealthScore: math.Round(n.HealthScore*100) / 100,
 			Status:      n.Status,
 			Metrics: NodeMetrics{
-				RequestRateRPS: math.Round(n.RequestRateRPS*100) / 100,
-				ErrorRate:      math.Round(n.ErrorRate*1000000) / 1000000,
-				AvgLatencyMs:   math.Round(n.AvgLatencyMs*100) / 100,
-				P99LatencyMs:   math.Round(n.P99LatencyMs*100) / 100,
-				SpanCount1H:    n.SpanCount,
+				RequestRateRPS:    math.Round(n.RequestRateRPS*100) / 100,
+				ErrorRate:         math.Round(n.ErrorRate*1000000) / 1000000,
+				AvgLatencyMs:      math.Round(n.AvgLatencyMs*100) / 100,
+				P99LatencyMs:      math.Round(n.P99LatencyMs*100) / 100,
+				LatencyProvenance: n.LatencyProvenance,
+				SpanCount1H:       n.SpanCount,
 			},
 			Alerts: alerts,
 		})
@@ -260,11 +264,12 @@ func (s *Server) buildGraphFromGraphRAG(ctx context.Context) *SystemGraphRespons
 			HealthScore: math.Round(svc.HealthScore*100) / 100,
 			Status:      healthStatus(svc.HealthScore),
 			Metrics: NodeMetrics{
-				RequestRateRPS: math.Round(float64(svc.CallCount)/300*100) / 100, // approx 5min window
-				ErrorRate:      math.Round(svc.ErrorRate*1000000) / 1000000,
-				AvgLatencyMs:   math.Round(svc.AvgLatency*100) / 100,
-				P99LatencyMs:   math.Round(svc.AvgLatency*2.5*100) / 100, // estimate
-				SpanCount1H:    svc.CallCount,
+				RequestRateRPS:    math.Round(float64(svc.CallCount)/300*100) / 100, // approx 5min window
+				ErrorRate:         math.Round(svc.ErrorRate*1000000) / 1000000,
+				AvgLatencyMs:      math.Round(svc.AvgLatency*100) / 100,
+				P99LatencyMs:      math.Round(svc.P99Latency*100) / 100,
+				LatencyProvenance: svc.LatencyProvenance,
+				SpanCount1H:       svc.CallCount,
 			},
 			Alerts: alerts,
 		})
@@ -339,11 +344,12 @@ func (s *Server) buildGraphFromDB(ctx context.Context) *SystemGraphResponse {
 			HealthScore: healthScore,
 			Status:      healthStatus(healthScore),
 			Metrics: NodeMetrics{
-				RequestRateRPS: math.Round(float64(n.TotalTraces)/3600*100) / 100,
-				ErrorRate:      math.Round(errorRate*1000000) / 1000000,
-				AvgLatencyMs:   n.AvgLatencyMs,
-				P99LatencyMs:   n.AvgLatencyMs * 2.5,
-				SpanCount1H:    n.TotalTraces,
+				RequestRateRPS:    math.Round(float64(n.TotalTraces)/3600*100) / 100,
+				ErrorRate:         math.Round(errorRate*1000000) / 1000000,
+				AvgLatencyMs:      n.AvgLatencyMs,
+				P99LatencyMs:      n.P99LatencyMs,
+				LatencyProvenance: n.LatencyProvenance,
+				SpanCount1H:       n.TotalTraces,
 			},
 			Alerts: alerts,
 		})

--- a/internal/api/topology_provider_test.go
+++ b/internal/api/topology_provider_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/api/views"
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/RandomCodeSpace/otelcontext/internal/topology"
 )
 
@@ -30,7 +31,7 @@ func TestAggregateTopologyProviderOwnsBothRESTGraphs(t *testing.T) {
 		source:   topology.SourceAggregate,
 		identity: topology.Identity{Epoch: "boot-a", Revision: 7},
 		snapshot: topology.Snapshot{
-			Nodes: []topology.Node{{Name: "gateway"}, {Name: "aggregate-payments"}},
+			Nodes: []topology.Node{{Name: "gateway", P99LatencyMs: 1000, LatencyProvenance: &latency.Provenance{P99: &latency.Percentile{Status: latency.StatusApproximate, Method: latency.MethodDDSketch, SampleCount: 1000}}}, {Name: "aggregate-payments"}},
 			Edges: []topology.Edge{{Source: "gateway", Target: "aggregate-payments", CallCount: 4}},
 			Meta: topology.Metadata{
 				Source:   topology.SourceAggregate,
@@ -59,6 +60,9 @@ func TestAggregateTopologyProviderOwnsBothRESTGraphs(t *testing.T) {
 	if serviceMap.Epoch != "boot-a" || serviceMap.Revision != 7 {
 		t.Fatalf("service map identity = %q/%d, want boot-a/7", serviceMap.Epoch, serviceMap.Revision)
 	}
+	if serviceMap.Nodes[0].P99LatencyMs != 1000 || serviceMap.Nodes[0].LatencyProvenance == nil || serviceMap.Nodes[0].LatencyProvenance.P99.Status != latency.StatusApproximate {
+		t.Fatalf("service map latency = %+v", serviceMap.Nodes[0])
+	}
 
 	systemReq := httptest.NewRequest("GET", "/api/system/graph", nil)
 	systemRec := httptest.NewRecorder()
@@ -75,6 +79,9 @@ func TestAggregateTopologyProviderOwnsBothRESTGraphs(t *testing.T) {
 	}
 	if systemGraph.Epoch != "boot-a" || systemGraph.Revision != 7 {
 		t.Fatalf("system graph identity = %q/%d, want boot-a/7", systemGraph.Epoch, systemGraph.Revision)
+	}
+	if systemGraph.Nodes[0].Metrics.P99LatencyMs != 1000 || systemGraph.Nodes[0].Metrics.LatencyProvenance == nil || systemGraph.Nodes[0].Metrics.LatencyProvenance.P99.SampleCount != 1000 {
+		t.Fatalf("system graph latency = %+v", systemGraph.Nodes[0].Metrics)
 	}
 }
 

--- a/internal/api/views/views.go
+++ b/internal/api/views/views.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"github.com/RandomCodeSpace/otelcontext/internal/topology"
 )
@@ -108,14 +109,15 @@ type ServiceError struct {
 // and spans/span_errors/span_error_rate carry the span basis the old aggregate
 // payload was mislabelling as traces. Both rates are percents, like error_rate.
 type DashboardStats struct {
-	TotalTraces        int64          `json:"total_traces"`
-	TotalLogs          int64          `json:"total_logs"`
-	TotalErrors        int64          `json:"total_errors"`
-	AvgLatencyMs       float64        `json:"avg_latency_ms"`
-	ErrorRate          float64        `json:"error_rate"`
-	ActiveServices     int64          `json:"active_services"`
-	P99LatencyMs       float64        `json:"p99_latency_ms"`
-	TopFailingServices []ServiceError `json:"top_failing_services"`
+	TotalTraces        int64               `json:"total_traces"`
+	TotalLogs          int64               `json:"total_logs"`
+	TotalErrors        int64               `json:"total_errors"`
+	AvgLatencyMs       float64             `json:"avg_latency_ms"`
+	ErrorRate          float64             `json:"error_rate"`
+	ActiveServices     int64               `json:"active_services"`
+	P99LatencyMs       float64             `json:"p99_latency_ms"`
+	LatencyProvenance  *latency.Provenance `json:"latency_provenance,omitempty"`
+	TopFailingServices []ServiceError      `json:"top_failing_services"`
 
 	Requests         int64   `json:"requests,omitempty"`
 	RequestErrors    int64   `json:"request_errors,omitempty"`
@@ -133,10 +135,12 @@ type DashboardStats struct {
 
 // ServiceMapNode is a node on the service topology view.
 type ServiceMapNode struct {
-	Name         string  `json:"name"`
-	TotalTraces  int64   `json:"total_traces"`
-	ErrorCount   int64   `json:"error_count"`
-	AvgLatencyMs float64 `json:"avg_latency_ms"`
+	Name              string              `json:"name"`
+	TotalTraces       int64               `json:"total_traces"`
+	ErrorCount        int64               `json:"error_count"`
+	AvgLatencyMs      float64             `json:"avg_latency_ms"`
+	P99LatencyMs      float64             `json:"p99_latency_ms,omitempty"`
+	LatencyProvenance *latency.Provenance `json:"latency_provenance,omitempty"`
 }
 
 // ServiceMapEdge is an edge on the service topology view.
@@ -372,7 +376,8 @@ func DashboardStatsFromModel(s *storage.DashboardStats) DashboardStats {
 		ActiveServices: s.ActiveServices,
 		// storage.P99Latency is microseconds (storage tests assert µs); convert
 		// to milliseconds here so the API matches AvgLatencyMs and the field name.
-		P99LatencyMs: float64(s.P99Latency) / 1000.0,
+		P99LatencyMs:      float64(s.P99Latency) / 1000.0,
+		LatencyProvenance: s.LatencyProvenance,
 	}
 	if len(s.TopFailingServices) > 0 {
 		out.TopFailingServices = make([]ServiceError, len(s.TopFailingServices))
@@ -397,6 +402,7 @@ func DashboardStatsFromAggregate(r *aggregate.DashboardResult) DashboardStats {
 		return DashboardStats{}
 	}
 	acc := r.Accuracy
+	provenance := r.LatencyProvenance
 	out := DashboardStats{
 		// The headline trio is the REQUEST basis: that is what a dashboard
 		// labelled "traces" and "error rate" has always meant to a reader.
@@ -414,12 +420,13 @@ func DashboardStatsFromAggregate(r *aggregate.DashboardResult) DashboardStats {
 		ActiveServices:   r.ActiveServices,
 		// The engine reports microseconds, matching storage.P99Latency; the
 		// view is milliseconds in both modes.
-		P99LatencyMs: r.P99LatencyMicros / 1000.0,
-		Coverage:     string(r.Coverage),
-		CoverageNote: r.Coverage.Note(),
-		Accuracy:     &acc,
-		Epoch:        r.Epoch,
-		Revision:     r.Revision,
+		P99LatencyMs:      r.P99LatencyMicros / 1000.0,
+		LatencyProvenance: &provenance,
+		Coverage:          string(r.Coverage),
+		CoverageNote:      r.Coverage.Note(),
+		Accuracy:          &acc,
+		Epoch:             r.Epoch,
+		Revision:          r.Revision,
 	}
 	if len(r.TopFailing) > 0 {
 		out.TopFailingServices = make([]ServiceError, len(r.TopFailing))
@@ -449,10 +456,12 @@ func ServiceMapMetricsFromAggregate(r *aggregate.TopologyResult) ServiceMapMetri
 	nodes := make([]ServiceMapNode, len(r.Nodes))
 	for i, n := range r.Nodes {
 		nodes[i] = ServiceMapNode{
-			Name:         n.Service,
-			TotalTraces:  n.Count,
-			ErrorCount:   n.ErrorCount,
-			AvgLatencyMs: n.AvgLatencyMs,
+			Name:              n.Service,
+			TotalTraces:       n.Count,
+			ErrorCount:        n.ErrorCount,
+			AvgLatencyMs:      n.AvgLatencyMs,
+			P99LatencyMs:      n.P99LatencyMicros / 1000.0,
+			LatencyProvenance: &n.LatencyProvenance,
 		}
 	}
 	edges := make([]ServiceMapEdge, len(r.Edges))
@@ -481,10 +490,12 @@ func ServiceMapMetricsFromTopology(snapshot topology.Snapshot) ServiceMapMetrics
 	nodes := make([]ServiceMapNode, len(snapshot.Nodes))
 	for i, node := range snapshot.Nodes {
 		nodes[i] = ServiceMapNode{
-			Name:         node.Name,
-			TotalTraces:  node.TotalTraces,
-			ErrorCount:   node.ErrorCount,
-			AvgLatencyMs: node.AvgLatencyMs,
+			Name:              node.Name,
+			TotalTraces:       node.TotalTraces,
+			ErrorCount:        node.ErrorCount,
+			AvgLatencyMs:      node.AvgLatencyMs,
+			P99LatencyMs:      node.P99LatencyMs,
+			LatencyProvenance: node.LatencyProvenance,
 		}
 	}
 	edges := make([]ServiceMapEdge, len(snapshot.Edges))
@@ -521,10 +532,12 @@ func ServiceMapMetricsFromModel(m *storage.ServiceMapMetrics) ServiceMapMetrics 
 	nodes := make([]ServiceMapNode, len(m.Nodes))
 	for i, n := range m.Nodes {
 		nodes[i] = ServiceMapNode{
-			Name:         n.Name,
-			TotalTraces:  n.TotalTraces,
-			ErrorCount:   n.ErrorCount,
-			AvgLatencyMs: n.AvgLatencyMs,
+			Name:              n.Name,
+			TotalTraces:       n.TotalTraces,
+			ErrorCount:        n.ErrorCount,
+			AvgLatencyMs:      n.AvgLatencyMs,
+			P99LatencyMs:      n.P99LatencyMs,
+			LatencyProvenance: n.LatencyProvenance,
 		}
 	}
 	edges := make([]ServiceMapEdge, len(m.Edges))

--- a/internal/api/views/views_test.go
+++ b/internal/api/views/views_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"gorm.io/gorm"
 )
@@ -213,7 +214,8 @@ func TestDashboardStatsBasisFields(t *testing.T) {
 		RequestCount: 7, ErrorRequestCount: 2, RequestErrorRate: 28.5,
 		SpanCount: 140, SpanErrorCount: 30, SpanErrorRate: 21.4,
 		TotalLogs: 9, ActiveServices: 3, P99LatencyMicros: 2500,
-		Coverage: aggregate.CoverageFull,
+		LatencyProvenance: latency.Provenance{P99: &latency.Percentile{Status: latency.StatusApproximate, Method: latency.MethodDDSketch, SampleCount: 140}},
+		Coverage:          aggregate.CoverageFull,
 	})
 	if agg.TotalTraces != 7 || agg.TotalErrors != 2 || agg.ErrorRate != 28.5 {
 		t.Fatalf("headline trio = %d/%d/%v, want the request basis 7/2/28.5",
@@ -230,7 +232,7 @@ func TestDashboardStatsBasisFields(t *testing.T) {
 		t.Fatalf("marshal aggregate dashboard: %v", err)
 	}
 	for _, key := range []string{`"requests":7`, `"request_errors":2`, `"request_error_rate":28.5`,
-		`"spans":140`, `"span_errors":30`, `"span_error_rate":21.4`} {
+		`"spans":140`, `"span_errors":30`, `"span_error_rate":21.4`, `"latency_provenance":{"p99":{"status":"approximate"`} {
 		if !strings.Contains(string(b), key) {
 			t.Errorf("aggregate dashboard JSON missing %s: %s", key, b)
 		}

--- a/internal/backup/native_integration_test.go
+++ b/internal/backup/native_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/RandomCodeSpace/otelcontext/internal/migrate"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"github.com/testcontainers/testcontainers-go"
@@ -230,13 +231,44 @@ func prepareNativeSource(t *testing.T, fixture *nativeFixture) {
 		t.Fatal(err)
 	}
 	now := time.Now().UTC().Truncate(time.Microsecond)
-	trace := storage.Trace{
+	traces := make([]storage.Trace, 1000)
+	traces[0] = storage.Trace{
 		TenantID: "default", TraceID: "native-backup-fixture", ServiceName: "checkout",
-		Duration: 42, Status: storage.StatusCodeError, Timestamp: now,
+		Duration: 10_000, Status: storage.StatusCodeError, Timestamp: now,
 	}
-	if err := db.Create(&trace).Error; err != nil {
+	for index := 1; index < len(traces); index++ {
+		duration := int64(10_000)
+		if index >= 989 {
+			duration = 1_000_000
+		}
+		traces[index] = storage.Trace{
+			TenantID: "default", TraceID: fmt.Sprintf("native-latency-%04d", index), ServiceName: "checkout",
+			Duration: duration, Status: "OK", Timestamp: now,
+		}
+	}
+	if err := db.CreateInBatches(traces, 100).Error; err != nil {
 		t.Fatal(err)
 	}
+}
+
+type nativeLatencyProof struct {
+	P99Micros  int64               `json:"p99_micros"`
+	Provenance *latency.Provenance `json:"latency_provenance"`
+}
+
+func inspectNativeLatency(t *testing.T, adapter, dsn string) nativeLatencyProof {
+	t.Helper()
+	db, err := storage.NewDatabase(adapter, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := storage.NewRepositoryFromDB(db, adapter)
+	defer func() { _ = repo.Close() }()
+	stats, err := repo.GetDashboardStats(context.Background(), time.Now().Add(-24*time.Hour), time.Now().Add(24*time.Hour), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return nativeLatencyProof{P99Micros: stats.P99Latency, Provenance: stats.LatencyProvenance}
 }
 
 func nativeConfig(root, adapter, dsn, suffix string) Config {
@@ -277,16 +309,18 @@ func writeNativeShutdownProof(t *testing.T, cfg Config, candidate Candidate) {
 }
 
 type nativeProof struct {
-	SchemaVersion     string        `json:"schema_version"`
-	Adapter           string        `json:"adapter"`
-	CandidateSHA      string        `json:"candidate_sha,omitempty"`
-	EngineVersion     string        `json:"engine_version"`
-	MigrationState    string        `json:"migration_state"`
-	SourceLifecycle   string        `json:"source_lifecycle_fingerprint"`
-	RestoredLifecycle string        `json:"restored_lifecycle_fingerprint"`
-	Create            CreateReport  `json:"create"`
-	Restore           RestoreReport `json:"restore"`
-	ManifestSHA256    string        `json:"manifest_sha256"`
+	SchemaVersion     string             `json:"schema_version"`
+	Adapter           string             `json:"adapter"`
+	CandidateSHA      string             `json:"candidate_sha,omitempty"`
+	EngineVersion     string             `json:"engine_version"`
+	MigrationState    string             `json:"migration_state"`
+	SourceLifecycle   string             `json:"source_lifecycle_fingerprint"`
+	RestoredLifecycle string             `json:"restored_lifecycle_fingerprint"`
+	Create            CreateReport       `json:"create"`
+	Restore           RestoreReport      `json:"restore"`
+	ManifestSHA256    string             `json:"manifest_sha256"`
+	SourceLatency     nativeLatencyProof `json:"source_latency"`
+	RestoredLatency   nativeLatencyProof `json:"restored_latency"`
 	Assertions        []struct {
 		Name   string `json:"name"`
 		Passed bool   `json:"passed"`
@@ -300,6 +334,7 @@ func TestNativeBackupRestoreLifecycle(t *testing.T) {
 	}
 	fixture := startNativeFixture(t, adapter)
 	prepareNativeSource(t, fixture)
+	sourceLatency := inspectNativeLatency(t, adapter, fixture.sourceDSN)
 	candidate, err := CurrentCandidate("integration-test")
 	if err != nil {
 		t.Fatal(err)
@@ -339,6 +374,7 @@ func TestNativeBackupRestoreLifecycle(t *testing.T) {
 	if err := compareMain(manifest.Main, restored); err != nil {
 		t.Fatal(err)
 	}
+	restoredLatency := inspectNativeLatency(t, adapter, fixture.targetDSN)
 	targetDB, err := storage.NewDatabase(adapter, fixture.targetDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -350,6 +386,10 @@ func TestNativeBackupRestoreLifecycle(t *testing.T) {
 	}
 	closeGORM(targetDB)
 	prefix := map[string]string{"postgres": "16.", "mysql": "8.4.", "mssql": "16."}[adapter]
+	latencyMethod := latency.MethodOrderedRank
+	if adapter == "postgres" {
+		latencyMethod = latency.MethodPercentileDisc
+	}
 	checks := []struct {
 		Name   string `json:"name"`
 		Passed bool   `json:"passed"`
@@ -364,6 +404,8 @@ func TestNativeBackupRestoreLifecycle(t *testing.T) {
 		{"lifecycle_fingerprint_equal", manifest.Main.LifecycleFingerprint == restored.LifecycleFingerprint},
 		{"fixture_row_restored", restoredFixtureRows == 1},
 		{"bundle_lifecycle_equal", manifest.LifecycleFingerprint == restore.LifecycleFingerprint},
+		{"source_p99_nearest_rank", sourceLatency.P99Micros == 1_000_000 && sourceLatency.Provenance != nil && sourceLatency.Provenance.P99.SampleCount == 1000 && sourceLatency.Provenance.P99.Method == latencyMethod},
+		{"restored_p99_equal", restoredLatency.P99Micros == sourceLatency.P99Micros && restoredLatency.Provenance.P99.Status == latency.StatusMeasured},
 	}
 	for _, check := range checks {
 		if !check.Passed {
@@ -382,6 +424,8 @@ func TestNativeBackupRestoreLifecycle(t *testing.T) {
 		Create:            create,
 		Restore:           restore,
 		ManifestSHA256:    digest,
+		SourceLatency:     sourceLatency,
+		RestoredLatency:   restoredLatency,
 		Assertions:        checks,
 	}
 	proofDir := os.Getenv("OTELCONTEXT_NATIVE_BACKUP_PROOF_DIR")

--- a/internal/graph/service_graph.go
+++ b/internal/graph/service_graph.go
@@ -8,7 +8,11 @@ import (
 	"math"
 	"sync"
 	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 )
+
+const serviceLatencySampleLimit = 1000
 
 // SpanRow is the minimal span data needed to build the graph.
 // Callers supply this via the DataProvider to decouple the graph from GORM.
@@ -39,7 +43,7 @@ type edgeStats struct {
 	totalMs    float64
 	minMs      float64
 	maxMs      float64
-	latencies  []float64 // capped at 1000 samples for p99
+	latencies  []float64 // capped at serviceLatencySampleLimit for p99
 }
 
 // ServiceNode holds aggregated health data for a single service.
@@ -48,12 +52,13 @@ type ServiceNode struct {
 	HealthScore float64 // 0.0–1.0
 	Status      string  // "healthy" | "degraded" | "critical"
 
-	RequestRateRPS float64
-	ErrorRate      float64
-	AvgLatencyMs   float64
-	P99LatencyMs   float64
-	SpanCount      int64
-	LogErrorCount  int64 // set externally by callers if needed
+	RequestRateRPS    float64
+	ErrorRate         float64
+	AvgLatencyMs      float64
+	P99LatencyMs      float64
+	LatencyProvenance *latency.Provenance `json:"latency_provenance,omitempty"`
+	SpanCount         int64
+	LogErrorCount     int64 // set externally by callers if needed
 
 	Alerts []string
 }
@@ -178,7 +183,7 @@ func (g *Graph) rebuild() {
 		if r.IsError {
 			n.errorCount++
 		}
-		if len(n.latencies) < 1000 {
+		if len(n.latencies) < serviceLatencySampleLimit {
 			n.latencies = append(n.latencies, r.DurationMs)
 		}
 		if r.Timestamp.Before(n.firstSeen) {
@@ -209,7 +214,7 @@ func (g *Graph) rebuild() {
 				if r.IsError {
 					e.errorCount++
 				}
-				if len(e.latencies) < 1000 {
+				if len(e.latencies) < serviceLatencySampleLimit {
 					e.latencies = append(e.latencies, r.DurationMs)
 				}
 			}
@@ -227,22 +232,36 @@ func (g *Graph) rebuild() {
 			errorRate = float64(acc.errorCount) / float64(acc.spanCount)
 		}
 		p99Ms = percentile(acc.latencies, 99)
+		sampleCount := uint64(len(acc.latencies))
+		p99Provenance := &latency.Percentile{
+			Status:      latency.StatusMeasured,
+			Method:      latency.MethodNearestRank,
+			SampleCount: sampleCount,
+			LowSample:   sampleCount < latency.LowSampleThreshold,
+		}
+		if acc.spanCount > int64(len(acc.latencies)) {
+			p99Provenance.Status = latency.StatusBounded
+			p99Provenance.Method = latency.MethodRetainedPrefix
+			p99Provenance.PopulationCount = uint64(acc.spanCount) // #nosec G115 -- spanCount is increment-only.
+			p99Provenance.SampleLimit = serviceLatencySampleLimit
+		}
 
 		rps := float64(acc.spanCount) / windowSeconds
 
 		score, status := healthScore(errorRate, avgMs)
-		alerts := buildAlerts(name, errorRate, p99Ms)
+		alerts := buildAlerts(name, errorRate, p99Ms, p99Provenance.Status)
 
 		resultNodes[name] = &ServiceNode{
-			Name:           name,
-			HealthScore:    score,
-			Status:         status,
-			RequestRateRPS: rps,
-			ErrorRate:      errorRate,
-			AvgLatencyMs:   avgMs,
-			P99LatencyMs:   p99Ms,
-			SpanCount:      acc.spanCount,
-			Alerts:         alerts,
+			Name:              name,
+			HealthScore:       score,
+			Status:            status,
+			RequestRateRPS:    rps,
+			ErrorRate:         errorRate,
+			AvgLatencyMs:      avgMs,
+			P99LatencyMs:      p99Ms,
+			LatencyProvenance: &latency.Provenance{P99: p99Provenance},
+			SpanCount:         acc.spanCount,
+			Alerts:            alerts,
 		}
 	}
 
@@ -293,13 +312,17 @@ func healthScore(errorRate, avgLatencyMs float64) (float64, string) {
 }
 
 // buildAlerts generates human-readable alert strings for AI agent consumption.
-func buildAlerts(service string, errorRate, p99Ms float64) []string {
+func buildAlerts(service string, errorRate, p99Ms float64, status latency.Status) []string {
 	var alerts []string
 	if errorRate > 0.05 {
 		alerts = append(alerts, "high error rate: "+pctStr(errorRate))
 	}
 	if p99Ms > 500 {
-		alerts = append(alerts, "p99 latency exceeds 500ms")
+		if status == latency.StatusBounded {
+			alerts = append(alerts, "sample p99 latency exceeds 500ms")
+		} else {
+			alerts = append(alerts, "p99 latency exceeds 500ms")
+		}
 	}
 	return alerts
 }

--- a/internal/graph/service_graph_latency_test.go
+++ b/internal/graph/service_graph_latency_test.go
@@ -1,0 +1,48 @@
+package graph
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
+)
+
+func TestServiceLatencyProvenanceBoundaries(t *testing.T) {
+	for _, count := range []int{1, 99, 100, 1000, 1001} {
+		t.Run(strconv.Itoa(count), func(t *testing.T) {
+			rows := make([]SpanRow, count)
+			for i := range rows {
+				duration := 10.0
+				if count >= 1000 && i >= 989 {
+					duration = 1000
+				}
+				rows[i] = SpanRow{SpanID: strconv.Itoa(i), ServiceName: "api", DurationMs: duration, Timestamp: time.Now().UTC()}
+			}
+			g := New(func(time.Time) ([]SpanRow, error) { return rows, nil }, 5*time.Minute, time.Minute)
+			g.rebuild()
+			node := g.Snapshot().Nodes["api"]
+			if node == nil || node.LatencyProvenance == nil || node.LatencyProvenance.P99 == nil {
+				t.Fatalf("node provenance missing: %+v", node)
+			}
+			p99 := node.LatencyProvenance.P99
+			wantStatus := latency.StatusMeasured
+			wantMethod := latency.MethodNearestRank
+			wantSamples := count
+			if count > serviceLatencySampleLimit {
+				wantStatus = latency.StatusBounded
+				wantMethod = latency.MethodRetainedPrefix
+				wantSamples = serviceLatencySampleLimit
+			}
+			if p99.Status != wantStatus || p99.Method != wantMethod || p99.SampleCount != uint64(wantSamples) || p99.LowSample != (wantSamples < 100) {
+				t.Fatalf("count=%d provenance=%+v", count, p99)
+			}
+			if count >= 1000 && node.P99LatencyMs != 1000 {
+				t.Fatalf("count=%d p99=%v, want 1000", count, node.P99LatencyMs)
+			}
+			if count == 1001 && (p99.PopulationCount != 1001 || p99.SampleLimit != 1000) {
+				t.Fatalf("bounded provenance=%+v", p99)
+			}
+		})
+	}
+}

--- a/internal/graphrag/aggregate.go
+++ b/internal/graphrag/aggregate.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 )
 
@@ -140,16 +141,17 @@ func applyTopologySnapshot(stores *tenantStores, snap aggregate.TopologySnapshot
 // windowTotals sums a snapshot entity's retained windows into the absolute
 // counters a graph node carries.
 type windowTotals struct {
-	count      uint64
-	errors     uint64
-	durCount   uint64
-	durSumMs   float64
-	p95Ms      float64
-	p99Ms      float64
-	valueCount uint64
-	valueSum   float64
-	valueMin   float64
-	valueMax   float64
+	count             uint64
+	errors            uint64
+	durCount          uint64
+	durSumMs          float64
+	p95Ms             float64
+	p99Ms             float64
+	latencyProvenance *latency.Provenance
+	valueCount        uint64
+	valueSum          float64
+	valueMin          float64
+	valueMax          float64
 }
 
 func totalsOf(windows []aggregate.TopologyWindow) windowTotals {
@@ -170,11 +172,13 @@ func totalsOf(windows []aggregate.TopologyWindow) windowTotals {
 		// Percentiles do not sum. The most recent window that carries a
 		// sketch is the current picture; older windows are baseline material
 		// for the anomaly detector, not for the node's displayed latency.
-		if w.P95Micros > 0 {
+		if w.LatencyProvenance != nil && w.LatencyProvenance.P95 != nil {
 			t.p95Ms = w.P95Micros / 1000.0
 		}
-		if w.P99Micros > 0 {
+		if w.LatencyProvenance != nil && w.LatencyProvenance.P99 != nil {
 			t.p99Ms = w.P99Micros / 1000.0
+			provenance := *w.LatencyProvenance
+			t.latencyProvenance = &provenance
 		}
 	}
 	return t
@@ -207,6 +211,16 @@ func serviceNodeFrom(svc aggregate.TopologyService) *ServiceNode {
 	}
 	node.ErrorRate = t.errorRate()
 	node.AvgLatency = t.avgLatencyMs()
+	node.P95Latency = t.p95Ms
+	node.P99Latency = t.p99Ms
+	node.LatencyProvenance = t.latencyProvenance
+	if node.LatencyProvenance == nil {
+		node.LatencyProvenance = &latency.Provenance{P99: &latency.Percentile{
+			Status: latency.StatusUnavailable,
+			Method: latency.MethodDDSketch,
+			Reason: latency.ReasonNoObservations,
+		}}
+	}
 	node.HealthScore = computeHealth(node.ErrorRate, node.AvgLatency)
 	return node
 }
@@ -225,6 +239,7 @@ func operationNodeFrom(op aggregate.TopologyOperation) *OperationNode {
 	}
 	node.ErrorRate = t.errorRate()
 	node.AvgLatency = t.avgLatencyMs()
+	node.LatencyProvenance = unavailableOperationLatency()
 	node.HealthScore = computeHealth(node.ErrorRate, node.AvgLatency)
 	return node
 }

--- a/internal/graphrag/aggregate_test.go
+++ b/internal/graphrag/aggregate_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"gorm.io/gorm"
 )
@@ -51,6 +52,8 @@ func (f *fakeAggregateSource) PruneTopology() { f.prunes.Add(1) }
 
 // aggWindow builds one finalized topology window.
 func aggWindow(start time.Time, count, errors uint64, p99Micros float64) aggregate.TopologyWindow {
+	p95 := &latency.Percentile{Status: latency.StatusApproximate, Method: latency.MethodDDSketch, SampleCount: count, RelativeErrorBound: 0.0217}
+	p99 := *p95
 	return aggregate.TopologyWindow{
 		Start:             start,
 		End:               start.Add(aggregate.WindowSize),
@@ -63,6 +66,7 @@ func aggWindow(start time.Time, count, errors uint64, p99Micros float64) aggrega
 		DurationSumMicros: float64(count) * 1000,
 		P95Micros:         p99Micros * 0.8,
 		P99Micros:         p99Micros,
+		LatencyProvenance: &latency.Provenance{P95: p95, P99: &p99},
 	}
 }
 
@@ -124,6 +128,13 @@ func TestReconcileReplacesRatherThanAccumulates(t *testing.T) {
 	svc, ok := stores.service.GetService("checkout")
 	if !ok || svc.CallCount != 100 || svc.ErrorCount != 5 {
 		t.Fatalf("after first reconcile: %+v, want CallCount 100 / ErrorCount 5", svc)
+	}
+	if svc.P99Latency != 4 || svc.P95Latency != 3.2 || svc.LatencyProvenance == nil || svc.LatencyProvenance.P99.SampleCount != 100 {
+		t.Fatalf("service latency projection = %+v provenance=%+v", svc, svc.LatencyProvenance)
+	}
+	ops := stores.service.OperationsForService("checkout")
+	if len(ops) != 1 || ops[0].LatencyProvenance == nil || ops[0].LatencyProvenance.P50.Status != latency.StatusUnavailable || ops[0].LatencyProvenance.P99.Reason != latency.ReasonPercentileNotRecorded {
+		t.Fatalf("operation latency projection = %+v", ops)
 	}
 
 	// Force a re-render of the identical snapshot by bumping only the epoch's

--- a/internal/graphrag/anomaly_aggregate.go
+++ b/internal/graphrag/anomaly_aggregate.go
@@ -220,14 +220,23 @@ func latencyAnomaly(service string, current aggregate.TopologyWindow, baseline [
 	if current.P99Micros <= threshold || mean <= 0 {
 		return AnomalyNode{}, false
 	}
+	accuracy := "DDSketch accuracy unavailable"
+	if current.LatencyProvenance != nil && current.LatencyProvenance.P99 != nil {
+		p99 := current.LatencyProvenance.P99
+		if p99.Degraded {
+			accuracy = "DDSketch degraded"
+		} else if p99.RelativeErrorBound > 0 {
+			accuracy = fmt.Sprintf("DDSketch ±%.1f%%", p99.RelativeErrorBound*100)
+		}
+	}
 	return AnomalyNode{
 		ID:       fmt.Sprintf("anom_%s_lat", service),
 		Type:     AnomalyLatencySpike,
 		Severity: relativeSeverity(current.P99Micros, mean),
 		Service:  service,
 		Evidence: fmt.Sprintf(
-			"p99 %.0fms (p95 %.0fms) vs %.0fms baseline (sd %.0fms) over %d finalized windows",
-			current.P99Micros/1000, current.P95Micros/1000, mean/1000, stddev/1000, len(samples),
+			"approx. p99 %.0fms (p95 %.0fms; %s) vs %.0fms baseline (sd %.0fms) over %d finalized windows",
+			current.P99Micros/1000, current.P95Micros/1000, accuracy, mean/1000, stddev/1000, len(samples),
 		),
 		Timestamp: now,
 	}, true

--- a/internal/graphrag/schema.go
+++ b/internal/graphrag/schema.go
@@ -5,6 +5,8 @@ package graphrag
 
 import (
 	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 )
 
 // --- Node Types ---
@@ -30,11 +32,14 @@ type ServiceNode struct {
 	LastSeen    time.Time `json:"last_seen"`
 	HealthScore float64   `json:"health_score"` // 0.0–1.0
 
-	CallCount  int64   `json:"call_count"`
-	ErrorCount int64   `json:"error_count"`
-	ErrorRate  float64 `json:"error_rate"`
-	AvgLatency float64 `json:"avg_latency_ms"`
-	TotalMs    float64 `json:"-"` // for computing avg
+	CallCount         int64               `json:"call_count"`
+	ErrorCount        int64               `json:"error_count"`
+	ErrorRate         float64             `json:"error_rate"`
+	AvgLatency        float64             `json:"avg_latency_ms"`
+	P95Latency        float64             `json:"p95_latency_ms,omitempty"`
+	P99Latency        float64             `json:"p99_latency_ms,omitempty"`
+	LatencyProvenance *latency.Provenance `json:"latency_provenance,omitempty"`
+	TotalMs           float64             `json:"-"` // for computing avg
 }
 
 // OperationNode represents an endpoint/RPC within a service.
@@ -46,14 +51,15 @@ type OperationNode struct {
 	LastSeen    time.Time `json:"last_seen"`
 	HealthScore float64   `json:"health_score"`
 
-	CallCount  int64   `json:"call_count"`
-	ErrorCount int64   `json:"error_count"`
-	ErrorRate  float64 `json:"error_rate"`
-	AvgLatency float64 `json:"avg_latency_ms"`
-	P50Latency float64 `json:"p50_latency_ms"`
-	P95Latency float64 `json:"p95_latency_ms"`
-	P99Latency float64 `json:"p99_latency_ms"`
-	TotalMs    float64 `json:"-"`
+	CallCount         int64               `json:"call_count"`
+	ErrorCount        int64               `json:"error_count"`
+	ErrorRate         float64             `json:"error_rate"`
+	AvgLatency        float64             `json:"avg_latency_ms"`
+	P50Latency        float64             `json:"p50_latency_ms"`
+	P95Latency        float64             `json:"p95_latency_ms"`
+	P99Latency        float64             `json:"p99_latency_ms"`
+	LatencyProvenance *latency.Provenance `json:"latency_provenance,omitempty"`
+	TotalMs           float64             `json:"-"`
 }
 
 // TraceNode represents a distributed trace.

--- a/internal/graphrag/store.go
+++ b/internal/graphrag/store.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 )
 
 // tenantStores bundles one tenant's slice of the four layered in-memory
@@ -193,6 +194,15 @@ func (s *ServiceStore) UpsertService(name string, durationMs float64, isError bo
 		svc.FirstSeen = ts
 	}
 	svc.AvgLatency = svc.TotalMs / float64(svc.CallCount)
+	svc.P99Latency = svc.AvgLatency * 2.5
+	sampleCount := uint64(svc.CallCount) // #nosec G115 -- call count is increment-only.
+	svc.LatencyProvenance = &latency.Provenance{P99: &latency.Percentile{
+		Status:         latency.StatusEstimated,
+		Method:         latency.MethodAverageMultiplier,
+		SampleCount:    sampleCount,
+		LowSample:      sampleCount < latency.LowSampleThreshold,
+		EstimateFactor: 2.5,
+	}}
 	svc.ErrorRate = float64(svc.ErrorCount) / float64(svc.CallCount)
 	svc.HealthScore = computeHealth(svc.ErrorRate, svc.AvgLatency)
 }
@@ -223,6 +233,7 @@ func (s *ServiceStore) UpsertOperation(service, operation string, durationMs flo
 		op.LastSeen = ts
 	}
 	op.AvgLatency = op.TotalMs / float64(op.CallCount)
+	op.LatencyProvenance = unavailableOperationLatency()
 	op.ErrorRate = float64(op.ErrorCount) / float64(op.CallCount)
 	op.HealthScore = computeHealth(op.ErrorRate, op.AvgLatency)
 
@@ -236,6 +247,16 @@ func (s *ServiceStore) UpsertOperation(service, operation string, durationMs flo
 			UpdatedAt: ts,
 		}
 	}
+}
+
+func unavailableOperationLatency() *latency.Provenance {
+	percentile := func() *latency.Percentile {
+		return &latency.Percentile{
+			Status: latency.StatusUnavailable,
+			Reason: latency.ReasonPercentileNotRecorded,
+		}
+	}
+	return &latency.Provenance{P50: percentile(), P95: percentile(), P99: percentile()}
 }
 
 func (s *ServiceStore) UpsertCallEdge(source, target string, durationMs float64, isError bool, ts time.Time) {
@@ -287,6 +308,11 @@ func (s *ServiceStore) EnsureService(name string, ts time.Time) bool {
 		Name:      name,
 		FirstSeen: ts,
 		LastSeen:  ts,
+		LatencyProvenance: &latency.Provenance{P99: &latency.Percentile{
+			Status: latency.StatusUnavailable,
+			Method: latency.MethodAverageMultiplier,
+			Reason: latency.ReasonNoObservations,
+		}},
 	}
 	return true
 }

--- a/internal/latency/provenance.go
+++ b/internal/latency/provenance.go
@@ -1,0 +1,61 @@
+// Package latency defines the shared provenance vocabulary for percentile
+// values. Percentile algorithms remain with the packages that own the data.
+package latency
+
+// Status says what kind of claim a percentile value can support.
+type Status string
+
+const (
+	StatusMeasured    Status = "measured"
+	StatusApproximate Status = "approximate"
+	StatusEstimated   Status = "estimated"
+	StatusBounded     Status = "bounded"
+	StatusUnavailable Status = "unavailable"
+)
+
+const (
+	MethodPercentileDisc           = "percentile_disc"
+	MethodOrderedRank              = "ordered_rank"
+	MethodDDSketch                 = "ddsketch"
+	MethodNearestRank              = "nearest_rank"
+	MethodRetainedPrefix           = "retained_prefix"
+	MethodAverageMultiplier        = "average_multiplier"
+	MethodRollingObservationWindow = "rolling_observation_window"
+)
+
+const (
+	ReasonNoObservations           = "no_observations"
+	ReasonPercentileNotRecorded    = "percentile_not_recorded"
+	ReasonInvalidDistribution      = "invalid_source_distribution"
+	ReasonSketchCollapsed          = "sketch_collapsed"
+	ReasonSketchSaturated          = "sketch_saturated"
+	ReasonSketchCollapsedSaturated = "sketch_collapsed_and_saturated"
+)
+
+// LowSampleThreshold is descriptive, not suppressive. Empirical percentiles
+// below this population remain visible with LowSample set.
+const LowSampleThreshold uint64 = 100
+
+// Provenance carries the claim independently for each percentile.
+type Provenance struct {
+	P50 *Percentile `json:"p50,omitempty"`
+	P95 *Percentile `json:"p95,omitempty"`
+	P99 *Percentile `json:"p99,omitempty"`
+}
+
+// Percentile describes how one numeric percentile was produced.
+type Percentile struct {
+	Status             Status  `json:"status"`
+	Method             string  `json:"method"`
+	SampleCount        uint64  `json:"sample_count"`
+	PopulationCount    uint64  `json:"population_count,omitempty"`
+	SampleLimit        uint64  `json:"sample_limit,omitempty"`
+	LowSample          bool    `json:"low_sample,omitempty"`
+	SketchScale        uint8   `json:"sketch_scale,omitempty"`
+	RelativeErrorBound float64 `json:"relative_error_bound,omitempty"`
+	Degraded           bool    `json:"degraded,omitempty"`
+	Collapsed          bool    `json:"collapsed,omitempty"`
+	Saturations        uint64  `json:"saturations,omitempty"`
+	EstimateFactor     float64 `json:"estimate_factor,omitempty"`
+	Reason             string  `json:"reason,omitempty"`
+}

--- a/internal/latency/provenance_test.go
+++ b/internal/latency/provenance_test.go
@@ -1,0 +1,31 @@
+package latency
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestProvenanceJSONContract(t *testing.T) {
+	value := Provenance{P99: &Percentile{
+		Status:             StatusApproximate,
+		Method:             MethodDDSketch,
+		SampleCount:        1000,
+		RelativeErrorBound: 0.0217,
+	}}
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	for _, field := range []string{`"p99"`, `"status":"approximate"`, `"method":"ddsketch"`, `"sample_count":1000`, `"relative_error_bound":0.0217`} {
+		if !strings.Contains(got, field) {
+			t.Fatalf("%s missing %s", got, field)
+		}
+	}
+	for _, omitted := range []string{`"p50"`, `"population_count"`, `"degraded"`, `"reason"`} {
+		if strings.Contains(got, omitted) {
+			t.Fatalf("%s unexpectedly contains %s", got, omitted)
+		}
+	}
+}

--- a/internal/mcp/honesty_test.go
+++ b/internal/mcp/honesty_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 )
 
@@ -149,6 +150,42 @@ func TestToolDescriptionsStateTheirCoverageLimits(t *testing.T) {
 		if !strings.Contains(byName[name], want) {
 			t.Errorf("%s description does not state %q: %s", name, want, byName[name])
 		}
+	}
+}
+
+func TestTopologyToolsPreserveLatencyProvenance(t *testing.T) {
+	srv, g, _ := honestyServer(t)
+	g.OnSpanIngested(storage.Span{
+		TenantID: storage.DefaultTenantID, TraceID: "latency-trace", SpanID: "latency-span",
+		ServiceName: "checkout", OperationName: "/pay", StartTime: time.Now(), Duration: 20_000,
+	})
+	ctx := storage.WithTenantContext(context.Background(), storage.DefaultTenantID)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(g.ServiceMap(ctx, 0)) == 1 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	mapResult := srv.toolHandler(context.Background(), "get_service_map", nil)
+	if mapResult.IsError || len(mapResult.Content) == 0 {
+		t.Fatalf("get_service_map = %+v", mapResult)
+	}
+	var entries []graphrag.ServiceMapEntry
+	if err := json.Unmarshal([]byte(mapResult.Content[0].Text), &entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Service.LatencyProvenance == nil || entries[0].Service.LatencyProvenance.P99.Status != latency.StatusEstimated || entries[0].Service.P99Latency != 50 {
+		t.Fatalf("service map latency = %+v", entries)
+	}
+	if len(entries[0].Operations) != 1 || entries[0].Operations[0].LatencyProvenance.P99.Status != latency.StatusUnavailable {
+		t.Fatalf("operation latency = %+v", entries[0].Operations)
+	}
+
+	health := srv.toolHandler(context.Background(), "get_service_health", map[string]any{"service_name": "checkout"})
+	if health.IsError || len(health.Content) == 0 || !strings.Contains(health.Content[0].Text, `"latency_provenance"`) {
+		t.Fatalf("get_service_health = %+v", health)
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -503,15 +503,16 @@ func (s *Server) topologyNotification(ctx context.Context, last topology.Identit
 			alerts = []string{}
 		}
 		payload.Nodes[node.Name] = &graph.ServiceNode{
-			Name:           node.Name,
-			HealthScore:    node.HealthScore,
-			Status:         node.Status,
-			RequestRateRPS: node.RequestRateRPS,
-			ErrorRate:      node.ErrorRate,
-			AvgLatencyMs:   node.AvgLatencyMs,
-			P99LatencyMs:   node.P99LatencyMs,
-			SpanCount:      node.SpanCount,
-			Alerts:         alerts,
+			Name:              node.Name,
+			HealthScore:       node.HealthScore,
+			Status:            node.Status,
+			RequestRateRPS:    node.RequestRateRPS,
+			ErrorRate:         node.ErrorRate,
+			AvgLatencyMs:      node.AvgLatencyMs,
+			P99LatencyMs:      node.P99LatencyMs,
+			LatencyProvenance: node.LatencyProvenance,
+			SpanCount:         node.SpanCount,
+			Alerts:            alerts,
 		}
 	}
 	for _, edge := range snapshot.Edges {

--- a/internal/realtime/aggregate_publisher.go
+++ b/internal/realtime/aggregate_publisher.go
@@ -125,22 +125,24 @@ func (p *EnginePublisher) Snapshot(ctx context.Context, service string) *LiveSna
 	}
 
 	if dash, err := p.engine.QueryDashboard(q); err == nil {
+		provenance := dash.LatencyProvenance
 		snap.Dashboard = &storage.DashboardStats{
 			// Headline trio on the REQUEST basis, restated by name alongside
 			// the span basis — same contract as the HTTP dashboard view.
-			TotalTraces:      dash.RequestCount,
-			TotalErrors:      dash.ErrorRequestCount,
-			ErrorRate:        dash.RequestErrorRate,
-			Requests:         dash.RequestCount,
-			RequestErrors:    dash.ErrorRequestCount,
-			RequestErrorRate: dash.RequestErrorRate,
-			Spans:            dash.SpanCount,
-			SpanErrors:       dash.SpanErrorCount,
-			SpanErrorRate:    dash.SpanErrorRate,
-			TotalLogs:        dash.TotalLogs,
-			AvgLatencyMs:     dash.AvgLatencyMs,
-			ActiveServices:   dash.ActiveServices,
-			P99Latency:       int64(dash.P99LatencyMicros),
+			TotalTraces:       dash.RequestCount,
+			TotalErrors:       dash.ErrorRequestCount,
+			ErrorRate:         dash.RequestErrorRate,
+			Requests:          dash.RequestCount,
+			RequestErrors:     dash.ErrorRequestCount,
+			RequestErrorRate:  dash.RequestErrorRate,
+			Spans:             dash.SpanCount,
+			SpanErrors:        dash.SpanErrorCount,
+			SpanErrorRate:     dash.SpanErrorRate,
+			TotalLogs:         dash.TotalLogs,
+			AvgLatencyMs:      dash.AvgLatencyMs,
+			ActiveServices:    dash.ActiveServices,
+			P99Latency:        int64(dash.P99LatencyMicros),
+			LatencyProvenance: &provenance,
 		}
 		for _, s := range dash.TopFailing {
 			snap.Dashboard.TopFailingServices = append(snap.Dashboard.TopFailingServices, storage.ServiceError{
@@ -171,10 +173,12 @@ func (p *EnginePublisher) Snapshot(ctx context.Context, service string) *LiveSna
 		}
 		for _, n := range topologySnapshot.Nodes {
 			sm.Nodes = append(sm.Nodes, storage.ServiceMapNode{
-				Name:         n.Name,
-				TotalTraces:  n.TotalTraces,
-				ErrorCount:   n.ErrorCount,
-				AvgLatencyMs: n.AvgLatencyMs,
+				Name:              n.Name,
+				TotalTraces:       n.TotalTraces,
+				ErrorCount:        n.ErrorCount,
+				AvgLatencyMs:      n.AvgLatencyMs,
+				P99LatencyMs:      n.P99LatencyMs,
+				LatencyProvenance: n.LatencyProvenance,
 			})
 		}
 		for _, e := range topologySnapshot.Edges {

--- a/internal/realtime/aggregate_ws_test.go
+++ b/internal/realtime/aggregate_ws_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"github.com/coder/websocket"
 )
 
@@ -309,5 +311,30 @@ func TestAggregateSnapshotNeverCarriesTraces(t *testing.T) {
 	snap := pub.Snapshot(context.Background(), "")
 	if snap.Traces != nil {
 		t.Fatal("coalesced aggregate snapshot carries raw traces")
+	}
+}
+
+func TestWebSocketDashboardPreservesMicrosecondsAndProvenance(t *testing.T) {
+	snap := LiveSnapshot{Dashboard: &storage.DashboardStats{
+		P99Latency: 1_000_000,
+		LatencyProvenance: &latency.Provenance{P99: &latency.Percentile{
+			Status: latency.StatusApproximate, Method: latency.MethodDDSketch, SampleCount: 1000,
+		}},
+	}}
+	data, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wire struct {
+		Dashboard struct {
+			P99               int64              `json:"p99_latency"`
+			LatencyProvenance latency.Provenance `json:"latency_provenance"`
+		} `json:"dashboard"`
+	}
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatal(err)
+	}
+	if wire.Dashboard.P99 != 1_000_000 || wire.Dashboard.LatencyProvenance.P99.Status != latency.StatusApproximate {
+		t.Fatalf("wire dashboard = %+v", wire.Dashboard)
 	}
 }

--- a/internal/storage/metrics_p99_test.go
+++ b/internal/storage/metrics_p99_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"gorm.io/gorm"
 )
 
@@ -12,10 +13,9 @@ import (
 // Step 1: dialect-dispatch tests (DryRun + real SQLite)
 // ---------------------------------------------------------------------------
 
-// TestP99_SQLite_DispatchLimit verifies that the SQLite path issues a query
-// with Limit(sqliteP99RowCap+1). We use a real in-memory SQLite DB with a
-// DryRun session to capture the generated SQL.
-func TestP99_SQLite_DispatchLimit(t *testing.T) {
+// TestP99_SQLite_DispatchOrderedRank verifies the SQLite path is callable on
+// an empty filtered population without inventing a percentile.
+func TestP99_SQLite_DispatchOrderedRank(t *testing.T) {
 	repo := newTestRepo(t)
 
 	// Build a session identical to how GetDashboardStats passes it:
@@ -131,49 +131,70 @@ func TestP99_SQLite_SingleRow(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Step 3b: Large-data / cap test
+// Step 3b: contradictory distribution and retained-adapter parity
 // ---------------------------------------------------------------------------
 
-// TestP99_SQLite_CapTriggers temporarily shrinks sqliteP99RowCap and inserts
-// just over that amount, verifying the cap path is exercised:
-//  1. GetDashboardStats returns without error.
-//  2. P99Latency is non-zero.
-//  3. The call completes quickly (small dataset).
-//
-// The cap is a var specifically so this test can run under -race without
-// seeding 200k rows. Default cap remains 200_000 in production.
-func TestP99_SQLite_CapTriggers(t *testing.T) {
-	orig := sqliteP99RowCap
-	sqliteP99RowCap = 200
-	t.Cleanup(func() { sqliteP99RowCap = orig })
-
-	repo := newTestRepo(t)
-	now := time.Now().UTC()
-
-	insertCount := sqliteP99RowCap + 50 // just over the (shrunk) cap
-
-	batch := make([]Trace, 0, insertCount)
-	for i := 0; i < insertCount; i++ {
-		batch = append(batch, Trace{
-			TraceID:     "t" + p99Itoa(i),
-			ServiceName: "svc",
-			Duration:    int64(i + 1),
-			Status:      "OK",
-			Timestamp:   now,
-			TenantID:    "default",
+func TestP99OrderedRankAdaptersContradictAverage(t *testing.T) {
+	for _, driver := range []string{"sqlite", "mysql", "sqlserver", "mssql"} {
+		t.Run(driver, func(t *testing.T) {
+			repo := newTestRepo(t)
+			repo.driver = driver
+			now := time.Now().UTC()
+			batch := make([]Trace, 1000)
+			for i := range batch {
+				duration := int64(10_000)
+				if i >= 989 {
+					duration = 1_000_000
+				}
+				batch[i] = Trace{
+					TraceID: "sentinel-" + p99Itoa(i), ServiceName: "svc",
+					Duration: duration, Status: "OK", Timestamp: now, TenantID: "default",
+				}
+			}
+			if err := repo.db.CreateInBatches(batch, 100).Error; err != nil {
+				t.Fatal(err)
+			}
+			stats, err := repo.GetDashboardStats(context.Background(), now.Add(-time.Hour), now.Add(time.Hour), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stats.P99Latency != 1_000_000 {
+				t.Fatalf("p99 = %d µs, want 1000000", stats.P99Latency)
+			}
+			p99 := stats.LatencyProvenance.P99
+			if p99.Status != latency.StatusMeasured || p99.Method != latency.MethodOrderedRank || p99.SampleCount != 1000 || p99.LowSample {
+				t.Fatalf("provenance = %+v", p99)
+			}
 		})
 	}
-	if err := repo.db.CreateInBatches(batch, 100).Error; err != nil {
-		t.Fatalf("seed batch: %v", err)
-	}
+}
 
-	ctx := context.Background()
-	stats, err := repo.GetDashboardStats(ctx, now.Add(-time.Hour), now.Add(time.Hour), nil)
-	if err != nil {
-		t.Fatalf("GetDashboardStats: %v", err)
-	}
-	if stats.P99Latency <= 0 {
-		t.Fatalf("P99Latency should be positive, got %d", stats.P99Latency)
+func TestP99ObservationBoundaries(t *testing.T) {
+	for _, count := range []int{0, 1, 99, 100} {
+		t.Run(p99Itoa(count), func(t *testing.T) {
+			repo := newTestRepo(t)
+			now := time.Now().UTC()
+			if count > 0 {
+				rows := makeTraces(t, count, now)
+				if err := repo.db.Create(&rows).Error; err != nil {
+					t.Fatal(err)
+				}
+			}
+			stats, err := repo.GetDashboardStats(context.Background(), now.Add(-time.Hour), now.Add(time.Hour), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			p99 := stats.LatencyProvenance.P99
+			if count == 0 {
+				if stats.P99Latency != 0 || p99.Status != latency.StatusUnavailable || p99.Reason != latency.ReasonNoObservations {
+					t.Fatalf("empty stats = %+v provenance=%+v", stats, p99)
+				}
+				return
+			}
+			if p99.Status != latency.StatusMeasured || p99.SampleCount != uint64(count) || p99.LowSample != (count < 100) {
+				t.Fatalf("count %d provenance = %+v", count, p99)
+			}
+		})
 	}
 }
 

--- a/internal/storage/metrics_repo.go
+++ b/internal/storage/metrics_repo.go
@@ -9,15 +9,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"gorm.io/gorm"
 )
-
-// sqliteP99RowCap is the maximum number of duration rows fetched for the
-// in-memory p99 sort on SQLite. Queries returning more rows than this are
-// capped with a warning; accuracy degrades gracefully at the tail.
-// Declared as var (not const) so tests can temporarily shrink it to exercise
-// the cap path without seeding 200k rows under -race.
-var sqliteP99RowCap = 200_000
 
 // TrafficPoint represents a data point for the traffic chart.
 //
@@ -60,14 +54,15 @@ type ServiceError struct {
 // they should always have been. The six additive fields below are populated
 // only in aggregate mode and name their basis explicitly (#197 Q3).
 type DashboardStats struct {
-	TotalTraces        int64          `json:"total_traces"`
-	TotalLogs          int64          `json:"total_logs"`
-	TotalErrors        int64          `json:"total_errors"`
-	AvgLatencyMs       float64        `json:"avg_latency_ms"`
-	ErrorRate          float64        `json:"error_rate"`
-	ActiveServices     int64          `json:"active_services"`
-	P99Latency         int64          `json:"p99_latency"`
-	TopFailingServices []ServiceError `json:"top_failing_services"`
+	TotalTraces        int64               `json:"total_traces"`
+	TotalLogs          int64               `json:"total_logs"`
+	TotalErrors        int64               `json:"total_errors"`
+	AvgLatencyMs       float64             `json:"avg_latency_ms"`
+	ErrorRate          float64             `json:"error_rate"`
+	ActiveServices     int64               `json:"active_services"`
+	P99Latency         int64               `json:"p99_latency"`
+	LatencyProvenance  *latency.Provenance `json:"latency_provenance,omitempty"`
+	TopFailingServices []ServiceError      `json:"top_failing_services"`
 
 	Requests         int64   `json:"requests,omitempty"`
 	RequestErrors    int64   `json:"request_errors,omitempty"`
@@ -125,8 +120,7 @@ func (r *Repository) GetMetricNames(ctx context.Context, serviceName string) ([]
 // matching rows of session. It dispatches on r.driver:
 //
 //   - postgres / postgresql: native percentile_disc aggregate (single query).
-//   - mysql: two-query COUNT + ORDER BY … OFFSET approach.
-//   - default (sqlite + unknown): in-memory sort capped at sqliteP99RowCap rows.
+//   - every other retained adapter: COUNT + ORDER BY … OFFSET.
 //
 // The caller must pass a fresh Session so nothing leaks across subsequent calls.
 // ctx is threaded into every sub-session so client cancellation (disconnect/timeout)
@@ -152,7 +146,7 @@ func (r *Repository) p99DurationForQuery(ctx context.Context, session *gorm.DB) 
 		}
 		return p, nil
 
-	case "mysql":
+	default:
 		var n int64
 		if err := session.Session(&gorm.Session{Context: ctx}).Model(&Trace{}).Count(&n).Error; err != nil {
 			return 0, err
@@ -171,33 +165,6 @@ func (r *Repository) p99DurationForQuery(ctx context.Context, session *gorm.DB) 
 			return 0, err
 		}
 		return p, nil
-
-	default: // sqlite and any unknown driver
-		var durations []int64
-		q := session.Session(&gorm.Session{Context: ctx}).Select("duration").Order("duration ASC").Limit(sqliteP99RowCap + 1)
-		if err := q.Find(&durations).Error; err != nil {
-			return 0, err
-		}
-		if len(durations) == 0 {
-			return 0, nil
-		}
-		if len(durations) > sqliteP99RowCap {
-			// Truncate to cap — accuracy degrades gracefully. Operators alert on
-			// the counter (dataset is too large for in-memory p99 — migrate to
-			// Postgres). Keep a low-volume debug log for dev observability.
-			if r.metrics != nil {
-				r.metrics.DashboardP99RowCapHitsTotal.Inc()
-			}
-			slog.Debug("p99 SQLite fallback capped rows", "cap", sqliteP99RowCap)
-			durations = durations[:sqliteP99RowCap]
-		}
-		idx := int(math.Ceil(float64(len(durations))*0.99)) - 1
-		if idx < 0 {
-			idx = 0
-		} else if idx >= len(durations) {
-			idx = len(durations) - 1
-		}
-		return durations[idx], nil
 	}
 }
 
@@ -264,6 +231,23 @@ func (r *Repository) GetDashboardStats(ctx context.Context, start, end time.Time
 		return nil, fmt.Errorf("failed to compute p99 latency: %w", err)
 	}
 	stats.P99Latency = p99
+	method := latency.MethodOrderedRank
+	if driver := strings.ToLower(r.driver); driver == "postgres" || driver == "postgresql" {
+		method = latency.MethodPercentileDisc
+	}
+	percentile := &latency.Percentile{
+		Status:          latency.StatusUnavailable,
+		Method:          method,
+		PopulationCount: uint64(stats.TotalTraces), // #nosec G115 -- database counts cannot be negative.
+		Reason:          latency.ReasonNoObservations,
+	}
+	if stats.TotalTraces > 0 {
+		percentile.Status = latency.StatusMeasured
+		percentile.SampleCount = uint64(stats.TotalTraces) // #nosec G115 -- database counts cannot be negative.
+		percentile.LowSample = percentile.SampleCount < latency.LowSampleThreshold
+		percentile.Reason = ""
+	}
+	stats.LatencyProvenance = &latency.Provenance{P99: percentile}
 
 	// 7. Top Failing Services
 	type svcCount struct {

--- a/internal/storage/service_map_test.go
+++ b/internal/storage/service_map_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"reflect"
 	"sort"
 	"testing"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"gorm.io/gorm"
 )
 
@@ -241,10 +243,16 @@ func TestGetServiceMapMetrics_FixtureValues(t *testing.T) {
 	}
 	sortServiceMap(got)
 
+	estimated := func(count uint64) *latency.Provenance {
+		return &latency.Provenance{P99: &latency.Percentile{
+			Status: latency.StatusEstimated, Method: latency.MethodAverageMultiplier,
+			SampleCount: count, LowSample: true, EstimateFactor: 2.5,
+		}}
+	}
 	wantNodes := []ServiceMapNode{
-		{Name: "svc-a", TotalTraces: 2, ErrorCount: 0, AvgLatencyMs: 55},
-		{Name: "svc-b", TotalTraces: 4, ErrorCount: 1, AvgLatencyMs: 25},
-		{Name: "svc-c", TotalTraces: 2, ErrorCount: 1, AvgLatencyMs: 30},
+		{Name: "svc-a", TotalTraces: 2, ErrorCount: 0, AvgLatencyMs: 55, P99LatencyMs: 137.5, LatencyProvenance: estimated(2)},
+		{Name: "svc-b", TotalTraces: 4, ErrorCount: 1, AvgLatencyMs: 25, P99LatencyMs: 62.5, LatencyProvenance: estimated(4)},
+		{Name: "svc-c", TotalTraces: 2, ErrorCount: 1, AvgLatencyMs: 30, P99LatencyMs: 75, LatencyProvenance: estimated(2)},
 	}
 	wantEdges := []ServiceMapEdge{
 		{Source: "svc-a", Target: "svc-b", CallCount: 2, AvgLatencyMs: 40},
@@ -255,7 +263,7 @@ func TestGetServiceMapMetrics_FixtureValues(t *testing.T) {
 		t.Fatalf("nodes: got %+v want %+v", got.Nodes, wantNodes)
 	}
 	for i := range wantNodes {
-		if got.Nodes[i] != wantNodes[i] {
+		if !reflect.DeepEqual(got.Nodes[i], wantNodes[i]) {
 			t.Errorf("node %d: got %+v want %+v", i, got.Nodes[i], wantNodes[i])
 		}
 	}

--- a/internal/storage/trace_repo.go
+++ b/internal/storage/trace_repo.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"golang.org/x/sync/errgroup"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -23,10 +24,12 @@ type TracesResponse struct {
 
 // ServiceMapNode represents a single service node on the service map.
 type ServiceMapNode struct {
-	Name         string  `json:"name"`
-	TotalTraces  int64   `json:"total_traces"`
-	ErrorCount   int64   `json:"error_count"`
-	AvgLatencyMs float64 `json:"avg_latency_ms"`
+	Name              string              `json:"name"`
+	TotalTraces       int64               `json:"total_traces"`
+	ErrorCount        int64               `json:"error_count"`
+	AvgLatencyMs      float64             `json:"avg_latency_ms"`
+	P99LatencyMs      float64             `json:"p99_latency_ms,omitempty"`
+	LatencyProvenance *latency.Provenance `json:"latency_provenance,omitempty"`
 }
 
 // ServiceMapEdge represents a connection between two services.
@@ -412,12 +415,22 @@ func (r *Repository) GetServiceMapMetrics(ctx context.Context, start, end time.T
 
 	nodes := make([]ServiceMapNode, 0, len(nodeRows))
 	for _, nr := range nodeRows {
+		avgLatencyMs := math.Round(nr.AvgDuration/1000.0*100) / 100
+		sampleCount := uint64(nr.SpanCount) // #nosec G115 -- grouped database counts cannot be negative.
 		nodes = append(nodes, ServiceMapNode{
 			Name:        nr.ServiceName,
 			TotalTraces: nr.SpanCount,
 			ErrorCount:  nr.ErrorCount,
 			// AVG(duration) is microseconds; convert to ms and round to 2dp.
-			AvgLatencyMs: math.Round(nr.AvgDuration/1000.0*100) / 100,
+			AvgLatencyMs: avgLatencyMs,
+			P99LatencyMs: avgLatencyMs * 2.5,
+			LatencyProvenance: &latency.Provenance{P99: &latency.Percentile{
+				Status:         latency.StatusEstimated,
+				Method:         latency.MethodAverageMultiplier,
+				SampleCount:    sampleCount,
+				LowSample:      sampleCount < latency.LowSampleThreshold,
+				EstimateFactor: 2.5,
+			}},
 		})
 	}
 

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -3,11 +3,15 @@ package telemetry
 import (
 	"database/sql"
 	"encoding/json"
+	"math"
 	"net/http"
 	"runtime"
+	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -349,11 +353,16 @@ type Metrics struct {
 	ExemplarPurgeDurationSeconds prometheus.Histogram
 
 	// Atomic counters for JSON health endpoint (avoids scraping Prometheus)
-	totalIngested  atomic.Int64
-	activeConns    atomic.Int64
-	dlqFileCount   atomic.Int64
-	dbLatencyP99Ms atomic.Int64
-	startTime      time.Time
+	totalIngested     atomic.Int64
+	activeConns       atomic.Int64
+	dlqFileCount      atomic.Int64
+	dbLatencyMu       sync.Mutex
+	dbLatencyRing     [1024]float64
+	dbLatencyNext     int
+	dbLatencyLen      int
+	dbLatencyObserved uint64
+	dbLatencyLastMs   float64
+	startTime         time.Time
 }
 
 // New creates and registers all OtelContext internal metrics.
@@ -946,33 +955,75 @@ func (m *Metrics) SetDLQSize(n int) {
 
 func (m *Metrics) ObserveDBLatency(seconds float64) {
 	m.DBLatency.Observe(seconds)
-	m.dbLatencyP99Ms.Store(int64(seconds * 1000))
+	m.dbLatencyMu.Lock()
+	m.dbLatencyLastMs = seconds * 1000
+	m.dbLatencyRing[m.dbLatencyNext] = m.dbLatencyLastMs
+	m.dbLatencyNext = (m.dbLatencyNext + 1) % len(m.dbLatencyRing)
+	if m.dbLatencyLen < len(m.dbLatencyRing) {
+		m.dbLatencyLen++
+	}
+	m.dbLatencyObserved++
+	m.dbLatencyMu.Unlock()
 }
 
 // --- Health endpoint ---
 
 // HealthStats is the JSON response for GET /api/health.
 type HealthStats struct {
-	IngestionRate  int64   `json:"ingestion_rate"`
-	DLQSize        int64   `json:"dlq_size"`
-	ActiveConns    int64   `json:"active_connections"`
-	DBLatencyP99Ms float64 `json:"db_latency_p99_ms"`
-	Goroutines     int     `json:"goroutines"`
-	HeapAllocMB    float64 `json:"heap_alloc_mb"`
-	UptimeSeconds  float64 `json:"uptime_seconds"`
+	IngestionRate     int64               `json:"ingestion_rate"`
+	DLQSize           int64               `json:"dlq_size"`
+	ActiveConns       int64               `json:"active_connections"`
+	DBLatencyP99Ms    float64             `json:"db_latency_p99_ms"`
+	DBLatencyLastMs   float64             `json:"db_latency_last_ms"`
+	LatencyProvenance *latency.Provenance `json:"latency_provenance,omitempty"`
+	Goroutines        int                 `json:"goroutines"`
+	HeapAllocMB       float64             `json:"heap_alloc_mb"`
+	UptimeSeconds     float64             `json:"uptime_seconds"`
+}
+
+func (m *Metrics) dbLatencySnapshot() (float64, float64, *latency.Provenance) {
+	m.dbLatencyMu.Lock()
+	values := append([]float64(nil), m.dbLatencyRing[:m.dbLatencyLen]...)
+	observed := m.dbLatencyObserved
+	last := m.dbLatencyLastMs
+	m.dbLatencyMu.Unlock()
+
+	percentile := &latency.Percentile{
+		Status: latency.StatusUnavailable,
+		Method: latency.MethodRollingObservationWindow,
+		Reason: latency.ReasonNoObservations,
+	}
+	if len(values) == 0 {
+		return 0, last, &latency.Provenance{P99: percentile}
+	}
+	sort.Float64s(values)
+	index := int(math.Ceil(float64(len(values))*0.99)) - 1
+	percentile.Status = latency.StatusMeasured
+	percentile.SampleCount = uint64(len(values))
+	percentile.LowSample = percentile.SampleCount < latency.LowSampleThreshold
+	percentile.Reason = ""
+	if observed > uint64(len(m.dbLatencyRing)) {
+		percentile.Status = latency.StatusBounded
+		percentile.PopulationCount = observed
+		percentile.SampleLimit = uint64(len(m.dbLatencyRing))
+	}
+	return values[index], last, &latency.Provenance{P99: percentile}
 }
 
 func (m *Metrics) GetHealthStats() HealthStats {
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
+	dbP99, dbLast, provenance := m.dbLatencySnapshot()
 	return HealthStats{
-		IngestionRate:  m.totalIngested.Load(),
-		DLQSize:        m.dlqFileCount.Load(),
-		ActiveConns:    m.activeConns.Load(),
-		DBLatencyP99Ms: float64(m.dbLatencyP99Ms.Load()),
-		Goroutines:     runtime.NumGoroutine(),
-		HeapAllocMB:    float64(ms.HeapAlloc) / 1024 / 1024,
-		UptimeSeconds:  time.Since(m.startTime).Seconds(),
+		IngestionRate:     m.totalIngested.Load(),
+		DLQSize:           m.dlqFileCount.Load(),
+		ActiveConns:       m.activeConns.Load(),
+		DBLatencyP99Ms:    dbP99,
+		DBLatencyLastMs:   dbLast,
+		LatencyProvenance: provenance,
+		Goroutines:        runtime.NumGoroutine(),
+		HeapAllocMB:       float64(ms.HeapAlloc) / 1024 / 1024,
+		UptimeSeconds:     time.Since(m.startTime).Seconds(),
 	}
 }
 

--- a/internal/telemetry/metrics_latency_test.go
+++ b/internal/telemetry/metrics_latency_test.go
@@ -1,0 +1,61 @@
+package telemetry
+
+import (
+	"math"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func testLatencyMetrics() *Metrics {
+	return &Metrics{
+		DBLatency: prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_db_latency_seconds"}),
+		startTime: time.Now(),
+	}
+}
+
+func TestDBLatencyObservationBoundaries(t *testing.T) {
+	for _, count := range []int{0, 1, 99, 100} {
+		t.Run(strconv.Itoa(count), func(t *testing.T) {
+			m := testLatencyMetrics()
+			for i := 0; i < count; i++ {
+				m.ObserveDBLatency(float64(i+1) / 1000)
+			}
+			stats := m.GetHealthStats()
+			p99 := stats.LatencyProvenance.P99
+			if count == 0 {
+				if stats.DBLatencyP99Ms != 0 || p99.Status != latency.StatusUnavailable || p99.Reason != latency.ReasonNoObservations {
+					t.Fatalf("empty stats=%+v provenance=%+v", stats, p99)
+				}
+				return
+			}
+			if p99.Status != latency.StatusMeasured || p99.Method != latency.MethodRollingObservationWindow || p99.SampleCount != uint64(count) || p99.LowSample != (count < 100) {
+				t.Fatalf("count=%d provenance=%+v", count, p99)
+			}
+			if stats.DBLatencyLastMs != float64(count) {
+				t.Fatalf("last=%v, want %d", stats.DBLatencyLastMs, count)
+			}
+		})
+	}
+}
+
+func TestDBLatencyRingBecomesBoundedAfterWrap(t *testing.T) {
+	m := testLatencyMetrics()
+	for i := 0; i < 1025; i++ {
+		m.ObserveDBLatency(float64(i+1) / 1000)
+	}
+	stats := m.GetHealthStats()
+	p99 := stats.LatencyProvenance.P99
+	if p99.Status != latency.StatusBounded || p99.SampleCount != 1024 || p99.PopulationCount != 1025 || p99.SampleLimit != 1024 {
+		t.Fatalf("provenance=%+v", p99)
+	}
+	if stats.DBLatencyLastMs != 1025 {
+		t.Fatalf("last=%v, want 1025", stats.DBLatencyLastMs)
+	}
+	if math.Abs(stats.DBLatencyP99Ms-1015) > 1e-9 {
+		t.Fatalf("p99=%v, want nearest-rank 1015", stats.DBLatencyP99Ms)
+	}
+}

--- a/internal/topology/aggregate.go
+++ b/internal/topology/aggregate.go
@@ -6,6 +6,7 @@ import (
 	"math"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 )
 
@@ -73,15 +74,17 @@ func (p *AggregateProvider) Snapshot(ctx context.Context, q Query) (Snapshot, er
 		errorRate := node.ErrorRate
 		health := aggregateHealth(errorRate, node.AvgLatencyMs)
 		snap.Nodes = append(snap.Nodes, Node{
-			Name:         node.Service,
-			TotalTraces:  node.Count,
-			ErrorCount:   node.ErrorCount,
-			AvgLatencyMs: node.AvgLatencyMs,
-			ErrorRate:    errorRate,
-			SpanCount:    node.Count,
-			HealthScore:  health,
-			Status:       healthStatus(health),
-			Alerts:       alerts(errorRate, node.AvgLatencyMs),
+			Name:              node.Service,
+			TotalTraces:       node.Count,
+			ErrorCount:        node.ErrorCount,
+			AvgLatencyMs:      node.AvgLatencyMs,
+			P99LatencyMs:      node.P99LatencyMicros / 1000.0,
+			LatencyProvenance: &node.LatencyProvenance,
+			ErrorRate:         errorRate,
+			SpanCount:         node.Count,
+			HealthScore:       health,
+			Status:            healthStatus(health),
+			Alerts:            alerts(errorRate, node.AvgLatencyMs),
 		})
 	}
 	for _, edge := range result.Edges {
@@ -129,18 +132,27 @@ func fromAggregateProjection(projection aggregate.TopologySnapshot) Snapshot {
 		errorRate := totals.errorRate()
 		avg := totals.avgLatencyMs()
 		health := aggregateHealth(errorRate, avg)
+		provenance := totals.latencyProvenance
+		if provenance == nil {
+			provenance = &latency.Provenance{P99: &latency.Percentile{
+				Status: latency.StatusUnavailable,
+				Method: latency.MethodDDSketch,
+				Reason: latency.ReasonNoObservations,
+			}}
+		}
 		snap.Nodes = append(snap.Nodes, Node{
-			Name:           service.Name,
-			TotalTraces:    saturatingInt64(totals.count),
-			ErrorCount:     saturatingInt64(totals.errors),
-			AvgLatencyMs:   avg,
-			RequestRateRPS: float64(totals.count) / 300,
-			ErrorRate:      errorRate,
-			P99LatencyMs:   totals.p99Ms,
-			SpanCount:      saturatingInt64(totals.count),
-			HealthScore:    health,
-			Status:         healthStatus(health),
-			Alerts:         alerts(errorRate, avg),
+			Name:              service.Name,
+			TotalTraces:       saturatingInt64(totals.count),
+			ErrorCount:        saturatingInt64(totals.errors),
+			AvgLatencyMs:      avg,
+			RequestRateRPS:    float64(totals.count) / 300,
+			ErrorRate:         errorRate,
+			P99LatencyMs:      totals.p99Ms,
+			LatencyProvenance: provenance,
+			SpanCount:         saturatingInt64(totals.count),
+			HealthScore:       health,
+			Status:            healthStatus(health),
+			Alerts:            alerts(errorRate, avg),
 		})
 	}
 	for _, edge := range projection.Edges {
@@ -162,6 +174,7 @@ func fromAggregateProjection(projection aggregate.TopologySnapshot) Snapshot {
 type windowTotals struct {
 	count, errors, durationCount uint64
 	durationSumMicros, p99Ms     float64
+	latencyProvenance            *latency.Provenance
 }
 
 func sumWindows(windows []aggregate.TopologyWindow) windowTotals {
@@ -171,8 +184,10 @@ func sumWindows(windows []aggregate.TopologyWindow) windowTotals {
 		totals.errors += window.ErrorCount
 		totals.durationCount += window.DurationCount
 		totals.durationSumMicros += window.DurationSumMicros
-		if window.P99Micros > 0 {
+		if window.LatencyProvenance != nil && window.LatencyProvenance.P99 != nil {
 			totals.p99Ms = window.P99Micros / 1000
+			provenance := *window.LatencyProvenance
+			totals.latencyProvenance = &provenance
 		}
 	}
 	return totals

--- a/internal/topology/legacy.go
+++ b/internal/topology/legacy.go
@@ -70,17 +70,18 @@ func (p *LegacyProvider) liveSnapshot(ctx context.Context, services []string) (S
 				}
 				svc := entry.Service
 				snap.Nodes = append(snap.Nodes, Node{
-					Name:           svc.Name,
-					TotalTraces:    svc.CallCount,
-					ErrorCount:     svc.ErrorCount,
-					AvgLatencyMs:   svc.AvgLatency,
-					RequestRateRPS: float64(svc.CallCount) / 300,
-					ErrorRate:      svc.ErrorRate,
-					P99LatencyMs:   svc.AvgLatency * 2.5,
-					SpanCount:      svc.CallCount,
-					HealthScore:    svc.HealthScore,
-					Status:         healthStatus(svc.HealthScore),
-					Alerts:         alerts(svc.ErrorRate, svc.AvgLatency),
+					Name:              svc.Name,
+					TotalTraces:       svc.CallCount,
+					ErrorCount:        svc.ErrorCount,
+					AvgLatencyMs:      svc.AvgLatency,
+					RequestRateRPS:    float64(svc.CallCount) / 300,
+					ErrorRate:         svc.ErrorRate,
+					P99LatencyMs:      svc.P99Latency,
+					LatencyProvenance: svc.LatencyProvenance,
+					SpanCount:         svc.CallCount,
+					HealthScore:       svc.HealthScore,
+					Status:            healthStatus(svc.HealthScore),
+					Alerts:            alerts(svc.ErrorRate, svc.AvgLatency),
 				})
 			}
 			for _, edge := range p.graphRAG.AllServiceEdges(ctx) {
@@ -114,16 +115,17 @@ func (p *LegacyProvider) liveSnapshot(ctx context.Context, services []string) (S
 					continue
 				}
 				snap.Nodes = append(snap.Nodes, Node{
-					Name:           node.Name,
-					TotalTraces:    node.SpanCount,
-					AvgLatencyMs:   node.AvgLatencyMs,
-					RequestRateRPS: node.RequestRateRPS,
-					ErrorRate:      node.ErrorRate,
-					P99LatencyMs:   node.P99LatencyMs,
-					SpanCount:      node.SpanCount,
-					HealthScore:    node.HealthScore,
-					Status:         node.Status,
-					Alerts:         append([]string(nil), node.Alerts...),
+					Name:              node.Name,
+					TotalTraces:       node.SpanCount,
+					AvgLatencyMs:      node.AvgLatencyMs,
+					RequestRateRPS:    node.RequestRateRPS,
+					ErrorRate:         node.ErrorRate,
+					P99LatencyMs:      node.P99LatencyMs,
+					LatencyProvenance: node.LatencyProvenance,
+					SpanCount:         node.SpanCount,
+					HealthScore:       node.HealthScore,
+					Status:            node.Status,
+					Alerts:            append([]string(nil), node.Alerts...),
 				})
 			}
 			for _, edge := range current.Edges {
@@ -157,17 +159,18 @@ func fromStorage(metrics *storage.ServiceMapMetrics) Snapshot {
 		}
 		health := legacyHealth(errorRate, node.AvgLatencyMs)
 		snap.Nodes = append(snap.Nodes, Node{
-			Name:           node.Name,
-			TotalTraces:    node.TotalTraces,
-			ErrorCount:     node.ErrorCount,
-			AvgLatencyMs:   node.AvgLatencyMs,
-			RequestRateRPS: float64(node.TotalTraces) / 3600,
-			ErrorRate:      errorRate,
-			P99LatencyMs:   node.AvgLatencyMs * 2.5,
-			SpanCount:      node.TotalTraces,
-			HealthScore:    health,
-			Status:         healthStatus(health),
-			Alerts:         alerts(errorRate, node.AvgLatencyMs),
+			Name:              node.Name,
+			TotalTraces:       node.TotalTraces,
+			ErrorCount:        node.ErrorCount,
+			AvgLatencyMs:      node.AvgLatencyMs,
+			RequestRateRPS:    float64(node.TotalTraces) / 3600,
+			ErrorRate:         errorRate,
+			P99LatencyMs:      node.P99LatencyMs,
+			LatencyProvenance: node.LatencyProvenance,
+			SpanCount:         node.TotalTraces,
+			HealthScore:       health,
+			Status:            healthStatus(health),
+			Alerts:            alerts(errorRate, node.AvgLatencyMs),
 		})
 	}
 	snap.Edges = make([]Edge, 0, len(metrics.Edges))

--- a/internal/topology/provider.go
+++ b/internal/topology/provider.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"strconv"
 	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 )
 
 // Source identifies the producer that owns a snapshot.
@@ -66,13 +68,14 @@ type Node struct {
 	ErrorCount   int64   `json:"error_count"`
 	AvgLatencyMs float64 `json:"avg_latency_ms"`
 
-	RequestRateRPS float64  `json:"request_rate_rps,omitempty"`
-	ErrorRate      float64  `json:"error_rate,omitempty"`
-	P99LatencyMs   float64  `json:"p99_latency_ms,omitempty"`
-	SpanCount      int64    `json:"span_count,omitempty"`
-	HealthScore    float64  `json:"health_score,omitempty"`
-	Status         string   `json:"status,omitempty"`
-	Alerts         []string `json:"alerts,omitempty"`
+	RequestRateRPS    float64             `json:"request_rate_rps,omitempty"`
+	ErrorRate         float64             `json:"error_rate,omitempty"`
+	P99LatencyMs      float64             `json:"p99_latency_ms,omitempty"`
+	LatencyProvenance *latency.Provenance `json:"latency_provenance,omitempty"`
+	SpanCount         int64               `json:"span_count,omitempty"`
+	HealthScore       float64             `json:"health_score,omitempty"`
+	Status            string              `json:"status,omitempty"`
+	Alerts            []string            `json:"alerts,omitempty"`
 }
 
 // Edge is one directed service dependency.

--- a/internal/topology/provider_test.go
+++ b/internal/topology/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 )
 
@@ -21,7 +22,7 @@ func (f fakeLegacyRepository) GetServiceMapMetrics(context.Context, time.Time, t
 func TestLegacyProviderExplicitRangeUsesLegacyTopology(t *testing.T) {
 	repo := fakeLegacyRepository{result: &storage.ServiceMapMetrics{
 		Nodes: []storage.ServiceMapNode{
-			{Name: "gateway", TotalTraces: 4},
+			{Name: "gateway", TotalTraces: 4, P99LatencyMs: 52, LatencyProvenance: &latency.Provenance{P99: &latency.Percentile{Status: latency.StatusEstimated, Method: latency.MethodAverageMultiplier, SampleCount: 4, EstimateFactor: 2.5}}},
 			{Name: "legacy-payments", TotalTraces: 3},
 		},
 		Edges: []storage.ServiceMapEdge{{Source: "gateway", Target: "legacy-payments", CallCount: 3}},
@@ -45,6 +46,27 @@ func TestLegacyProviderExplicitRangeUsesLegacyTopology(t *testing.T) {
 	}
 	if got := snapshot.Edges[0]; got.Source != "gateway" || got.Target != "legacy-payments" {
 		t.Fatalf("edge = %+v, want gateway -> legacy-payments", got)
+	}
+	if got := snapshot.Nodes[0]; got.P99LatencyMs != 52 || got.LatencyProvenance == nil || got.LatencyProvenance.P99.Status != latency.StatusEstimated {
+		t.Fatalf("latency contract = %+v", got)
+	}
+}
+
+func TestAggregateProjectionCarriesLatestSketchProvenance(t *testing.T) {
+	p99 := &latency.Percentile{Status: latency.StatusApproximate, Method: latency.MethodDDSketch, SampleCount: 1000, SketchScale: 4, RelativeErrorBound: 0.0217}
+	snapshot := fromAggregateProjection(aggregate.TopologySnapshot{Services: []aggregate.TopologyService{{
+		Name: "checkout",
+		Windows: []aggregate.TopologyWindow{{
+			Count: 1000, DurationCount: 1000, P99Micros: 1_000_000,
+			LatencyProvenance: &latency.Provenance{P99: p99},
+		}},
+	}}})
+	if len(snapshot.Nodes) != 1 {
+		t.Fatalf("nodes = %+v", snapshot.Nodes)
+	}
+	node := snapshot.Nodes[0]
+	if node.P99LatencyMs != 1000 || node.LatencyProvenance == nil || node.LatencyProvenance.P99.SampleCount != 1000 || node.LatencyProvenance.P99.RelativeErrorBound != 0.0217 {
+		t.Fatalf("node latency = %+v", node)
 	}
 }
 

--- a/internal/ui/static/app.js
+++ b/internal/ui/static/app.js
@@ -9,6 +9,7 @@ const dom = {
   connectionLabel: byId("connection-label"),
   pulseHealth: byId("pulse-health"),
   pulseErrors: byId("pulse-errors"),
+  pulseLatencyLabel: byId("pulse-latency-label"),
   pulseP99: byId("pulse-p99"),
   pulseServices: byId("pulse-services"),
   pulseUptime: byId("pulse-uptime"),
@@ -130,6 +131,64 @@ function formatMs(value) {
   if (ms < 1000) return trimFixed(ms, 0) + "ms";
   if (ms < 60000) return trimFixed(ms / 1000, 1) + "s";
   return trimFixed(ms / 60000, 1) + "m";
+}
+
+function formatP99(value, provenance) {
+  const p99 = provenance && typeof provenance === "object" && provenance.p99 && typeof provenance.p99 === "object"
+    ? provenance.p99
+    : null;
+  if (!p99) {
+    return {
+      label: "Reported p99",
+      value: formatMs(value),
+      explanation: "Server did not report percentile provenance",
+    };
+  }
+
+  const samples = Math.max(0, finite(p99.sample_count, 0));
+  const lowSample = p99.low_sample
+    ? (samples ? formatCount(samples) + " samples; low sample" : "Low sample")
+    : "";
+  const explain = (text) => lowSample ? text + "; " + lowSample : text;
+  switch (String(p99.status || "")) {
+  case "measured":
+    return {
+      label: "P99",
+      value: formatMs(value),
+      explanation: explain("Measured from " + formatCount(samples) + " spans"),
+    };
+  case "approximate": {
+    const bound = Number(p99.relative_error_bound);
+    const accuracy = p99.degraded
+      ? "DDSketch; degraded accuracy"
+      : Number.isFinite(bound) && bound > 0
+        ? "DDSketch, ±" + trimFixed(bound * 100, 1) + "%"
+        : "DDSketch approximation";
+    return { label: "Approx. p99", value: formatMs(value), explanation: explain(accuracy) };
+  }
+  case "estimated":
+    return {
+      label: "Estimated tail",
+      value: Number.isFinite(Number(value)) ? "~" + formatMs(value) : "—",
+      explanation: explain("Derived from average latency; not a measured percentile"),
+    };
+  case "bounded": {
+    const population = Math.max(0, finite(p99.population_count, 0));
+    return {
+      label: "Sample p99",
+      value: formatMs(value),
+      explanation: explain(formatCount(samples) + " retained spans out of " + formatCount(population)),
+    };
+  }
+  case "unavailable":
+    return { label: "P99 unavailable", value: "—", explanation: "No percentile data" };
+  default:
+    return {
+      label: "Reported p99",
+      value: formatMs(value),
+      explanation: "Server reported unknown percentile provenance",
+    };
+  }
 }
 
 function formatCount(value) {
@@ -483,6 +542,16 @@ function normalizeGraph(graph) {
   return value;
 }
 
+function formatPulseLatency(summary, dashboard) {
+  if (Object.prototype.hasOwnProperty.call(dashboard, "p99_latency_ms") || dashboard.latency_provenance) {
+    return formatP99(dashboard.p99_latency_ms, dashboard.latency_provenance);
+  }
+  if (Number.isFinite(Number(summary.avg_latency_ms))) {
+    return { label: "Average", value: formatMs(summary.avg_latency_ms), explanation: "Arithmetic mean latency" };
+  }
+  return { label: "P99 unavailable", value: "—", explanation: "No percentile data" };
+}
+
 function renderStates() {
   const nodeCount = state.graph && state.graph.nodes ? state.graph.nodes.length : 0;
   dom.loading.hidden = !state.loading;
@@ -505,9 +574,11 @@ function renderPulse() {
   dom.pulseErrors.textContent = Number.isFinite(Number(dashboard.error_rate))
     ? formatPercent(dashboard.error_rate, 1)
     : formatRatio(summary.total_error_rate, 1);
-  dom.pulseP99.textContent = Number.isFinite(Number(dashboard.p99_latency_ms))
-    ? formatMs(dashboard.p99_latency_ms)
-    : formatMs(summary.avg_latency_ms);
+  const tail = formatPulseLatency(summary, dashboard);
+  dom.pulseLatencyLabel.textContent = tail.label;
+  dom.pulseP99.textContent = tail.value;
+  dom.pulseP99.title = tail.explanation;
+  dom.pulseP99.setAttribute("aria-label", tail.label + ": " + tail.value + ". " + tail.explanation);
   dom.pulseServices.textContent = formatCount(summary.total_services);
   const uptime = Number(summary.uptime_seconds);
   if (Number.isFinite(uptime) && uptime !== state.uptimeAuthoritative) {
@@ -580,9 +651,11 @@ function serviceButton(node) {
   main.className = "service-row-main";
   main.appendChild(textElement("span", "service-name", node.id));
   const metrics = node.metrics || {};
-  let detail = formatMs(metrics.p99_latency_ms) + " p99 · " + formatRatio(metrics.error_rate, 1) + " error";
+  const tail = formatP99(metrics.p99_latency_ms, metrics.latency_provenance);
+  let detail = tail.value + " " + tail.label.toLowerCase() + " · " + formatRatio(metrics.error_rate, 1) + " error";
   if (state.anomalies.has(node.id)) detail += " · anomaly";
   main.appendChild(textElement("span", "service-meta", detail));
+  main.title = tail.explanation;
   const health = textElement("span", "service-health", formatRatio(node.health_score, 0));
   health.style.color = statusColor(status);
   button.append(dot, main, health);
@@ -799,7 +872,8 @@ function renderGraph() {
       group.appendChild(label);
     }
     const title = svgElement("title");
-    title.textContent = node.id + " — " + status + ", p99 " + formatMs(node.metrics.p99_latency_ms);
+    const tail = formatP99(node.metrics.p99_latency_ms, node.metrics.latency_provenance);
+    title.textContent = node.id + " — " + status + ", " + tail.label + " " + tail.value + ". " + tail.explanation;
     group.appendChild(title);
     group.addEventListener("click", (event) => {
       event.stopPropagation();
@@ -864,9 +938,10 @@ function setMobileMode(mode) {
   renderStates();
 }
 
-function statCard(label, value, critical) {
+function statCard(label, value, critical, explanation) {
   const card = document.createElement("div");
   card.className = "stat-card" + (critical ? " is-critical" : "");
+  if (explanation) card.title = explanation;
   card.append(textElement("span", "stat-label", label), textElement("strong", "", value));
   return card;
 }
@@ -876,11 +951,12 @@ function renderOverview(node) {
   const metrics = node.metrics || {};
   const stats = document.createElement("div");
   stats.className = "stat-grid";
+  const tail = formatP99(metrics.p99_latency_ms, metrics.latency_provenance);
   stats.append(
     statCard("RPS", formatCount(metrics.request_rate_rps) + "/s"),
     statCard("Error", formatRatio(metrics.error_rate, 1), finite(metrics.error_rate, 0) > 0),
     statCard("Average", formatMs(metrics.avg_latency_ms)),
-    statCard("P99", formatMs(metrics.p99_latency_ms))
+    statCard(tail.label, tail.value, false, tail.explanation)
   );
   wrapper.appendChild(stats);
 
@@ -1590,3 +1666,5 @@ refresh({ silent: false });
 refreshAnomalies();
 connectWebSocket();
 startPolling();
+
+export { formatP99, formatPulseLatency };

--- a/internal/ui/static/index.html
+++ b/internal/ui/static/index.html
@@ -35,7 +35,7 @@
             <dd id="pulse-errors">—</dd>
           </div>
           <div>
-            <dt>P99</dt>
+            <dt id="pulse-latency-label">P99</dt>
             <dd id="pulse-p99">—</dd>
           </div>
           <div>

--- a/test/browser/browser_test.go
+++ b/test/browser/browser_test.go
@@ -770,6 +770,9 @@ func assertNoUnexpectedBrowserEvents(t *testing.T, recorder *eventRecorder) {
 }
 
 func TestProtectedBrowserWorkflow(t *testing.T) {
+	if browserCase := strings.TrimSpace(os.Getenv("OTELCONTEXT_BROWSER_CASE")); browserCase != "" && browserCase != "protected" {
+		t.Skip("OTELCONTEXT_BROWSER_CASE selects " + browserCase)
+	}
 	binary := requiredBinary(t)
 	chrome := requiredChrome(t)
 	artifacts := artifactDirectory(t)
@@ -1111,4 +1114,96 @@ func TestProtectedBrowserWorkflow(t *testing.T) {
 
 	smoke.validateInventory()
 	assertNoUnexpectedBrowserEvents(t, recorder)
+}
+
+func TestLatencyLabels(t *testing.T) {
+	if strings.TrimSpace(os.Getenv("OTELCONTEXT_BROWSER_CASE")) != "latency" {
+		t.Skip("set OTELCONTEXT_BROWSER_CASE=latency")
+	}
+	binary := requiredBinary(t)
+	chrome := requiredChrome(t)
+	app := newAppProcess(t, binary)
+	if err := app.start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = app.stop() })
+	readyCtx, readyCancel := context.WithTimeout(context.Background(), readyTimeout)
+	if err := waitReady(readyCtx, app.baseURL()); err != nil {
+		readyCancel()
+		t.Fatalf("application did not become ready: %v\n%s", err, app.log.Bytes())
+	}
+	readyCancel()
+
+	allocatorOptions := append([]chromedp.ExecAllocatorOption{}, chromedp.DefaultExecAllocatorOptions[:]...)
+	allocatorOptions = append(allocatorOptions, chromedp.ExecPath(chrome), chromedp.Flag("disable-dev-shm-usage", true))
+	if os.Geteuid() == 0 {
+		allocatorOptions = append(allocatorOptions, chromedp.NoSandbox)
+	}
+	allocatorCtx, cancelAllocator := chromedp.NewExecAllocator(context.Background(), allocatorOptions...)
+	defer cancelAllocator()
+	browserCtx, cancelBrowser := chromedp.NewContext(allocatorCtx)
+	defer cancelBrowser()
+	ctx, cancel := context.WithTimeout(browserCtx, 60*time.Second)
+	defer cancel()
+	if err := chromedp.Run(ctx, chromedp.Navigate(app.baseURL()+"/")); err != nil {
+		t.Fatal(err)
+	}
+	requireJS(t, ctx, `document.readyState === "complete" && !!document.querySelector('script[type="module"][src="/static/app.js"]')`, 10*time.Second)
+
+	var raw string
+	if err := chromedp.Run(ctx, chromedp.Evaluate(`
+		(async () => {
+			const ui = await import("/static/app.js");
+			return JSON.stringify({
+				cases: [
+					ui.formatP99(1000, {p99:{status:"measured",method:"ordered_rank",sample_count:1000}}),
+					ui.formatP99(980, {p99:{status:"approximate",method:"ddsketch",sample_count:1000,relative_error_bound:0.0217}}),
+					ui.formatP99(52, {p99:{status:"estimated",method:"average_multiplier",sample_count:1000,estimate_factor:2.5}}),
+					ui.formatP99(1000, {p99:{status:"bounded",method:"retained_prefix",sample_count:1000,population_count:1001,sample_limit:1000}}),
+					ui.formatP99(0, {p99:{status:"unavailable",reason:"no_observations"}}),
+					ui.formatP99(42, null),
+					ui.formatP99(10, {p99:{status:"measured",method:"ordered_rank",sample_count:99,low_sample:true}})
+				],
+				estimatedPulse: ui.formatPulseLatency(
+					{avg_latency_ms:21},
+					{p99_latency_ms:52,latency_provenance:{p99:{status:"estimated",method:"average_multiplier",sample_count:1000,estimate_factor:2.5}}}
+				),
+				averagePulse: ui.formatPulseLatency({avg_latency_ms:21}, {})
+			});
+		})()
+	`, &raw, func(params *cdpruntime.EvaluateParams) *cdpruntime.EvaluateParams {
+		return params.WithAwaitPromise(true)
+	})); err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Cases []struct {
+			Label       string `json:"label"`
+			Value       string `json:"value"`
+			Explanation string `json:"explanation"`
+		} `json:"cases"`
+		EstimatedPulse struct {
+			Label string `json:"label"`
+			Value string `json:"value"`
+		} `json:"estimatedPulse"`
+		AveragePulse struct {
+			Label string `json:"label"`
+			Value string `json:"value"`
+		} `json:"averagePulse"`
+	}
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatal(err)
+	}
+	wantLabels := []string{"P99", "Approx. p99", "Estimated tail", "Sample p99", "P99 unavailable", "Reported p99", "P99"}
+	for i, label := range wantLabels {
+		if got.Cases[i].Label != label {
+			t.Fatalf("case %d label=%q, want %q", i, got.Cases[i].Label, label)
+		}
+	}
+	if got.Cases[2].Value != "~52ms" || got.Cases[4].Value != "—" || !strings.Contains(got.Cases[1].Explanation, "±2.2%") || !strings.Contains(got.Cases[6].Explanation, "low sample") {
+		t.Fatalf("formatter cases = %+v", got.Cases)
+	}
+	if got.EstimatedPulse.Label != "Estimated tail" || got.EstimatedPulse.Value != "~52ms" || got.AveragePulse.Label != "Average" || got.AveragePulse.Value != "21ms" {
+		t.Fatalf("pulse cases = estimated %+v average %+v", got.EstimatedPulse, got.AveragePulse)
+	}
 }

--- a/test/topologyproof/latency_proof_test.go
+++ b/test/topologyproof/latency_proof_test.go
@@ -1,0 +1,494 @@
+package topologyproof
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/api"
+	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
+	"github.com/RandomCodeSpace/otelcontext/internal/mcp"
+	"github.com/RandomCodeSpace/otelcontext/internal/realtime"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/RandomCodeSpace/otelcontext/internal/telemetry"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
+)
+
+const (
+	latencyProofModeEnv = "OTELCONTEXT_LATENCY_PROOF_MODE"
+	latencyProofDirEnv  = "OTELCONTEXT_LATENCY_PROOF_DIR"
+	latencyService      = "latency-sentinel"
+	latencyLowMicros    = 10_000
+	latencyTailMicros   = 1_000_000
+	latencyLowCount     = 989
+	latencyTailCount    = 11
+)
+
+type latencySentinel struct {
+	LowCount     int     `json:"low_count"`
+	LowMS        float64 `json:"low_ms"`
+	TailCount    int     `json:"tail_count"`
+	TailMS       float64 `json:"tail_ms"`
+	Population   int     `json:"population"`
+	AverageMS    float64 `json:"average_ms"`
+	NearestP99MS float64 `json:"nearest_rank_p99_ms"`
+	MultiplierMS float64 `json:"average_multiplier_ms"`
+	Multiplier   float64 `json:"average_multiplier"`
+}
+
+type latencySurface struct {
+	Value      float64             `json:"value"`
+	Unit       string              `json:"unit"`
+	Provenance *latency.Provenance `json:"latency_provenance,omitempty"`
+}
+
+type latencyContractProof struct {
+	SchemaVersion string                    `json:"schema_version"`
+	Mode          string                    `json:"mode"`
+	Sentinel      latencySentinel           `json:"sentinel"`
+	Dashboard     latencySurface            `json:"rest_dashboard"`
+	SystemGraph   latencySurface            `json:"rest_system_graph"`
+	WebSocket     latencySurface            `json:"websocket_dashboard"`
+	GraphRAG      latencySurface            `json:"graphrag_service"`
+	MCPMap        latencySurface            `json:"mcp_get_service_map"`
+	MCPHealth     latencySurface            `json:"mcp_get_service_health"`
+	Operation     latencySurface            `json:"graphrag_operation"`
+	UILabels      []string                  `json:"ui_labels"`
+	Assertions    map[string]proofAssertion `json:"assertions"`
+}
+
+func newLatencyContractProof(mode string) *latencyContractProof {
+	return &latencyContractProof{
+		SchemaVersion: "otelcontext.latency-contract.v1",
+		Mode:          mode,
+		Sentinel: latencySentinel{
+			LowCount:     latencyLowCount,
+			LowMS:        latencyLowMicros / 1000,
+			TailCount:    latencyTailCount,
+			TailMS:       latencyTailMicros / 1000,
+			Population:   latencyLowCount + latencyTailCount,
+			AverageMS:    20.89,
+			NearestP99MS: 1000,
+			MultiplierMS: 52.225,
+			Multiplier:   2.5,
+		},
+		UILabels: []string{
+			"P99",
+			"Approx. p99",
+			"Estimated tail",
+			"Sample p99",
+			"P99 unavailable",
+			"Reported p99",
+			"Average",
+		},
+		Assertions: make(map[string]proofAssertion),
+	}
+}
+
+func (p *latencyContractProof) check(t *testing.T, name string, passed bool, detail string) {
+	t.Helper()
+	p.Assertions[name] = proofAssertion{Passed: passed, Detail: detail}
+	if !passed {
+		t.Errorf("%s: %s", name, detail)
+	}
+}
+
+func (p *latencyContractProof) write(t *testing.T) {
+	t.Helper()
+	dir := os.Getenv(latencyProofDirEnv)
+	if dir == "" {
+		dir = t.TempDir()
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Errorf("create latency proof directory: %v", err)
+		return
+	}
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		t.Errorf("marshal latency proof: %v", err)
+		return
+	}
+	path := filepath.Join(dir, p.Mode+".json")
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		t.Errorf("write latency proof: %v", err)
+		return
+	}
+	t.Logf("latency proof: %s", path)
+}
+
+func TestLatencyModeProof(t *testing.T) {
+	mode := os.Getenv(latencyProofModeEnv)
+	if mode == "" {
+		t.Skipf("%s is set by the dedicated latency-proof CI job", latencyProofModeEnv)
+	}
+	if mode != aggregate.ModeLegacy && mode != aggregate.ModeShadow && mode != aggregate.ModeAggregate {
+		t.Fatalf("unsupported proof mode %q", mode)
+	}
+
+	proof := newLatencyContractProof(mode)
+	defer proof.write(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	repo := proofRepository(t)
+	seedLatencyRepository(t, repo, now)
+
+	var engine *aggregate.Engine
+	var provider topology.Provider
+	var graphRAG *graphrag.GraphRAG
+	if mode == aggregate.ModeAggregate {
+		engine = latencyAggregateEngine(t, now)
+		aggregateProvider, err := topology.NewAggregateProvider(engine)
+		if err != nil {
+			t.Fatalf("new aggregate topology provider: %v", err)
+		}
+		provider = aggregateProvider
+		graphRAG = newLatencyGraphRAG(t, mode, now, aggregateProvider)
+	} else {
+		graphRAG = newLatencyGraphRAG(t, mode, now, nil)
+		legacyProvider, err := topology.NewLegacyProvider(repo, nil, graphRAG)
+		if err != nil {
+			t.Fatalf("new legacy topology provider: %v", err)
+		}
+		provider = legacyProvider
+	}
+
+	metrics := telemetry.New()
+	rawHub := realtime.NewHub(nil)
+	rawHub.SetTopologyProvider(provider, proofFloor)
+	if mode == aggregate.ModeAggregate {
+		rawHub.SetAggregateMode(true)
+	}
+	go rawHub.Run()
+
+	eventHub := realtime.NewEventHub(repo, nil, nil)
+	if mode == aggregate.ModeAggregate {
+		publisher := realtime.NewEnginePublisher(realtime.EnginePublisherConfig{
+			Engine: engine, Topology: provider, Window: 15 * time.Minute,
+		})
+		if publisher == nil {
+			t.Fatal("aggregate latency publisher was not constructed")
+		}
+		eventHub.SetAggregatePublisher(publisher, proofFloor)
+	}
+	eventCtx, cancelEvents := context.WithCancel(context.Background())
+	go eventHub.Start(eventCtx, 50*time.Millisecond, 20*time.Millisecond)
+
+	apiServer := api.NewServer(repo, rawHub, eventHub, metrics)
+	apiServer.SetGraphRAG(graphRAG)
+	apiServer.SetTopologyProvider(provider)
+	if mode == aggregate.ModeAggregate {
+		apiServer.SetAggregateEngine(engine)
+	}
+	mux := http.NewServeMux()
+	apiServer.RegisterRoutes(mux)
+	httpServer := httptest.NewServer(mux)
+
+	mcpServer := mcp.New(storage.DefaultTenantID, repo, metrics, provider)
+	mcpServer.SetGraphRAG(graphRAG)
+	mcpServer.SetAggregateMode(mode == aggregate.ModeAggregate)
+	mcpHTTP := httptest.NewServer(mcpServer.Handler())
+
+	t.Cleanup(func() {
+		mcpHTTP.Close()
+		httpServer.Close()
+		cancelEvents()
+		eventHub.Stop()
+		rawHub.Stop()
+		graphRAG.Stop()
+	})
+
+	var dashboard struct {
+		P99LatencyMS      float64             `json:"p99_latency_ms"`
+		LatencyProvenance *latency.Provenance `json:"latency_provenance"`
+	}
+	getProofJSON(t, httpServer.URL+"/api/metrics/dashboard", &dashboard)
+	proof.Dashboard = latencySurface{Value: dashboard.P99LatencyMS, Unit: "milliseconds", Provenance: dashboard.LatencyProvenance}
+
+	var systemGraph api.SystemGraphResponse
+	getProofJSON(t, httpServer.URL+"/api/system/graph", &systemGraph)
+	systemNode := findGraphNode(t, systemGraph.Nodes, latencyService)
+	proof.SystemGraph = latencySurface{Value: systemNode.Metrics.P99LatencyMs, Unit: "milliseconds", Provenance: systemNode.Metrics.LatencyProvenance}
+
+	graphEntry := findServiceEntry(t, graphRAG.ServiceMap(context.Background(), 0), latencyService)
+	proof.GraphRAG = latencySurface{Value: graphEntry.Service.P99Latency, Unit: "milliseconds", Provenance: graphEntry.Service.LatencyProvenance}
+	if len(graphEntry.Operations) == 0 {
+		t.Fatal("latency sentinel operation is absent from GraphRAG")
+	}
+	operation := graphEntry.Operations[0]
+	proof.Operation = latencySurface{Value: operation.P99Latency, Unit: "milliseconds", Provenance: operation.LatencyProvenance}
+
+	mapRaw := callTool(t, mcpHTTP.URL, "get_service_map", nil)
+	var mapEntries []graphrag.ServiceMapEntry
+	decodeFirstJSON(t, mapRaw, &mapEntries)
+	mapEntry := findServiceEntry(t, mapEntries, latencyService)
+	proof.MCPMap = latencySurface{Value: mapEntry.Service.P99Latency, Unit: "milliseconds", Provenance: mapEntry.Service.LatencyProvenance}
+
+	healthRaw := callTool(t, mcpHTTP.URL, "get_service_health", map[string]any{"service_name": latencyService})
+	var healthEntry graphrag.ServiceMapEntry
+	decodeFirstJSON(t, healthRaw, &healthEntry)
+	if healthEntry.Service == nil {
+		t.Fatalf("MCP service health omitted %q: %s", latencyService, compact(healthRaw))
+	}
+	proof.MCPHealth = latencySurface{Value: healthEntry.Service.P99Latency, Unit: "milliseconds", Provenance: healthEntry.Service.LatencyProvenance}
+
+	eventConn := dialWS(t, httpServer.URL+"/ws/events")
+	eventSnapshot := readEventSnapshot(t, eventConn, 3*time.Second)
+	if eventSnapshot.Dashboard == nil {
+		t.Fatal("WebSocket snapshot omitted dashboard")
+	}
+	proof.WebSocket = latencySurface{
+		Value:      float64(eventSnapshot.Dashboard.P99Latency),
+		Unit:       "microseconds",
+		Provenance: eventSnapshot.Dashboard.LatencyProvenance,
+	}
+
+	if mode == aggregate.ModeAggregate {
+		proof.check(t, "rest_dashboard_approximate", validApproximate(proof.Dashboard, 1000), describeLatency(proof.Dashboard))
+		proof.check(t, "rest_system_graph_approximate", validApproximate(proof.SystemGraph, 1000), describeLatency(proof.SystemGraph))
+		proof.check(t, "websocket_approximate", validApproximate(proof.WebSocket, latencyTailMicros), describeLatency(proof.WebSocket))
+		proof.check(t, "graphrag_approximate", validApproximate(proof.GraphRAG, 1000), describeLatency(proof.GraphRAG))
+		proof.check(t, "mcp_map_approximate", validApproximate(proof.MCPMap, 1000), describeLatency(proof.MCPMap))
+		proof.check(t, "mcp_health_approximate", validApproximate(proof.MCPHealth, 1000), describeLatency(proof.MCPHealth))
+		proof.check(t, "aggregate_source_owned", systemGraph.Source == "aggregate", fmt.Sprintf("graph=%q", systemGraph.Source))
+	} else {
+		proof.check(t, "rest_dashboard_measured", validMeasured(proof.Dashboard, 1000, latency.MethodOrderedRank), describeLatency(proof.Dashboard))
+		proof.check(t, "rest_system_graph_estimated", validEstimated(proof.SystemGraph), describeLatency(proof.SystemGraph))
+		proof.check(t, "websocket_measured", validMeasured(proof.WebSocket, latencyTailMicros, latency.MethodOrderedRank), describeLatency(proof.WebSocket))
+		proof.check(t, "graphrag_estimated", validEstimated(proof.GraphRAG), describeLatency(proof.GraphRAG))
+		proof.check(t, "mcp_map_estimated", validEstimated(proof.MCPMap), describeLatency(proof.MCPMap))
+		proof.check(t, "mcp_health_estimated", validEstimated(proof.MCPHealth), describeLatency(proof.MCPHealth))
+		proof.check(t, "legacy_source_owned", systemGraph.Source == "", fmt.Sprintf("graph=%q", systemGraph.Source))
+	}
+
+	proof.check(t, "websocket_unit_preserved", proof.WebSocket.Unit == "microseconds" && math.Abs(proof.WebSocket.Value-proof.Dashboard.Value*1000) <= 1, fmt.Sprintf("REST=%vms websocket=%vµs", proof.Dashboard.Value, proof.WebSocket.Value))
+	proof.check(t, "graphrag_mcp_consistent", sameLatency(proof.GraphRAG, proof.MCPMap) && sameLatency(proof.GraphRAG, proof.MCPHealth), fmt.Sprintf("graph=%s map=%s health=%s", describeLatency(proof.GraphRAG), describeLatency(proof.MCPMap), describeLatency(proof.MCPHealth)))
+	proof.check(t, "operation_percentiles_unavailable", unavailableOperation(operation), fmt.Sprintf("value=%v provenance=%+v", operation.P99Latency, operation.LatencyProvenance))
+	proof.check(t, "sample_count_preserved", allSampleCounts(proof, latencyLowCount+latencyTailCount), "every available surface reports the 1,000-observation source population")
+	proof.check(t, "ui_label_contract", len(proof.UILabels) == 7 && proof.UILabels[0] == "P99" && proof.UILabels[6] == "Average", strings.Join(proof.UILabels, ", "))
+}
+
+func seedLatencyRepository(t *testing.T, repo *storage.Repository, now time.Time) {
+	t.Helper()
+	traces := make([]storage.Trace, 0, latencyLowCount+latencyTailCount)
+	for i := 0; i < latencyLowCount+latencyTailCount; i++ {
+		duration := int64(latencyLowMicros)
+		if i >= latencyLowCount {
+			duration = latencyTailMicros
+		}
+		traces = append(traces, storage.Trace{
+			TenantID: storage.DefaultTenantID, TraceID: fmt.Sprintf("latency-%04d", i),
+			ServiceName: latencyService, Duration: duration, Status: "STATUS_CODE_UNSET",
+			Timestamp: now.Add(-time.Minute),
+		})
+	}
+	if err := repo.BatchCreateTraces(traces); err != nil {
+		t.Fatalf("seed latency traces: %v", err)
+	}
+}
+
+func latencyAggregateEngine(t *testing.T, now time.Time) *aggregate.Engine {
+	t.Helper()
+	engine, err := aggregate.NewEngine(aggregate.EngineConfig{
+		Mode: aggregate.ModeAggregate, Epoch: 99, Now: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("new aggregate engine: %v", err)
+	}
+	reducer := engine.NewReducer(now)
+	for i := 0; i < latencyLowCount+latencyTailCount; i++ {
+		duration := float64(latencyLowMicros)
+		if i >= latencyLowCount {
+			duration = latencyTailMicros
+		}
+		reducer.ReduceSpan(aggregate.SpanInput{
+			Tenant: storage.DefaultTenantID, Service: latencyService, SpanName: "GET /latency",
+			SpanKind: int32(aggregate.SpanKindServer), Root: true,
+			Timestamp: now.Add(-time.Minute), DurationMicros: duration,
+		})
+	}
+	if revision := engine.ApplyReducer(reducer); revision == 0 {
+		t.Fatal("aggregate latency reducer produced no revision")
+	}
+	return engine
+}
+
+func newLatencyGraphRAG(t *testing.T, mode string, now time.Time, source graphrag.AggregateSource) *graphrag.GraphRAG {
+	t.Helper()
+	cfg := graphrag.DefaultConfig()
+	cfg.Mode = mode
+	cfg.WorkerCount = 1
+	cfg.ChannelSize = 2048
+	cfg.RefreshEvery = time.Hour
+	cfg.SnapshotEvery = time.Hour
+	cfg.AnomalyEvery = time.Hour
+	graphRAG := graphrag.New(nil, nil, nil, cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if mode == aggregate.ModeAggregate {
+		graphRAG.SetAggregateSource(source)
+	}
+	graphRAG.Start(ctx)
+	if mode == aggregate.ModeAggregate {
+		entry := findServiceEntry(t, graphRAG.ServiceMap(context.Background(), 0), latencyService)
+		if entry.Service.CallCount != latencyLowCount+latencyTailCount {
+			t.Fatalf("aggregate GraphRAG call count = %d", entry.Service.CallCount)
+		}
+		shutdownLatencyGraphRAG(t, graphRAG)
+		return graphRAG
+	}
+
+	for i := 0; i < latencyLowCount+latencyTailCount; i++ {
+		duration := int64(latencyLowMicros)
+		if i >= latencyLowCount {
+			duration = latencyTailMicros
+		}
+		graphRAG.OnSpanIngested(storage.Span{
+			TenantID: storage.DefaultTenantID, TraceID: fmt.Sprintf("latency-%04d", i),
+			SpanID: fmt.Sprintf("%016x", i+1), ServiceName: latencyService,
+			OperationName: "GET /latency", StartTime: now.Add(-time.Minute),
+			Duration: duration, Status: "STATUS_CODE_UNSET",
+		})
+	}
+	shutdownLatencyGraphRAG(t, graphRAG)
+	entry := findServiceEntry(t, graphRAG.ServiceMap(context.Background(), 0), latencyService)
+	if entry.Service.CallCount != latencyLowCount+latencyTailCount {
+		t.Fatalf("legacy GraphRAG call count = %d", entry.Service.CallCount)
+	}
+	return graphRAG
+}
+
+func shutdownLatencyGraphRAG(t *testing.T, graphRAG *graphrag.GraphRAG) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := graphRAG.Shutdown(ctx); err != nil {
+		t.Fatalf("drain latency GraphRAG: %v", err)
+	}
+}
+
+func getProofJSON(t *testing.T, url string, target any) {
+	t.Helper()
+	response, err := http.Get(url) //nolint:gosec // local httptest endpoint
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s status %d", url, response.StatusCode)
+	}
+	if err := json.NewDecoder(response.Body).Decode(target); err != nil {
+		t.Fatalf("decode %s: %v", url, err)
+	}
+}
+
+func decodeFirstJSON(t *testing.T, raw string, target any) {
+	t.Helper()
+	if err := json.NewDecoder(strings.NewReader(raw)).Decode(target); err != nil {
+		t.Fatalf("decode MCP JSON: %v (%s)", err, compact(raw))
+	}
+}
+
+func findGraphNode(t *testing.T, nodes []api.GraphNode, name string) api.GraphNode {
+	t.Helper()
+	for _, node := range nodes {
+		if node.ID == name {
+			return node
+		}
+	}
+	t.Fatalf("system graph omitted %q", name)
+	return api.GraphNode{}
+}
+
+func findServiceEntry(t *testing.T, entries []graphrag.ServiceMapEntry, name string) graphrag.ServiceMapEntry {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.Service != nil && entry.Service.Name == name {
+			return entry
+		}
+	}
+	t.Fatalf("service map omitted %q", name)
+	return graphrag.ServiceMapEntry{}
+}
+
+func p99(surface latencySurface) *latency.Percentile {
+	if surface.Provenance == nil {
+		return nil
+	}
+	return surface.Provenance.P99
+}
+
+func validMeasured(surface latencySurface, want float64, method string) bool {
+	claim := p99(surface)
+	return math.Abs(surface.Value-want) < 1e-9 && claim != nil &&
+		claim.Status == latency.StatusMeasured && claim.Method == method &&
+		claim.SampleCount == latencyLowCount+latencyTailCount && !claim.LowSample
+}
+
+func validEstimated(surface latencySurface) bool {
+	claim := p99(surface)
+	return math.Abs(surface.Value-52.225) <= 0.01 && claim != nil &&
+		claim.Status == latency.StatusEstimated && claim.Method == latency.MethodAverageMultiplier &&
+		claim.SampleCount == latencyLowCount+latencyTailCount && claim.EstimateFactor == 2.5
+}
+
+func validApproximate(surface latencySurface, exact float64) bool {
+	claim := p99(surface)
+	if claim == nil || claim.Status != latency.StatusApproximate || claim.Method != latency.MethodDDSketch ||
+		claim.SampleCount != latencyLowCount+latencyTailCount || claim.RelativeErrorBound <= 0 || claim.Degraded {
+		return false
+	}
+	return math.Abs(surface.Value-exact)/exact <= claim.RelativeErrorBound+1e-6
+}
+
+func sameLatency(left, right latencySurface) bool {
+	lp, rp := p99(left), p99(right)
+	return math.Abs(left.Value-right.Value) < 1e-9 && lp != nil && rp != nil &&
+		lp.Status == rp.Status && lp.Method == rp.Method && lp.SampleCount == rp.SampleCount
+}
+
+func unavailableOperation(operation *graphrag.OperationNode) bool {
+	if operation == nil || operation.P50Latency != 0 || operation.P95Latency != 0 || operation.P99Latency != 0 || operation.LatencyProvenance == nil {
+		return false
+	}
+	claims := []*latency.Percentile{
+		operation.LatencyProvenance.P50,
+		operation.LatencyProvenance.P95,
+		operation.LatencyProvenance.P99,
+	}
+	for _, claim := range claims {
+		if claim == nil || claim.Status != latency.StatusUnavailable || claim.Reason != latency.ReasonPercentileNotRecorded {
+			return false
+		}
+	}
+	return true
+}
+
+func allSampleCounts(proof *latencyContractProof, want int) bool {
+	for _, surface := range []latencySurface{
+		proof.Dashboard, proof.SystemGraph, proof.WebSocket,
+		proof.GraphRAG, proof.MCPMap, proof.MCPHealth,
+	} {
+		claim := p99(surface)
+		if claim == nil || claim.SampleCount != uint64(want) {
+			return false
+		}
+	}
+	return true
+}
+
+func describeLatency(surface latencySurface) string {
+	claim := p99(surface)
+	if claim == nil {
+		return fmt.Sprintf("value=%v%s provenance=nil", surface.Value, surface.Unit)
+	}
+	return fmt.Sprintf("value=%v%s status=%s method=%s samples=%d bound=%v", surface.Value, surface.Unit, claim.Status, claim.Method, claim.SampleCount, claim.RelativeErrorBound)
+}

--- a/test/topologyproof/topology_proof_test.go
+++ b/test/topologyproof/topology_proof_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/api"
 	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/RandomCodeSpace/otelcontext/internal/mcp"
 	"github.com/RandomCodeSpace/otelcontext/internal/realtime"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
@@ -200,10 +201,22 @@ func topologySnapshot(source topology.Source, epoch string, revision uint64, tar
 	if empty {
 		return topology.Snapshot{Nodes: []topology.Node{}, Edges: []topology.Edge{}, Meta: meta}
 	}
+	p99 := &latency.Percentile{
+		Status: latency.StatusEstimated, Method: latency.MethodAverageMultiplier,
+		SampleCount: 1000, EstimateFactor: 2.5,
+	}
+	p99LatencyMs := 52.225
+	if source == topology.SourceAggregate {
+		p99 = &latency.Percentile{
+			Status: latency.StatusApproximate, Method: latency.MethodDDSketch,
+			SampleCount: 1000, SketchScale: aggregate.SketchDefaultScale, RelativeErrorBound: 0.0217,
+		}
+		p99LatencyMs = 1000
+	}
 	return topology.Snapshot{
 		Nodes: []topology.Node{
-			{Name: "gateway", TotalTraces: 10, SpanCount: 10, HealthScore: 100, Status: "healthy"},
-			{Name: target, TotalTraces: 10, SpanCount: 10, HealthScore: 100, Status: "healthy"},
+			{Name: "gateway", TotalTraces: 1000, AvgLatencyMs: 20.89, P99LatencyMs: p99LatencyMs, LatencyProvenance: &latency.Provenance{P99: p99}, SpanCount: 1000, HealthScore: 100, Status: "healthy"},
+			{Name: target, TotalTraces: 1000, AvgLatencyMs: 20.89, P99LatencyMs: p99LatencyMs, LatencyProvenance: &latency.Provenance{P99: p99}, SpanCount: 1000, HealthScore: 100, Status: "healthy"},
 		},
 		Edges: []topology.Edge{{Source: "gateway", Target: target, CallCount: 10, AvgLatencyMs: 4, Status: "healthy"}},
 		Meta:  meta,
@@ -231,11 +244,16 @@ func aggregateSnapshot(epoch, revision uint64, target string, empty bool) aggreg
 		Closed:            true,
 		Final:             true,
 		Elapsed:           aggregate.WindowSize,
-		Count:             10,
-		DurationCount:     10,
-		DurationSumMicros: 40_000,
-		P95Micros:         5_000,
-		P99Micros:         6_000,
+		Count:             1000,
+		DurationCount:     1000,
+		DurationSumMicros: 20_890_000,
+		P95Micros:         10_000,
+		P99Micros:         1_000_000,
+		LatencyProvenance: &latency.Provenance{P95: &latency.Percentile{
+			Status: latency.StatusApproximate, Method: latency.MethodDDSketch, SampleCount: 1000, SketchScale: aggregate.SketchDefaultScale, RelativeErrorBound: 0.0217,
+		}, P99: &latency.Percentile{
+			Status: latency.StatusApproximate, Method: latency.MethodDDSketch, SampleCount: 1000, SketchScale: aggregate.SketchDefaultScale, RelativeErrorBound: 0.0217,
+		}},
 	}
 	base.Services = []aggregate.TopologyService{
 		{Name: "gateway", FirstSeen: now, LastSeen: window.End, Windows: []aggregate.TopologyWindow{window}},
@@ -263,7 +281,7 @@ func (p providerPublisher) Snapshot(ctx context.Context, _ string) *realtime.Liv
 	}
 	nodes := make([]storage.ServiceMapNode, len(snapshot.Nodes))
 	for i, node := range snapshot.Nodes {
-		nodes[i] = storage.ServiceMapNode{Name: node.Name, TotalTraces: node.TotalTraces, ErrorCount: node.ErrorCount, AvgLatencyMs: node.AvgLatencyMs}
+		nodes[i] = storage.ServiceMapNode{Name: node.Name, TotalTraces: node.TotalTraces, ErrorCount: node.ErrorCount, AvgLatencyMs: node.AvgLatencyMs, P99LatencyMs: node.P99LatencyMs, LatencyProvenance: node.LatencyProvenance}
 	}
 	edges := make([]storage.ServiceMapEdge, len(snapshot.Edges))
 	for i, edge := range snapshot.Edges {


### PR DESCRIPTION
Closes #249

## Summary

- keep every existing latency number, field name, type, and unit while adding shared measured, approximate, estimated, bounded, and unavailable provenance
- replace capped SQLite percentile sorting with adapter-owned nearest-rank queries and carry DDSketch accuracy through aggregate topology, GraphRAG, REST, WebSocket, and MCP
- render honest labels from one embedded native-JavaScript formatter with no Node project dependency
- add contradictory-distribution artifacts for legacy, aggregate-shadow, and aggregate modes plus native adapter restore parity

## Targeted local verification

- go test -race -count=1 ./internal/latency ./internal/storage ./internal/graph
- go test -race -count=1 ./internal/telemetry ./internal/aggregate ./internal/graphrag
- go test -race -count=1 ./internal/api ./internal/realtime ./internal/mcp ./internal/ui
- three latency proof modes under the race detector, including artifact jq validation
- three existing topology proof modes under the race detector
- integration-tag backup fixture compile
- exact embedded binary Chrome latency-label check
- actionlint .github/workflows/ci.yml

Full repository regression and native PostgreSQL, MySQL, and SQL Server lifecycle checks are intentionally left to GitHub CI.