### PR TITLE
feat: certify signed aggregate candidates

### DIFF
--- a/.github/workflows/aggregate-release-gate.yml
+++ b/.github/workflows/aggregate-release-gate.yml
@@ -1,0 +1,176 @@
+name: Aggregate signed-candidate gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Immutable signed release tag to certify (for example v0.5.0)
+        required: true
+        type: string
+      sha:
+        description: Dereferenced 40-character commit SHA for the tag
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  aggregate:
+    name: aggregate gate · linux-amd64 · 2 CPU · 4 GiB
+    runs-on: [self-hosted, linux, x64, otelcontext-aggregate-gate]
+    timeout-minutes: 420
+    env:
+      TAG: ${{ inputs.tag }}
+      SHA: ${{ inputs.sha }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Initialize external evidence path
+        run: |
+          set -euo pipefail
+          proof_root="${RUNNER_TEMP}/otelcontext-aggregate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          case "${proof_root}" in
+            "${GITHUB_WORKSPACE}"|"${GITHUB_WORKSPACE}"/*)
+              echo "proof root must be outside the checkout" >&2
+              exit 1
+              ;;
+          esac
+          install -d -m 0755 "${proof_root}/aggregate/report"
+          echo "PROOF_ROOT=${proof_root}" >> "${GITHUB_ENV}"
+
+      - name: Checkout exact tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+        with:
+          cosign-release: 'v2.6.5'
+
+      - name: Verify immutable candidate identity
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${SHA}"
+          test "$(git rev-parse "${TAG}^{commit}")" = "${SHA}"
+          test -z "$(git status --porcelain --untracked-files=all)"
+          install -d -m 0755 \
+            "${PROOF_ROOT}/release" \
+            "${PROOF_ROOT}/extracted" \
+            "${PROOF_ROOT}/bin" \
+            "${PROOF_ROOT}/aggregate/work" \
+            "${PROOF_ROOT}/aggregate/report"
+
+      - name: Download and verify signed Linux archive
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          archive="otelcontext_${version}_linux_amd64.tar.gz"
+          gh release download "${TAG}" --repo "${GITHUB_REPOSITORY}" --dir "${PROOF_ROOT}/release" \
+            --pattern "${archive}" \
+            --pattern checksums.txt \
+            --pattern checksums.txt.sig \
+            --pattern checksums.txt.pem
+          cd "${PROOF_ROOT}/release"
+          grep " ${archive}$" checksums.txt | sha256sum --check -
+          if grep -q '^-----BEGIN CERTIFICATE-----' checksums.txt.pem; then
+            cp checksums.txt.pem checksums-certificate.pem
+          else
+            base64 --decode checksums.txt.pem > checksums-certificate.pem
+          fi
+          cosign verify-blob \
+            --certificate checksums-certificate.pem \
+            --signature checksums.txt.sig \
+            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@refs/tags/${TAG}" \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+            checksums.txt
+          tar -xzf "${archive}" -C "${PROOF_ROOT}/extracted"
+          candidate="$(find "${PROOF_ROOT}/extracted" -type f -name otelcontext -print -quit)"
+          test -n "${candidate}"
+          chmod 0755 "${candidate}"
+          test "$("${candidate}" --version)" = "OtelContext version ${TAG}"
+          archive_sha="$(awk -v name="${archive}" '$2 == name {print $1}' checksums.txt)"
+          test "${#archive_sha}" -eq 64
+          candidate_sha="$(sha256sum "${candidate}" | awk '{print $1}')"
+          {
+            echo "ARCHIVE=${PROOF_ROOT}/release/${archive}"
+            echo "ARCHIVE_SHA=${archive_sha}"
+            echo "CANDIDATE=${candidate}"
+            echo "CANDIDATE_SHA=${candidate_sha}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Build source-bound gate tools only
+        run: |
+          set -euo pipefail
+          make gate-tools GATE_BIN_DIR="${PROOF_ROOT}/bin"
+          sha256sum \
+            "${PROOF_ROOT}/bin/gate" \
+            "${PROOF_ROOT}/bin/loadsim" \
+            "${PROOF_ROOT}/bin/aggprefill" \
+            > "${PROOF_ROOT}/aggregate/tool-digests.txt"
+          cp test/gate/release.config.json "${PROOF_ROOT}/aggregate/release.config.json"
+
+      - name: Run aggregate certification protocol
+        id: gate
+        run: |
+          set +e
+          "${PROOF_ROOT}/bin/gate" \
+            -config "${GITHUB_WORKSPACE}/test/gate/release.config.json" \
+            -server "${CANDIDATE}" \
+            -expected-server-sha256 "${CANDIDATE_SHA}" \
+            -loadsim "${PROOF_ROOT}/bin/loadsim" \
+            -prefill "${PROOF_ROOT}/bin/aggprefill" \
+            -tag "${TAG}" \
+            -expected-commit-sha "${SHA}" \
+            -archive "${ARCHIVE}" \
+            -expected-archive-sha256 "${ARCHIVE_SHA}" \
+            -work-dir "${PROOF_ROOT}/aggregate/work" \
+            -out "${PROOF_ROOT}/aggregate/report" \
+            > "${PROOF_ROOT}/aggregate/gate.stdout.log" 2>&1
+          status=$?
+          printf '%s\n' "${status}" > "${PROOF_ROOT}/aggregate/gate.exit-code"
+          exit 0
+
+      - name: Record workflow evidence
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg schema_version 'otelcontext.aggregate-workflow.v1' \
+            --arg tag "${TAG}" \
+            --arg sha "${SHA}" \
+            --arg run_id "${GITHUB_RUN_ID}" \
+            --arg run_attempt "${GITHUB_RUN_ATTEMPT}" \
+            --arg run_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{schema_version:$schema_version,tag:$tag,sha:$sha,run_id:$run_id,run_attempt:$run_attempt,run_url:$run_url}' \
+            > "${PROOF_ROOT}/aggregate/workflow-evidence.json"
+          find "${PROOF_ROOT}/aggregate" -type f ! -name artifact-digests.txt -print0 2>/dev/null \
+            | sort -z \
+            | xargs -0 -r sha256sum \
+            > "${PROOF_ROOT}/aggregate/artifact-digests.txt"
+
+      - name: Upload aggregate evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: aggregate-gate-${{ inputs.tag }}-${{ inputs.sha }}
+          path: ${{ env.PROOF_ROOT }}/aggregate
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Enforce aggregate verdict
+        if: ${{ always() }}
+        run: |
+          test -f "${PROOF_ROOT}/aggregate/gate.exit-code"
+          test "$(cat "${PROOF_ROOT}/aggregate/gate.exit-code")" -eq 0
+          report="$(find "${PROOF_ROOT}/aggregate/report" -maxdepth 1 -name '*-aggregate-7day-gate.json' -print -quit)"
+          test -n "${report}"
+          jq -e '.passed == true and all(.assertions[]; .pass == true)' "${report}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
+      - -X main.Version={{ .Tag }}
 
 archives:
   - id: otelcontext

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test vet check setup-hooks loadtest loadtest-build release gate-build gate-run
+.PHONY: build test vet check setup-hooks loadtest loadtest-build release gate-tools gate-build gate-run
 
 build:
 	CGO_ENABLED=0 go build ./...
@@ -19,14 +19,21 @@ loadtest: loadtest-build
 	@echo "Running 200-service load simulator (60s) against localhost:4317..."
 	./bin/loadsim
 
-## gate-build builds every binary the seven-day release gate drives.
+GATE_BIN_DIR ?= bin
+
+## gate-tools builds the source-bound test tools without rebuilding the signed
+## server candidate consumed by a certifying release run.
+gate-tools:
+	install -d "$(GATE_BIN_DIR)"
+	CGO_ENABLED=0 go build -trimpath -tags loadtest -o "$(GATE_BIN_DIR)/loadsim" ./test/loadsim
+	CGO_ENABLED=1 go build -trimpath -tags prefill -o "$(GATE_BIN_DIR)/aggprefill" ./test/aggprefill
+	CGO_ENABLED=0 go build -trimpath -tags gate -o "$(GATE_BIN_DIR)/gate" ./test/gate
+
+## gate-build builds every binary the historical diagnostic gate drives.
 ## The gate itself is behind the gate build tag, so ordinary Go commands
 ## ignore it.
-gate-build:
-	CGO_ENABLED=1 go build -o bin/otelcontext .
-	CGO_ENABLED=0 go build -tags loadtest -o bin/loadsim ./test/loadsim
-	CGO_ENABLED=1 go build -tags prefill -o bin/aggprefill ./test/aggprefill
-	CGO_ENABLED=0 go build -tags gate -o bin/gate ./test/gate
+gate-build: gate-tools
+	CGO_ENABLED=1 go build -o "$(GATE_BIN_DIR)/otelcontext" .
 
 ## gate-run executes the manual seven-day gate protocol. It writes reports
 ## under docs/gates and exits non-zero unless every assertion passes.

--- a/internal/aggregate/engine_test.go
+++ b/internal/aggregate/engine_test.go
@@ -9,7 +9,7 @@ import (
 
 // testEngine builds an engine with a fixed clock and generous caps, so a test
 // that is not about cardinality never trips a cap by accident.
-func testEngine(t *testing.T, now time.Time) *Engine {
+func testEngine(t testing.TB, now time.Time) *Engine {
 	t.Helper()
 	e, err := NewEngine(EngineConfig{
 		Mode: ModeShadow,
@@ -21,7 +21,7 @@ func testEngine(t *testing.T, now time.Time) *Engine {
 	return e
 }
 
-func mustTime(t *testing.T, s string) time.Time {
+func mustTime(t testing.TB, s string) time.Time {
 	t.Helper()
 	ts, err := time.Parse(time.RFC3339, s)
 	if err != nil {

--- a/internal/aggregate/metrics.go
+++ b/internal/aggregate/metrics.go
@@ -67,6 +67,19 @@ func NewPrometheusRecorder(m *telemetry.Metrics) MetricsRecorder {
 	if m == nil {
 		return noopRecorder{}
 	}
+	// Prometheus omits a CounterVec until at least one child exists. Materialize
+	// every bounded zero-drop label up front so a release gate can distinguish
+	// an explicit zero from a renamed or deleted metric family.
+	for signal := SignalTraceOp; signal <= signalMax; signal++ {
+		for _, reason := range []PointDisposition{PointLate, PointFuture} {
+			m.AggregateLatePointsTotal.WithLabelValues(signal.String(), reason.String())
+		}
+	}
+	for kind := KindTenant; kind <= kindMax; kind++ {
+		for _, bound := range []string{"length", "count"} {
+			m.AggregateIdentityOverflowTotal.WithLabelValues(kind.String(), bound)
+		}
+	}
 	return promRecorder{m: m}
 }
 
@@ -149,6 +162,9 @@ type promStoreRecorder struct{ m *telemetry.Metrics }
 func NewPrometheusStoreMetrics(m *telemetry.Metrics) StoreMetrics {
 	if m == nil {
 		return noopStoreMetrics{}
+	}
+	for _, bound := range []string{"bytes", "waiters", "deltas"} {
+		m.AggregateAdmissionRejectedTotal.WithLabelValues(bound)
 	}
 	return promStoreRecorder{m: m}
 }

--- a/internal/aggregate/metrics_zero_test.go
+++ b/internal/aggregate/metrics_zero_test.go
@@ -1,0 +1,34 @@
+package aggregate
+
+import (
+	"testing"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/telemetry"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestPrometheusRecordersExposeExplicitZeroDropSeries(t *testing.T) {
+	metrics := telemetry.New()
+	NewPrometheusRecorder(metrics)
+	NewPrometheusStoreMetrics(metrics)
+
+	for name, tc := range map[string]struct {
+		collector prometheus.Collector
+		want      int
+	}{
+		"late points":        {metrics.AggregateLatePointsTotal, 8},
+		"identity overflow":  {metrics.AggregateIdentityOverflowTotal, 16},
+		"admission rejected": {metrics.AggregateAdmissionRejectedTotal, 3},
+	} {
+		if got := collectedMetricCount(tc.collector); got != tc.want {
+			t.Errorf("%s child series = %d, want %d explicit zero series", name, got, tc.want)
+		}
+	}
+}
+
+func collectedMetricCount(collector prometheus.Collector) int {
+	metrics := make(chan prometheus.Metric, 64)
+	collector.Collect(metrics)
+	close(metrics)
+	return len(metrics)
+}

--- a/internal/aggregate/read_contract_test.go
+++ b/internal/aggregate/read_contract_test.go
@@ -123,7 +123,7 @@ type seedFixture struct {
 // SLOWER, for the same reason the production commit path gives (store_sqlite.go
 // mergeDeltas) — the cost is per-parameter binding, and a wide statement pays
 // extra to compile on top of it.
-func insertRows(t *testing.T, tx *sql.Tx, table string, ids []SeriesID, windows []int64, deltas []*AggregateDelta) {
+func insertRows(t testing.TB, tx *sql.Tx, table string, ids []SeriesID, windows []int64, deltas []*AggregateDelta) {
 	t.Helper()
 	stmt, err := tx.Prepare(`INSERT INTO ` + table + ` (window_start, series_id, ` + deltaColumnList + `)
 		VALUES (?,?,` + deltaValuePlaceholders + `)`)
@@ -151,7 +151,7 @@ func insertRows(t *testing.T, tx *sql.Tx, table string, ids []SeriesID, windows 
 
 // seedSeries writes the series identities the seeded rows join against,
 // through the store's own registration statement.
-func seedSeries(t *testing.T, tx *sql.Tx, rows []SeriesRow) {
+func seedSeries(t testing.TB, tx *sql.Tx, rows []SeriesRow) {
 	t.Helper()
 	if err := insertSeries(tx, rows); err != nil {
 		t.Fatalf("insert series: %v", err)

--- a/internal/aggregate/store_test.go
+++ b/internal/aggregate/store_test.go
@@ -14,7 +14,7 @@ func newTestStore(t *testing.T) *SQLiteStore {
 	return newTestStoreAt(t, filepath.Join(t.TempDir(), "aggregate.db"), StoreConfig{})
 }
 
-func newTestStoreAt(t *testing.T, path string, cfg StoreConfig) *SQLiteStore {
+func newTestStoreAt(t testing.TB, path string, cfg StoreConfig) *SQLiteStore {
 	t.Helper()
 	cfg.Path = path
 	store, err := OpenSQLiteStore(cfg)

--- a/internal/aggregate/wide_range_timing_test.go
+++ b/internal/aggregate/wide_range_timing_test.go
@@ -122,3 +122,72 @@ func TestManualWideRangeTiming(t *testing.T) {
 	}
 	t.Logf("speedup: %.1fx", float64(oldDur)/float64(newDur))
 }
+
+// BenchmarkQueryDashboardSevenDay measures the production dashboard query
+// over the same seven-day, 5-minute-window horizon used by the release gate.
+// The signed-candidate gate owns the exact 6,000-series threshold; this focused
+// benchmark keeps a stable 1,000-series local regression signal affordable.
+func BenchmarkQueryDashboardSevenDay(b *testing.B) {
+	const (
+		seriesN  = 1000
+		windowsN = 2016
+	)
+	now := mustTime(b, "2026-08-21T12:02:00Z")
+	e := testEngine(b, now)
+	store := newTestStoreAt(b, filepath.Join(b.TempDir(), "aggregate.db"), StoreConfig{})
+	e.SetStore(store)
+
+	tenantID, _ := e.TenantID("default")
+	windowSecs := int64(WindowSize / time.Second)
+	base := WindowStart(now) - int64(windowsN+2)*windowSecs
+	series := make([]SeriesRow, 0, seriesN)
+	deltas := make([]*AggregateDelta, 0, seriesN)
+	for i := 0; i < seriesN; i++ {
+		id := SeriesID(i + 1)
+		series = append(series, SeriesRow{ID: id, Key: SeriesKey{
+			TenantID:  tenantID,
+			ServiceID: e.Cache().Intern(tenantID, KindService, fmt.Sprintf("svc-%03d", i%120)),
+			NameID:    e.Cache().Intern(tenantID, KindOperation, fmt.Sprintf("op-%05d", i)),
+			Signal:    SignalTraceOp,
+			Variant:   SpanKindServer,
+		}})
+		d := &AggregateDelta{}
+		d.ObserveSpan(float64(100+i%900), false, true)
+		deltas = append(deltas, d)
+	}
+
+	tx, err := store.writer.Begin()
+	if err != nil {
+		b.Fatalf("begin seed tx: %v", err)
+	}
+	seedSeries(b, tx, series)
+	ids := make([]SeriesID, seriesN)
+	wins := make([]int64, seriesN)
+	for w := 0; w < windowsN; w++ {
+		for i := 0; i < seriesN; i++ {
+			ids[i] = SeriesID(i + 1)
+			wins[i] = base + int64(w)*windowSecs
+		}
+		insertRows(b, tx, "aggregate_buckets", ids, wins, deltas)
+	}
+	if err := tx.Commit(); err != nil {
+		b.Fatalf("commit seed tx: %v", err)
+	}
+
+	q := Query{
+		Tenant: "default",
+		Start:  time.Unix(base, 0).UTC(),
+		End:    time.Unix(base+int64(windowsN)*windowSecs, 0).UTC(),
+	}
+	b.ReportMetric(float64(seriesN*windowsN), "rows/query")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result, err := e.QueryDashboard(q)
+		if err != nil {
+			b.Fatalf("QueryDashboard: %v", err)
+		}
+		if result.SpanCount != int64(seriesN*windowsN) {
+			b.Fatalf("span count = %d, want %d", result.SpanCount, seriesN*windowsN)
+		}
+	}
+}

--- a/internal/ingest/pipeline.go
+++ b/internal/ingest/pipeline.go
@@ -360,6 +360,13 @@ func NewPipeline(writer pipelineWriter, metrics *telemetry.Metrics, cfg Pipeline
 	if cfg.SoftThreshold <= 0 || cfg.SoftThreshold >= 1.0 {
 		cfg.SoftThreshold = d.SoftThreshold
 	}
+	if metrics != nil && metrics.IngestPipelineDroppedTotal != nil {
+		for _, signal := range []SignalType{SignalTraces, SignalLogs} {
+			for _, reason := range []string{"soft_backpressure", "tenant_backpressure", "bytes_full", "queue_full"} {
+				metrics.IngestPipelineDroppedTotal.WithLabelValues(signalLabel(signal), reason)
+			}
+		}
+	}
 	return &Pipeline{
 		writer:         writer,
 		metrics:        metrics,

--- a/internal/ingest/pipeline_metrics_zero_test.go
+++ b/internal/ingest/pipeline_metrics_zero_test.go
@@ -1,0 +1,20 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/telemetry"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestPipelineExposesExplicitZeroDropSeries(t *testing.T) {
+	metrics := telemetry.New()
+	NewPipeline(nil, metrics, PipelineConfig{})
+
+	children := make(chan prometheus.Metric, 16)
+	metrics.IngestPipelineDroppedTotal.Collect(children)
+	close(children)
+	if got := len(children); got != 8 {
+		t.Fatalf("pipeline drop child series = %d, want 8 (two signals x four bounded reasons)", got)
+	}
+}

--- a/test/aggprefill/main.go
+++ b/test/aggprefill/main.go
@@ -76,13 +76,18 @@ type seriesSpec struct {
 }
 
 type workerStats struct {
-	sketchN      int64
-	sketchBytes  int64
-	binCountSum  int64
-	maxSize      int
-	maxBins      int
-	sizeHist     [sizeHistBuckets]int64
-	observations int64
+	sketchN       int64
+	sketchBytes   int64
+	binCountSum   int64
+	maxSize       int
+	maxBins       int
+	sizeHist      [sizeHistBuckets]int64
+	observations  int64
+	requests      uint64
+	requestErrors uint64
+	spans         uint64
+	spanErrors    uint64
+	logs          uint64
 }
 
 func main() {
@@ -221,6 +226,14 @@ func main() {
 	}
 
 	elapsed := time.Since(start)
+	var requests, requestErrors, spans, spanErrors, logs uint64
+	for _, st := range stats {
+		requests += st.requests
+		requestErrors += st.requestErrors
+		spans += st.spans
+		spanErrors += st.spanErrors
+		logs += st.logs
+	}
 
 	// Pre-checkpoint sizes, store still open.
 	db, wal, shm, sum := dbSizes(*dbPath)
@@ -230,6 +243,13 @@ func main() {
 	fmt.Printf("bucket_rows_written: %d\n", totalBuckets)
 	fmt.Printf("delta_rows_incorporated: %d\n", totalDeltaRows)
 	fmt.Printf("first_window: %d  last_window: %d\n", firstWindow, endWindow)
+	fmt.Printf("series_total: %d\n", len(specs))
+	fmt.Printf("services_total: %d\n", numServices)
+	fmt.Printf("dashboard_requests: %d\n", requests)
+	fmt.Printf("dashboard_request_errors: %d\n", requestErrors)
+	fmt.Printf("dashboard_spans: %d\n", spans)
+	fmt.Printf("dashboard_span_errors: %d\n", spanErrors)
+	fmt.Printf("dashboard_logs: %d\n", logs)
 	fmt.Printf("PRE-CLOSE sizes: db=%d wal=%d shm=%d sum=%d\n", db, wal, shm, sum)
 
 	if err := store.Close(); err != nil {
@@ -344,6 +364,15 @@ func buildRange(specs []seriesSpec, deltas []aggregate.AggregateDelta, sketches 
 			d.Sketch = nil
 		}
 		rows[i] = aggregate.DeltaRow{SeriesID: sp.id, WindowStart: windowStart, Delta: d}
+		switch sp.key.Signal {
+		case aggregate.SignalTraceOp:
+			st.requests += d.RequestCount
+			st.requestErrors += d.ErrorRequestCount
+			st.spans += d.Count
+			st.spanErrors += d.ErrorCount
+		case aggregate.SignalLog:
+			st.logs += d.LogCount
+		}
 	}
 }
 

--- a/test/gate/control_test.go
+++ b/test/gate/control_test.go
@@ -3,8 +3,12 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,6 +25,180 @@ func hangingServer(t *testing.T) *httptest.Server {
 	}))
 	t.Cleanup(func() { close(block); srv.Close() })
 	return srv
+}
+
+func TestParsePrefillOutputCarriesExactFixtureTotals(t *testing.T) {
+	out := strings.Join([]string{
+		"windows_finalized: 2016",
+		"bucket_rows_written: 12096000",
+		"delta_rows_incorporated: 12096000",
+		"first_window: 100  last_window: 200",
+		"series_total: 6000",
+		"services_total: 120",
+		"dashboard_requests: 700000",
+		"dashboard_request_errors: 7000",
+		"dashboard_spans: 900000",
+		"dashboard_span_errors: 9000",
+		"dashboard_logs: 300000",
+	}, "\n")
+	facts, err := parsePrefillOutput(out)
+	if err != nil {
+		t.Fatalf("parsePrefillOutput: %v", err)
+	}
+	if facts.WindowsFinalized != 2016 || facts.Series != 6000 || facts.Services != 120 ||
+		facts.Requests != 700000 || facts.RequestErrors != 7000 || facts.Spans != 900000 ||
+		facts.SpanErrors != 9000 || facts.Logs != 300000 {
+		t.Fatalf("prefill facts lost exact totals: %+v", facts)
+	}
+}
+
+func TestCertifyingPathsMustBeOutsideCheckout(t *testing.T) {
+	root := t.TempDir()
+	cfg := gatecore.DefaultConfig()
+	cfg.RepoRoot = root
+	cfg.Certification.Required = true
+	cfg.Confinement.AllowFallback = false
+	cfg.WorkDir = filepath.Join(root, "work")
+	cfg.ReportDir = filepath.Join(root, "report")
+	candidate := candidateSpec{
+		configPath: "test/gate/release.config.json", tag: "v1.0.0",
+		expectedCommitSHA: strings.Repeat("a", 40), archivePath: "/proof/release.tar.gz",
+		expectedArchiveSHA256: strings.Repeat("b", 64), expectedServerSHA256: strings.Repeat("c", 64),
+	}
+	if err := validateCandidateConfig(cfg, candidate); err == nil || !strings.Contains(err.Error(), "outside repo_root") {
+		t.Fatalf("inside-checkout evidence paths were accepted: %v", err)
+	}
+	cfg.WorkDir = filepath.Join(filepath.Dir(root), "proof-work")
+	cfg.ReportDir = filepath.Join(filepath.Dir(root), "proof-report")
+	if err := validateCandidateConfig(cfg, candidate); err != nil {
+		t.Fatalf("external evidence paths were rejected: %v", err)
+	}
+}
+
+func TestCertifyingCandidateRejectsNonHexadecimalBindings(t *testing.T) {
+	root := t.TempDir()
+	cfg := gatecore.DefaultConfig()
+	cfg.RepoRoot = root
+	cfg.Certification.Required = true
+	cfg.Confinement.AllowFallback = false
+	cfg.WorkDir = filepath.Join(filepath.Dir(root), "proof-work")
+	cfg.ReportDir = filepath.Join(filepath.Dir(root), "proof-report")
+	candidate := candidateSpec{
+		configPath: "test/gate/release.config.json", tag: "v1.0.0",
+		expectedCommitSHA: strings.Repeat("z", 40), archivePath: "/proof/release.tar.gz",
+		expectedArchiveSHA256: strings.Repeat("b", 64), expectedServerSHA256: strings.Repeat("c", 64),
+	}
+	if err := validateCandidateConfig(cfg, candidate); err == nil || !strings.Contains(err.Error(), "hexadecimal") {
+		t.Fatalf("non-hexadecimal candidate binding was accepted: %v", err)
+	}
+}
+
+func TestReleaseConfigFreezesCertificationContract(t *testing.T) {
+	cfg, err := gatecore.LoadConfigFile("release.config.json")
+	if err != nil {
+		t.Fatalf("LoadConfigFile: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("release config is invalid: %v", err)
+	}
+	if !cfg.Certification.Required || cfg.Confinement.AllowFallback {
+		t.Fatalf("release config is not strict: certification=%t allow_fallback=%t",
+			cfg.Certification.Required, cfg.Confinement.AllowFallback)
+	}
+	th := cfg.Thresholds
+	if th.PrefillWindows != 2016 || th.PrefillSeries != 6000 || th.PrefillServices != 120 ||
+		th.ColdQueryMaxSeconds != 5 || th.WarmQueryP95MaxSeconds != 0.5 ||
+		th.SevenDayQueryMaxSeconds != 15 || th.MCPQueryMaxSeconds != 5 || th.ProbeMaxSeconds != 1 {
+		t.Fatalf("release thresholds drifted: %+v", th)
+	}
+	required := strings.Join(cfg.Sampling.RequiredMetrics, "\n")
+	for _, metric := range []string{
+		"otelcontext_aggregate_identity_overflow_total",
+		"otelcontext_ingest_pipeline_dropped_total",
+	} {
+		if !strings.Contains(required, metric) {
+			t.Errorf("release config does not require %s", metric)
+		}
+	}
+}
+
+func TestWriteDigestManifestBindsEveryNamedFile(t *testing.T) {
+	dir := t.TempDir()
+	server := filepath.Join(dir, "server")
+	gate := filepath.Join(dir, "gate")
+	if err := os.WriteFile(server, []byte("server candidate"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(gate, []byte("gate tool"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifest := filepath.Join(dir, "digests.txt")
+	if err := writeDigestManifest(manifest, map[string]string{"server": server, "gate": gate}); err != nil {
+		t.Fatalf("writeDigestManifest: %v", err)
+	}
+	body, err := os.ReadFile(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateSHA, _ := sha256File(gate)
+	serverSHA, _ := sha256File(server)
+	want := gateSHA + "  gate\n" + serverSHA + "  server\n"
+	if string(body) != want {
+		t.Fatalf("manifest = %q, want %q", body, want)
+	}
+}
+
+func TestWaitLatencySentinelRetriesUntilExactSampleCount(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Query().Get("service_name") != "latency-sentinel" || r.URL.Query().Get("_gate_wait") == "" {
+			t.Errorf("sentinel probe query = %q", r.URL.RawQuery)
+		}
+		samples := 12
+		if requests >= 2 {
+			samples = 1000
+		}
+		fmt.Fprintf(w, `{"latency_provenance":{"p99":{"sample_count":%d}}}`, samples)
+	}))
+	defer srv.Close()
+	g := gateAgainst(t, srv, time.Second)
+	if err := g.waitLatencySentinel("latency-sentinel", 1000, time.Second); err != nil {
+		t.Fatalf("waitLatencySentinel: %v", err)
+	}
+	if requests < 2 {
+		t.Fatalf("sentinel visibility was not retried: %d request", requests)
+	}
+}
+
+func TestLatencySurfaceFromMCPAcceptsMapAndHealthShapes(t *testing.T) {
+	service := `{"service":{"name":"latency-sentinel","p99_latency_ms":1000,"latency_provenance":{"p99":{"status":"approximate","method":"ddsketch","sample_count":1000,"sketch_scale":4,"relative_error_bound":0.02165746232622625}}}}`
+	for name, body := range map[string]string{
+		"service map":    "[" + service + "]",
+		"service health": service,
+	} {
+		t.Run(name, func(t *testing.T) {
+			surface := latencySurfaceFromMCP("consumer", "latency-sentinel", body)
+			if surface.Error != "" || surface.ValueMS != 1000 || surface.SampleCount != 1000 ||
+				surface.SketchScale != 4 || surface.Status != "approximate" || surface.Method != "ddsketch" {
+				t.Fatalf("parsed MCP latency surface = %+v", surface)
+			}
+		})
+	}
+}
+
+func TestServiceMapCheckCountsTopLevelServices(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"coverage":"full","nodes":[{"name":"a"},{"name":"b"}]}`))
+	}))
+	defer srv.Close()
+	g := gateAgainst(t, srv, time.Second)
+	check := g.runAPICheck(gatecore.APICheck{
+		Name: "service_map_seven_day", Path: "/api/metrics/service-map", ExpectCoverage: "full",
+	}, time.Time{}, time.Time{}, nil)
+	if check.Error != "" || check.Scalars["services"] != 2 {
+		t.Fatalf("service-map check = %+v", check)
+	}
 }
 
 func gateAgainst(t *testing.T, srv *httptest.Server, ctl time.Duration) *gate {

--- a/test/gate/gatecore/assert.go
+++ b/test/gate/gatecore/assert.go
@@ -2,6 +2,7 @@ package gatecore
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 )
@@ -14,6 +15,7 @@ import (
 
 const (
 	catPhase       = "phase"
+	catProvenance  = "provenance"
 	catConfinement = "confinement"
 	catSustained   = "sustained"
 	catBurst       = "burst"
@@ -29,6 +31,7 @@ func Evaluate(r *Result) []Assertion {
 	t := r.Config.Thresholds
 	var a []Assertion
 
+	a = append(a, certificationAssertions(r)...)
 	a = append(a, phaseAssertions(r)...)
 	a = append(a, confinementAssertions(r, t)...)
 	a = append(a, sustainedAssertions(r, t)...)
@@ -38,7 +41,119 @@ func Evaluate(r *Result) []Assertion {
 	a = append(a, diskAssertions(r, t)...)
 	a = append(a, projectionAssertions(r, t)...)
 	a = append(a, queryAssertions(r, t)...)
+	if r.Config.Certification.Required {
+		degraded := 0
+		for _, assertion := range a {
+			if assertion.Degraded {
+				degraded++
+			}
+		}
+		a = append(a, eqInt("certification.degraded_evidence", catProvenance,
+			"a certifying run used no degraded evidence basis", "assertion table",
+			int64(degraded), 0, "diagnostic fallbacks cannot approve a release"))
+	}
 	return a
+}
+
+func certificationAssertions(r *Result) []Assertion {
+	if !r.Config.Certification.Required {
+		return nil
+	}
+	p := r.Provenance
+	out := []Assertion{
+		boolAssert("candidate.commit", catProvenance, "checkout commit matches the expected candidate commit",
+			"git rev-parse HEAD", p.CommitSHA != "" && p.CommitSHA == p.ExpectedCommitSHA,
+			fmt.Sprintf("checkout=%s expected=%s", p.CommitSHA, p.ExpectedCommitSHA)),
+		boolAssert("candidate.tag", catProvenance, "candidate tag resolves to the expected commit",
+			"git rev-parse tag^{commit}", p.TagCommitSHA != "" && p.TagCommitSHA == p.ExpectedCommitSHA,
+			fmt.Sprintf("tag=%s resolved=%s expected=%s", p.CandidateTag, p.TagCommitSHA, p.ExpectedCommitSHA)),
+		boolAssert("candidate.clean", catProvenance, "candidate source checkout is clean",
+			"git status --porcelain --untracked-files=all", !p.DirtyTree,
+			strings.Join(p.DirtyFiles, ", ")),
+		boolAssert("candidate.archive_digest", catProvenance, "release archive matches its signed expected digest",
+			p.ArchivePath, p.ArchiveSHA256 != "" && p.ArchiveSHA256 == p.ExpectedArchiveSHA256,
+			fmt.Sprintf("actual=%s expected=%s", p.ArchiveSHA256, p.ExpectedArchiveSHA256)),
+		boolAssert("candidate.server_digest", catProvenance, "extracted server matches its expected archive-bound digest",
+			"sha256 candidate server", p.BinarySHA256["server"] != "" && p.BinarySHA256["server"] == p.ExpectedServerSHA256,
+			fmt.Sprintf("actual=%s expected=%s", p.BinarySHA256["server"], p.ExpectedServerSHA256)),
+		boolAssert("candidate.version", catProvenance, "candidate server reports the candidate tag",
+			"candidate --version", p.ServerVersion != "" && p.ServerVersion == p.CandidateTag,
+			fmt.Sprintf("version=%s tag=%s", p.ServerVersion, p.CandidateTag)),
+		boolAssert("candidate.config_digest", catProvenance, "committed certifying config digest was recorded",
+			p.ConfigPath, len(p.ConfigSHA256) == 64, p.ConfigSHA256),
+		boolAssert("candidate.host", catProvenance, "aggregate approval is Linux amd64 on cgroup v2",
+			"host inspection", r.Host.OS == "linux" && r.Host.Arch == "amd64" && r.Host.CgroupV2,
+			fmt.Sprintf("%s/%s cgroup_v2=%t", r.Host.OS, r.Host.Arch, r.Host.CgroupV2)),
+		boolAssert("candidate.filesystem", catProvenance, "gate data is on the required ext4 volume",
+			"/proc/self/mounts", r.Host.DataDirFSType == "ext4",
+			fmt.Sprintf("path=%s device=%s mount=%s fs=%s", r.Host.DataDir, r.Host.DataDirDevice, r.Host.DataDirMount, r.Host.DataDirFSType)),
+	}
+	for _, name := range []string{"gate", "loadsim", "prefill"} {
+		digest := p.BinarySHA256[name]
+		out = append(out, boolAssert("candidate.tool_digest."+name, catProvenance,
+			"gate tool digest was recorded: "+name, "sha256", len(digest) == 64, digest))
+	}
+
+	wantPhases := []string{"prefill", "server_start", "main_load", "post_burst", "quiet_gap", "crash_run", "latency_sentinel", "measure"}
+	for _, name := range wantPhases {
+		found := false
+		for _, phase := range r.Phases {
+			if phase.Name == name {
+				found = true
+				break
+			}
+		}
+		out = append(out, boolAssert("candidate.phase."+name, catProvenance,
+			"required protocol phase was recorded: "+name, "phase inventory", found, ""))
+	}
+	wantCommands := []struct {
+		name        string
+		requireZero bool
+	}{
+		{"prefill", true}, {"server-initial", false}, {"main_load", true},
+		{"post_burst", true}, {"crash_run", true}, {"server-restarted", false}, {"latency_sentinel", true},
+	}
+	for _, want := range wantCommands {
+		found, valid := false, false
+		for _, command := range r.Commands {
+			if command.Phase != want.name {
+				continue
+			}
+			found = true
+			valid = len(command.Argv) > 0 && command.Error == "" && (!want.requireZero || command.ExitCode == 0)
+			break
+		}
+		out = append(out, boolAssert("candidate.command."+want.name, catProvenance,
+			"required command was recorded: "+want.name, "command inventory", found && valid, ""))
+	}
+	for _, metric := range r.Config.Sampling.RequiredMetrics {
+		samples, missing := metricPresenceInPhase(r.MetricSeries, "sustained", metric)
+		out = append(out, boolAssert("candidate.metric."+metric, catProvenance,
+			"required metric was present in every sustained-phase scrape", "Prometheus scrapes",
+			samples > 0 && missing == 0,
+			fmt.Sprintf("metric=%s sustained_scrapes=%d missing_scrapes=%d", metric, samples, missing)))
+	}
+	return out
+}
+
+func metricPresenceInPhase(samples []MetricSample, phase, name string) (total, missing int) {
+	for _, sample := range samples {
+		if sample.Phase != phase {
+			continue
+		}
+		total++
+		found := false
+		for key := range sample.Values {
+			if key == name || strings.HasPrefix(key, name+"{") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing++
+		}
+	}
+	return total, missing
 }
 
 // Finalize stamps the verdict onto the result from its own assertion table.
@@ -199,6 +314,7 @@ func sustainedAssertions(r *Result, t Thresholds) []Assertion {
 		{"sustained.late_points", "otelcontext_aggregate_late_points_total", t.MaxLatePointsDelta},
 		{"sustained.admission_rejected", "otelcontext_aggregate_admission_rejected_total", t.MaxAdmissionRejectedDelta},
 		{"sustained.identity_overflow", "otelcontext_aggregate_identity_overflow_total", t.MaxIdentityOverflowDelta},
+		{"sustained.ingest_pipeline_dropped", "otelcontext_ingest_pipeline_dropped_total", t.MaxIngestPipelineDropDelta},
 	} {
 		delta, verdict := MetricDeltaWitnessed(r.MetricSeries, "sustained", m.key, DropCounterWitness)
 		if verdict == MetricAbsent {
@@ -211,7 +327,11 @@ func sustainedAssertions(r *Result, t Thresholds) []Assertion {
 		a := lte(m.id, catSustained,
 			"no silent aggregate drops: "+m.key+" did not move", "prometheus counter delta",
 			delta, m.limit, Float, "delta across the sustained phase")
-		if verdict == MetricEmptyVector {
+		if verdict == MetricEmptyVector && r.Config.Certification.Required {
+			a.Pass = false
+			a.Actual = "absent"
+			a.Detail = "a certifying run requires an explicit zero-valued counter series"
+		} else if verdict == MetricEmptyVector {
 			a.Basis = "prometheus counter vector with no children"
 			a.Degraded = true
 			a.Detail = "the counter vector had no child series in any sustained-phase scrape, which for a " +
@@ -551,6 +671,33 @@ func queryAssertions(r *Result, t Thresholds) []Assertion {
 				"==", c.CoverageExpected, c.Coverage, c.CoverageSource,
 				c.Coverage == c.CoverageExpected, ""))
 		}
+		if r.Config.Certification.Required && len(c.ExpectedScalars) > 0 {
+			keys := make([]string, 0, len(c.ExpectedScalars))
+			for key := range c.ExpectedScalars {
+				keys = append(keys, key)
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				expected := c.ExpectedScalars[key]
+				actual, found := c.Scalars[key]
+				out = append(out, boolAssert(id+".scalar."+key, catQuery,
+					"query surface "+c.Name+" returned the generator-derived scalar "+key,
+					c.URL, found && actual == expected,
+					fmt.Sprintf("expected=%v actual=%v present=%t", expected, actual, found)))
+			}
+		}
+		if r.Config.Certification.Required && (c.Name == "dashboard_seven_day" || c.Name == "traffic_seven_day" || c.Name == "service_map_seven_day") {
+			out = append(out, lte(id+".latency", catQuery,
+				"seven-day query completed inside the user-facing latency bound", c.URL,
+				c.DurationSec, t.SevenDayQueryMaxSeconds, Secs, "single uncached full-range request"))
+		}
+	}
+	if r.Config.Certification.Required {
+		out = append(out,
+			eqInt("query.prefill.windows", catQuery, "deterministic prefill window count is exact", "prefill report", int64(q.PrefillWindows), int64(t.PrefillWindows), ""),
+			eqInt("query.prefill.series", catQuery, "deterministic prefill series count is exact", "prefill report", int64(q.PrefillSeries), int64(t.PrefillSeries), ""),
+			eqInt("query.prefill.services", catQuery, "deterministic prefill service count is exact", "prefill report", int64(q.PrefillServices), int64(t.PrefillServices), ""),
+		)
 	}
 
 	if len(q.MCPTools) == 0 {
@@ -569,8 +716,88 @@ func queryAssertions(r *Result, t Thresholds) []Assertion {
 		out = append(out, boolAssert(id, catQuery,
 			"MCP tool "+m.Tool+" answered over the full seven-day range", "POST "+r.Config.MCPPath,
 			ok, detail))
+		if r.Config.Certification.Required {
+			out = append(out, lte(id+".latency", catQuery,
+				"MCP tool completed inside the latency bound", "POST "+r.Config.MCPPath,
+				m.DurationSec, t.MCPQueryMaxSeconds, Secs, detail))
+		}
+	}
+	if r.Config.Certification.Required {
+		out = append(out, queryLatencyAssertions(q.LatencyChecks, t)...)
+		out = append(out, latencySentinelAssertions(q.LatencySentinel)...)
 	}
 	return out
+}
+
+func queryLatencyAssertions(checks []QueryLatencyCheck, t Thresholds) []Assertion {
+	byName := make(map[string]QueryLatencyCheck, len(checks))
+	for _, check := range checks {
+		byName[check.Name] = check
+	}
+	var out []Assertion
+	for _, name := range []string{"default_dashboard", "system_graph"} {
+		check, ok := byName[name]
+		out = append(out, boolAssert("query.latency."+name+".present", catQuery,
+			"query latency samples were recorded for "+name, "orchestrator", ok && check.Error == "" && check.Status == 200 && check.ColdCache == "MISS",
+			fmt.Sprintf("error=%s first_cache=%s", check.Error, check.ColdCache)))
+		out = append(out, lte("query.latency."+name+".cold", catQuery,
+			"first uncached "+name+" request completed inside the bound", check.URL,
+			check.ColdSeconds, t.ColdQueryMaxSeconds, Secs, "cache="+check.ColdCache))
+		out = append(out, eqInt("query.latency."+name+".warm_samples", catQuery,
+			"twenty sequential warm requests were recorded", check.URL,
+			int64(len(check.WarmSeconds)), 20, ""))
+		out = append(out, eqInt("query.latency."+name+".warm_cache_hits", catQuery,
+			"all sequential warm requests were served from the response cache", check.URL,
+			int64(check.WarmCacheHits), 20, ""))
+		out = append(out, lte("query.latency."+name+".warm_p95", catQuery,
+			"warm request p95 completed inside the bound", check.URL,
+			check.WarmP95, t.WarmQueryP95MaxSeconds, Secs,
+			fmt.Sprintf("p50=%.3fs p95=%.3fs max=%.3fs", check.WarmP50, check.WarmP95, check.WarmMax)))
+	}
+	for _, name := range []string{"live", "ready"} {
+		check, ok := byName[name]
+		out = append(out, boolAssert("query.latency."+name+".present", catQuery,
+			"probe latency was recorded for "+name, "orchestrator", ok && check.Error == "" && check.Status == 200, check.Error))
+		out = append(out, lte("query.latency."+name, catQuery,
+			"probe completed inside the latency bound", check.URL,
+			check.ColdSeconds, t.ProbeMaxSeconds, Secs, ""))
+	}
+	return out
+}
+
+func latencySentinelAssertions(proof LatencySentinelProof) []Assertion {
+	wantNames := []string{"rest_dashboard", "rest_system_graph", "websocket_dashboard", "graphrag_service", "mcp_get_service_map", "mcp_get_service_health"}
+	byName := make(map[string]LatencySurface, len(proof.Surfaces))
+	for _, surface := range proof.Surfaces {
+		byName[surface.Name] = surface
+	}
+	out := []Assertion{
+		boolAssert("latency_sentinel.fixture", catQuery,
+			"contradictory latency fixture is exactly 989x10ms plus 11x1000ms",
+			"loadsim sentinel report", proof.Service == "latency-sentinel" && proof.LowCount == 989 && proof.LowMS == 10 && proof.TailCount == 11 && proof.TailMS == 1000,
+			fmt.Sprintf("service=%s low=%dx%.0fms tail=%dx%.0fms", proof.Service, proof.LowCount, proof.LowMS, proof.TailCount, proof.TailMS)),
+	}
+	for _, name := range wantNames {
+		surface, ok := byName[name]
+		bound := surface.RelativeErrorBound
+		expectedBound := sketchRelativeError(4)
+		within := math.Abs(surface.ValueMS-proof.TailMS) <= proof.TailMS*bound
+		valid := ok && surface.Error == "" && surface.Status == "approximate" && surface.Method == "ddsketch" &&
+			surface.SampleCount == uint64(proof.LowCount+proof.TailCount) && surface.SketchScale == 4 &&
+			math.Abs(bound-expectedBound) <= 1e-12 &&
+			within && !surface.Degraded && !surface.Collapsed && surface.Saturations == 0
+		out = append(out, boolAssert("latency_sentinel."+name, catQuery,
+			"latency sentinel remains within its reported scale-4 sketch bound on "+name,
+			"consumer response provenance", valid,
+			fmt.Sprintf("value=%.3fms target=%.0fms bound=%.5f status=%s method=%s samples=%d error=%s",
+				surface.ValueMS, proof.TailMS, bound, surface.Status, surface.Method, surface.SampleCount, surface.Error)))
+	}
+	return out
+}
+
+func sketchRelativeError(scale uint8) float64 {
+	gamma := math.Exp2(math.Ldexp(1, -int(scale)))
+	return (gamma - 1) / (gamma + 1)
 }
 
 // missing renders a FAILED assertion for evidence that never arrived. The

--- a/test/gate/gatecore/assert_test.go
+++ b/test/gate/gatecore/assert_test.go
@@ -122,7 +122,7 @@ func passingResult() *Result {
 		Projection: FitProjection(synthSamples(24, 1*GiB, 4*MiB, 0), 576, 2, 6),
 	}
 
-	// Sustained-phase counter samples: the three silent-drop counters do not
+	// Sustained-phase counter samples: the silent-drop counters do not
 	// move, and the backlog oscillates without trending.
 	for i := 0; i < 20; i++ {
 		r.MetricSeries = append(r.MetricSeries, MetricSample{
@@ -131,6 +131,7 @@ func passingResult() *Result {
 				"otelcontext_aggregate_late_points_total":        0,
 				"otelcontext_aggregate_admission_rejected_total": 0,
 				"otelcontext_aggregate_identity_overflow_total":  0,
+				"otelcontext_ingest_pipeline_dropped_total":      0,
 				cfg.Sampling.BacklogMetric:                       10000,
 			},
 		})
@@ -162,6 +163,126 @@ func TestPassingResultPasses(t *testing.T) {
 	}
 	if len(r.Assertions) == 0 {
 		t.Fatal("no assertions produced")
+	}
+}
+
+func certifyingResult() *Result {
+	r := passingResult()
+	r.Config.Certification.Required = true
+	r.Config.Confinement.AllowFallback = false
+	digest := strings.Repeat("a", 64)
+	commit := strings.Repeat("b", 40)
+	r.Provenance = Provenance{
+		CommitSHA: commit, ExpectedCommitSHA: commit, CandidateTag: "v1.0.0", TagCommitSHA: commit,
+		BinarySHA256:         map[string]string{"server": digest, "gate": digest, "loadsim": digest, "prefill": digest},
+		ExpectedServerSHA256: digest, ArchivePath: "/proof/release.tar.gz", ArchiveSHA256: digest,
+		ExpectedArchiveSHA256: digest, ConfigPath: "/repo/test/gate/release.config.json", ConfigSHA256: digest,
+		ServerVersion: "v1.0.0",
+	}
+	r.Host = HostInfo{OS: "linux", Arch: "amd64", CgroupV2: true, DataDirFSType: "ext4", DataDir: "/proof/data"}
+	r.Phases = append(r.Phases, Phase{Name: "latency_sentinel", Completed: true})
+	for _, command := range []struct {
+		name string
+		exit int
+	}{
+		{"prefill", 0}, {"server-initial", -1}, {"main_load", 0}, {"post_burst", 0},
+		{"crash_run", 0}, {"server-restarted", -1}, {"latency_sentinel", 0},
+	} {
+		r.Commands = append(r.Commands, Command{Phase: command.name, Argv: []string{"tool"}, ExitCode: command.exit})
+	}
+	for i := range r.MetricSeries {
+		if r.MetricSeries[i].Phase != "sustained" {
+			continue
+		}
+		for _, metric := range r.Config.Sampling.RequiredMetrics {
+			if _, exists := r.MetricSeries[i].Values[metric]; !exists {
+				r.MetricSeries[i].Values[metric] = 0
+			}
+		}
+	}
+	r.Queries.PrefillSeries = 6000
+	r.Queries.PrefillServices = 120
+	r.Queries.Checks = append(r.Queries.Checks, QueryCheck{
+		Name: "service_map_seven_day", URL: "/api/metrics/service-map", Status: 200,
+		Coverage: "full", CoverageExpected: "full", DurationSec: 1,
+		Scalars: map[string]float64{"services": 120}, ExpectedScalars: map[string]float64{"services": 120},
+	})
+	for i := range r.Queries.Checks {
+		r.Queries.Checks[i].DurationSec = 1
+		if r.Queries.Checks[i].Name == "dashboard_seven_day" {
+			r.Queries.Checks[i].Scalars = map[string]float64{"requests": 42}
+			r.Queries.Checks[i].ExpectedScalars = map[string]float64{"requests": 42}
+		}
+	}
+	for i := range r.Queries.MCPTools {
+		r.Queries.MCPTools[i].DurationSec = 1
+	}
+	warm := make([]float64, 20)
+	for i := range warm {
+		warm[i] = 0.1
+	}
+	r.Queries.LatencyChecks = []QueryLatencyCheck{
+		{Name: "default_dashboard", URL: "/api/metrics/dashboard", Status: 200, ColdSeconds: 1, ColdCache: "MISS", WarmSeconds: warm, WarmCacheHits: 20, WarmP50: 0.1, WarmP95: 0.1, WarmMax: 0.1},
+		{Name: "system_graph", URL: "/api/system/graph", Status: 200, ColdSeconds: 1, ColdCache: "MISS", WarmSeconds: warm, WarmCacheHits: 20, WarmP50: 0.1, WarmP95: 0.1, WarmMax: 0.1},
+		{Name: "live", URL: "/live", Status: 200, ColdSeconds: 0.1},
+		{Name: "ready", URL: "/ready", Status: 200, ColdSeconds: 0.1},
+	}
+	r.Queries.LatencySentinel = LatencySentinelProof{
+		Service: "latency-sentinel", LowCount: 989, LowMS: 10, TailCount: 11, TailMS: 1000,
+	}
+	for _, name := range []string{"rest_dashboard", "rest_system_graph", "websocket_dashboard", "graphrag_service", "mcp_get_service_map", "mcp_get_service_health"} {
+		r.Queries.LatencySentinel.Surfaces = append(r.Queries.LatencySentinel.Surfaces, LatencySurface{
+			Name: name, ValueMS: 1000, Status: "approximate", Method: "ddsketch", SampleCount: 1000,
+			SketchScale: 4, RelativeErrorBound: sketchRelativeError(4),
+		})
+	}
+	return r
+}
+
+func TestCertifyingResultRequiresExactNonDegradedEvidence(t *testing.T) {
+	passing := certifyingResult()
+	passing.Finalize()
+	if !passing.Passed {
+		t.Fatalf("reference certifying result failed:\n  %s", strings.Join(passing.Failures, "\n  "))
+	}
+
+	cases := []struct {
+		name          string
+		id            string
+		breakEvidence func(*Result)
+	}{
+		{"candidate digest", "candidate.server_digest", func(r *Result) { r.Provenance.BinarySHA256["server"] = strings.Repeat("f", 64) }},
+		{"missing required metric", "candidate.metric.otelcontext_ingest_pipeline_dropped_total", func(r *Result) {
+			for i := range r.MetricSeries {
+				delete(r.MetricSeries[i].Values, "otelcontext_ingest_pipeline_dropped_total")
+			}
+		}},
+		{"metric missing from one scrape", "candidate.metric.otelcontext_aggregate_input_points_total", func(r *Result) {
+			delete(r.MetricSeries[0].Values, "otelcontext_aggregate_input_points_total")
+		}},
+		{"wrong scalar", "query.api.dashboard_seven_day.scalar.requests", func(r *Result) { r.Queries.Checks[1].Scalars["requests"] = 41 }},
+		{"wrong service map count", "query.api.service_map_seven_day.scalar.services", func(r *Result) { r.Queries.Checks[2].Scalars["services"] = 119 }},
+		{"slow warm query", "query.latency.default_dashboard.warm_p95", func(r *Result) { r.Queries.LatencyChecks[0].WarmP95 = 0.6 }},
+		{"collapsed latency proof", "latency_sentinel.rest_dashboard", func(r *Result) { r.Queries.LatencySentinel.Surfaces[0].Collapsed = true }},
+		{"inflated latency bound", "latency_sentinel.rest_dashboard", func(r *Result) { r.Queries.LatencySentinel.Surfaces[0].RelativeErrorBound = 0.5 }},
+		{"degraded confinement evidence", "certification.degraded_evidence", func(r *Result) {
+			r.Confinement = Confinement{
+				Mode: ConfinementTaskset, TasksetCPUs: "0,1", GOMAXPROCS: 2,
+				EffectiveCPUs: 2, Note: TasksetNote,
+			}
+			r.Memory.Basis = string(ConfinementTaskset)
+			r.Memory.PeakSource = "/proc/1/status VmHWM"
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := certifyingResult()
+			tc.breakEvidence(r)
+			r.Finalize()
+			if assertionByID(t, r, tc.id).Pass {
+				t.Fatalf("%s passed after its evidence was broken", tc.id)
+			}
+		})
 	}
 }
 

--- a/test/gate/gatecore/config.go
+++ b/test/gate/gatecore/config.go
@@ -20,17 +20,18 @@ type Config struct {
 	DataDir   string `json:"data_dir"`
 	ReportDir string `json:"report_dir"`
 
-	Binaries    Binaries          `json:"binaries"`
-	HTTPAddr    string            `json:"http_addr"`
-	GRPCAddr    string            `json:"grpc_addr"`
-	MCPPath     string            `json:"mcp_path"`
-	APIKey      string            `json:"api_key"`
-	Confinement ConfinementConfig `json:"confinement"`
-	Prefill     PrefillConfig     `json:"prefill"`
-	Load        LoadConfig        `json:"load"`
-	Sampling    SamplingConfig    `json:"sampling"`
-	Queries     QueryConfig       `json:"queries"`
-	Thresholds  Thresholds        `json:"thresholds"`
+	Binaries      Binaries            `json:"binaries"`
+	Certification CertificationConfig `json:"certification"`
+	HTTPAddr      string              `json:"http_addr"`
+	GRPCAddr      string              `json:"grpc_addr"`
+	MCPPath       string              `json:"mcp_path"`
+	APIKey        string              `json:"api_key"`
+	Confinement   ConfinementConfig   `json:"confinement"`
+	Prefill       PrefillConfig       `json:"prefill"`
+	Load          LoadConfig          `json:"load"`
+	Sampling      SamplingConfig      `json:"sampling"`
+	Queries       QueryConfig         `json:"queries"`
+	Thresholds    Thresholds          `json:"thresholds"`
 
 	// ServerEnv is the environment the server under test is started with. It
 	// is recorded in full; AGGREGATE_SYNCHRONOUS in particular is a durability
@@ -47,6 +48,14 @@ type Binaries struct {
 	Server  string `json:"server"`
 	Loadsim string `json:"loadsim"`
 	Prefill string `json:"prefill"`
+}
+
+// CertificationConfig switches the historical diagnostic protocol into the
+// strict release-candidate contract. Candidate paths and expected digests are
+// supplied by the workflow flags because they do not exist until the signed
+// draft release has been downloaded and verified.
+type CertificationConfig struct {
+	Required bool `json:"required"`
 }
 
 // ConfinementConfig configures Q2.
@@ -229,8 +238,10 @@ func DefaultRequiredMetrics() []string {
 		"otelcontext_aggregate_input_points_total",
 		"otelcontext_aggregate_late_points_total",
 		"otelcontext_aggregate_admission_rejected_total",
+		"otelcontext_aggregate_identity_overflow_total",
 		"otelcontext_aggregate_delta_log_rows",
 		"otelcontext_disk_component_bytes",
+		"otelcontext_ingest_pipeline_dropped_total",
 	}
 }
 

--- a/test/gate/gatecore/render.go
+++ b/test/gate/gatecore/render.go
@@ -111,6 +111,10 @@ func renderProvenance(b *strings.Builder, r *Result) {
 	p := r.Provenance
 	b.WriteString("## Provenance\n\n| | |\n|---|---|\n")
 	fmt.Fprintf(b, "| Commit | `%s` |\n", p.CommitSHA)
+	if p.CandidateTag != "" {
+		fmt.Fprintf(b, "| Candidate | `%s` -> `%s` |\n", p.CandidateTag, p.TagCommitSHA)
+		fmt.Fprintf(b, "| Expected commit | `%s` |\n", p.ExpectedCommitSHA)
+	}
 	fmt.Fprintf(b, "| Branch | `%s` |\n", p.Branch)
 	fmt.Fprintf(b, "| Dirty tree | %t |\n", p.DirtyTree)
 	if len(p.DirtyFiles) > 0 {
@@ -119,6 +123,17 @@ func renderProvenance(b *strings.Builder, r *Result) {
 	fmt.Fprintf(b, "| Go | `%s` |\n", p.GoVersion)
 	for _, name := range sortedKeys(p.BinarySHA256) {
 		fmt.Fprintf(b, "| sha256 `%s` | `%s` |\n", name, p.BinarySHA256[name])
+	}
+	if p.ArchivePath != "" {
+		fmt.Fprintf(b, "| Archive | `%s` |\n", p.ArchivePath)
+		fmt.Fprintf(b, "| Archive sha256 | `%s` |\n", p.ArchiveSHA256)
+	}
+	if p.ConfigPath != "" {
+		fmt.Fprintf(b, "| Config | `%s` |\n", p.ConfigPath)
+		fmt.Fprintf(b, "| Config sha256 | `%s` |\n", p.ConfigSHA256)
+	}
+	if p.ServerVersion != "" {
+		fmt.Fprintf(b, "| Candidate version | `%s` |\n", p.ServerVersion)
 	}
 	h := r.Host
 	fmt.Fprintf(b, "| Host | `%s` (%s/%s, %d CPU, %s RAM) |\n",
@@ -421,9 +436,9 @@ func renderProjection(b *strings.Builder, r *Result) {
 func renderQueries(b *strings.Builder, r *Result) {
 	q := r.Queries
 	b.WriteString("## Query completeness\n\n")
-	fmt.Fprintf(b, "Seven-day range: %s .. %s (%d seeded windows expected).\n\n",
+	fmt.Fprintf(b, "Seven-day range: %s .. %s (%d seeded windows, %d series, %d services).\n\n",
 		q.PrefillRangeStart.UTC().Format(time.RFC3339), q.PrefillRangeEnd.UTC().Format(time.RFC3339),
-		q.PrefillWindows)
+		q.PrefillWindows, q.PrefillSeries, q.PrefillServices)
 	b.WriteString("| Surface | Status | Time | Coverage | Windows | truncated flag | Scalars |\n")
 	b.WriteString("|---|---|---|---|---|---|---|\n")
 	for _, c := range q.Checks {
@@ -452,6 +467,29 @@ func renderQueries(b *strings.Builder, r *Result) {
 		}
 		fmt.Fprintf(b, "| `%s` | `%s` | %d | %.2f s | %d | %s | %s |\n",
 			m.Tool, mdEscape(m.Arguments), m.Status, m.DurationSec, m.ResultBytes, trunc, mdEscape(orDash(e)))
+	}
+	if len(q.LatencyChecks) > 0 {
+		b.WriteString("\n### User-facing query latency\n\n")
+		b.WriteString("| Surface | Cold | Cache | Warm samples | Warm p50 | Warm p95 | Warm max |\n")
+		b.WriteString("|---|---:|---|---:|---:|---:|---:|\n")
+		for _, check := range q.LatencyChecks {
+			fmt.Fprintf(b, "| `%s` | %.3f s | %s | %d | %.3f s | %.3f s | %.3f s |\n",
+				check.Name, check.ColdSeconds, orDash(check.ColdCache), len(check.WarmSeconds),
+				check.WarmP50, check.WarmP95, check.WarmMax)
+		}
+	}
+	if len(q.LatencySentinel.Surfaces) > 0 {
+		s := q.LatencySentinel
+		b.WriteString("\n### Contradictory latency sentinel\n\n")
+		fmt.Fprintf(b, "Fixture: `%s`, %d × %.0f ms plus %d × %.0f ms.\n\n",
+			s.Service, s.LowCount, s.LowMS, s.TailCount, s.TailMS)
+		b.WriteString("| Consumer | P99 | Status | Method | Samples | Scale | Relative error | Degraded |\n")
+		b.WriteString("|---|---:|---|---|---:|---:|---:|---|\n")
+		for _, surface := range s.Surfaces {
+			fmt.Fprintf(b, "| `%s` | %.3f ms | %s | %s | %d | %d | %.3f%% | %t |\n",
+				surface.Name, surface.ValueMS, orDash(surface.Status), orDash(surface.Method),
+				surface.SampleCount, surface.SketchScale, surface.RelativeErrorBound*100, surface.Degraded)
+		}
 	}
 	b.WriteString("\n")
 }

--- a/test/gate/gatecore/result.go
+++ b/test/gate/gatecore/result.go
@@ -74,14 +74,24 @@ type Result struct {
 
 // Provenance identifies exactly what was measured.
 type Provenance struct {
-	CommitSHA       string            `json:"commit_sha"`
-	Branch          string            `json:"branch"`
-	DirtyTree       bool              `json:"dirty_tree"`
-	DirtyFiles      []string          `json:"dirty_files,omitempty"`
-	GoVersion       string            `json:"go_version"`
-	BinarySHA256    map[string]string `json:"binary_sha256"`
-	BuiltAt         time.Time         `json:"built_at"`
-	OrchestratorPID int               `json:"orchestrator_pid"`
+	CommitSHA             string            `json:"commit_sha"`
+	ExpectedCommitSHA     string            `json:"expected_commit_sha,omitempty"`
+	CandidateTag          string            `json:"candidate_tag,omitempty"`
+	TagCommitSHA          string            `json:"tag_commit_sha,omitempty"`
+	Branch                string            `json:"branch"`
+	DirtyTree             bool              `json:"dirty_tree"`
+	DirtyFiles            []string          `json:"dirty_files,omitempty"`
+	GoVersion             string            `json:"go_version"`
+	BinarySHA256          map[string]string `json:"binary_sha256"`
+	ExpectedServerSHA256  string            `json:"expected_server_sha256,omitempty"`
+	ArchivePath           string            `json:"archive_path,omitempty"`
+	ArchiveSHA256         string            `json:"archive_sha256,omitempty"`
+	ExpectedArchiveSHA256 string            `json:"expected_archive_sha256,omitempty"`
+	ConfigPath            string            `json:"config_path,omitempty"`
+	ConfigSHA256          string            `json:"config_sha256,omitempty"`
+	ServerVersion         string            `json:"server_version,omitempty"`
+	BuiltAt               time.Time         `json:"built_at"`
+	OrchestratorPID       int               `json:"orchestrator_pid"`
 }
 
 // HostInfo is the machine the numbers came off.
@@ -327,11 +337,15 @@ type DiskTier struct {
 
 // QueryResults is the completeness evidence.
 type QueryResults struct {
-	PrefillRangeStart time.Time     `json:"prefill_range_start"`
-	PrefillRangeEnd   time.Time     `json:"prefill_range_end"`
-	PrefillWindows    int           `json:"prefill_windows_expected"`
-	Checks            []QueryCheck  `json:"checks"`
-	MCPTools          []MCPToolCall `json:"mcp_tools"`
+	PrefillRangeStart time.Time            `json:"prefill_range_start"`
+	PrefillRangeEnd   time.Time            `json:"prefill_range_end"`
+	PrefillWindows    int                  `json:"prefill_windows_expected"`
+	PrefillSeries     int                  `json:"prefill_series"`
+	PrefillServices   int                  `json:"prefill_services"`
+	Checks            []QueryCheck         `json:"checks"`
+	MCPTools          []MCPToolCall        `json:"mcp_tools"`
+	LatencyChecks     []QueryLatencyCheck  `json:"latency_checks"`
+	LatencySentinel   LatencySentinelProof `json:"latency_sentinel"`
 }
 
 // QueryCheck is one HTTP query surface answered over the seven-day range.
@@ -353,8 +367,51 @@ type QueryCheck struct {
 	MissingWindows  int                `json:"missing_windows,omitempty"`
 	ExtraWindows    int                `json:"extra_windows,omitempty"`
 	Scalars         map[string]float64 `json:"scalars,omitempty"`
+	ExpectedScalars map[string]float64 `json:"expected_scalars,omitempty"`
 	BodyBytes       int                `json:"body_bytes"`
 	Error           string             `json:"error,omitempty"`
+}
+
+// QueryLatencyCheck records the first uncached request and the sequential
+// warm samples for one user-facing surface.
+type QueryLatencyCheck struct {
+	Name          string    `json:"name"`
+	URL           string    `json:"url"`
+	Status        int       `json:"status"`
+	ColdSeconds   float64   `json:"cold_seconds"`
+	ColdCache     string    `json:"cold_cache,omitempty"`
+	WarmSeconds   []float64 `json:"warm_seconds,omitempty"`
+	WarmCacheHits int       `json:"warm_cache_hits,omitempty"`
+	WarmP50       float64   `json:"warm_p50_seconds,omitempty"`
+	WarmP95       float64   `json:"warm_p95_seconds,omitempty"`
+	WarmMax       float64   `json:"warm_max_seconds,omitempty"`
+	Error         string    `json:"error,omitempty"`
+}
+
+// LatencySentinelProof carries the contradictory 989x10ms + 11x1000ms
+// fixture through every aggregate consumer named by the release contract.
+type LatencySentinelProof struct {
+	Service   string           `json:"service"`
+	LowCount  int              `json:"low_count"`
+	LowMS     float64          `json:"low_ms"`
+	TailCount int              `json:"tail_count"`
+	TailMS    float64          `json:"tail_ms"`
+	Surfaces  []LatencySurface `json:"surfaces"`
+}
+
+// LatencySurface is one consumer's value and the provenance that bounds it.
+type LatencySurface struct {
+	Name               string  `json:"name"`
+	ValueMS            float64 `json:"value_ms"`
+	Status             string  `json:"status"`
+	Method             string  `json:"method"`
+	SampleCount        uint64  `json:"sample_count"`
+	SketchScale        uint8   `json:"sketch_scale"`
+	RelativeErrorBound float64 `json:"relative_error_bound"`
+	Degraded           bool    `json:"degraded"`
+	Collapsed          bool    `json:"collapsed"`
+	Saturations        uint64  `json:"saturations"`
+	Error              string  `json:"error,omitempty"`
 }
 
 // MCPToolCall is one aggregate-backed MCP tool answered over the full range.
@@ -368,6 +425,7 @@ type MCPToolCall struct {
 	TruncatedTrue  bool    `json:"truncated_true"`
 	ResultBytes    int     `json:"result_bytes"`
 	Error          string  `json:"error,omitempty"`
+	PrimaryText    string  `json:"-"`
 }
 
 // MetricSample is one Prometheus scrape, reduced to the metrics the gate

--- a/test/gate/gatecore/thresholds.go
+++ b/test/gate/gatecore/thresholds.go
@@ -14,13 +14,14 @@ type Thresholds struct {
 	// rate may sit before the phase is judged not to have run at the
 	// contracted load. A phase that quietly ran at 4k pts/s must not pass a
 	// 10k pts/s gate on the strength of its excellent latency.
-	SustainedRateTolerance    float64 `json:"sustained_rate_tolerance"`
-	AckP99MaxMs               float64 `json:"ack_p99_max_ms"`
-	AckRatioMin               float64 `json:"ack_ratio_min"`
-	MaxResourceExhausted      int64   `json:"max_resource_exhausted"`
-	MaxLatePointsDelta        float64 `json:"max_late_points_delta"`
-	MaxAdmissionRejectedDelta float64 `json:"max_admission_rejected_delta"`
-	MaxIdentityOverflowDelta  float64 `json:"max_identity_overflow_delta"`
+	SustainedRateTolerance     float64 `json:"sustained_rate_tolerance"`
+	AckP99MaxMs                float64 `json:"ack_p99_max_ms"`
+	AckRatioMin                float64 `json:"ack_ratio_min"`
+	MaxResourceExhausted       int64   `json:"max_resource_exhausted"`
+	MaxLatePointsDelta         float64 `json:"max_late_points_delta"`
+	MaxAdmissionRejectedDelta  float64 `json:"max_admission_rejected_delta"`
+	MaxIdentityOverflowDelta   float64 `json:"max_identity_overflow_delta"`
+	MaxIngestPipelineDropDelta float64 `json:"max_ingest_pipeline_drop_delta"`
 
 	// BacklogAllowanceFraction and BacklogAllowanceFloorRows define "no
 	// sustained backlog growth": the fitted growth across the phase and the
@@ -61,8 +62,14 @@ type Thresholds struct {
 	ProjectionHorizonWindows int     `json:"projection_horizon_windows"`
 
 	// --- Query completeness ---
-	PrefillWindows int `json:"prefill_windows"`
-	PrefillSeries  int `json:"prefill_series"`
+	PrefillWindows          int     `json:"prefill_windows"`
+	PrefillSeries           int     `json:"prefill_series"`
+	PrefillServices         int     `json:"prefill_services"`
+	ColdQueryMaxSeconds     float64 `json:"cold_query_max_seconds"`
+	WarmQueryP95MaxSeconds  float64 `json:"warm_query_p95_max_seconds"`
+	SevenDayQueryMaxSeconds float64 `json:"seven_day_query_max_seconds"`
+	MCPQueryMaxSeconds      float64 `json:"mcp_query_max_seconds"`
+	ProbeMaxSeconds         float64 `json:"probe_max_seconds"`
 	// RequiredCoverage is the marker a fully aggregate-derived surface must
 	// declare. Per-surface expectations live in QueryConfig.
 	RequiredCoverage string `json:"required_coverage"`
@@ -78,15 +85,16 @@ const (
 // DefaultThresholds returns the frozen contract.
 func DefaultThresholds() Thresholds {
 	return Thresholds{
-		SustainedHours:            3,
-		SustainedPointsPerSec:     10000,
-		SustainedRateTolerance:    0.05,
-		AckP99MaxMs:               500,
-		AckRatioMin:               0.999,
-		MaxResourceExhausted:      0,
-		MaxLatePointsDelta:        0,
-		MaxAdmissionRejectedDelta: 0,
-		MaxIdentityOverflowDelta:  0,
+		SustainedHours:             3,
+		SustainedPointsPerSec:      10000,
+		SustainedRateTolerance:     0.05,
+		AckP99MaxMs:                500,
+		AckRatioMin:                0.999,
+		MaxResourceExhausted:       0,
+		MaxLatePointsDelta:         0,
+		MaxAdmissionRejectedDelta:  0,
+		MaxIdentityOverflowDelta:   0,
+		MaxIngestPipelineDropDelta: 0,
 
 		BacklogAllowanceFraction:  0.10,
 		BacklogAllowanceFloorRows: 5000,
@@ -114,8 +122,14 @@ func DefaultThresholds() Thresholds {
 		ProjectionZ:              2,
 		ProjectionHorizonWindows: HorizonWindows,
 
-		PrefillWindows:   2016,
-		PrefillSeries:    6000,
-		RequiredCoverage: "full",
+		PrefillWindows:          2016,
+		PrefillSeries:           6000,
+		PrefillServices:         120,
+		ColdQueryMaxSeconds:     5,
+		WarmQueryP95MaxSeconds:  0.5,
+		SevenDayQueryMaxSeconds: 15,
+		MCPQueryMaxSeconds:      5,
+		ProbeMaxSeconds:         1,
+		RequiredCoverage:        "full",
 	}
 }

--- a/test/gate/host.go
+++ b/test/gate/host.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -88,14 +89,23 @@ func mountFor(path string) (device, mount, fsType string) {
 }
 
 // collectProvenance records exactly what was measured.
-func collectProvenance(repoRoot string, binaries gatecore.Binaries) gatecore.Provenance {
+func collectProvenance(repoRoot string, binaries gatecore.Binaries, candidate candidateSpec) gatecore.Provenance {
 	p := gatecore.Provenance{
-		GoVersion:       runtime.Version(),
-		BinarySHA256:    map[string]string{},
-		BuiltAt:         time.Now().UTC(),
-		OrchestratorPID: os.Getpid(),
+		ExpectedCommitSHA:     candidate.expectedCommitSHA,
+		CandidateTag:          candidate.tag,
+		ExpectedServerSHA256:  candidate.expectedServerSHA256,
+		ArchivePath:           candidate.archivePath,
+		ExpectedArchiveSHA256: candidate.expectedArchiveSHA256,
+		ConfigPath:            candidate.configPath,
+		GoVersion:             runtime.Version(),
+		BinarySHA256:          map[string]string{},
+		BuiltAt:               time.Now().UTC(),
+		OrchestratorPID:       os.Getpid(),
 	}
 	p.CommitSHA = gitOutput(repoRoot, "rev-parse", "HEAD")
+	if candidate.tag != "" {
+		p.TagCommitSHA = gitOutput(repoRoot, "rev-parse", candidate.tag+"^{commit}")
+	}
 	p.Branch = gitOutput(repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
 	status := gitOutput(repoRoot, "status", "--porcelain")
 	if status != "" {
@@ -112,13 +122,50 @@ func collectProvenance(repoRoot string, binaries gatecore.Binaries) gatecore.Pro
 		if path == "" {
 			continue
 		}
+		path = rootedPath(repoRoot, path)
 		if sum, err := sha256File(path); err == nil {
-			p.BinarySHA256[name+" ("+filepath.Base(path)+")"] = sum
+			p.BinarySHA256[name] = sum
 		} else {
-			p.BinarySHA256[name+" ("+filepath.Base(path)+")"] = "unreadable: " + err.Error()
+			p.BinarySHA256[name] = "unreadable: " + err.Error()
 		}
 	}
+	if exe, err := os.Executable(); err == nil {
+		if sum, err := sha256File(exe); err == nil {
+			p.BinarySHA256["gate"] = sum
+		} else {
+			p.BinarySHA256["gate"] = "unreadable: " + err.Error()
+		}
+	}
+	if candidate.archivePath != "" {
+		candidate.archivePath = rootedPath(repoRoot, candidate.archivePath)
+		p.ArchivePath = candidate.archivePath
+		if sum, err := sha256File(candidate.archivePath); err == nil {
+			p.ArchiveSHA256 = sum
+		} else {
+			p.ArchiveSHA256 = "unreadable: " + err.Error()
+		}
+	}
+	if candidate.configPath != "" {
+		candidate.configPath = rootedPath(repoRoot, candidate.configPath)
+		p.ConfigPath = candidate.configPath
+		if sum, err := sha256File(candidate.configPath); err == nil {
+			p.ConfigSHA256 = sum
+		} else {
+			p.ConfigSHA256 = "unreadable: " + err.Error()
+		}
+	}
+	serverPath := rootedPath(repoRoot, binaries.Server)
+	if out, err := exec.Command(serverPath, "--version").Output(); err == nil { // #nosec G204 -- operator-selected candidate path
+		p.ServerVersion = strings.TrimSpace(strings.TrimPrefix(string(out), "OtelContext version "))
+	}
 	return p
+}
+
+func rootedPath(root, path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(root, path)
 }
 
 func gitOutput(dir string, args ...string) string {
@@ -148,6 +195,25 @@ func sha256File(path string) (string, error) {
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
+func writeDigestManifest(path string, entries map[string]string) error {
+	names := make([]string, 0, len(entries))
+	for name, filePath := range entries {
+		if filePath != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	var body strings.Builder
+	for _, name := range names {
+		digest, err := sha256File(entries[name])
+		if err != nil {
+			return fmt.Errorf("digest %s: %w", name, err)
+		}
+		fmt.Fprintf(&body, "%s  %s\n", digest, name)
+	}
+	return os.WriteFile(path, []byte(body.String()), 0o600)
+}
+
 // parsePrefillOutput pulls the deterministic seeded counts out of the prefill
 // binary's stdout. Those numbers are the only exact totals the prefill tier
 // publishes, so the gate reads them rather than assuming them.
@@ -157,6 +223,13 @@ type prefillFacts struct {
 	DeltaRows        int64
 	FirstWindow      int64
 	LastWindow       int64
+	Series           int
+	Services         int
+	Requests         int64
+	RequestErrors    int64
+	Spans            int64
+	SpanErrors       int64
+	Logs             int64
 }
 
 func parsePrefillOutput(out string) (prefillFacts, error) {
@@ -181,10 +254,38 @@ func parsePrefillOutput(out string) (prefillFacts, error) {
 			if _, err := fmt.Sscanf(line, "first_window: %d  last_window: %d", &f.FirstWindow, &f.LastWindow); err == nil {
 				seen++
 			}
+		case strings.HasPrefix(line, "series_total:"):
+			if _, err := fmt.Sscanf(line, "series_total: %d", &f.Series); err == nil {
+				seen++
+			}
+		case strings.HasPrefix(line, "services_total:"):
+			if _, err := fmt.Sscanf(line, "services_total: %d", &f.Services); err == nil {
+				seen++
+			}
+		case strings.HasPrefix(line, "dashboard_requests:"):
+			if _, err := fmt.Sscanf(line, "dashboard_requests: %d", &f.Requests); err == nil {
+				seen++
+			}
+		case strings.HasPrefix(line, "dashboard_request_errors:"):
+			if _, err := fmt.Sscanf(line, "dashboard_request_errors: %d", &f.RequestErrors); err == nil {
+				seen++
+			}
+		case strings.HasPrefix(line, "dashboard_spans:"):
+			if _, err := fmt.Sscanf(line, "dashboard_spans: %d", &f.Spans); err == nil {
+				seen++
+			}
+		case strings.HasPrefix(line, "dashboard_span_errors:"):
+			if _, err := fmt.Sscanf(line, "dashboard_span_errors: %d", &f.SpanErrors); err == nil {
+				seen++
+			}
+		case strings.HasPrefix(line, "dashboard_logs:"):
+			if _, err := fmt.Sscanf(line, "dashboard_logs: %d", &f.Logs); err == nil {
+				seen++
+			}
 		}
 	}
-	if seen < 4 {
-		return f, fmt.Errorf("prefill output did not carry the four seeded-count lines (found %d)", seen)
+	if seen < 11 {
+		return f, fmt.Errorf("prefill output did not carry the eleven seeded-count lines (found %d)", seen)
 	}
 	return f, nil
 }

--- a/test/gate/main.go
+++ b/test/gate/main.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -29,6 +30,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -48,8 +50,9 @@ const phaseGuard = 5 * time.Second
 const ctlTimeout = 5 * time.Second
 
 type gate struct {
-	cfg gatecore.Config
-	res *gatecore.Result
+	cfg       gatecore.Config
+	res       *gatecore.Result
+	candidate candidateSpec
 
 	// http is the query client: its long timeout exists for the seven-day
 	// completeness surfaces (the dashboard percentile path pages 12.1M
@@ -71,9 +74,27 @@ type gate struct {
 	mu sync.Mutex
 }
 
+type candidateSpec struct {
+	configPath            string
+	tag                   string
+	expectedCommitSHA     string
+	archivePath           string
+	expectedArchiveSHA256 string
+	expectedServerSHA256  string
+}
+
 func main() {
 	cfgPath := flag.String("config", "", "gate configuration JSON; unstated fields keep the frozen defaults")
 	outDir := flag.String("out", "", "report directory override (default: report_dir from the config)")
+	workDir := flag.String("work-dir", "", "work directory override; data is written below it")
+	server := flag.String("server", "", "server binary override (the extracted signed candidate for a certifying run)")
+	loadsim := flag.String("loadsim", "", "load generator binary override")
+	prefill := flag.String("prefill", "", "deterministic prefill binary override")
+	tag := flag.String("tag", "", "candidate version tag")
+	expectedCommit := flag.String("expected-commit-sha", "", "candidate tag's expected 40-character commit SHA")
+	archive := flag.String("archive", "", "verified release archive containing the candidate")
+	expectedArchiveSHA := flag.String("expected-archive-sha256", "", "expected SHA-256 of the verified release archive")
+	expectedServerSHA := flag.String("expected-server-sha256", "", "expected SHA-256 of the extracted candidate server")
 	runID := flag.String("run-id", "", "run identifier (default: UTC timestamp)")
 	printCfg := flag.Bool("print-config", false, "print the effective configuration and exit")
 	flag.Parse()
@@ -84,6 +105,19 @@ func main() {
 	}
 	if *outDir != "" {
 		cfg.ReportDir = *outDir
+	}
+	if *workDir != "" {
+		cfg.WorkDir = *workDir
+		cfg.DataDir = filepath.Join(*workDir, "data")
+	}
+	if *server != "" {
+		cfg.Binaries.Server = *server
+	}
+	if *loadsim != "" {
+		cfg.Binaries.Loadsim = *loadsim
+	}
+	if *prefill != "" {
+		cfg.Binaries.Prefill = *prefill
 	}
 	if cfg.RunID == "" {
 		cfg.RunID = *runID
@@ -96,6 +130,14 @@ func main() {
 			cfg.RepoRoot = wd
 		}
 	}
+	if root, err := filepath.Abs(cfg.RepoRoot); err == nil {
+		cfg.RepoRoot = root
+	}
+	candidate := candidateSpec{
+		configPath: *cfgPath, tag: *tag, expectedCommitSHA: strings.ToLower(*expectedCommit),
+		archivePath: *archive, expectedArchiveSHA256: strings.ToLower(*expectedArchiveSHA),
+		expectedServerSHA256: strings.ToLower(*expectedServerSHA),
+	}
 	if *printCfg {
 		fmt.Println(mustJSON(cfg))
 		return
@@ -103,8 +145,11 @@ func main() {
 	if err := cfg.Validate(); err != nil {
 		log.Fatalf("gate: %v", err)
 	}
+	if err := validateCandidateConfig(cfg, candidate); err != nil {
+		log.Fatalf("gate: %v", err)
+	}
 
-	g := newGate(cfg)
+	g := newGate(cfg, candidate)
 	runErr := g.run()
 
 	g.res.EndedAt = time.Now().UTC()
@@ -113,14 +158,36 @@ func main() {
 	jsonPath, mdPath, werr := gatecore.WriteReports(g.abs(cfg.ReportDir), g.res.StartedAt, g.res)
 	if werr != nil {
 		log.Printf("gate: writing the report failed: %v", werr)
+		runErr = errors.Join(runErr, fmt.Errorf("write gate reports: %w", werr))
 	} else {
 		log.Printf("gate: report written to %s and %s", jsonPath, mdPath)
+		digestPath := strings.TrimSuffix(jsonPath, ".json") + "-digests.txt"
+		manifestEntries := map[string]string{
+			"report.json":     jsonPath,
+			"report.md":       mdPath,
+			"config":          g.res.Provenance.ConfigPath,
+			"release-archive": g.res.Provenance.ArchivePath,
+			"server":          g.abs(g.cfg.Binaries.Server),
+			"loadsim":         g.abs(g.cfg.Binaries.Loadsim),
+			"prefill":         g.abs(g.cfg.Binaries.Prefill),
+		}
+		if gateExe, err := os.Executable(); err == nil {
+			manifestEntries["gate"] = gateExe
+		} else {
+			log.Printf("gate: resolving the gate executable for the digest manifest failed: %v", err)
+		}
+		if err := writeDigestManifest(digestPath, manifestEntries); err != nil {
+			log.Printf("gate: writing the digest manifest failed: %v", err)
+			runErr = errors.Join(runErr, fmt.Errorf("write digest manifest: %w", err))
+		} else {
+			log.Printf("gate: digest manifest written to %s", digestPath)
+		}
 	}
 
 	if runErr != nil {
 		log.Printf("gate: protocol error: %v", runErr)
 	}
-	if !g.res.Passed {
+	if runErr != nil || !g.res.Passed {
 		log.Printf("gate: FAILED with %d failing assertions", len(g.res.Failures))
 		for _, f := range g.res.Failures {
 			log.Printf("  - %s", f)
@@ -130,11 +197,12 @@ func main() {
 	log.Printf("gate: PASSED %d assertions", len(g.res.Assertions))
 }
 
-func newGate(cfg gatecore.Config) *gate {
+func newGate(cfg gatecore.Config, candidate candidateSpec) *gate {
 	g := &gate{
-		cfg:  cfg,
-		http: &http.Client{Timeout: time.Duration(cfg.Queries.Timeout * float64(time.Second))},
-		ctl:  &http.Client{Timeout: ctlTimeout},
+		cfg:       cfg,
+		candidate: candidate,
+		http:      &http.Client{Timeout: time.Duration(cfg.Queries.Timeout * float64(time.Second))},
+		ctl:       &http.Client{Timeout: ctlTimeout},
 		res: &gatecore.Result{
 			Schema:      gatecore.Schema,
 			GateVersion: gateVersion,
@@ -149,6 +217,63 @@ func newGate(cfg gatecore.Config) *gate {
 	}
 	g.sampler = newSampler(g)
 	return g
+}
+
+func validateCandidateConfig(cfg gatecore.Config, c candidateSpec) error {
+	if !cfg.Certification.Required {
+		return nil
+	}
+	var missing []string
+	for name, value := range map[string]string{
+		"-config": c.configPath, "-tag": c.tag, "-expected-commit-sha": c.expectedCommitSHA,
+		"-archive": c.archivePath, "-expected-archive-sha256": c.expectedArchiveSHA256,
+		"-expected-server-sha256": c.expectedServerSHA256,
+	} {
+		if strings.TrimSpace(value) == "" {
+			missing = append(missing, name)
+		}
+	}
+	if !validHex(c.expectedCommitSHA, 20) {
+		missing = append(missing, "-expected-commit-sha must be 40 hexadecimal characters")
+	}
+	for name, digest := range map[string]string{
+		"-expected-archive-sha256": c.expectedArchiveSHA256,
+		"-expected-server-sha256":  c.expectedServerSHA256,
+	} {
+		if !validHex(digest, 32) {
+			missing = append(missing, name+" must be 64 hexadecimal characters")
+		}
+	}
+	if cfg.Confinement.AllowFallback {
+		missing = append(missing, "confinement.allow_fallback must be false")
+	}
+	for name, path := range map[string]string{"work_dir": cfg.WorkDir, "report_dir": cfg.ReportDir} {
+		if pathWithin(cfg.RepoRoot, path) {
+			missing = append(missing, name+" must be outside repo_root")
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("certifying candidate configuration is incomplete: %s", strings.Join(missing, "; "))
+	}
+	return nil
+}
+
+func validHex(value string, bytes int) bool {
+	if len(value) != bytes*2 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func pathWithin(root, path string) bool {
+	rootAbs, rootErr := filepath.Abs(root)
+	pathAbs, pathErr := filepath.Abs(path)
+	if rootErr != nil || pathErr != nil {
+		return true
+	}
+	rel, err := filepath.Rel(rootAbs, pathAbs)
+	return err != nil || rel == "." || (!strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != "..")
 }
 
 func (g *gate) abs(p string) string {
@@ -214,8 +339,11 @@ func (g *gate) run() error {
 	g.res.Config = g.cfg
 	g.res.ServerEnv = g.cfg.ServerEnv
 
-	g.res.Provenance = collectProvenance(g.cfg.RepoRoot, g.cfg.Binaries)
+	g.res.Provenance = collectProvenance(g.cfg.RepoRoot, g.cfg.Binaries, g.candidate)
 	g.res.Host = collectHost(g.cfg.DataDir)
+	if err := g.preflightCandidate(); err != nil {
+		return err
+	}
 	if err := g.preflightDisk(); err != nil {
 		return err
 	}
@@ -262,7 +390,41 @@ func (g *gate) run() error {
 	if err := g.runCrashPhase(); err != nil {
 		return err
 	}
+	if g.cfg.Certification.Required {
+		if err := g.runLatencySentinel(); err != nil {
+			return err
+		}
+	}
 	return g.measure(prefill)
+}
+
+func (g *gate) preflightCandidate() error {
+	if !g.cfg.Certification.Required {
+		return nil
+	}
+	p := g.res.Provenance
+	serverDigest := p.BinarySHA256["server"]
+	var failures []string
+	checks := []struct {
+		ok     bool
+		detail string
+	}{
+		{p.CommitSHA == p.ExpectedCommitSHA, "checkout commit does not match expected commit"},
+		{p.TagCommitSHA == p.ExpectedCommitSHA, "candidate tag does not resolve to expected commit"},
+		{!p.DirtyTree, "candidate checkout is dirty"},
+		{p.ArchiveSHA256 == p.ExpectedArchiveSHA256, "release archive digest mismatch"},
+		{serverDigest == p.ExpectedServerSHA256, "candidate server digest mismatch"},
+		{p.ServerVersion == p.CandidateTag, "candidate server version does not match tag"},
+	}
+	for _, check := range checks {
+		if !check.ok {
+			failures = append(failures, check.detail)
+		}
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("candidate preflight failed: %s", strings.Join(failures, "; "))
+	}
+	return nil
 }
 
 // pinServerPaths forces every file the server writes into the gate's own data
@@ -585,6 +747,48 @@ func (g *gate) runCrashPhase() error {
 	})
 }
 
+func (g *gate) runLatencySentinel() error {
+	return g.phase("latency_sentinel", func() error {
+		reportPath := filepath.Join(g.cfg.WorkDir, "latency-sentinel.json")
+		argv := []string{
+			g.abs(g.cfg.Binaries.Loadsim),
+			"--latency-sentinel",
+			"--endpoint", g.cfg.GRPCAddr,
+			"--call-timeout", dur(g.cfg.Load.CallTimeoutSec).String(),
+			"--report", reportPath,
+		}
+		if g.cfg.Load.TenantID != "" {
+			argv = append(argv, "--tenant-id", g.cfg.Load.TenantID)
+		}
+		if _, err := g.runCommand("latency_sentinel", argv, "latency-sentinel.log"); err != nil {
+			return err
+		}
+		body, err := os.ReadFile(reportPath) // #nosec G304 -- gate-owned work path
+		if err != nil {
+			return err
+		}
+		var fixture struct {
+			SchemaVersion string  `json:"schema_version"`
+			Service       string  `json:"service"`
+			LowCount      int     `json:"low_count"`
+			LowMS         float64 `json:"low_ms"`
+			TailCount     int     `json:"tail_count"`
+			TailMS        float64 `json:"tail_ms"`
+		}
+		if err := json.Unmarshal(body, &fixture); err != nil {
+			return fmt.Errorf("decode latency sentinel report: %w", err)
+		}
+		if fixture.SchemaVersion != "otelcontext.latency-sentinel.v1" {
+			return fmt.Errorf("latency sentinel schema is %q", fixture.SchemaVersion)
+		}
+		g.res.Queries.LatencySentinel = gatecore.LatencySentinelProof{
+			Service: fixture.Service, LowCount: fixture.LowCount, LowMS: fixture.LowMS,
+			TailCount: fixture.TailCount, TailMS: fixture.TailMS,
+		}
+		return g.waitLatencySentinel(fixture.Service, uint64(fixture.LowCount+fixture.TailCount), 30*time.Second)
+	})
+}
+
 // --- measurement ----------------------------------------------------------
 
 func (g *gate) measure(prefill prefillFacts) error {
@@ -719,8 +923,35 @@ func (g *gate) collectQueries(prefill prefillFacts) {
 	g.res.Queries.PrefillRangeStart = start
 	g.res.Queries.PrefillRangeEnd = end
 	g.res.Queries.PrefillWindows = len(expected)
+	g.res.Queries.PrefillSeries = prefill.Series
+	g.res.Queries.PrefillServices = prefill.Services
+	if g.cfg.Certification.Required {
+		g.res.Queries.LatencyChecks = g.runQueryLatencyChecks()
+	}
 	g.res.Queries.Checks = g.runAPIChecks(start, end, expected)
+	for i := range g.res.Queries.Checks {
+		switch g.res.Queries.Checks[i].Name {
+		case "dashboard_seven_day":
+			g.res.Queries.Checks[i].ExpectedScalars = map[string]float64{
+				"total_traces":    float64(prefill.Requests),
+				"total_errors":    float64(prefill.RequestErrors),
+				"requests":        float64(prefill.Requests),
+				"request_errors":  float64(prefill.RequestErrors),
+				"spans":           float64(prefill.Spans),
+				"span_errors":     float64(prefill.SpanErrors),
+				"total_logs":      float64(prefill.Logs),
+				"active_services": float64(prefill.Services),
+			}
+		case "service_map_seven_day":
+			g.res.Queries.Checks[i].ExpectedScalars = map[string]float64{
+				"services": float64(prefill.Services),
+			}
+		}
+	}
 	g.res.Queries.MCPTools = g.runMCPTools(start, end)
+	if g.cfg.Certification.Required {
+		g.res.Queries.LatencySentinel.Surfaces = g.collectLatencySentinel()
+	}
 }
 
 // collectCrashBounds compares the post-restart per-window span totals against

--- a/test/gate/queries.go
+++ b/test/gate/queries.go
@@ -10,7 +10,12 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
+
+	"github.com/coder/websocket"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/test/gate/gatecore"
@@ -31,7 +36,7 @@ func (g *gate) runAPIChecks(start, end time.Time, expectedWindows []int64) []gat
 }
 
 func (g *gate) runAPICheck(spec gatecore.APICheck, sevenDayStart, sevenDayEnd time.Time, expectedWindows []int64) gatecore.QueryCheck {
-	c := gatecore.QueryCheck{Name: spec.Name}
+	c := gatecore.QueryCheck{Name: spec.Name, CoverageExpected: spec.ExpectCoverage}
 
 	u := g.baseURL() + spec.Path
 	q := url.Values{}
@@ -72,6 +77,18 @@ func (g *gate) runAPICheck(spec gatecore.APICheck, sevenDayStart, sevenDayEnd ti
 	if len(spec.ScalarKeys) > 0 {
 		c.Scalars = gatecore.TopLevelScalars(decoded, spec.ScalarKeys)
 	}
+	if spec.Name == "service_map_seven_day" {
+		object, objectOK := decoded.(map[string]any)
+		nodes, nodesOK := object["nodes"].([]any)
+		if !objectOK || !nodesOK {
+			c.Error = "service-map response does not carry a top-level nodes array"
+			return c
+		}
+		if c.Scalars == nil {
+			c.Scalars = map[string]float64{}
+		}
+		c.Scalars["services"] = float64(len(nodes))
+	}
 	if spec.PerWindow && len(expectedWindows) > 0 {
 		pts, perr := gatecore.ParseWindowPoints(body)
 		if perr != nil {
@@ -82,9 +99,6 @@ func (g *gate) runAPICheck(spec gatecore.APICheck, sevenDayStart, sevenDayEnd ti
 		c.WindowsReturned, c.MissingWindows, c.WindowsExpected = returned, missing, len(expectedWindows)
 		c.ExtraWindows = extra
 	}
-	// Whatever coverage marker arrived is always recorded; only surfaces the
-	// config marks as required are gated on it.
-	c.CoverageExpected = spec.ExpectCoverage
 	return c
 }
 
@@ -175,8 +189,15 @@ func (g *gate) runMCPTool(spec gatecore.MCPToolSpec, start, end time.Time) gatec
 	call.Status, call.ResultBytes = resp.StatusCode, len(body)
 
 	var envelope struct {
-		Result any `json:"result"`
-		Error  *struct {
+		Result struct {
+			Content []struct {
+				Text     string `json:"text"`
+				Resource *struct {
+					Text string `json:"text"`
+				} `json:"resource"`
+			} `json:"content"`
+		} `json:"result"`
+		Error *struct {
 			Code    int    `json:"code"`
 			Message string `json:"message"`
 		} `json:"error"`
@@ -189,8 +210,286 @@ func (g *gate) runMCPTool(spec gatecore.MCPToolSpec, start, end time.Time) gatec
 		call.RPCError = fmt.Sprintf("%d %s", envelope.Error.Code, envelope.Error.Message)
 		return call
 	}
+	if len(envelope.Result.Content) > 0 {
+		call.PrimaryText = envelope.Result.Content[0].Text
+		if call.PrimaryText == "" && envelope.Result.Content[0].Resource != nil {
+			call.PrimaryText = envelope.Result.Content[0].Resource.Text
+		}
+	}
 	call.TruncatedFound, call.TruncatedTrue = gatecore.ScanTruncated(envelope.Result)
 	return call
+}
+
+func (g *gate) runQueryLatencyChecks() []gatecore.QueryLatencyCheck {
+	checks := []struct {
+		name string
+		path string
+		warm int
+	}{
+		{"default_dashboard", "/api/metrics/dashboard", 20},
+		{"system_graph", "/api/system/graph", 20},
+		{"live", "/live", 0},
+		{"ready", "/ready", 0},
+	}
+	out := make([]gatecore.QueryLatencyCheck, 0, len(checks))
+	for _, spec := range checks {
+		check := gatecore.QueryLatencyCheck{Name: spec.name, URL: g.baseURL() + spec.path}
+		_, status, header, elapsed, err := g.get(check.URL)
+		check.Status, check.ColdSeconds = status, elapsed.Seconds()
+		if header != nil {
+			check.ColdCache = header.Get("X-Cache")
+		}
+		if err != nil || status != http.StatusOK {
+			if err != nil {
+				check.Error = err.Error()
+			} else {
+				check.Error = fmt.Sprintf("HTTP %d", status)
+			}
+			out = append(out, check)
+			continue
+		}
+		for i := 0; i < spec.warm; i++ {
+			_, warmStatus, warmHeader, warmElapsed, warmErr := g.get(check.URL)
+			if warmErr != nil || warmStatus != http.StatusOK {
+				if warmErr != nil {
+					check.Error = warmErr.Error()
+				} else {
+					check.Error = fmt.Sprintf("warm request %d: HTTP %d", i+1, warmStatus)
+				}
+				break
+			}
+			if warmHeader.Get("X-Cache") == "HIT" {
+				check.WarmCacheHits++
+			}
+			check.WarmSeconds = append(check.WarmSeconds, warmElapsed.Seconds())
+		}
+		check.WarmP50 = nearestRank(check.WarmSeconds, 0.50)
+		check.WarmP95 = nearestRank(check.WarmSeconds, 0.95)
+		check.WarmMax = nearestRank(check.WarmSeconds, 1)
+		out = append(out, check)
+	}
+	return out
+}
+
+// waitLatencySentinel keeps the async ingest pipeline from turning a valid
+// fixture into a timing race. Each probe has a unique ignored query parameter,
+// so a zero-result response cannot poison the dashboard response cache.
+func (g *gate) waitLatencySentinel(service string, want uint64, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	last := "no response"
+	for time.Now().Before(deadline) {
+		q := url.Values{
+			"service_name": {service},
+			"_gate_wait":   {strconv.FormatInt(time.Now().UnixNano(), 10)},
+		}
+		u := g.baseURL() + "/api/metrics/dashboard?" + q.Encode()
+		remaining := time.Until(deadline)
+		ctx, cancel := context.WithTimeout(context.Background(), remaining)
+		body, status, _, _, err := g.doGet(g.ctl, ctx, u)
+		cancel()
+		if err == nil && status == http.StatusOK {
+			var payload struct {
+				Provenance *latencyProvenanceWire `json:"latency_provenance"`
+			}
+			if decodeErr := json.Unmarshal(body, &payload); decodeErr != nil {
+				last = decodeErr.Error()
+			} else if payload.Provenance != nil && payload.Provenance.P99 != nil {
+				got := payload.Provenance.P99.SampleCount
+				if got == want {
+					return nil
+				}
+				last = fmt.Sprintf("sample_count=%d, want %d", got, want)
+			} else {
+				last = "p99 latency provenance is absent"
+			}
+		} else {
+			last = requestError(status, err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("latency sentinel did not become query-visible within %s (last: %s)", timeout, last)
+}
+
+func nearestRank(values []float64, q float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+	idx := int(float64(len(sorted))*q+0.999999999) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+type latencyPercentileWire struct {
+	Status             string  `json:"status"`
+	Method             string  `json:"method"`
+	SampleCount        uint64  `json:"sample_count"`
+	SketchScale        uint8   `json:"sketch_scale"`
+	RelativeErrorBound float64 `json:"relative_error_bound"`
+	Degraded           bool    `json:"degraded"`
+	Collapsed          bool    `json:"collapsed"`
+	Saturations        uint64  `json:"saturations"`
+}
+
+type latencyProvenanceWire struct {
+	P99 *latencyPercentileWire `json:"p99"`
+}
+
+type latencyServiceWire struct {
+	Name              string                 `json:"name"`
+	P99LatencyMS      float64                `json:"p99_latency_ms"`
+	LatencyProvenance *latencyProvenanceWire `json:"latency_provenance"`
+}
+
+func latencySurface(name string, value float64, provenance *latencyProvenanceWire) gatecore.LatencySurface {
+	surface := gatecore.LatencySurface{Name: name, ValueMS: value}
+	if provenance == nil || provenance.P99 == nil {
+		surface.Error = "p99 latency provenance is absent"
+		return surface
+	}
+	p := provenance.P99
+	surface.Status, surface.Method, surface.SampleCount = p.Status, p.Method, p.SampleCount
+	surface.SketchScale, surface.RelativeErrorBound = p.SketchScale, p.RelativeErrorBound
+	surface.Degraded, surface.Collapsed, surface.Saturations = p.Degraded, p.Collapsed, p.Saturations
+	return surface
+}
+
+func (g *gate) collectLatencySentinel() []gatecore.LatencySurface {
+	service := g.res.Queries.LatencySentinel.Service
+	var out []gatecore.LatencySurface
+
+	dashboardURL := g.baseURL() + "/api/metrics/dashboard?service_name=" + url.QueryEscape(service)
+	if body, status, _, _, err := g.get(dashboardURL); err != nil || status != http.StatusOK {
+		out = append(out, gatecore.LatencySurface{Name: "rest_dashboard", Error: requestError(status, err)})
+	} else {
+		var payload struct {
+			P99LatencyMS float64                `json:"p99_latency_ms"`
+			Provenance   *latencyProvenanceWire `json:"latency_provenance"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			out = append(out, gatecore.LatencySurface{Name: "rest_dashboard", Error: err.Error()})
+		} else {
+			out = append(out, latencySurface("rest_dashboard", payload.P99LatencyMS, payload.Provenance))
+		}
+	}
+
+	graphURL := g.baseURL() + "/api/system/graph"
+	if body, status, _, _, err := g.get(graphURL); err != nil || status != http.StatusOK {
+		out = append(out, gatecore.LatencySurface{Name: "rest_system_graph", Error: requestError(status, err)})
+	} else {
+		var payload struct {
+			Nodes []struct {
+				ID      string `json:"id"`
+				Metrics struct {
+					P99LatencyMS float64                `json:"p99_latency_ms"`
+					Provenance   *latencyProvenanceWire `json:"latency_provenance"`
+				} `json:"metrics"`
+			} `json:"nodes"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			out = append(out, gatecore.LatencySurface{Name: "rest_system_graph", Error: err.Error()})
+		} else {
+			found := false
+			for _, node := range payload.Nodes {
+				if node.ID == service {
+					out = append(out, latencySurface("rest_system_graph", node.Metrics.P99LatencyMS, node.Metrics.Provenance))
+					found = true
+					break
+				}
+			}
+			if !found {
+				out = append(out, gatecore.LatencySurface{Name: "rest_system_graph", Error: "sentinel service is absent"})
+			}
+		}
+	}
+
+	out = append(out, g.websocketLatencySurface(service))
+	mapCall := g.runMCPTool(gatecore.MCPToolSpec{Name: "get_service_map", Arguments: map[string]any{"service": service, "depth": 1}}, time.Time{}, time.Time{})
+	mapSurface := latencySurfaceFromMCP("mcp_get_service_map", service, mapCall.PrimaryText)
+	out = append(out, mapSurface)
+	graphRAGSurface := mapSurface
+	graphRAGSurface.Name = "graphrag_service"
+	out = append(out, graphRAGSurface)
+	healthCall := g.runMCPTool(gatecore.MCPToolSpec{Name: "get_service_health", Arguments: map[string]any{"service_name": service}}, time.Time{}, time.Time{})
+	out = append(out, latencySurfaceFromMCP("mcp_get_service_health", service, healthCall.PrimaryText))
+	return out
+}
+
+func (g *gate) websocketLatencySurface(service string) gatecore.LatencySurface {
+	name := "websocket_dashboard"
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	header := http.Header{}
+	if g.cfg.APIKey != "" {
+		header.Set("Authorization", "Bearer "+g.cfg.APIKey)
+	}
+	u := "ws" + strings.TrimPrefix(g.baseURL(), "http") + "/ws/events?service=" + url.QueryEscape(service)
+	conn, response, err := websocket.Dial(ctx, u, &websocket.DialOptions{HTTPHeader: header})
+	if response != nil && response.Body != nil {
+		_ = response.Body.Close()
+	}
+	if err != nil {
+		return gatecore.LatencySurface{Name: name, Error: err.Error()}
+	}
+	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "gate proof complete") }()
+	_, body, err := conn.Read(ctx)
+	if err != nil {
+		return gatecore.LatencySurface{Name: name, Error: err.Error()}
+	}
+	var payload struct {
+		Dashboard *struct {
+			P99Micros  int64                  `json:"p99_latency"`
+			Provenance *latencyProvenanceWire `json:"latency_provenance"`
+		} `json:"dashboard"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return gatecore.LatencySurface{Name: name, Error: err.Error()}
+	}
+	if payload.Dashboard == nil {
+		return gatecore.LatencySurface{Name: name, Error: "dashboard is absent"}
+	}
+	return latencySurface(name, float64(payload.Dashboard.P99Micros)/1000, payload.Dashboard.Provenance)
+}
+
+func latencySurfaceFromMCP(name, service, text string) gatecore.LatencySurface {
+	if text == "" {
+		return gatecore.LatencySurface{Name: name, Error: "MCP primary result text is absent"}
+	}
+	var entries []struct {
+		Service *latencyServiceWire `json:"service"`
+	}
+	if strings.HasPrefix(strings.TrimSpace(text), "[") {
+		if err := json.Unmarshal([]byte(text), &entries); err != nil {
+			return gatecore.LatencySurface{Name: name, Error: err.Error()}
+		}
+	} else {
+		var entry struct {
+			Service *latencyServiceWire `json:"service"`
+		}
+		if err := json.Unmarshal([]byte(text), &entry); err != nil {
+			return gatecore.LatencySurface{Name: name, Error: err.Error()}
+		}
+		entries = append(entries, entry)
+	}
+	for _, entry := range entries {
+		if entry.Service != nil && entry.Service.Name == service {
+			return latencySurface(name, entry.Service.P99LatencyMS, entry.Service.LatencyProvenance)
+		}
+	}
+	return gatecore.LatencySurface{Name: name, Error: "sentinel service is absent"}
+}
+
+func requestError(status int, err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return fmt.Sprintf("HTTP %d", status)
 }
 
 // get performs an authorized GET on the query client (long timeout, for the

--- a/test/gate/release.config.json
+++ b/test/gate/release.config.json
@@ -1,0 +1,11 @@
+{
+  "certification": {
+    "required": true
+  },
+  "confinement": {
+    "allow_fallback": false
+  },
+  "queries": {
+    "timeout_sec": 20
+  }
+}

--- a/test/loadsim/main.go
+++ b/test/loadsim/main.go
@@ -588,9 +588,18 @@ func main() {
 	batchInterval := flag.Duration("batch-interval", 250*time.Millisecond, "Direct engine: per-emitter batch tick")
 	callTimeout := flag.Duration("call-timeout", 30*time.Second, "Direct engine: per-Export deadline")
 	reportPath := flag.String("report", "", "Direct engine: write the JSON latency/throughput report to this path")
+	latencySentinel := flag.Bool("latency-sentinel", false, "Emit the deterministic 989x10ms + 11x1000ms aggregate latency fixture and exit")
 	ackLedgerPath := flag.String("ack-ledger", "", "Direct engine: persist the per-window attempted/ACKed contribution ledger to this path (required by the #202 recovery gate)")
 	ackLedgerFlush := flag.Duration("ack-ledger-flush", 2*time.Second, "Direct engine: how often the ACK ledger is fsynced to disk")
 	flag.Parse()
+	if *latencySentinel {
+		ctx, cancel := context.WithTimeout(context.Background(), *callTimeout)
+		defer cancel()
+		if err := emitLatencySentinel(ctx, *endpoint, *tenantID, *insecure, *reportPath); err != nil {
+			log.Fatalf("latency sentinel: %v", err)
+		}
+		return
+	}
 
 	// Apply profile if set.
 	if *profile != "" {

--- a/test/loadsim/main_test.go
+++ b/test/loadsim/main_test.go
@@ -83,6 +83,36 @@ func TestSpanFactory(t *testing.T) {
 	}
 }
 
+func TestLatencySentinelRequestIsContradictoryAndExact(t *testing.T) {
+	end := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	req := latencySentinelRequest(end)
+	if len(req.ResourceSpans) != 1 || len(req.ResourceSpans[0].ScopeSpans) != 1 {
+		t.Fatalf("sentinel request shape = %+v", req.ResourceSpans)
+	}
+	spans := req.ResourceSpans[0].ScopeSpans[0].Spans
+	if len(spans) != 1000 {
+		t.Fatalf("sentinel spans = %d, want 1000", len(spans))
+	}
+	low, tail := 0, 0
+	for _, span := range spans {
+		duration := time.Duration(span.EndTimeUnixNano - span.StartTimeUnixNano)
+		switch duration {
+		case latencySentinelLow:
+			low++
+		case latencySentinelTail:
+			tail++
+		default:
+			t.Fatalf("unexpected sentinel duration %s", duration)
+		}
+		if span.Kind.String() != "SPAN_KIND_SERVER" || len(span.ParentSpanId) != 0 {
+			t.Fatalf("sentinel span is not an independent server request: %+v", span)
+		}
+	}
+	if low != 989 || tail != 11 {
+		t.Fatalf("sentinel distribution = %d low / %d tail, want 989 / 11", low, tail)
+	}
+}
+
 // TestRateLimiter drives the ticker-based limiter for ~1 second and checks throughput.
 func TestRateLimiter(t *testing.T) {
 	const targetRPS = 50

--- a/test/loadsim/otlpdirect.go
+++ b/test/loadsim/otlpdirect.go
@@ -82,6 +82,14 @@ const (
 
 var signalNames = [kindCount]string{"spans", "logs", "metrics"}
 
+const (
+	latencySentinelService   = "latency-sentinel"
+	latencySentinelLowCount  = 989
+	latencySentinelTailCount = 11
+	latencySentinelLow       = 10 * time.Millisecond
+	latencySentinelTail      = time.Second
+)
+
 // routes are the (method, route) pairs the synthetic services serve. They are
 // derived from the existing operations pool so span names stay identical to
 // the SDK producer's.
@@ -399,6 +407,79 @@ func (e *directEmitter) buildSpans(n int) (*coltracepb.ExportTraceServiceRequest
 			}},
 		}},
 	}, contrib
+}
+
+type latencySentinelReport struct {
+	SchemaVersion string  `json:"schema_version"`
+	Service       string  `json:"service"`
+	LowCount      int     `json:"low_count"`
+	LowMS         float64 `json:"low_ms"`
+	TailCount     int     `json:"tail_count"`
+	TailMS        float64 `json:"tail_ms"`
+	ExportMS      float64 `json:"export_ms"`
+}
+
+func emitLatencySentinel(ctx context.Context, endpoint, tenantID string, useInsecure bool, reportPath string) error {
+	dialOpts := []grpc.DialOption{grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(16 << 20))}
+	if useInsecure {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+	conn, err := grpc.NewClient(endpoint, dialOpts...)
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	end := time.Now().UTC()
+	req := latencySentinelRequest(end)
+	if tenantID != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, "x-tenant-id", tenantID)
+	}
+	started := time.Now()
+	if _, err := coltracepb.NewTraceServiceClient(conn).Export(ctx, req); err != nil {
+		return fmt.Errorf("export: %w", err)
+	}
+	report := latencySentinelReport{
+		SchemaVersion: "otelcontext.latency-sentinel.v1", Service: latencySentinelService,
+		LowCount: latencySentinelLowCount, LowMS: float64(latencySentinelLow / time.Millisecond),
+		TailCount: latencySentinelTailCount, TailMS: float64(latencySentinelTail / time.Millisecond),
+		ExportMS: float64(time.Since(started)) / float64(time.Millisecond),
+	}
+	if reportPath != "" {
+		body, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(reportPath, append(body, '\n'), 0o600); err != nil {
+			return err
+		}
+	}
+	fmt.Printf("latency sentinel: service=%s low=%dx%.0fms tail=%dx%.0fms export=%.1fms\n",
+		report.Service, report.LowCount, report.LowMS, report.TailCount, report.TailMS, report.ExportMS)
+	return nil
+}
+
+func latencySentinelRequest(end time.Time) *coltracepb.ExportTraceServiceRequest {
+	spans := make([]*tracepb.Span, 0, latencySentinelLowCount+latencySentinelTailCount)
+	for i := 0; i < latencySentinelLowCount+latencySentinelTailCount; i++ {
+		duration := latencySentinelLow
+		if i >= latencySentinelLowCount {
+			duration = latencySentinelTail
+		}
+		spans = append(spans, &tracepb.Span{
+			TraceId: randomID(16), SpanId: randomID(8), Name: "GET /latency",
+			Kind:              tracepb.Span_SPAN_KIND_SERVER,
+			StartTimeUnixNano: uint64(end.Add(-duration).UnixNano()), // #nosec G115 -- current wall clock
+			EndTimeUnixNano:   uint64(end.UnixNano()),                // #nosec G115 -- current wall clock
+			Status:            &tracepb.Status{Code: tracepb.Status_STATUS_CODE_OK},
+		})
+	}
+	return &coltracepb.ExportTraceServiceRequest{ResourceSpans: []*tracepb.ResourceSpans{{
+		Resource: newResource(latencySentinelService, latencySentinelService+"-instance-0"),
+		ScopeSpans: []*tracepb.ScopeSpans{{
+			Scope: &commonpb.InstrumentationScope{Name: "otelcontext-release-gate"}, Spans: spans,
+		}},
+	}}}
 }
 
 func (e *directEmitter) randomDur() time.Duration {


### PR DESCRIPTION
## Result

Makes the aggregate gate certify the extracted signed release candidate instead of a locally rebuilt server, while preserving the historical diagnostic configuration and every query field and horizon.

## Changed

- binds tag, commit, clean checkout, signed archive, extracted server, config, gate tools, reports, and digests
- builds gate tools separately and injects the immutable tag into release binaries
- writes work and evidence outside the checkout and requires cgroup v2 plus the frozen resource limits
- makes missing phases, commands, sustained metrics, explicit zero drop counters, scalars, service counts, or degraded evidence fail
- adds exact 2,016-window, 6,000-series, 120-service and generator-derived dashboard checks
- adds cold and 20-sample warm latency checks for the dashboard and system graph, seven-day API and MCP bounds, and probe bounds
- emits the contradictory 989 x 10 ms plus 11 x 1,000 ms OTLP sentinel and verifies all six named consumers within the real scale-4 DDSketch bound
- adds the dispatch-only dedicated-runner workflow with always-uploaded evidence and a final non-zero verdict

## Targeted local verification

- go test -tags=gate -race -count=1 ./test/gate/... — passed
- go test -race -count=1 ./internal/aggregate ./internal/api — passed
- go test -tags=loadtest -count=1 ./test/loadsim — 8 passed
- go test -count=1 ./internal/aggregate ./internal/ingest — 558 passed
- focused seven-day dashboard benchmark, 2,016,000 rows — 7.537 s
- focused streaming A/B, 2,016,000 rows — 3.125 s versus 41.527 s, 13.3x faster, identical count
- exact trimpath builds for loadsim, aggprefill, and gate — passed
- actionlint for aggregate-release-gate.yml — passed with the repository custom runner label declared locally
- goreleaser check — passed
- git diff --check — passed

The multi-hour protocol is intentionally not run locally. GitHub CI owns the full repository regression suite; final signed-candidate execution remains in #254. Security hardening remains out of scope.

Closes #252