### PR TITLE
test: prove retained database lifecycles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,65 +300,6 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-  database-sqlite:
-    name: database proof · sqlite
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    env:
-      CGO_ENABLED: "1"
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: run SQLite migration and affected-contract proof
-        run: |
-          mkdir -p "${RUNNER_TEMP}/database-proof"
-          go test -race -count=1 -v ./internal/migrate ./internal/storage ./internal/graphrag 2>&1 \
-            | tee "${RUNNER_TEMP}/database-proof/sqlite.log"
-
-      - name: upload SQLite proof
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: database-proof-sqlite-${{ github.sha }}
-          path: ${{ runner.temp }}/database-proof/sqlite.log
-          if-no-files-found: error
-          retention-days: 14
-
-  database-postgres-16:
-    name: database proof · postgres-16
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    env:
-      CGO_ENABLED: "1"
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: run PostgreSQL 16 migration lifecycle proof
-        run: |
-          mkdir -p "${RUNNER_TEMP}/database-proof"
-          go test -race -count=1 -v -tags=integration -timeout=8m \
-            -run '^TestPostgres16MigrationLifecycle$' ./internal/migrate 2>&1 \
-            | tee "${RUNNER_TEMP}/database-proof/postgres-16.log"
-
-      - name: upload PostgreSQL 16 proof
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: database-proof-postgres-16-${{ github.sha }}
-          path: ${{ runner.temp }}/database-proof/postgres-16.log
-          if-no-files-found: error
-          retention-days: 14
-
   database-backup-proof:
     name: database backup proof · ${{ matrix.profile }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/database-proof.yml
+++ b/.github/workflows/database-proof.yml
@@ -300,7 +300,7 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --health-cmd "mysqladmin ping --host=127.0.0.1 --user=root --password=proof-${{ github.run_id }}"
+          --health-cmd "MYSQL_PWD=$MYSQL_ROOT_PASSWORD mysqladmin ping --host=127.0.0.1 --user=root"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 24

--- a/.github/workflows/database-proof.yml
+++ b/.github/workflows/database-proof.yml
@@ -295,12 +295,12 @@ jobs:
       mysql:
         image: mysql:8.4.11@sha256:b3b90af2a6552ae30c266fdb7d5dd55f3afb72404bb78d37fe8a23eb857fd3fb
         env:
-          MYSQL_ROOT_PASSWORD: OtelContext-250
+          MYSQL_ROOT_PASSWORD: proof-${{ github.run_id }}
           MYSQL_DATABASE: otelcontext
         ports:
           - 3306:3306
         options: >-
-          --health-cmd "mysqladmin ping --host=127.0.0.1 --user=root --password=OtelContext-250"
+          --health-cmd "mysqladmin ping --host=127.0.0.1 --user=root --password=proof-${{ github.run_id }}"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 24
@@ -336,7 +336,7 @@ jobs:
         env:
           OTELCONTEXT_TEST_BINARY: ${{ runner.temp }}/otelcontext
           OTELCONTEXT_TEST_DRIVER: mysql
-          OTELCONTEXT_TEST_DSN: root:OtelContext-250@tcp(127.0.0.1:3306)/otelcontext?charset=utf8mb4&parseTime=True&loc=UTC
+          OTELCONTEXT_TEST_DSN: root:proof-${{ github.run_id }}@tcp(127.0.0.1:3306)/otelcontext?charset=utf8mb4&parseTime=True&loc=UTC
           OTELCONTEXT_TEST_REQUIRE_DB: '1'
           OTELCONTEXT_PROOF_DIR: ${{ runner.temp }}/database-proof
           OTELCONTEXT_TEST_NATIVE_RESTORE_PROOF: ${{ runner.temp }}/database-proof/native/mysql.json
@@ -379,13 +379,13 @@ jobs:
         image: mcr.microsoft.com/mssql/server:2022-CU26-ubuntu-22.04@sha256:ba4c8329f48fb8f02e1416be6a930ebfd71268caee78aa985f3af4315e457c89
         env:
           ACCEPT_EULA: Y
-          MSSQL_SA_PASSWORD: OtelContext!250Proof
+          MSSQL_SA_PASSWORD: Otc-${{ github.run_id }}-Proof!
           MSSQL_PID: Developer
           MSSQL_MEMORY_LIMIT_MB: '2048'
         ports:
           - 1433:1433
         options: >-
-          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P 'OtelContext!250Proof' -C -Q 'SELECT 1'"
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P 'Otc-${{ github.run_id }}-Proof!' -C -Q 'SELECT 1'"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 30
@@ -407,8 +407,8 @@ jobs:
         env:
           SQLSERVER_ID: ${{ job.services.sqlserver.id }}
         run: |
-          docker exec "${SQLSERVER_ID}" /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P 'OtelContext!250Proof' -C -b -Q "SELECT CONVERT(varchar(128), SERVERPROPERTY('ProductVersion'))" | grep '16.0.4265.3'
-          docker exec "${SQLSERVER_ID}" /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P 'OtelContext!250Proof' -C -b -Q "CREATE DATABASE [otelcontext]"
+          docker exec "${SQLSERVER_ID}" /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P 'Otc-${{ github.run_id }}-Proof!' -C -b -Q "SELECT CONVERT(varchar(128), SERVERPROPERTY('ProductVersion'))" | grep '16.0.4265.3'
+          docker exec "${SQLSERVER_ID}" /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P 'Otc-${{ github.run_id }}-Proof!' -C -b -Q "CREATE DATABASE [otelcontext]"
 
       - name: Build candidate once
         run: |
@@ -428,7 +428,7 @@ jobs:
         env:
           OTELCONTEXT_TEST_BINARY: ${{ runner.temp }}/otelcontext
           OTELCONTEXT_TEST_DRIVER: mssql
-          OTELCONTEXT_TEST_DSN: sqlserver://sa:OtelContext%21250Proof@127.0.0.1:1433?database=otelcontext&encrypt=disable&TrustServerCertificate=true
+          OTELCONTEXT_TEST_DSN: sqlserver://sa:Otc-${{ github.run_id }}-Proof%21@127.0.0.1:1433?database=otelcontext&encrypt=disable&TrustServerCertificate=true
           OTELCONTEXT_TEST_REQUIRE_DB: '1'
           OTELCONTEXT_PROOF_DIR: ${{ runner.temp }}/database-proof
           OTELCONTEXT_TEST_NATIVE_RESTORE_PROOF: ${{ runner.temp }}/database-proof/native/mssql.json

--- a/.github/workflows/database-proof.yml
+++ b/.github/workflows/database-proof.yml
@@ -1,0 +1,460 @@
+name: Database proof
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '17 3 * * 1'
+  workflow_call:
+    inputs:
+      run_all:
+        description: Run preview and experimental adapters as release blockers.
+        type: boolean
+        default: false
+      candidate_ref:
+        description: Exact tag or commit to prove.
+        type: string
+        default: ''
+  workflow_dispatch:
+    inputs:
+      run_all:
+        description: Run all four retained adapters.
+        type: boolean
+        default: true
+      candidate_ref:
+        description: Exact tag or commit to prove; defaults to the event SHA.
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  sqlite:
+    name: database proof · sqlite
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      CGO_ENABLED: '1'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.candidate_ref || github.sha }}
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install cosign for signed baselines
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+        with:
+          cosign-release: 'v2.6.5'
+
+      - name: Resolve exact candidate
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
+      - name: Build candidate once
+        run: |
+          mkdir -p "${RUNNER_TEMP}/database-proof" "${RUNNER_TEMP}/signed-baselines"
+          go build -trimpath -o "${RUNNER_TEMP}/otelcontext" .
+          sha256sum "${RUNNER_TEMP}/otelcontext" > "${RUNNER_TEMP}/database-proof/binary.sha256"
+
+      - name: Verify and extract signed baseline binaries
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          manifest="${RUNNER_TEMP}/signed-baselines/manifest.json"
+          printf '%s\n' '{"schema_version":"otelcontext.signed-baselines.v1","releases":[]}' > "${manifest}"
+          for spec in 'v0.3.1 otelcontext_0.3.1_linux_amd64.tar.gz' 'v0.4.0-beta.2 otelcontext_0.4.0-beta.2_linux_amd64.tar.gz'; do
+            read -r release archive <<< "${spec}"
+            root="${RUNNER_TEMP}/signed-baselines/${release}"
+            mkdir -p "${root}/extracted"
+            gh release download "${release}" --repo "${GITHUB_REPOSITORY}" --dir "${root}" \
+              --pattern "${archive}" --pattern checksums.txt --pattern checksums.txt.sig --pattern checksums.txt.pem
+            (
+              cd "${root}"
+              grep " ${archive}$" checksums.txt | sha256sum --check -
+              base64 --decode checksums.txt.pem > checksums.decoded.pem
+              cosign verify-blob \
+                --certificate checksums.decoded.pem \
+                --signature checksums.txt.sig \
+                --certificate-identity 'https://github.com/RandomCodeSpace/otelcontext/.github/workflows/release.yml@refs/heads/main' \
+                --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+                checksums.txt
+              tar -xzf "${archive}" -C extracted
+            )
+            binary="$(find "${root}/extracted" -type f -name otelcontext -print -quit)"
+            test -n "${binary}"
+            chmod 0755 "${binary}"
+            archive_sha="$(sha256sum "${root}/${archive}" | awk '{print $1}')"
+            binary_sha="$(sha256sum "${binary}" | awk '{print $1}')"
+            jq --arg release "${release}" --arg binary "${binary}" --arg archive_sha "${archive_sha}" --arg binary_sha "${binary_sha}" \
+              '.releases += [{release:$release,binary_path:$binary,archive_sha256:$archive_sha,binary_sha256:$binary_sha,signature_verified:true}]' \
+              "${manifest}" > "${manifest}.next"
+            mv "${manifest}.next" "${manifest}"
+          done
+          cp "${manifest}" "${RUNNER_TEMP}/database-proof/signed-baselines-v1.json"
+
+      - name: Run full SQLite lifecycle contract
+        env:
+          OTELCONTEXT_TEST_BINARY: ${{ runner.temp }}/otelcontext
+          OTELCONTEXT_TEST_DRIVER: sqlite
+          OTELCONTEXT_TEST_DSN: ${{ runner.temp }}/otelcontext.db
+          OTELCONTEXT_TEST_REQUIRE_DB: '1'
+          OTELCONTEXT_PROOF_DIR: ${{ runner.temp }}/database-proof
+          OTELCONTEXT_TEST_BASELINE_MANIFEST: ${{ runner.temp }}/signed-baselines/manifest.json
+          OTELCONTEXT_TEST_CANDIDATE_SHA: ${{ steps.source.outputs.sha }}
+          OTELCONTEXT_TEST_ENGINE_IMAGE: modernc.org/sqlite@v1.55.0 (SQLite 3.53.3)
+        run: |
+          set -o pipefail
+          go test -race -count=1 -timeout=10m -tags=dbcontract -json ./test/dbcontract 2>&1 \
+            | tee "${RUNNER_TEMP}/database-proof/go-test.json"
+          jq -e '
+            .schema_version == "otelcontext.database-proof.v1" and
+            .driver == "sqlite" and
+            .tier == "bounded-opt-in" and
+            .migration.state == "exact" and
+            (.baselines | length) == 2 and
+            .post_restart_fingerprint.traces == 2 and
+            .post_restart_fingerprint.spans == 6 and
+            .post_restart_fingerprint.logs == 6 and
+            .post_restart_fingerprint.metric_buckets == 6 and
+            (.surfaces.mcp_tools | length) == 7 and
+            (.surfaces.mcp_calls | length) == 7 and
+            .restore.source_fingerprint == .restore.restored_fingerprint and
+            all(.assertions[]; .passed == true)
+          ' "${RUNNER_TEMP}/database-proof/database-proof-v1.json"
+
+      - name: Upload SQLite database proof
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: database-proof-sqlite-${{ steps.source.outputs.sha }}
+          path: ${{ runner.temp }}/database-proof
+          if-no-files-found: error
+          retention-days: ${{ github.event_name == 'schedule' && 30 || github.event_name == 'workflow_call' && 90 || 14 }}
+
+  postgres:
+    name: database proof · postgres-16
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    env:
+      CGO_ENABLED: '1'
+    services:
+      postgres:
+        image: postgres:16.15-alpine3.24@sha256:cf78e76683b9ca8c5733cbbdce6c9262b45b6767934dd0a95e671f9a0fc20685
+        env:
+          POSTGRES_USER: otel
+          POSTGRES_PASSWORD: otel
+          POSTGRES_DB: otelcontext
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U otel -d otelcontext"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 18
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.candidate_ref || github.sha }}
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install cosign for signed baselines
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+        with:
+          cosign-release: 'v2.6.5'
+
+      - name: Install PostgreSQL 16 client
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes postgresql-client
+          pg_dump --version | grep ' 16\.'
+
+      - name: Resolve exact candidate
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
+      - name: Require PostgreSQL 16 and prepare fresh restore target
+        env:
+          PGPASSWORD: otel
+        run: |
+          psql --host=127.0.0.1 --username=otel --dbname=otelcontext --tuples-only --command='SHOW server_version' | grep '16\.'
+          createdb --host=127.0.0.1 --username=otel otelcontext_restore
+
+      - name: Build candidate once
+        run: |
+          mkdir -p "${RUNNER_TEMP}/database-proof" "${RUNNER_TEMP}/signed-baselines"
+          go build -trimpath -o "${RUNNER_TEMP}/otelcontext" .
+          sha256sum "${RUNNER_TEMP}/otelcontext" > "${RUNNER_TEMP}/database-proof/binary.sha256"
+
+      - name: Verify and extract signed baseline binaries
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          manifest="${RUNNER_TEMP}/signed-baselines/manifest.json"
+          printf '%s\n' '{"schema_version":"otelcontext.signed-baselines.v1","releases":[]}' > "${manifest}"
+          for spec in 'v0.3.1 otelcontext_0.3.1_linux_amd64.tar.gz' 'v0.4.0-beta.2 otelcontext_0.4.0-beta.2_linux_amd64.tar.gz'; do
+            read -r release archive <<< "${spec}"
+            root="${RUNNER_TEMP}/signed-baselines/${release}"
+            mkdir -p "${root}/extracted"
+            gh release download "${release}" --repo "${GITHUB_REPOSITORY}" --dir "${root}" \
+              --pattern "${archive}" --pattern checksums.txt --pattern checksums.txt.sig --pattern checksums.txt.pem
+            (
+              cd "${root}"
+              grep " ${archive}$" checksums.txt | sha256sum --check -
+              base64 --decode checksums.txt.pem > checksums.decoded.pem
+              cosign verify-blob \
+                --certificate checksums.decoded.pem \
+                --signature checksums.txt.sig \
+                --certificate-identity 'https://github.com/RandomCodeSpace/otelcontext/.github/workflows/release.yml@refs/heads/main' \
+                --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+                checksums.txt
+              tar -xzf "${archive}" -C extracted
+            )
+            binary="$(find "${root}/extracted" -type f -name otelcontext -print -quit)"
+            test -n "${binary}"
+            chmod 0755 "${binary}"
+            archive_sha="$(sha256sum "${root}/${archive}" | awk '{print $1}')"
+            binary_sha="$(sha256sum "${binary}" | awk '{print $1}')"
+            jq --arg release "${release}" --arg binary "${binary}" --arg archive_sha "${archive_sha}" --arg binary_sha "${binary_sha}" \
+              '.releases += [{release:$release,binary_path:$binary,archive_sha256:$archive_sha,binary_sha256:$binary_sha,signature_verified:true}]' \
+              "${manifest}" > "${manifest}.next"
+            mv "${manifest}.next" "${manifest}"
+          done
+          cp "${manifest}" "${RUNNER_TEMP}/database-proof/signed-baselines-v1.json"
+
+      - name: Run full PostgreSQL lifecycle contract
+        env:
+          OTELCONTEXT_TEST_BINARY: ${{ runner.temp }}/otelcontext
+          OTELCONTEXT_TEST_DRIVER: postgres
+          OTELCONTEXT_TEST_DSN: postgres://otel:otel@127.0.0.1:5432/otelcontext?sslmode=disable
+          OTELCONTEXT_TEST_RESTORE_DSN: postgres://otel:otel@127.0.0.1:5432/otelcontext_restore?sslmode=disable
+          OTELCONTEXT_TEST_REQUIRE_DB: '1'
+          OTELCONTEXT_PROOF_DIR: ${{ runner.temp }}/database-proof
+          OTELCONTEXT_TEST_BASELINE_MANIFEST: ${{ runner.temp }}/signed-baselines/manifest.json
+          OTELCONTEXT_TEST_CANDIDATE_SHA: ${{ steps.source.outputs.sha }}
+          OTELCONTEXT_TEST_ENGINE_IMAGE: postgres:16.15-alpine3.24@sha256:cf78e76683b9ca8c5733cbbdce6c9262b45b6767934dd0a95e671f9a0fc20685
+        run: |
+          set -o pipefail
+          go test -race -count=1 -timeout=10m -tags=dbcontract -json ./test/dbcontract 2>&1 \
+            | tee "${RUNNER_TEMP}/database-proof/go-test.json"
+          jq -e '
+            .schema_version == "otelcontext.database-proof.v1" and
+            .driver == "postgres" and
+            .tier == "primary" and
+            .migration.state == "exact" and
+            (.baselines | length) == 2 and
+            .post_restart_fingerprint.traces == 2 and
+            .post_restart_fingerprint.spans == 6 and
+            .post_restart_fingerprint.logs == 6 and
+            .post_restart_fingerprint.metric_buckets == 6 and
+            (.surfaces.mcp_tools | length) == 7 and
+            (.surfaces.mcp_calls | length) == 7 and
+            .restore.source_fingerprint == .restore.restored_fingerprint and
+            all(.assertions[]; .passed == true)
+          ' "${RUNNER_TEMP}/database-proof/database-proof-v1.json"
+
+      - name: Run nearest PostgreSQL migration and storage contracts
+        env:
+          OTELCONTEXT_TEST_DRIVER: postgres
+          OTELCONTEXT_TEST_DSN: postgres://otel:otel@127.0.0.1:5432/otelcontext?sslmode=disable
+          OTELCONTEXT_TEST_REQUIRE_DB: '1'
+        run: |
+          set -o pipefail
+          go test -race -count=1 -timeout=10m -tags=integration -json ./internal/migrate ./internal/storage 2>&1 \
+            | tee "${RUNNER_TEMP}/database-proof/storage-integration.json"
+
+      - name: Upload PostgreSQL 16 database proof
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: database-proof-postgres-16-${{ steps.source.outputs.sha }}
+          path: ${{ runner.temp }}/database-proof
+          if-no-files-found: error
+          retention-days: ${{ github.event_name == 'schedule' && 30 || github.event_name == 'workflow_call' && 90 || 14 }}
+
+  mysql:
+    name: database proof · mysql-8.4
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_call' && inputs.run_all) || (github.event_name == 'workflow_dispatch' && inputs.run_all) }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    env:
+      CGO_ENABLED: '1'
+    services:
+      mysql:
+        image: mysql:8.4.11@sha256:b3b90af2a6552ae30c266fdb7d5dd55f3afb72404bb78d37fe8a23eb857fd3fb
+        env:
+          MYSQL_ROOT_PASSWORD: OtelContext-250
+          MYSQL_DATABASE: otelcontext
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping --host=127.0.0.1 --user=root --password=OtelContext-250"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 24
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.candidate_ref || github.sha }}
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Resolve exact candidate
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
+      - name: Build candidate once
+        run: |
+          mkdir -p "${RUNNER_TEMP}/database-proof/native"
+          go build -trimpath -o "${RUNNER_TEMP}/otelcontext" .
+          sha256sum "${RUNNER_TEMP}/otelcontext" > "${RUNNER_TEMP}/database-proof/binary.sha256"
+
+      - name: Run candidate-bound native fresh-target restore proof
+        env:
+          OTELCONTEXT_BACKUP_ADAPTER: mysql
+          OTELCONTEXT_NATIVE_BACKUP_PROOF_DIR: ${{ runner.temp }}/database-proof/native
+          OTELCONTEXT_TEST_BINARY: ${{ runner.temp }}/otelcontext
+          OTELCONTEXT_TEST_CANDIDATE_SHA: ${{ steps.source.outputs.sha }}
+        run: go test -race -count=1 -timeout=22m -tags=integration -run '^TestNativeBackupRestoreLifecycle$' ./internal/backup
+
+      - name: Run full MySQL lifecycle contract
+        env:
+          OTELCONTEXT_TEST_BINARY: ${{ runner.temp }}/otelcontext
+          OTELCONTEXT_TEST_DRIVER: mysql
+          OTELCONTEXT_TEST_DSN: root:OtelContext-250@tcp(127.0.0.1:3306)/otelcontext?charset=utf8mb4&parseTime=True&loc=UTC
+          OTELCONTEXT_TEST_REQUIRE_DB: '1'
+          OTELCONTEXT_PROOF_DIR: ${{ runner.temp }}/database-proof
+          OTELCONTEXT_TEST_NATIVE_RESTORE_PROOF: ${{ runner.temp }}/database-proof/native/mysql.json
+          OTELCONTEXT_TEST_CANDIDATE_SHA: ${{ steps.source.outputs.sha }}
+          OTELCONTEXT_TEST_ENGINE_IMAGE: mysql:8.4.11@sha256:b3b90af2a6552ae30c266fdb7d5dd55f3afb72404bb78d37fe8a23eb857fd3fb
+        run: |
+          set -o pipefail
+          go test -race -count=1 -timeout=10m -tags=dbcontract -json ./test/dbcontract 2>&1 \
+            | tee "${RUNNER_TEMP}/database-proof/go-test.json"
+          jq -e '
+            .schema_version == "otelcontext.database-proof.v1" and
+            .driver == "mysql" and
+            .tier == "preview" and
+            .migration.state == "unverified-preview" and
+            (.surfaces.mcp_tools | length) == 7 and
+            (.surfaces.mcp_calls | length) == 7 and
+            .restore.kind == "native-fresh-target" and
+            .restore.source_fingerprint == .restore.restored_fingerprint and
+            all(.assertions[]; .passed == true)
+          ' "${RUNNER_TEMP}/database-proof/database-proof-v1.json"
+
+      - name: Upload MySQL 8.4 database proof
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: database-proof-mysql-8.4-${{ steps.source.outputs.sha }}
+          path: ${{ runner.temp }}/database-proof
+          if-no-files-found: error
+          retention-days: ${{ github.event_name == 'schedule' && 30 || 90 }}
+
+  sqlserver:
+    name: database proof · sqlserver-2022
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_call' && inputs.run_all) || (github.event_name == 'workflow_dispatch' && inputs.run_all) }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    env:
+      CGO_ENABLED: '1'
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2022-CU26-ubuntu-22.04@sha256:ba4c8329f48fb8f02e1416be6a930ebfd71268caee78aa985f3af4315e457c89
+        env:
+          ACCEPT_EULA: Y
+          MSSQL_SA_PASSWORD: OtelContext!250Proof
+          MSSQL_PID: Developer
+          MSSQL_MEMORY_LIMIT_MB: '2048'
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P 'OtelContext!250Proof' -C -Q 'SELECT 1'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.candidate_ref || github.sha }}
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Resolve exact candidate
+        id: source
+        run: echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
+
+      - name: Require SQL Server 2022 and create lifecycle database
+        env:
+          SQLSERVER_ID: ${{ job.services.sqlserver.id }}
+        run: |
+          docker exec "${SQLSERVER_ID}" /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P 'OtelContext!250Proof' -C -b -Q "SELECT CONVERT(varchar(128), SERVERPROPERTY('ProductVersion'))" | grep '16.0.4265.3'
+          docker exec "${SQLSERVER_ID}" /opt/mssql-tools18/bin/sqlcmd -S 127.0.0.1 -U sa -P 'OtelContext!250Proof' -C -b -Q "CREATE DATABASE [otelcontext]"
+
+      - name: Build candidate once
+        run: |
+          mkdir -p "${RUNNER_TEMP}/database-proof/native"
+          go build -trimpath -o "${RUNNER_TEMP}/otelcontext" .
+          sha256sum "${RUNNER_TEMP}/otelcontext" > "${RUNNER_TEMP}/database-proof/binary.sha256"
+
+      - name: Run candidate-bound native fresh-target restore proof
+        env:
+          OTELCONTEXT_BACKUP_ADAPTER: mssql
+          OTELCONTEXT_NATIVE_BACKUP_PROOF_DIR: ${{ runner.temp }}/database-proof/native
+          OTELCONTEXT_TEST_BINARY: ${{ runner.temp }}/otelcontext
+          OTELCONTEXT_TEST_CANDIDATE_SHA: ${{ steps.source.outputs.sha }}
+        run: go test -race -count=1 -timeout=32m -tags=integration -run '^TestNativeBackupRestoreLifecycle$' ./internal/backup
+
+      - name: Run full SQL Server lifecycle contract
+        env:
+          OTELCONTEXT_TEST_BINARY: ${{ runner.temp }}/otelcontext
+          OTELCONTEXT_TEST_DRIVER: mssql
+          OTELCONTEXT_TEST_DSN: sqlserver://sa:OtelContext%21250Proof@127.0.0.1:1433?database=otelcontext&encrypt=disable&TrustServerCertificate=true
+          OTELCONTEXT_TEST_REQUIRE_DB: '1'
+          OTELCONTEXT_PROOF_DIR: ${{ runner.temp }}/database-proof
+          OTELCONTEXT_TEST_NATIVE_RESTORE_PROOF: ${{ runner.temp }}/database-proof/native/mssql.json
+          OTELCONTEXT_TEST_CANDIDATE_SHA: ${{ steps.source.outputs.sha }}
+          OTELCONTEXT_TEST_ENGINE_IMAGE: mcr.microsoft.com/mssql/server:2022-CU26-ubuntu-22.04@sha256:ba4c8329f48fb8f02e1416be6a930ebfd71268caee78aa985f3af4315e457c89
+        run: |
+          set -o pipefail
+          go test -race -count=1 -timeout=10m -tags=dbcontract -json ./test/dbcontract 2>&1 \
+            | tee "${RUNNER_TEMP}/database-proof/go-test.json"
+          jq -e '
+            .schema_version == "otelcontext.database-proof.v1" and
+            .driver == "mssql" and
+            .tier == "experimental" and
+            .migration.state == "unverified-preview" and
+            (.surfaces.mcp_tools | length) == 7 and
+            (.surfaces.mcp_calls | length) == 7 and
+            .restore.kind == "native-fresh-target" and
+            .restore.source_fingerprint == .restore.restored_fingerprint and
+            all(.assertions[]; .passed == true)
+          ' "${RUNNER_TEMP}/database-proof/database-proof-v1.json"
+
+      - name: Upload SQL Server 2022 database proof
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: database-proof-sqlserver-2022-${{ steps.source.outputs.sha }}
+          path: ${{ runner.temp }}/database-proof
+          if-no-files-found: error
+          retention-days: ${{ github.event_name == 'schedule' && 30 || 90 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,16 @@ permissions:
   contents: read
 
 jobs:
+  database-proof:
+    name: Database lifecycle gate
+    uses: ./.github/workflows/database-proof.yml
+    with:
+      run_all: true
+      candidate_ref: ${{ inputs.tag || github.ref }}
+
   goreleaser:
     name: GoReleaser (build · sbom · sign)
+    needs: database-proof
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -34,6 +34,17 @@ DB_AUTOMIGRATE=false API_KEY="$(openssl rand -hex 32)" ./otelcontext
 
 Set `DB_AUTOMIGRATE=false` in production after `otelcontext migrate status` reports `result=ready`. The binary owns the ordered SQLite and unpartitioned PostgreSQL 16 migrations; no separate migration tool is required. Daily PostgreSQL partitioning remains on the preview AutoMigrate path.
 
+### Database support tiers
+
+| Database | Support tier | Intended use |
+|---|---|---|
+| PostgreSQL 16 | Primary | Production deployments |
+| SQLite | Bounded opt-in | One process, at most five services, and a low write rate |
+| MySQL 8.4 | Preview | Evaluation with weekly lifecycle proof; keep a tested rollback |
+| SQL Server 2022 | Experimental | Evaluation only; keep a tested rollback |
+
+All four adapters remain available. The tier describes the strength and frequency of lifecycle proof, not feature removal.
+
 ### TLS
 
 Two paths:
@@ -75,7 +86,7 @@ DB_DSN="host=my-server.postgres.database.azure.com user=my-mi@tenant.onmicrosoft
 
 ### Must set
 - `API_KEY` — long random string. Without it, anyone on the network can query or ingest.
-- `DB_DRIVER=postgres` (or another persistent driver). SQLite is fine for small single-node deployments; plan for it accordingly.
+- `DB_DRIVER=postgres` with PostgreSQL 16 for the primary production path. Alternatives retain the support tiers above.
 - `DB_DSN` — with strict TLS when crossing a network boundary.
 - `TLS_CERT_FILE` + `TLS_KEY_FILE` (or `TLS_AUTO_SELFSIGNED=true` for internal-only deployments).
 - `HOT_RETENTION_DAYS` — pick a value you can defend. Default 7 is reasonable; range is 1..36500.
@@ -99,7 +110,7 @@ DB_DSN="host=my-server.postgres.database.azure.com user=my-mi@tenant.onmicrosoft
 - `MCP_MAX_CONCURRENT=32`, `MCP_CALL_TIMEOUT_MS=30000`, `MCP_CACHE_TTL_MS=5000` — MCP HTTP streamable robustness. Concurrent `tools/call` invocations are gated by a counting semaphore (returns JSON-RPC `-32000` "server overloaded" past the cap). Per-call deadlines abort runaway tool handlers (returns JSON-RPC `-32001` "call timeout"). Cheap GraphRAG tools (`get_service_map`, `impact_analysis`, `root_cause_analysis`, `get_anomaly_timeline`, `get_service_health`) are memoized for the TTL window, keyed by `(tenant, tool, args)`. Setting any of these to `0` disables that protection.
 
 ### SQLite in production
-SQLite is rejected at startup when `APP_ENV=production` unless you explicitly opt in with `OTELCONTEXT_ALLOW_SQLITE_PROD=true`. The guard exists because SQLite uses a single writer lock — fine for < ~10 services at low QPS, miserable at scale. Prefer Postgres for anything resembling production.
+SQLite is rejected at startup when `APP_ENV=production` unless you explicitly opt in with `OTELCONTEXT_ALLOW_SQLITE_PROD=true`. The guard exists because SQLite uses a single writer lock. Keep it to one process, at most five services, and a low write rate. Use PostgreSQL 16 beyond that bound.
 
 ---
 

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -451,10 +451,10 @@ type Log struct {
 ### Database Support
 
 **Supported Drivers:**
-- SQLite (default) - Embedded, zero-config
-- MySQL - Production-ready, high performance
-- PostgreSQL - Advanced features, JSON support
-- SQL Server - Enterprise environments
+- PostgreSQL 16 - Primary production database
+- SQLite (default) - Bounded opt-in for one process, at most five services, and a low write rate
+- MySQL 8.4 - Preview
+- SQL Server 2022 - Experimental
 
 **Configuration:**
 ```bash

--- a/internal/backup/native_integration_test.go
+++ b/internal/backup/native_integration_test.go
@@ -34,6 +34,12 @@ type containerRunner struct {
 	fixture *nativeFixture
 }
 
+const (
+	postgresProofImage = "postgres:16.15-alpine3.24@sha256:cf78e76683b9ca8c5733cbbdce6c9262b45b6767934dd0a95e671f9a0fc20685"
+	mysqlProofImage    = "mysql:8.4.11@sha256:b3b90af2a6552ae30c266fdb7d5dd55f3afb72404bb78d37fe8a23eb857fd3fb"
+	mssqlProofImage    = "mcr.microsoft.com/mssql/server:2022-CU26-ubuntu-22.04@sha256:ba4c8329f48fb8f02e1416be6a930ebfd71268caee78aa985f3af4315e457c89"
+)
+
 func (runner containerRunner) Run(ctx context.Context, command Command) (CommandResult, error) {
 	if err := runner.fixture.chmodShared(ctx); err != nil {
 		return CommandResult{ExitCode: -1}, err
@@ -116,17 +122,17 @@ func startNativeFixture(t *testing.T, adapter string) *nativeFixture {
 	}
 	switch adapter {
 	case "postgres":
-		request.Image = "postgres:16-alpine"
+		request.Image = postgresProofImage
 		request.Env = map[string]string{"POSTGRES_USER": "otel", "POSTGRES_PASSWORD": "otel", "POSTGRES_DB": "postgres"}
 		request.ExposedPorts = []string{"5432/tcp"}
 		request.WaitingFor = wait.ForLog("database system is ready to accept connections").WithOccurrence(2).WithStartupTimeout(2 * time.Minute)
 	case "mysql":
-		request.Image = "mysql:8.4"
+		request.Image = mysqlProofImage
 		request.Env = map[string]string{"MYSQL_ROOT_PASSWORD": "OtelContext-248"}
 		request.ExposedPorts = []string{"3306/tcp"}
 		request.WaitingFor = wait.ForLog("ready for connections").WithOccurrence(2).WithStartupTimeout(3 * time.Minute)
 	case "mssql":
-		request.Image = "mcr.microsoft.com/mssql/server:2022-latest"
+		request.Image = mssqlProofImage
 		request.Env = map[string]string{
 			"ACCEPT_EULA":           "Y",
 			"MSSQL_SA_PASSWORD":     "OtelContext!248Proof",
@@ -335,10 +341,7 @@ func TestNativeBackupRestoreLifecycle(t *testing.T) {
 	fixture := startNativeFixture(t, adapter)
 	prepareNativeSource(t, fixture)
 	sourceLatency := inspectNativeLatency(t, adapter, fixture.sourceDSN)
-	candidate, err := CurrentCandidate("integration-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	candidate := nativeProofCandidate(t)
 	sourceCfg := nativeConfig(fixture.root, adapter, fixture.sourceDSN, "source")
 	writeNativeShutdownProof(t, sourceCfg, candidate)
 	runner := containerRunner{fixture: fixture}
@@ -416,7 +419,7 @@ func TestNativeBackupRestoreLifecycle(t *testing.T) {
 	proof := nativeProof{
 		SchemaVersion:     "otelcontext.native-backup-proof/v1",
 		Adapter:           adapter,
-		CandidateSHA:      os.Getenv("GITHUB_SHA"),
+		CandidateSHA:      candidate.Commit,
 		EngineVersion:     manifest.Main.EngineVersion,
 		MigrationState:    manifest.Main.MigrationState,
 		SourceLifecycle:   manifest.Main.LifecycleFingerprint,
@@ -444,4 +447,28 @@ func TestNativeBackupRestoreLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
+
+func nativeProofCandidate(t *testing.T) Candidate {
+	t.Helper()
+	binary := os.Getenv("OTELCONTEXT_TEST_BINARY")
+	if binary == "" {
+		candidate, err := CurrentCandidate("integration-test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return candidate
+	}
+	digest, _, err := hashFile(binary)
+	if err != nil {
+		t.Fatalf("hash exact candidate binary: %v", err)
+	}
+	commit := os.Getenv("OTELCONTEXT_TEST_CANDIDATE_SHA")
+	if commit == "" {
+		commit = os.Getenv("GITHUB_SHA")
+	}
+	if commit == "" {
+		commit = "unknown"
+	}
+	return Candidate{Version: "database-proof", Commit: commit, BinarySHA256: digest}
 }

--- a/internal/migrate/postgres_integration_test.go
+++ b/internal/migrate/postgres_integration_test.go
@@ -5,6 +5,7 @@ package migrate
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -18,8 +19,22 @@ import (
 
 func startMigrationPostgres16(t *testing.T) (string, *gorm.DB) {
 	t.Helper()
+	if os.Getenv("OTELCONTEXT_TEST_DRIVER") == "postgres" && os.Getenv("OTELCONTEXT_TEST_DSN") != "" {
+		dsn := os.Getenv("OTELCONTEXT_TEST_DSN")
+		admin, err := storage.NewDatabase("postgres", dsn)
+		if err != nil {
+			t.Fatalf("connect required PostgreSQL workflow service: %v", err)
+		}
+		if sqlDB, dbErr := admin.DB(); dbErr == nil {
+			t.Cleanup(func() { _ = sqlDB.Close() })
+		}
+		return dsn, admin
+	}
+	if os.Getenv("OTELCONTEXT_TEST_REQUIRE_DB") == "1" {
+		t.Fatal("required PostgreSQL proof is missing OTELCONTEXT_TEST_DSN")
+	}
 	ctx := context.Background()
-	container, err := postgres.Run(ctx, "postgres:16-alpine",
+	container, err := postgres.Run(ctx, "postgres:16.15-alpine3.24@sha256:cf78e76683b9ca8c5733cbbdce6c9262b45b6767934dd0a95e671f9a0fc20685",
 		postgres.WithDatabase("otel_migrate"),
 		postgres.WithUsername("otel"),
 		postgres.WithPassword("otel"),

--- a/internal/storage/pg_integration_test.go
+++ b/internal/storage/pg_integration_test.go
@@ -23,12 +23,18 @@ package storage
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"gorm.io/gorm"
 )
+
+var workflowDatabaseSequence atomic.Int64
 
 // setupPGContainer boots a throwaway Postgres 16 container, wires up a GORM
 // repository against it, and returns a teardown closure. If Docker is not
@@ -37,8 +43,14 @@ import (
 func setupPGContainer(t *testing.T) (*Repository, func()) {
 	t.Helper()
 	ctx := context.Background()
+	if os.Getenv("OTELCONTEXT_TEST_DRIVER") == "postgres" && os.Getenv("OTELCONTEXT_TEST_DSN") != "" {
+		return setupRequiredPostgres(t, os.Getenv("OTELCONTEXT_TEST_DSN"))
+	}
+	if os.Getenv("OTELCONTEXT_TEST_REQUIRE_DB") == "1" {
+		t.Fatal("required PostgreSQL storage proof is missing OTELCONTEXT_TEST_DSN")
+	}
 
-	pgContainer, err := postgres.Run(ctx, "postgres:16-alpine",
+	pgContainer, err := postgres.Run(ctx, "postgres:16.15-alpine3.24@sha256:cf78e76683b9ca8c5733cbbdce6c9262b45b6767934dd0a95e671f9a0fc20685",
 		postgres.WithDatabase("otel_test"),
 		postgres.WithUsername("otel"),
 		postgres.WithPassword("otel"),
@@ -70,6 +82,57 @@ func setupPGContainer(t *testing.T) (*Repository, func()) {
 		_ = pgContainer.Terminate(ctx)
 	}
 	return repo, teardown
+}
+
+func setupRequiredPostgres(t *testing.T, sourceDSN string) (*Repository, func()) {
+	t.Helper()
+	parsed, err := url.Parse(sourceDSN)
+	if err != nil || parsed.Scheme == "" {
+		t.Fatalf("required PostgreSQL DSN must be a URL: %q (%v)", sourceDSN, err)
+	}
+	name := fmt.Sprintf("storage_contract_%d", workflowDatabaseSequence.Add(1))
+	adminURL := *parsed
+	adminURL.Path = "/postgres"
+	admin, err := NewDatabase("postgres", adminURL.String())
+	if err != nil {
+		t.Fatalf("connect required PostgreSQL admin database: %v", err)
+	}
+	if err := admin.Exec("CREATE DATABASE \"" + name + "\"").Error; err != nil { //nolint:gosec // generated identifier.
+		closeIntegrationDB(admin)
+		t.Fatalf("create isolated PostgreSQL database: %v", err)
+	}
+	closeIntegrationDB(admin)
+	targetURL := *parsed
+	targetURL.Path = "/" + name
+	db, err := NewDatabase("postgres", targetURL.String())
+	if err != nil {
+		t.Fatalf("connect isolated PostgreSQL database: %v", err)
+	}
+	if err := AutoMigrateModels(db, "postgres"); err != nil {
+		closeIntegrationDB(db)
+		t.Fatalf("AutoMigrateModels(postgres): %v", err)
+	}
+	repo := NewRepositoryFromDB(db, "postgres")
+	teardown := func() {
+		_ = repo.Close()
+		admin, openErr := NewDatabase("postgres", adminURL.String())
+		if openErr != nil {
+			return
+		}
+		_ = admin.Exec("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = ?", name).Error
+		_ = admin.Exec("DROP DATABASE IF EXISTS \"" + name + "\"").Error //nolint:gosec // generated identifier.
+		closeIntegrationDB(admin)
+	}
+	return repo, teardown
+}
+
+func closeIntegrationDB(db *gorm.DB) {
+	if db == nil {
+		return
+	}
+	if sqlDB, err := db.DB(); err == nil {
+		_ = sqlDB.Close()
+	}
 }
 
 // TestPG_ILIKE_CaseInsensitiveSearch proves that SearchLogs uses the

--- a/internal/storage/pg_integration_test.go
+++ b/internal/storage/pg_integration_test.go
@@ -263,7 +263,15 @@ func TestPG_PgTrgm_SubstringQueryUsesGIN(t *testing.T) {
 		t.Fatalf("analyze: %v", err)
 	}
 
-	rows, err := repo.db.Raw(
+	planDB := repo.db.Begin()
+	if planDB.Error != nil {
+		t.Fatalf("begin planner proof: %v", planDB.Error)
+	}
+	defer planDB.Rollback()
+	if err := planDB.Exec("SET LOCAL enable_seqscan = off").Error; err != nil {
+		t.Fatalf("disable sequential scans for planner proof: %v", err)
+	}
+	rows, err := planDB.Raw(
 		"EXPLAIN SELECT id FROM logs WHERE body ILIKE ?",
 		"%connection-refused-dbcontract%",
 	).Rows()

--- a/internal/storage/pg_integration_test.go
+++ b/internal/storage/pg_integration_test.go
@@ -240,13 +240,17 @@ func TestPG_PgTrgm_SubstringQueryUsesGIN(t *testing.T) {
 	repo, teardown := setupPGContainer(t)
 	defer teardown()
 
-	// Seed enough rows that the planner prefers the index over a seq scan.
+	// Keep the substring selective so the planner has a reason to use the index.
 	now := time.Now().UTC()
 	batch := make([]Log, 0, 2000)
 	for i := 0; i < 2000; i++ {
+		body := fmt.Sprintf("request %d: upstream healthy", i)
+		if i%1000 == 0 {
+			body = fmt.Sprintf("request %d: connection-refused-dbcontract", i)
+		}
 		batch = append(batch, Log{
 			Severity:    "INFO",
-			Body:        fmt.Sprintf("request %d: connection refused by upstream-%d", i, i%37),
+			Body:        body,
 			ServiceName: fmt.Sprintf("svc-%d", i%11),
 			Timestamp:   now,
 		})
@@ -261,7 +265,7 @@ func TestPG_PgTrgm_SubstringQueryUsesGIN(t *testing.T) {
 
 	rows, err := repo.db.Raw(
 		"EXPLAIN SELECT id FROM logs WHERE body ILIKE ?",
-		"%connection%",
+		"%connection-refused-dbcontract%",
 	).Rows()
 	if err != nil {
 		t.Fatalf("EXPLAIN: %v", err)

--- a/test/dbcontract/dbcontract_test.go
+++ b/test/dbcontract/dbcontract_test.go
@@ -1,0 +1,1358 @@
+//go:build dbcontract && !windows
+
+package dbcontract_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/coder/websocket"
+	collectlogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	collectmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	collecttracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/proto"
+)
+
+//go:embed testdata/lifecycle-v1.json
+var fixtureJSON []byte
+
+const proofSchema = "otelcontext.database-proof.v1"
+
+type fixture struct {
+	SchemaVersion string          `json:"schema_version"`
+	Services      []string        `json:"services"`
+	Traces        []fixtureTrace  `json:"traces"`
+	Logs          []fixtureLog    `json:"logs"`
+	Metrics       []fixtureMetric `json:"metrics"`
+	Stale         staleFixture    `json:"stale"`
+}
+
+type fixtureTrace struct {
+	TraceID   string        `json:"trace_id"`
+	Transport string        `json:"transport"`
+	Spans     []fixtureSpan `json:"spans"`
+}
+
+type fixtureSpan struct {
+	SpanID       string `json:"span_id"`
+	ParentSpanID string `json:"parent_span_id,omitempty"`
+	Service      string `json:"service"`
+	Operation    string `json:"operation"`
+	Status       string `json:"status"`
+}
+
+type fixtureLog struct {
+	Service   string `json:"service"`
+	Body      string `json:"body"`
+	Transport string `json:"transport"`
+	TraceID   string `json:"trace_id"`
+	SpanID    string `json:"span_id"`
+}
+
+type fixtureMetric struct {
+	Service   string  `json:"service"`
+	Name      string  `json:"name"`
+	Transport string  `json:"transport"`
+	Value     float64 `json:"value"`
+}
+
+type staleFixture struct {
+	Service    string `json:"service"`
+	TraceID    string `json:"trace_id"`
+	SpanID     string `json:"span_id"`
+	LogBody    string `json:"log_body"`
+	MetricName string `json:"metric_name"`
+}
+
+type lockedBuffer struct {
+	mu   sync.Mutex
+	data []byte
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	b.data = append(b.data, p...)
+	b.mu.Unlock()
+	return len(p), nil
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(append([]byte(nil), b.data...))
+}
+
+type appProcess struct {
+	binary      string
+	driver      string
+	dsn         string
+	dir         string
+	httpPort    int
+	grpcPort    int
+	autoMigrate bool
+	log         *lockedBuffer
+	cmd         *exec.Cmd
+	done        chan error
+}
+
+func newAppProcess(t *testing.T, binary, driver, dsn string) *appProcess {
+	t.Helper()
+	return &appProcess{
+		binary:      binary,
+		driver:      driver,
+		dsn:         dsn,
+		dir:         t.TempDir(),
+		httpPort:    freePort(t),
+		grpcPort:    freePort(t),
+		autoMigrate: false,
+		log:         &lockedBuffer{},
+	}
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+func (a *appProcess) environment() []string {
+	overrides := map[string]string{
+		"AGGREGATE_ALLOW_REBUILD":    "false",
+		"AGGREGATE_DB_PATH":          filepath.Join(a.dir, "aggregate.db"),
+		"AGGREGATE_MODE":             "legacy",
+		"API_KEY":                    "",
+		"API_TENANT_KEYS_FILE":       "",
+		"APP_ENV":                    "development",
+		"DATA_DISK_BUDGET_MB":        "1000000",
+		"DATA_DISK_PATH":             a.dir,
+		"DB_AUTOMIGRATE":             strconv.FormatBool(a.autoMigrate),
+		"DB_DRIVER":                  a.driver,
+		"DB_DSN":                     a.dsn,
+		"DLQ_PATH":                   filepath.Join(a.dir, "dlq"),
+		"DLQ_REPLAY_INTERVAL":        "1h",
+		"EXEMPLAR_RETENTION_DAYS":    "1",
+		"GRAPHRAG_EVENT_QUEUE_SIZE":  "128",
+		"GRAPHRAG_WORKER_COUNT":      "1",
+		"GRPC_PORT":                  strconv.Itoa(a.grpcPort),
+		"HOT_RETENTION_DAYS":         "1",
+		"HTTP_PORT":                  strconv.Itoa(a.httpPort),
+		"INGEST_ASYNC_ENABLED":       "true",
+		"INGEST_PIPELINE_QUEUE_SIZE": "256",
+		"INGEST_PIPELINE_WORKERS":    "1",
+		"INGEST_MIN_SEVERITY":        "INFO",
+		"LOG_LEVEL":                  "INFO",
+		"PPROF_ADDR":                 "",
+		"RETENTION_BATCH_SIZE":       "100",
+		"RETENTION_BATCH_SLEEP_MS":   "0",
+		"SAMPLING_RATE":              "1.0",
+		"STORE_MIN_SEVERITY":         "INFO",
+		"TLS_AUTO_SELFSIGNED":        "false",
+		"TLS_CERT_FILE":              "",
+		"TLS_KEY_FILE":               "",
+	}
+	env := make([]string, 0, len(os.Environ())+len(overrides))
+	for _, item := range os.Environ() {
+		key, _, _ := strings.Cut(item, "=")
+		if _, replaced := overrides[key]; !replaced {
+			env = append(env, item)
+		}
+	}
+	keys := make([]string, 0, len(overrides))
+	for key := range overrides {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		env = append(env, key+"="+overrides[key])
+	}
+	return env
+}
+
+func (a *appProcess) start() error {
+	if a.cmd != nil {
+		return errors.New("application already running")
+	}
+	command := exec.Command(a.binary)
+	command.Dir = a.dir
+	command.Env = a.environment()
+	command.Stdout = a.log
+	command.Stderr = a.log
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := command.Start(); err != nil {
+		return err
+	}
+	done := make(chan error, 1)
+	go func() { done <- command.Wait() }()
+	a.cmd = command
+	a.done = done
+	return nil
+}
+
+func (a *appProcess) stop() (int, error) {
+	command, done := a.cmd, a.done
+	a.cmd, a.done = nil, nil
+	if command == nil || command.Process == nil {
+		return 0, nil
+	}
+	if err := syscall.Kill(-command.Process.Pid, syscall.SIGTERM); err != nil {
+		return -1, err
+	}
+	select {
+	case err := <-done:
+		if err == nil {
+			return 0, nil
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode(), err
+		}
+		return -1, err
+	case <-time.After(35 * time.Second):
+		_ = syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+		<-done
+		return -1, errors.New("shutdown exceeded 35 seconds")
+	}
+}
+
+func (a *appProcess) waitReady(ctx context.Context) error {
+	client := &http.Client{Timeout: time.Second, Transport: &http.Transport{Proxy: nil}}
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		request, _ := http.NewRequestWithContext(ctx, http.MethodGet, a.baseURL()+"/ready", nil)
+		response, err := client.Do(request)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, response.Body)
+			_ = response.Body.Close()
+			if response.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("readiness: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func (a *appProcess) baseURL() string {
+	return "http://127.0.0.1:" + strconv.Itoa(a.httpPort)
+}
+
+type oneShotResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+	Elapsed  time.Duration
+}
+
+func runOneShot(t *testing.T, app *appProcess, args ...string) oneShotResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	command := exec.CommandContext(ctx, app.binary, args...)
+	command.Dir = app.dir
+	command.Env = app.environment()
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	started := time.Now()
+	err := command.Run()
+	result := oneShotResult{Stdout: stdout.String(), Stderr: stderr.String(), Elapsed: time.Since(started)}
+	if err == nil {
+		return result
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("%s timed out: %v\n%s", strings.Join(args, " "), ctx.Err(), stderr.String())
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("%s failed: %v\n%s", strings.Join(args, " "), err, stderr.String())
+	}
+	result.ExitCode = exitErr.ExitCode()
+	return result
+}
+
+func loadFixture(t *testing.T) fixture {
+	t.Helper()
+	var value fixture
+	if err := json.Unmarshal(fixtureJSON, &value); err != nil {
+		t.Fatal(err)
+	}
+	if value.SchemaVersion != "otelcontext.db-lifecycle-fixture.v1" || len(value.Services) != 5 || len(value.Traces) != 2 || len(value.Logs) != 6 || len(value.Metrics) != 6 {
+		t.Fatalf("fixture contract changed: %#v", value)
+	}
+	spanCount, errorsCount := 0, 0
+	transports := map[string]map[string]bool{"trace": {}, "log": {}, "metric": {}}
+	for _, trace := range value.Traces {
+		transports["trace"][trace.Transport] = true
+		spanCount += len(trace.Spans)
+		for _, span := range trace.Spans {
+			if span.Status == "error" {
+				errorsCount++
+			}
+		}
+	}
+	for _, record := range value.Logs {
+		transports["log"][record.Transport] = true
+	}
+	for _, metric := range value.Metrics {
+		transports["metric"][metric.Transport] = true
+	}
+	if spanCount != 6 || errorsCount != 2 {
+		t.Fatalf("fixture spans=%d errors=%d, want 6 and 2", spanCount, errorsCount)
+	}
+	for signal, seen := range transports {
+		if !seen["grpc"] || !seen["http"] {
+			t.Fatalf("fixture %s does not exercise both transports: %v", signal, seen)
+		}
+	}
+	return value
+}
+
+func resource(service string) *resourcepb.Resource {
+	return &resourcepb.Resource{Attributes: []*commonpb.KeyValue{{
+		Key: "service.name", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: service}},
+	}}}
+}
+
+func decodeHex(value string) []byte {
+	decoded, _ := hex.DecodeString(value)
+	return decoded
+}
+
+func traceRequest(fixture fixture, transport string, anchor time.Time) *collecttracepb.ExportTraceServiceRequest {
+	request := &collecttracepb.ExportTraceServiceRequest{}
+	for traceIndex, trace := range fixture.Traces {
+		if trace.Transport != transport {
+			continue
+		}
+		for spanIndex, span := range trace.Spans {
+			started := anchor.Add(time.Duration(traceIndex*10+spanIndex) * time.Millisecond)
+			status := tracepb.Status_STATUS_CODE_UNSET
+			if span.Status == "error" {
+				status = tracepb.Status_STATUS_CODE_ERROR
+			}
+			request.ResourceSpans = append(request.ResourceSpans, &tracepb.ResourceSpans{
+				Resource: resource(span.Service),
+				ScopeSpans: []*tracepb.ScopeSpans{{Spans: []*tracepb.Span{{
+					TraceId: decodeHex(trace.TraceID), SpanId: decodeHex(span.SpanID), ParentSpanId: decodeHex(span.ParentSpanID),
+					Name: span.Operation, StartTimeUnixNano: uint64(started.UnixNano()), EndTimeUnixNano: uint64(started.Add(10 * time.Millisecond).UnixNano()),
+					Status: &tracepb.Status{Code: status},
+				}}}},
+			})
+		}
+	}
+	return request
+}
+
+func logsRequest(fixture fixture, transport string, anchor time.Time) *collectlogspb.ExportLogsServiceRequest {
+	request := &collectlogspb.ExportLogsServiceRequest{}
+	for index, record := range fixture.Logs {
+		if record.Transport != transport {
+			continue
+		}
+		when := uint64(anchor.Add(time.Duration(index) * time.Millisecond).UnixNano())
+		request.ResourceLogs = append(request.ResourceLogs, &logspb.ResourceLogs{
+			Resource: resource(record.Service),
+			ScopeLogs: []*logspb.ScopeLogs{{LogRecords: []*logspb.LogRecord{{
+				TimeUnixNano: when, ObservedTimeUnixNano: when,
+				SeverityNumber: logspb.SeverityNumber_SEVERITY_NUMBER_ERROR, SeverityText: "ERROR",
+				Body:    &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: record.Body}},
+				TraceId: decodeHex(record.TraceID), SpanId: decodeHex(record.SpanID),
+			}}}},
+		})
+	}
+	return request
+}
+
+func metricsRequest(fixture fixture, transport string, anchor time.Time) *collectmetricspb.ExportMetricsServiceRequest {
+	request := &collectmetricspb.ExportMetricsServiceRequest{}
+	for index, metric := range fixture.Metrics {
+		if metric.Transport != transport {
+			continue
+		}
+		request.ResourceMetrics = append(request.ResourceMetrics, &metricspb.ResourceMetrics{
+			Resource: resource(metric.Service),
+			ScopeMetrics: []*metricspb.ScopeMetrics{{Metrics: []*metricspb.Metric{{
+				Name: metric.Name,
+				Data: &metricspb.Metric_Gauge{Gauge: &metricspb.Gauge{DataPoints: []*metricspb.NumberDataPoint{{
+					TimeUnixNano: uint64(anchor.Add(time.Duration(index) * time.Millisecond).UnixNano()),
+					Value:        &metricspb.NumberDataPoint_AsDouble{AsDouble: metric.Value},
+				}}}},
+			}}}},
+		})
+	}
+	return request
+}
+
+func staleRequests(value staleFixture, anchor time.Time) (*collecttracepb.ExportTraceServiceRequest, *collectlogspb.ExportLogsServiceRequest, *collectmetricspb.ExportMetricsServiceRequest) {
+	when := uint64(anchor.UnixNano())
+	traceID, spanID := decodeHex(value.TraceID), decodeHex(value.SpanID)
+	traces := &collecttracepb.ExportTraceServiceRequest{ResourceSpans: []*tracepb.ResourceSpans{{
+		Resource: resource(value.Service), ScopeSpans: []*tracepb.ScopeSpans{{Spans: []*tracepb.Span{{
+			TraceId: traceID, SpanId: spanID, Name: "stale-operation", StartTimeUnixNano: when, EndTimeUnixNano: when + uint64(time.Millisecond),
+		}}}},
+	}}}
+	logs := &collectlogspb.ExportLogsServiceRequest{ResourceLogs: []*logspb.ResourceLogs{{
+		Resource: resource(value.Service), ScopeLogs: []*logspb.ScopeLogs{{LogRecords: []*logspb.LogRecord{{
+			TimeUnixNano: when, ObservedTimeUnixNano: when, SeverityNumber: logspb.SeverityNumber_SEVERITY_NUMBER_INFO,
+			SeverityText: "INFO", Body: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: value.LogBody}},
+			TraceId: traceID, SpanId: spanID,
+		}}}},
+	}}}
+	metrics := &collectmetricspb.ExportMetricsServiceRequest{ResourceMetrics: []*metricspb.ResourceMetrics{{
+		Resource: resource(value.Service), ScopeMetrics: []*metricspb.ScopeMetrics{{Metrics: []*metricspb.Metric{{
+			Name: value.MetricName, Data: &metricspb.Metric_Gauge{Gauge: &metricspb.Gauge{DataPoints: []*metricspb.NumberDataPoint{{
+				TimeUnixNano: when, Value: &metricspb.NumberDataPoint_AsDouble{AsDouble: 1},
+			}}}},
+		}}}},
+	}}}
+	return traces, logs, metrics
+}
+
+func exportFixtures(ctx context.Context, app *appProcess, value fixture, anchor time.Time) error {
+	connection, err := grpc.NewClient("127.0.0.1:"+strconv.Itoa(app.grpcPort), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = connection.Close() }()
+	if _, err := collecttracepb.NewTraceServiceClient(connection).Export(ctx, traceRequest(value, "grpc", anchor)); err != nil {
+		return fmt.Errorf("gRPC traces: %w", err)
+	}
+	if _, err := collectlogspb.NewLogsServiceClient(connection).Export(ctx, logsRequest(value, "grpc", anchor)); err != nil {
+		return fmt.Errorf("gRPC logs: %w", err)
+	}
+	if _, err := collectmetricspb.NewMetricsServiceClient(connection).Export(ctx, metricsRequest(value, "grpc", anchor)); err != nil {
+		return fmt.Errorf("gRPC metrics: %w", err)
+	}
+	if err := postProto(ctx, app.baseURL()+"/v1/traces", traceRequest(value, "http", anchor)); err != nil {
+		return err
+	}
+	if err := postProto(ctx, app.baseURL()+"/v1/logs", logsRequest(value, "http", anchor)); err != nil {
+		return err
+	}
+	return postProto(ctx, app.baseURL()+"/v1/metrics", metricsRequest(value, "http", anchor))
+}
+
+func exportStale(ctx context.Context, app *appProcess, value staleFixture, anchor time.Time) error {
+	connection, err := grpc.NewClient("127.0.0.1:"+strconv.Itoa(app.grpcPort), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = connection.Close() }()
+	traces, logs, metrics := staleRequests(value, anchor)
+	if _, err := collecttracepb.NewTraceServiceClient(connection).Export(ctx, traces); err != nil {
+		return err
+	}
+	if _, err := collectlogspb.NewLogsServiceClient(connection).Export(ctx, logs); err != nil {
+		return err
+	}
+	_, err = collectmetricspb.NewMetricsServiceClient(connection).Export(ctx, metrics)
+	return err
+}
+
+func postProto(ctx context.Context, endpoint string, message proto.Message) error {
+	body, err := proto.Marshal(message)
+	if err != nil {
+		return err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/x-protobuf")
+	client := &http.Client{Timeout: 5 * time.Second, Transport: &http.Transport{Proxy: nil}}
+	response, err := client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	payload, _ := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("POST %s status=%d body=%s", endpoint, response.StatusCode, payload)
+	}
+	return nil
+}
+
+type rowFingerprint struct {
+	Traces        int64  `json:"traces"`
+	Spans         int64  `json:"spans"`
+	Logs          int64  `json:"logs"`
+	MetricBuckets int64  `json:"metric_buckets"`
+	Digest        string `json:"digest"`
+}
+
+func fingerprintRows(t *testing.T, driver, dsn string, value fixture, stale bool) rowFingerprint {
+	t.Helper()
+	db, err := storage.NewDatabase(driver, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sqlDB, sqlErr := db.DB(); sqlErr == nil {
+		defer func() { _ = sqlDB.Close() }()
+	}
+	traceIDs, spanIDs, logBodies, metricNames := make([]string, 0), make([]string, 0), make([]string, 0), make([]string, 0)
+	if stale {
+		traceIDs = append(traceIDs, value.Stale.TraceID)
+		spanIDs = append(spanIDs, value.Stale.SpanID)
+		logBodies = append(logBodies, value.Stale.LogBody)
+		metricNames = append(metricNames, value.Stale.MetricName)
+	} else {
+		for _, trace := range value.Traces {
+			traceIDs = append(traceIDs, trace.TraceID)
+			for _, span := range trace.Spans {
+				spanIDs = append(spanIDs, span.SpanID)
+			}
+		}
+		for _, record := range value.Logs {
+			logBodies = append(logBodies, record.Body)
+		}
+		for _, metric := range value.Metrics {
+			metricNames = append(metricNames, metric.Name)
+		}
+	}
+	result := rowFingerprint{}
+	for table, query := range map[string]struct {
+		column string
+		values []string
+	}{
+		"traces": {"trace_id", traceIDs}, "spans": {"span_id", spanIDs}, "logs": {"body", logBodies}, "metric_buckets": {"name", metricNames},
+	} {
+		var count int64
+		if err := db.Table(table).Where(query.column+" IN ?", query.values).Count(&count).Error; err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		switch table {
+		case "traces":
+			result.Traces = count
+		case "spans":
+			result.Spans = count
+		case "logs":
+			result.Logs = count
+		case "metric_buckets":
+			result.MetricBuckets = count
+		}
+	}
+	digestInput := fmt.Sprintf("%d|%d|%d|%d", result.Traces, result.Spans, result.Logs, result.MetricBuckets)
+	result.Digest = sha256Hex([]byte(digestInput))
+	return result
+}
+
+func waitForRows(t *testing.T, driver, dsn string, value fixture, wantStale bool) rowFingerprint {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		live := fingerprintRows(t, driver, dsn, value, false)
+		stale := fingerprintRows(t, driver, dsn, value, true)
+		liveReady := live.Traces == 2 && live.Spans == 6 && live.Logs == 6 && live.MetricBuckets == 6
+		staleReady := stale.Traces == 1 && stale.Spans == 1 && stale.Logs == 1 && stale.MetricBuckets == 1
+		if liveReady && staleReady == wantStale {
+			return live
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("row contract did not stabilize: live=%#v stale=%#v want_stale=%t", live, stale, wantStale)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func waitForRawRows(t *testing.T, driver, dsn string, value fixture) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		live := fingerprintRows(t, driver, dsn, value, false)
+		stale := fingerprintRows(t, driver, dsn, value, true)
+		if live.Traces == 2 && live.Spans == 6 && live.Logs == 6 && stale.Traces == 1 && stale.Spans == 1 && stale.Logs == 1 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("raw ingest did not stabilize: live=%#v stale=%#v", live, stale)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+type mcpCallProof struct {
+	Succeeded bool `json:"succeeded"`
+	HasBody   bool `json:"has_body"`
+}
+
+type surfaceProof struct {
+	RESTPaths  []string                `json:"rest_paths"`
+	MCPTools   []string                `json:"mcp_tools"`
+	MCPCalls   map[string]mcpCallProof `json:"mcp_calls"`
+	WebSockets []string                `json:"websockets"`
+}
+
+func collectSurfaces(t *testing.T, app *appProcess, value fixture) surfaceProof {
+	t.Helper()
+	deadline := time.Now().Add(25 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		result, err := trySurfaces(app, value)
+		if err == nil {
+			return result
+		}
+		lastErr = err
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("query surfaces did not stabilize: %v\n%s", lastErr, app.log.String())
+	return surfaceProof{}
+}
+
+func trySurfaces(app *appProcess, value fixture) (surfaceProof, error) {
+	paths := []string{
+		"/ready", "/api/metadata/services", "/api/traces?limit=50", "/api/traces/" + value.Traces[0].TraceID,
+		"/api/logs?limit=50", "/api/metrics?name=" + url.QueryEscape(value.Metrics[0].Name),
+		"/api/metrics/dashboard", "/api/metrics/service-map", "/api/system/graph",
+	}
+	bodies := make(map[string][]byte, len(paths))
+	for _, path := range paths {
+		body, err := getBody(app.baseURL() + path)
+		if err != nil {
+			return surfaceProof{}, err
+		}
+		bodies[path] = body
+	}
+	for _, service := range value.Services {
+		if !bytes.Contains(bodies["/api/metadata/services"], []byte(service)) || !bytes.Contains(bodies["/api/system/graph"], []byte(service)) {
+			return surfaceProof{}, fmt.Errorf("service %q missing from metadata or system graph", service)
+		}
+	}
+	for _, trace := range value.Traces {
+		if !bytes.Contains(bodies["/api/traces?limit=50"], []byte(trace.TraceID)) {
+			return surfaceProof{}, fmt.Errorf("trace %q missing", trace.TraceID)
+		}
+	}
+	for _, record := range value.Logs {
+		if !bytes.Contains(bodies["/api/logs?limit=50"], []byte(record.Body)) {
+			return surfaceProof{}, fmt.Errorf("log %q missing", record.Body)
+		}
+	}
+	tools, err := listMCPTools(app.baseURL() + "/mcp")
+	if err != nil {
+		return surfaceProof{}, err
+	}
+	wantTools := []string{"get_anomaly_timeline", "get_service_health", "get_service_map", "impact_analysis", "root_cause_analysis", "search_logs", "trace_graph"}
+	if !reflect.DeepEqual(tools, wantTools) {
+		return surfaceProof{}, fmt.Errorf("MCP tools=%v want=%v", tools, wantTools)
+	}
+	calls := []struct {
+		name string
+		args map[string]any
+	}{
+		{"get_anomaly_timeline", nil},
+		{"get_service_map", nil},
+		{"get_service_health", map[string]any{"service_name": "payments"}},
+		{"root_cause_analysis", map[string]any{"service": "payments"}},
+		{"impact_analysis", map[string]any{"service": "gateway"}},
+		{"trace_graph", map[string]any{"trace_id": value.Traces[0].TraceID}},
+		{"search_logs", map[string]any{"service": "payments", "query": "dbcontract"}},
+	}
+	callProof := make(map[string]mcpCallProof, len(calls))
+	for _, call := range calls {
+		text, succeeded, err := callMCPTool(app.baseURL()+"/mcp", call.name, call.args)
+		if err != nil {
+			return surfaceProof{}, err
+		}
+		if !succeeded {
+			return surfaceProof{}, fmt.Errorf("MCP %s failed: %s", call.name, text)
+		}
+		callProof[call.name] = mcpCallProof{Succeeded: true, HasBody: text != ""}
+	}
+	webSockets := []string{"/ws", "/ws/events"}
+	if err := probeWebSocket(app.baseURL() + "/ws"); err != nil {
+		return surfaceProof{}, fmt.Errorf("websocket /ws handshake: %w", err)
+	}
+	eventBody, err := readWebSocket(app.baseURL() + "/ws/events")
+	if err != nil {
+		return surfaceProof{}, fmt.Errorf("websocket /ws/events: %w", err)
+	}
+	if !containsAny(eventBody, value.Services) {
+		return surfaceProof{}, fmt.Errorf("websocket /ws/events omitted fixture services: %s", eventBody)
+	}
+	return surfaceProof{RESTPaths: paths, MCPTools: tools, MCPCalls: callProof, WebSockets: webSockets}, nil
+}
+
+func getBody(endpoint string) ([]byte, error) {
+	client := &http.Client{Timeout: 4 * time.Second, Transport: &http.Transport{Proxy: nil}}
+	response, err := client.Get(endpoint) //nolint:gosec // exact loopback proof endpoint.
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, 8<<20))
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s status=%d body=%s", endpoint, response.StatusCode, body)
+	}
+	return body, nil
+}
+
+func listMCPTools(endpoint string) ([]string, error) {
+	body, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+	response, err := http.Post(endpoint, "application/json", bytes.NewReader(body)) //nolint:gosec // exact loopback proof endpoint.
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	var envelope struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+		Error any `json:"error"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&envelope); err != nil {
+		return nil, err
+	}
+	if envelope.Error != nil {
+		return nil, fmt.Errorf("tools/list error: %v", envelope.Error)
+	}
+	names := make([]string, 0, len(envelope.Result.Tools))
+	for _, tool := range envelope.Result.Tools {
+		names = append(names, tool.Name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func callMCPTool(endpoint, name string, arguments map[string]any) (string, bool, error) {
+	if arguments == nil {
+		arguments = map[string]any{}
+	}
+	body, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{"name": name, "arguments": arguments},
+	})
+	response, err := http.Post(endpoint, "application/json", bytes.NewReader(body)) //nolint:gosec // exact loopback proof endpoint.
+	if err != nil {
+		return "", false, err
+	}
+	defer response.Body.Close()
+	var envelope struct {
+		Result struct {
+			IsError bool `json:"isError"`
+			Content []struct {
+				Text     string `json:"text"`
+				Resource *struct {
+					Text string `json:"text"`
+				} `json:"resource,omitempty"`
+			} `json:"content"`
+		} `json:"result"`
+		Error any `json:"error"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&envelope); err != nil {
+		return "", false, err
+	}
+	if envelope.Error != nil {
+		return fmt.Sprint(envelope.Error), false, nil
+	}
+	var text strings.Builder
+	for _, content := range envelope.Result.Content {
+		text.WriteString(content.Text)
+		if content.Resource != nil {
+			text.WriteString(content.Resource.Text)
+		}
+	}
+	return text.String(), !envelope.Result.IsError && text.Len() > 0, nil
+}
+
+func readWebSocket(httpURL string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	connection, response, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(httpURL, "http"), nil)
+	if response != nil && response.Body != nil {
+		_ = response.Body.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer connection.Close(websocket.StatusNormalClosure, "database proof complete")
+	_, body, err := connection.Read(ctx)
+	return body, err
+}
+
+func probeWebSocket(httpURL string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	connection, response, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(httpURL, "http"), nil)
+	if response != nil && response.Body != nil {
+		_ = response.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+	return connection.Close(websocket.StatusNormalClosure, "database proof handshake complete")
+}
+
+func containsAny(body []byte, values []string) bool {
+	for _, value := range values {
+		if bytes.Contains(body, []byte(value)) {
+			return true
+		}
+	}
+	return false
+}
+
+func assertPostConnectEvent(t *testing.T, app *appProcess, value fixture, export func() error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+	connection, response, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(app.baseURL()+"/ws/events", "http"), nil)
+	if response != nil && response.Body != nil {
+		_ = response.Body.Close()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer connection.Close(websocket.StatusNormalClosure, "fixture observed")
+	_, _, _ = connection.Read(ctx) // The immediate snapshot is not the post-connect event.
+	if err := export(); err != nil {
+		t.Fatal(err)
+	}
+	for {
+		_, body, err := connection.Read(ctx)
+		if err != nil {
+			t.Fatalf("post-connect WebSocket event: %v", err)
+		}
+		if containsAny(body, value.Services) {
+			return
+		}
+	}
+}
+
+func engineVersion(t *testing.T, driver, dsn string) string {
+	t.Helper()
+	db, err := storage.NewDatabase(driver, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sqlDB, sqlErr := db.DB(); sqlErr == nil {
+		defer func() { _ = sqlDB.Close() }()
+	}
+	query := map[string]string{
+		"sqlite": "SELECT sqlite_version()", "postgres": "SHOW server_version", "mysql": "SELECT VERSION()",
+		"mssql": "SELECT CONVERT(varchar(128), SERVERPROPERTY('ProductVersion'))",
+	}[driver]
+	var version string
+	if query == "" {
+		t.Fatalf("unsupported driver %q", driver)
+	}
+	if err := db.Raw(query).Scan(&version).Error; err != nil {
+		t.Fatal(err)
+	}
+	prefix := map[string]string{"sqlite": "3.53.", "postgres": "16.", "mysql": "8.4.", "mssql": "16.0.4265.3"}[driver]
+	if !strings.HasPrefix(version, prefix) {
+		t.Fatalf("%s engine version=%q, want prefix %q", driver, version, prefix)
+	}
+	return version
+}
+
+type migrationProof struct {
+	Before string `json:"before"`
+	Up     string `json:"up"`
+	After  string `json:"after"`
+	State  string `json:"state"`
+}
+
+func installSchema(t *testing.T, app *appProcess, proofDir string) migrationProof {
+	t.Helper()
+	if app.driver == "sqlite" || app.driver == "postgres" {
+		before := runOneShot(t, app, "migrate", "status")
+		if before.ExitCode != 10 || !strings.Contains(before.Stdout, "state=empty") {
+			t.Fatalf("initial migration status exit=%d stdout=%s stderr=%s", before.ExitCode, before.Stdout, before.Stderr)
+		}
+		up := runOneShot(t, app, "migrate", "up")
+		if up.ExitCode != 0 || !strings.Contains(up.Stdout, "result=ready") {
+			t.Fatalf("migrate up exit=%d stdout=%s stderr=%s", up.ExitCode, up.Stdout, up.Stderr)
+		}
+		after := runOneShot(t, app, "migrate", "status")
+		if after.ExitCode != 0 || !strings.Contains(after.Stdout, "state=exact") {
+			t.Fatalf("final migration status exit=%d stdout=%s stderr=%s", after.ExitCode, after.Stdout, after.Stderr)
+		}
+		writeProofFile(t, proofDir, "migration-before.txt", before.Stdout+before.Stderr)
+		writeProofFile(t, proofDir, "migration-after.txt", after.Stdout+after.Stderr)
+		return migrationProof{Before: strings.TrimSpace(before.Stdout), Up: strings.TrimSpace(up.Stdout), After: strings.TrimSpace(after.Stdout), State: "exact"}
+	}
+	app.autoMigrate = true
+	if err := app.start(); err != nil {
+		t.Fatal(err)
+	}
+	readyCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	if err := app.waitReady(readyCtx); err != nil {
+		cancel()
+		t.Fatalf("preview schema install: %v\n%s", err, app.log.String())
+	}
+	cancel()
+	if exit, err := app.stop(); err != nil || exit != 0 {
+		t.Fatalf("preview schema install shutdown exit=%d err=%v\n%s", exit, err, app.log.String())
+	}
+	app.autoMigrate = false
+	status := runOneShot(t, app, "migrate", "status")
+	if status.ExitCode != 16 || !strings.Contains(status.Stdout, "state=unverified") {
+		t.Fatalf("preview migration status exit=%d stdout=%s stderr=%s", status.ExitCode, status.Stdout, status.Stderr)
+	}
+	writeProofFile(t, proofDir, "migration-before.txt", "preview AutoMigrate install\n")
+	writeProofFile(t, proofDir, "migration-after.txt", status.Stdout+status.Stderr)
+	return migrationProof{Before: "preview AutoMigrate install", After: strings.TrimSpace(status.Stdout), State: "unverified-preview"}
+}
+
+type baselineRelease struct {
+	Release           string `json:"release"`
+	BinaryPath        string `json:"binary_path"`
+	ArchiveSHA256     string `json:"archive_sha256"`
+	BinarySHA256      string `json:"binary_sha256"`
+	SignatureVerified bool   `json:"signature_verified"`
+}
+
+type baselineManifest struct {
+	SchemaVersion string            `json:"schema_version"`
+	Releases      []baselineRelease `json:"releases"`
+}
+
+type baselineProof struct {
+	Release       string `json:"release"`
+	ArchiveSHA256 string `json:"archive_sha256"`
+	BinarySHA256  string `json:"binary_sha256"`
+	DataPreserved bool   `json:"data_preserved"`
+	State         string `json:"state"`
+}
+
+func proveSignedBaselines(t *testing.T, candidate *appProcess, value fixture) []baselineProof {
+	t.Helper()
+	manifestPath := os.Getenv("OTELCONTEXT_TEST_BASELINE_MANIFEST")
+	if manifestPath == "" {
+		if os.Getenv("GITHUB_ACTIONS") == "true" && (candidate.driver == "sqlite" || candidate.driver == "postgres") {
+			t.Fatal("OTELCONTEXT_TEST_BASELINE_MANIFEST is required in hosted production-profile proof")
+		}
+		return nil
+	}
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest baselineManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.SchemaVersion != "otelcontext.signed-baselines.v1" || len(manifest.Releases) != 2 {
+		t.Fatalf("invalid signed baseline manifest: %#v", manifest)
+	}
+	proofs := make([]baselineProof, 0, 2)
+	for _, release := range manifest.Releases {
+		if !release.SignatureVerified || sha256File(t, release.BinaryPath) != release.BinarySHA256 {
+			t.Fatalf("signed baseline %s is not bound to its binary", release.Release)
+		}
+		dsn, cleanup := baselineDSN(t, candidate.driver, candidate.dsn, release.Release)
+		defer cleanup()
+		old := newAppProcess(t, release.BinaryPath, candidate.driver, dsn)
+		old.autoMigrate = true
+		if err := old.start(); err != nil {
+			t.Fatal(err)
+		}
+		readyCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		if err := old.waitReady(readyCtx); err != nil {
+			cancel()
+			t.Fatalf("%s baseline readiness: %v\n%s", release.Release, err, old.log.String())
+		}
+		cancel()
+		ctx, cancelExport := context.WithTimeout(context.Background(), 10*time.Second)
+		baselineFixture := value
+		baselineFixture.Traces = value.Traces[:1]
+		baselineFixture.Logs = value.Logs[:1]
+		baselineFixture.Metrics = value.Metrics[:1]
+		baselineFixture.Traces[0].Transport = "grpc"
+		baselineFixture.Logs[0].Transport = "grpc"
+		baselineFixture.Metrics[0].Transport = "grpc"
+		if err := exportFixtures(ctx, old, baselineFixture, time.Now().UTC()); err != nil {
+			cancelExport()
+			t.Fatalf("seed %s baseline: %v", release.Release, err)
+		}
+		cancelExport()
+		if exit, err := old.stop(); err != nil || exit != 0 {
+			t.Fatalf("%s baseline shutdown exit=%d err=%v\n%s", release.Release, exit, err, old.log.String())
+		}
+		upgrade := newAppProcess(t, candidate.binary, candidate.driver, dsn)
+		status := runOneShot(t, upgrade, "migrate", "status")
+		if status.ExitCode != 11 || !strings.Contains(status.Stdout, "state=unmanaged") {
+			t.Fatalf("%s candidate pre-baseline status exit=%d stdout=%s stderr=%s", release.Release, status.ExitCode, status.Stdout, status.Stderr)
+		}
+		baseline := runOneShot(t, upgrade, "migrate", "baseline", "--from", release.Release)
+		if baseline.ExitCode != 0 {
+			t.Fatalf("%s baseline exit=%d stdout=%s stderr=%s", release.Release, baseline.ExitCode, baseline.Stdout, baseline.Stderr)
+		}
+		up := runOneShot(t, upgrade, "migrate", "up")
+		if up.ExitCode != 0 || !strings.Contains(up.Stdout, "state=exact") {
+			t.Fatalf("%s upgrade exit=%d stdout=%s stderr=%s", release.Release, up.ExitCode, up.Stdout, up.Stderr)
+		}
+		if err := upgrade.start(); err != nil {
+			t.Fatal(err)
+		}
+		upgradeReady, cancelUpgrade := context.WithTimeout(context.Background(), 30*time.Second)
+		if err := upgrade.waitReady(upgradeReady); err != nil {
+			cancelUpgrade()
+			t.Fatalf("%s upgraded readiness: %v\n%s", release.Release, err, upgrade.log.String())
+		}
+		cancelUpgrade()
+		body, err := getBody(upgrade.baseURL() + "/api/traces/" + value.Traces[0].TraceID)
+		preserved := err == nil && bytes.Contains(body, []byte(value.Traces[0].TraceID))
+		if exit, stopErr := upgrade.stop(); stopErr != nil || exit != 0 {
+			t.Fatalf("%s upgraded shutdown exit=%d err=%v", release.Release, exit, stopErr)
+		}
+		if !preserved {
+			t.Fatalf("%s baseline fixture was not preserved: err=%v body=%s", release.Release, err, body)
+		}
+		proofs = append(proofs, baselineProof{Release: release.Release, ArchiveSHA256: release.ArchiveSHA256, BinarySHA256: release.BinarySHA256, DataPreserved: true, State: "exact"})
+	}
+	return proofs
+}
+
+func baselineDSN(t *testing.T, driver, sourceDSN, release string) (string, func()) {
+	t.Helper()
+	if driver == "sqlite" {
+		return filepath.Join(t.TempDir(), strings.NewReplacer(".", "_", "-", "_").Replace(release)+".db"), func() {}
+	}
+	if driver != "postgres" {
+		t.Fatalf("signed baselines are not promoted for %s", driver)
+	}
+	parsed, err := url.Parse(sourceDSN)
+	if err != nil || parsed.Scheme == "" {
+		t.Fatalf("PostgreSQL dbcontract DSN must be a URL: %q (%v)", sourceDSN, err)
+	}
+	name := "dbcontract_" + strings.NewReplacer(".", "_", "-", "_").Replace(strings.TrimPrefix(release, "v")) + "_" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	adminURL := *parsed
+	adminURL.Path = "/postgres"
+	admin, err := storage.NewDatabase("postgres", adminURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := admin.Exec("CREATE DATABASE \"" + name + "\"").Error; err != nil { //nolint:gosec // generated safe identifier.
+		t.Fatal(err)
+	}
+	if sqlDB, sqlErr := admin.DB(); sqlErr == nil {
+		_ = sqlDB.Close()
+	}
+	target := *parsed
+	target.Path = "/" + name
+	cleanup := func() {
+		db, openErr := storage.NewDatabase("postgres", adminURL.String())
+		if openErr != nil {
+			return
+		}
+		_ = db.Exec("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = ?", name).Error
+		_ = db.Exec("DROP DATABASE IF EXISTS \"" + name + "\"").Error //nolint:gosec // generated safe identifier.
+		if sqlDB, sqlErr := db.DB(); sqlErr == nil {
+			_ = sqlDB.Close()
+		}
+	}
+	return target.String(), cleanup
+}
+
+type restoreProof struct {
+	Kind                string `json:"kind"`
+	SourceFingerprint   string `json:"source_fingerprint"`
+	RestoredFingerprint string `json:"restored_fingerprint"`
+	EvidenceSHA256      string `json:"evidence_sha256"`
+}
+
+func proveRestore(t *testing.T, source *appProcess, value fixture, sourceRows rowFingerprint, sourceSurfaces surfaceProof, proofDir string) restoreProof {
+	t.Helper()
+	if source.driver != "sqlite" && source.driver != "postgres" {
+		path := os.Getenv("OTELCONTEXT_TEST_NATIVE_RESTORE_PROOF")
+		if path == "" {
+			t.Fatal("OTELCONTEXT_TEST_NATIVE_RESTORE_PROOF is required for preview adapters")
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var native struct {
+			Adapter    string `json:"adapter"`
+			Source     string `json:"source_lifecycle_fingerprint"`
+			Restored   string `json:"restored_lifecycle_fingerprint"`
+			Assertions []struct {
+				Passed bool `json:"passed"`
+			} `json:"assertions"`
+		}
+		if err := json.Unmarshal(data, &native); err != nil {
+			t.Fatal(err)
+		}
+		if native.Adapter != source.driver || native.Source == "" || native.Source != native.Restored || len(native.Assertions) < 8 {
+			t.Fatalf("native restore proof mismatch: %#v", native)
+		}
+		for _, assertion := range native.Assertions {
+			if !assertion.Passed {
+				t.Fatal("native restore proof contains a failed assertion")
+			}
+		}
+		return restoreProof{Kind: "native-fresh-target", SourceFingerprint: native.Source, RestoredFingerprint: native.Restored, EvidenceSHA256: sha256Hex(data)}
+	}
+	backupParent := t.TempDir()
+	create := runOneShot(t, source, "backup", "create", "--out", backupParent)
+	if create.ExitCode != 0 {
+		t.Fatalf("backup create exit=%d stdout=%s stderr=%s", create.ExitCode, create.Stdout, create.Stderr)
+	}
+	var createReport struct {
+		Bundle string `json:"bundle"`
+	}
+	if err := json.Unmarshal([]byte(create.Stdout), &createReport); err != nil || createReport.Bundle == "" {
+		t.Fatalf("decode backup create: %v (%s)", err, create.Stdout)
+	}
+	targetDSN := os.Getenv("OTELCONTEXT_TEST_RESTORE_DSN")
+	if source.driver == "sqlite" {
+		targetDSN = filepath.Join(t.TempDir(), "restored.db")
+	}
+	if targetDSN == "" {
+		t.Fatal("OTELCONTEXT_TEST_RESTORE_DSN is required for PostgreSQL")
+	}
+	target := newAppProcess(t, source.binary, source.driver, targetDSN)
+	restore := runOneShot(t, target, "backup", "restore", "--bundle", createReport.Bundle)
+	if restore.ExitCode != 0 {
+		t.Fatalf("backup restore exit=%d stdout=%s stderr=%s", restore.ExitCode, restore.Stdout, restore.Stderr)
+	}
+	if err := target.start(); err != nil {
+		t.Fatal(err)
+	}
+	readyCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	if err := target.waitReady(readyCtx); err != nil {
+		cancel()
+		t.Fatalf("restored readiness: %v\n%s", err, target.log.String())
+	}
+	cancel()
+	restoredRows := waitForRows(t, source.driver, targetDSN, value, false)
+	restoredSurfaces := collectSurfaces(t, target, value)
+	if exit, err := target.stop(); err != nil || exit != 0 {
+		t.Fatalf("restored shutdown exit=%d err=%v\n%s", exit, err, target.log.String())
+	}
+	if !reflect.DeepEqual(sourceRows, restoredRows) || !reflect.DeepEqual(sourceSurfaces.MCPTools, restoredSurfaces.MCPTools) || len(restoredSurfaces.MCPCalls) != 7 {
+		t.Fatalf("restored contract mismatch: source=%#v target=%#v", sourceRows, restoredRows)
+	}
+	manifestData, err := os.ReadFile(filepath.Join(createReport.Bundle, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeJSONFile(t, proofDir, "post-restore-fingerprint.json", restoredRows)
+	return restoreProof{Kind: "candidate-backup-cli-fresh-target", SourceFingerprint: sourceRows.Digest, RestoredFingerprint: restoredRows.Digest, EvidenceSHA256: sha256Hex(manifestData)}
+}
+
+type assertion struct {
+	Name   string `json:"name"`
+	Passed bool   `json:"passed"`
+}
+
+type proofArtifact struct {
+	SchemaVersion  string          `json:"schema_version"`
+	CandidateSHA   string          `json:"candidate_sha,omitempty"`
+	BinarySHA256   string          `json:"binary_sha256"`
+	Driver         string          `json:"driver"`
+	Tier           string          `json:"tier"`
+	EngineImage    string          `json:"engine_image"`
+	EngineVersion  string          `json:"engine_version"`
+	FixtureSHA256  string          `json:"fixture_sha256"`
+	Migration      migrationProof  `json:"migration"`
+	Baselines      []baselineProof `json:"baselines"`
+	PreRestart     rowFingerprint  `json:"pre_restart_fingerprint"`
+	PostRestart    rowFingerprint  `json:"post_restart_fingerprint"`
+	Surfaces       surfaceProof    `json:"surfaces"`
+	Restore        restoreProof    `json:"restore"`
+	ElapsedSeconds float64         `json:"elapsed_seconds"`
+	Assertions     []assertion     `json:"assertions"`
+}
+
+func TestDatabaseLifecycle(t *testing.T) {
+	started := time.Now()
+	binary := os.Getenv("OTELCONTEXT_TEST_BINARY")
+	driver := strings.ToLower(strings.TrimSpace(os.Getenv("OTELCONTEXT_TEST_DRIVER")))
+	dsn := os.Getenv("OTELCONTEXT_TEST_DSN")
+	proofDir := os.Getenv("OTELCONTEXT_PROOF_DIR")
+	requireDB := os.Getenv("OTELCONTEXT_TEST_REQUIRE_DB") == "1"
+	if binary == "" || driver == "" || dsn == "" || proofDir == "" {
+		t.Fatal("OTELCONTEXT_TEST_BINARY, OTELCONTEXT_TEST_DRIVER, OTELCONTEXT_TEST_DSN, and OTELCONTEXT_PROOF_DIR are required")
+	}
+	if !requireDB {
+		t.Fatal("OTELCONTEXT_TEST_REQUIRE_DB=1 is required; lifecycle proof never auto-skips")
+	}
+	if driver != "sqlite" && driver != "postgres" && driver != "mysql" && driver != "mssql" {
+		t.Fatalf("unsupported driver %q", driver)
+	}
+	if err := os.MkdirAll(proofDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	value := loadFixture(t)
+	app := newAppProcess(t, binary, driver, dsn)
+	t.Cleanup(func() {
+		if app.cmd != nil {
+			_, _ = app.stop()
+		}
+	})
+	version := engineVersion(t, driver, dsn)
+	migration := installSchema(t, app, proofDir)
+	baselines := proveSignedBaselines(t, app, value)
+	if err := app.start(); err != nil {
+		t.Fatal(err)
+	}
+	readyCtx, cancelReady := context.WithTimeout(context.Background(), 30*time.Second)
+	if err := app.waitReady(readyCtx); err != nil {
+		cancelReady()
+		t.Fatalf("initial readiness: %v\n%s", err, app.log.String())
+	}
+	cancelReady()
+	anchor := time.Now().UTC().Truncate(time.Millisecond)
+	assertPostConnectEvent(t, app, value, func() error {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		return exportFixtures(ctx, app, value, anchor)
+	})
+	ctxStale, cancelStale := context.WithTimeout(context.Background(), 10*time.Second)
+	if err := exportStale(ctxStale, app, value.Stale, anchor.Add(-25*time.Hour)); err != nil {
+		cancelStale()
+		t.Fatal(err)
+	}
+	cancelStale()
+	waitForRawRows(t, driver, dsn, value)
+	surfaces := collectSurfaces(t, app, value)
+	if exit, err := app.stop(); err != nil || exit != 0 {
+		t.Fatalf("first shutdown exit=%d err=%v\n%s", exit, err, app.log.String())
+	}
+	preRestart := waitForRows(t, driver, dsn, value, true)
+	if err := app.start(); err != nil {
+		t.Fatal(err)
+	}
+	restartCtx, cancelRestart := context.WithTimeout(context.Background(), 30*time.Second)
+	if err := app.waitReady(restartCtx); err != nil {
+		cancelRestart()
+		t.Fatalf("restart readiness: %v\n%s", err, app.log.String())
+	}
+	cancelRestart()
+	postRestart := waitForRows(t, driver, dsn, value, false)
+	restartSurfaces := collectSurfaces(t, app, value)
+	if exit, err := app.stop(); err != nil || exit != 0 {
+		t.Fatalf("restart shutdown exit=%d err=%v\n%s", exit, err, app.log.String())
+	}
+	if !reflect.DeepEqual(preRestart, postRestart) {
+		t.Fatalf("restart fingerprint changed: before=%#v after=%#v", preRestart, postRestart)
+	}
+	if !reflect.DeepEqual(surfaces.MCPTools, restartSurfaces.MCPTools) || len(restartSurfaces.MCPCalls) != 7 {
+		t.Fatalf("restart surface contract changed: %#v", restartSurfaces)
+	}
+	restore := proveRestore(t, app, value, postRestart, restartSurfaces, proofDir)
+	tier := map[string]string{"postgres": "primary", "sqlite": "bounded-opt-in", "mysql": "preview", "mssql": "experimental"}[driver]
+	assertions := []assertion{
+		{Name: "database_required_no_skip", Passed: requireDB},
+		{Name: "engine_version_pinned", Passed: version != ""},
+		{Name: "migration_contract_recorded", Passed: migration.State == "exact" || migration.State == "unverified-preview"},
+		{Name: "signed_baselines_proved_or_preview", Passed: len(baselines) == 2 || driver == "mysql" || driver == "mssql" || os.Getenv("GITHUB_ACTIONS") != "true"},
+		{Name: "both_otlp_transports_all_signals", Passed: true},
+		{Name: "five_services_two_traces_six_spans", Passed: postRestart.Traces == 2 && postRestart.Spans == 6},
+		{Name: "six_logs_six_metric_series", Passed: postRestart.Logs == 6 && postRestart.MetricBuckets == 6},
+		{Name: "representative_rest_complete", Passed: len(restartSurfaces.RESTPaths) >= 9},
+		{Name: "both_websockets_complete", Passed: len(restartSurfaces.WebSockets) == 2},
+		{Name: "seven_mcp_tools_listed_and_called", Passed: len(restartSurfaces.MCPTools) == 7 && len(restartSurfaces.MCPCalls) == 7},
+		{Name: "stale_rows_purged_live_rows_retained", Passed: reflect.DeepEqual(preRestart, postRestart)},
+		{Name: "graceful_restart_preserved_fingerprint", Passed: preRestart.Digest == postRestart.Digest},
+		{Name: "fresh_target_restore_preserved_fingerprint", Passed: restore.SourceFingerprint == restore.RestoredFingerprint},
+	}
+	for _, check := range assertions {
+		if !check.Passed {
+			t.Fatalf("database proof assertion failed: %s", check.Name)
+		}
+	}
+	artifact := proofArtifact{
+		SchemaVersion: proofSchema, CandidateSHA: firstNonEmpty(os.Getenv("OTELCONTEXT_TEST_CANDIDATE_SHA"), os.Getenv("GITHUB_SHA")),
+		BinarySHA256: sha256File(t, binary), Driver: driver, Tier: tier, EngineImage: os.Getenv("OTELCONTEXT_TEST_ENGINE_IMAGE"),
+		EngineVersion: version, FixtureSHA256: sha256Hex(fixtureJSON), Migration: migration, Baselines: baselines,
+		PreRestart: preRestart, PostRestart: postRestart, Surfaces: restartSurfaces, Restore: restore,
+		ElapsedSeconds: time.Since(started).Seconds(), Assertions: assertions,
+	}
+	writeJSONFile(t, proofDir, "database-proof-v1.json", artifact)
+	writeJSONFile(t, proofDir, "pre-backup-fingerprint.json", preRestart)
+	writeProofFile(t, proofDir, "fixture-manifest.sha256", sha256Hex(fixtureJSON)+"  lifecycle-v1.json\n")
+	logOutput := strings.ReplaceAll(app.log.String(), dsn, "[redacted-dsn]")
+	writeProofFile(t, proofDir, "server.log", logOutput)
+}
+
+func writeProofFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeJSONFile(t *testing.T, dir, name string, value any) {
+	t.Helper()
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeProofFile(t, dir, name, string(append(data, '\n')))
+}
+
+func sha256File(t *testing.T, path string) string {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = file.Close() }()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func sha256Hex(data []byte) string {
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:])
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/test/dbcontract/dbcontract_test.go
+++ b/test/dbcontract/dbcontract_test.go
@@ -208,20 +208,26 @@ func (a *appProcess) start() error {
 	if a.cmd != nil {
 		return errors.New("application already running")
 	}
-	command := exec.Command(a.binary)
-	command.Dir = a.dir
-	command.Env = a.environment()
-	command.Stdout = a.log
-	command.Stderr = a.log
-	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	command := a.command()
 	if err := command.Start(); err != nil {
 		return err
 	}
 	done := make(chan error, 1)
-	go func() { done <- command.Wait() }()
+	go func() {
+		done <- command.Wait()
+		close(done)
+	}()
 	a.cmd = command
 	a.done = done
 	return nil
+}
+
+func (a *appProcess) command(arguments ...string) *exec.Cmd {
+	command := exec.Command(a.binary, arguments...)
+	command.Dir, command.Env = a.dir, a.environment()
+	command.Stdout, command.Stderr = a.log, a.log
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return command
 }
 
 func (a *appProcess) stop() (int, error) {
@@ -233,6 +239,12 @@ func (a *appProcess) stop() (int, error) {
 	if err := syscall.Kill(-command.Process.Pid, syscall.SIGTERM); err != nil {
 		return -1, err
 	}
+	return waitForExit(command, done)
+}
+
+func waitForExit(command *exec.Cmd, done <-chan error) (int, error) {
+	timer := time.NewTimer(35 * time.Second)
+	defer timer.Stop()
 	select {
 	case err := <-done:
 		if err == nil {
@@ -243,7 +255,7 @@ func (a *appProcess) stop() (int, error) {
 			return exitErr.ExitCode(), err
 		}
 		return -1, err
-	case <-time.After(35 * time.Second):
+	case <-timer.C:
 		_ = syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
 		<-done
 		return -1, errors.New("shutdown exceeded 35 seconds")
@@ -730,28 +742,16 @@ func getBody(endpoint string) ([]byte, error) {
 }
 
 func listMCPTools(endpoint string) ([]string, error) {
-	body, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
-	response, err := http.Post(endpoint, "application/json", bytes.NewReader(body)) //nolint:gosec // exact loopback proof endpoint.
-	if err != nil {
+	var result struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if err := postJSONRPC(endpoint, "tools/list", nil, &result); err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
-	var envelope struct {
-		Result struct {
-			Tools []struct {
-				Name string `json:"name"`
-			} `json:"tools"`
-		} `json:"result"`
-		Error any `json:"error"`
-	}
-	if err := json.NewDecoder(response.Body).Decode(&envelope); err != nil {
-		return nil, err
-	}
-	if envelope.Error != nil {
-		return nil, fmt.Errorf("tools/list error: %v", envelope.Error)
-	}
-	names := make([]string, 0, len(envelope.Result.Tools))
-	for _, tool := range envelope.Result.Tools {
+	names := make([]string, 0, len(result.Tools))
+	for _, tool := range result.Tools {
 		names = append(names, tool.Name)
 	}
 	sort.Strings(names)
@@ -762,41 +762,67 @@ func callMCPTool(endpoint, name string, arguments map[string]any) (string, bool,
 	if arguments == nil {
 		arguments = map[string]any{}
 	}
-	body, _ := json.Marshal(map[string]any{
-		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
-		"params": map[string]any{"name": name, "arguments": arguments},
-	})
-	response, err := http.Post(endpoint, "application/json", bytes.NewReader(body)) //nolint:gosec // exact loopback proof endpoint.
-	if err != nil {
+	var result struct {
+		IsError bool `json:"isError"`
+		Content []struct {
+			Text     string `json:"text"`
+			Resource *struct {
+				Text string `json:"text"`
+			} `json:"resource,omitempty"`
+		} `json:"content"`
+	}
+	params := map[string]any{"name": name, "arguments": arguments}
+	if err := postJSONRPC(endpoint, "tools/call", params, &result); err != nil {
 		return "", false, err
-	}
-	defer response.Body.Close()
-	var envelope struct {
-		Result struct {
-			IsError bool `json:"isError"`
-			Content []struct {
-				Text     string `json:"text"`
-				Resource *struct {
-					Text string `json:"text"`
-				} `json:"resource,omitempty"`
-			} `json:"content"`
-		} `json:"result"`
-		Error any `json:"error"`
-	}
-	if err := json.NewDecoder(response.Body).Decode(&envelope); err != nil {
-		return "", false, err
-	}
-	if envelope.Error != nil {
-		return fmt.Sprint(envelope.Error), false, nil
 	}
 	var text strings.Builder
-	for _, content := range envelope.Result.Content {
+	for _, content := range result.Content {
 		text.WriteString(content.Text)
 		if content.Resource != nil {
 			text.WriteString(content.Resource.Text)
 		}
 	}
-	return text.String(), !envelope.Result.IsError && text.Len() > 0, nil
+	return text.String(), !result.IsError && text.Len() > 0, nil
+}
+
+func postJSONRPC(endpoint, method string, params any, result any) error {
+	payload := map[string]any{"jsonrpc": "2.0", "id": 1, "method": method}
+	if params != nil {
+		payload["params"] = params
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := (&http.Client{Transport: &http.Transport{Proxy: nil}}).Do(request) //nolint:gosec // exact loopback proof endpoint.
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s status=%d", method, response.StatusCode)
+	}
+	var envelope struct {
+		Result json.RawMessage `json:"result"`
+		Error  json.RawMessage `json:"error"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&envelope); err != nil {
+		return err
+	}
+	if len(envelope.Error) > 0 && string(envelope.Error) != "null" {
+		return fmt.Errorf("%s error: %s", method, envelope.Error)
+	}
+	if len(envelope.Result) == 0 {
+		return fmt.Errorf("%s returned no result", method)
+	}
+	return json.Unmarshal(envelope.Result, result)
 }
 
 func readWebSocket(httpURL string) ([]byte, error) {

--- a/test/dbcontract/dbcontract_test.go
+++ b/test/dbcontract/dbcontract_test.go
@@ -94,21 +94,20 @@ type staleFixture struct {
 }
 
 type lockedBuffer struct {
-	mu   sync.Mutex
-	data []byte
+	sync.Mutex
+	bytes.Buffer
 }
 
 func (b *lockedBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	b.data = append(b.data, p...)
-	b.mu.Unlock()
-	return len(p), nil
+	b.Lock()
+	defer b.Unlock()
+	return b.Buffer.Write(p)
 }
 
 func (b *lockedBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return string(append([]byte(nil), b.data...))
+	b.Lock()
+	defer b.Unlock()
+	return b.Buffer.String()
 }
 
 type appProcess struct {

--- a/test/dbcontract/testdata/lifecycle-v1.json
+++ b/test/dbcontract/testdata/lifecycle-v1.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "otelcontext.db-lifecycle-fixture.v1",
+  "services": [
+    "gateway",
+    "orders",
+    "payments",
+    "inventory",
+    "notifications"
+  ],
+  "traces": [
+    {
+      "trace_id": "11111111111111111111111111111111",
+      "transport": "grpc",
+      "spans": [
+        {
+          "span_id": "1000000000000001",
+          "service": "gateway",
+          "operation": "POST /checkout",
+          "status": "ok"
+        },
+        {
+          "span_id": "1000000000000002",
+          "parent_span_id": "1000000000000001",
+          "service": "orders",
+          "operation": "create-order",
+          "status": "error"
+        },
+        {
+          "span_id": "1000000000000003",
+          "parent_span_id": "1000000000000002",
+          "service": "payments",
+          "operation": "charge-card",
+          "status": "error"
+        }
+      ]
+    },
+    {
+      "trace_id": "22222222222222222222222222222222",
+      "transport": "http",
+      "spans": [
+        {
+          "span_id": "2000000000000001",
+          "service": "gateway",
+          "operation": "GET /catalog",
+          "status": "ok"
+        },
+        {
+          "span_id": "2000000000000002",
+          "parent_span_id": "2000000000000001",
+          "service": "inventory",
+          "operation": "reserve-stock",
+          "status": "ok"
+        },
+        {
+          "span_id": "2000000000000003",
+          "parent_span_id": "2000000000000002",
+          "service": "notifications",
+          "operation": "publish-stock-event",
+          "status": "ok"
+        }
+      ]
+    }
+  ],
+  "logs": [
+    {
+      "service": "gateway",
+      "body": "dbcontract gateway accepted checkout",
+      "transport": "grpc",
+      "trace_id": "11111111111111111111111111111111",
+      "span_id": "1000000000000001"
+    },
+    {
+      "service": "orders",
+      "body": "dbcontract order write failed",
+      "transport": "grpc",
+      "trace_id": "11111111111111111111111111111111",
+      "span_id": "1000000000000002"
+    },
+    {
+      "service": "payments",
+      "body": "dbcontract payment declined",
+      "transport": "grpc",
+      "trace_id": "11111111111111111111111111111111",
+      "span_id": "1000000000000003"
+    },
+    {
+      "service": "gateway",
+      "body": "dbcontract catalog request accepted",
+      "transport": "http",
+      "trace_id": "22222222222222222222222222222222",
+      "span_id": "2000000000000001"
+    },
+    {
+      "service": "inventory",
+      "body": "dbcontract stock reserved",
+      "transport": "http",
+      "trace_id": "22222222222222222222222222222222",
+      "span_id": "2000000000000002"
+    },
+    {
+      "service": "notifications",
+      "body": "dbcontract stock event published",
+      "transport": "http",
+      "trace_id": "22222222222222222222222222222222",
+      "span_id": "2000000000000003"
+    }
+  ],
+  "metrics": [
+    {"service": "gateway", "name": "dbcontract_gateway_requests", "transport": "grpc", "value": 11},
+    {"service": "orders", "name": "dbcontract_orders_total", "transport": "grpc", "value": 12},
+    {"service": "payments", "name": "dbcontract_payments_total", "transport": "grpc", "value": 13},
+    {"service": "gateway", "name": "dbcontract_catalog_requests", "transport": "http", "value": 21},
+    {"service": "inventory", "name": "dbcontract_inventory_total", "transport": "http", "value": 22},
+    {"service": "notifications", "name": "dbcontract_notifications_total", "transport": "http", "value": 23}
+  ],
+  "stale": {
+    "service": "gateway",
+    "trace_id": "ffffffffffffffffffffffffffffffff",
+    "span_id": "f000000000000001",
+    "log_body": "dbcontract stale row must be purged",
+    "metric_name": "dbcontract_stale_metric"
+  }
+}


### PR DESCRIPTION
Closes #250

## Result

- adds one deterministic five-service lifecycle contract for every retained database adapter
- requires SQLite and PostgreSQL 16 on pull requests and main
- runs MySQL 8.4 and SQL Server 2022 weekly and before an exact-tag release
- binds migration, transport, signal, REST, WebSocket, GraphRAG, MCP, retention, restart, signed-upgrade, and fresh-restore evidence to the candidate
- documents PostgreSQL as primary, SQLite as bounded opt-in, MySQL as preview, and SQL Server as experimental

## Targeted local verification

- `go test -race -count=1 -timeout=10m -tags=dbcontract -run ^TestDatabaseLifecycle$ ./test/dbcontract` with the exact SQLite proof environment
- `go test -tags=integration -run ^$ ./internal/migrate ./internal/storage ./internal/backup`
- `actionlint .github/workflows/ci.yml .github/workflows/database-proof.yml .github/workflows/release.yml`
- `git diff --check`

The full repository suite and live PostgreSQL contract are intentionally delegated to GitHub CI. Security hardening is outside this ticket.