### PR TITLE
fix(mcp): honour the authenticated tenant binding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,6 +376,13 @@ Cut tools (clients now receive an `unknown tool` RPC error): `get_system_graph`,
 Cacheable surface (5s TTL via `MCP_CACHE_TTL_MS`): `get_anomaly_timeline`,
 `get_service_map`, `get_service_health`, `root_cause_analysis`, `impact_analysis`.
 
+Tenant scope: the MCP endpoint sits behind the HTTP auth gate, so a bound
+principal (tenant key or trusted external identity) pins every `tools/call`
+and the SSE stream to its tenant; a contradicting `X-Tenant-ID` is ignored and
+counted on `OtelContext_auth_tenant_conflicts_total{surface="mcp",reason="header"}`.
+Operator and unauthenticated requests keep the header-then-`DEFAULT_TENANT`
+precedence, and the 5s cache is keyed by the effective tenant.
+
 Every error-identifying tool returns a `root_cause` block:
 ```json
 {"root_cause": {"service": "...", "operation": "...", "error_message": "...", "span_id": "...", "trace_id": "..."}}

--- a/internal/mcp/bound_tenant_test.go
+++ b/internal/mcp/bound_tenant_test.go
@@ -1,0 +1,193 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
+)
+
+// mcpConflictRecorder captures authn.RecordConflict calls for one test.
+type mcpConflictRecorder struct{ calls [][2]string }
+
+func (c *mcpConflictRecorder) install(t *testing.T) {
+	t.Helper()
+	prev := authn.ConflictHook
+	t.Cleanup(func() { authn.ConflictHook = prev })
+	authn.ConflictHook = func(surface, reason string) {
+		c.calls = append(c.calls, [2]string{surface, reason})
+	}
+}
+
+// boundRequest builds an MCP request carrying a bound tenant principal, the
+// way api.AuthGate stashes it before the MCP handler runs, plus an optional
+// contradicting X-Tenant-ID header.
+func boundRequest(method, bound, header string, body []byte) *http.Request {
+	req := httptest.NewRequest(method, "/mcp", bytes.NewReader(body))
+	if header != "" {
+		req.Header.Set(mcpTenantHeader, header)
+	}
+	if bound != "" {
+		p := authn.Principal{Kind: authn.KindTenant, Tenant: bound}
+		req = req.WithContext(authn.WithPrincipal(req.Context(), p))
+	}
+	return req
+}
+
+func callServiceMapText(t *testing.T, srv *Server, req *http.Request) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeResp(t, rec.Body.Bytes())
+	if resp.Error != nil {
+		t.Fatalf("unexpected rpc error: %v", resp.Error)
+	}
+	var got ToolCallResult
+	if err := json.Unmarshal(resp.Result, &got); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	var sb strings.Builder
+	for _, c := range got.Content {
+		sb.WriteString(c.Text)
+	}
+	return sb.String()
+}
+
+// TestMCP_BoundTenant_POSTIgnoresHeader proves a tools/call from a bound
+// principal runs under the bound tenant even when X-Tenant-ID names another
+// one, and that the ignored assertion is counted on surface "mcp".
+func TestMCP_BoundTenant_POSTIgnoresHeader(t *testing.T) {
+	rec := &mcpConflictRecorder{}
+	rec.install(t)
+
+	srv := minimalServer(t)
+	srv.SetCallLimit(0)
+	srv.SetCacheTTL(5 * time.Second)
+	srv.cache.Set("acme", "get_service_map", nil, ToolCallResult{Content: []ContentItem{{Type: "text", Text: "cached-acme"}}})
+	srv.cache.Set("beta", "get_service_map", nil, ToolCallResult{Content: []ContentItem{{Type: "text", Text: "cached-beta"}}})
+
+	body := jsonRPCCallToolBody(t, "get_service_map", nil)
+	if got := callServiceMapText(t, srv, boundRequest(http.MethodPost, "acme", "beta", body)); got != "cached-acme" {
+		t.Fatalf("bound principal did not run under its tenant: got %q", got)
+	}
+	if len(rec.calls) != 1 || rec.calls[0] != [2]string{"mcp", "header"} {
+		t.Fatalf("conflict calls = %v, want [[mcp header]]", rec.calls)
+	}
+
+	// A header that agrees with the binding is not a conflict.
+	rec.calls = nil
+	if got := callServiceMapText(t, srv, boundRequest(http.MethodPost, "acme", "acme", body)); got != "cached-acme" {
+		t.Fatalf("agreeing header changed the tenant: got %q", got)
+	}
+	if len(rec.calls) != 0 {
+		t.Fatalf("agreeing header counted as conflict: %v", rec.calls)
+	}
+}
+
+// TestMCP_BoundTenant_CacheIsolated proves two bound principals asking for
+// the same cacheable tool get their own cache entries.
+func TestMCP_BoundTenant_CacheIsolated(t *testing.T) {
+	srv := minimalServer(t)
+	srv.SetCallLimit(0)
+	srv.SetCacheTTL(5 * time.Second)
+	srv.cache.Set("tenant-a", "get_service_map", nil, ToolCallResult{Content: []ContentItem{{Type: "text", Text: "cached-a"}}})
+
+	body := jsonRPCCallToolBody(t, "get_service_map", nil)
+	if got := callServiceMapText(t, srv, boundRequest(http.MethodPost, "tenant-a", "", body)); got != "cached-a" {
+		t.Fatalf("tenant-a: got %q, want cached-a", got)
+	}
+	if got := callServiceMapText(t, srv, boundRequest(http.MethodPost, "tenant-b", "", body)); got == "cached-a" {
+		t.Fatalf("tenant-b received tenant-a's cached result")
+	}
+	if hits := srv.Stats().CacheHits; hits != 1 {
+		t.Fatalf("CacheHits = %d, want 1", hits)
+	}
+}
+
+// TestMCP_UnauthenticatedHeaderSelectsTenant is the regression guard: with
+// no principal on the context the header still picks the tenant.
+func TestMCP_UnauthenticatedHeaderSelectsTenant(t *testing.T) {
+	rec := &mcpConflictRecorder{}
+	rec.install(t)
+
+	srv := minimalServer(t)
+	srv.SetCallLimit(0)
+	srv.SetCacheTTL(5 * time.Second)
+	srv.cache.Set("beta", "get_service_map", nil, ToolCallResult{Content: []ContentItem{{Type: "text", Text: "cached-beta"}}})
+
+	body := jsonRPCCallToolBody(t, "get_service_map", nil)
+	if got := callServiceMapText(t, srv, boundRequest(http.MethodPost, "", "beta", body)); got != "cached-beta" {
+		t.Fatalf("header tenant not honoured without a principal: got %q", got)
+	}
+	if len(rec.calls) != 0 {
+		t.Fatalf("unauthenticated request counted a conflict: %v", rec.calls)
+	}
+
+	// An operator principal is not bound and keeps the header precedence.
+	req := boundRequest(http.MethodPost, "", "beta", body)
+	req = req.WithContext(authn.WithPrincipal(req.Context(), authn.Principal{Kind: authn.KindOperator}))
+	if got := callServiceMapText(t, srv, req); got != "cached-beta" {
+		t.Fatalf("operator header tenant not honoured: got %q", got)
+	}
+}
+
+// tenantRecordingProvider records the tenant on the context it was called
+// with, so the SSE test can observe which tenant the stream runs under.
+type tenantRecordingProvider struct {
+	fakeMCPTopologyProvider
+	seen []string
+}
+
+func (p *tenantRecordingProvider) Identity(ctx context.Context) topology.Identity {
+	p.seen = append(p.seen, storage.TenantFromContext(ctx))
+	return p.fakeMCPTopologyProvider.Identity(ctx)
+}
+
+func (p *tenantRecordingProvider) Snapshot(ctx context.Context, q topology.Query) (topology.Snapshot, error) {
+	p.seen = append(p.seen, storage.TenantFromContext(ctx))
+	return p.fakeMCPTopologyProvider.Snapshot(ctx, q)
+}
+
+// TestMCP_BoundTenant_SSEIgnoresHeader proves the SSE stream's tenant
+// context is the bound one, not the contradicting header.
+func TestMCP_BoundTenant_SSEIgnoresHeader(t *testing.T) {
+	rec := &mcpConflictRecorder{}
+	rec.install(t)
+
+	provider := &tenantRecordingProvider{fakeMCPTopologyProvider: fakeMCPTopologyProvider{
+		epoch:    "boot-a",
+		snapshot: topology.Snapshot{Nodes: []topology.Node{{Name: "gateway"}}, Meta: topology.Metadata{Coverage: "full"}},
+	}}
+	provider.revision.Store(1)
+	srv := New("default", nil, nil, provider)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := boundRequest(http.MethodGet, "acme", "beta", nil).WithContext(
+		authn.WithPrincipal(ctx, authn.Principal{Kind: authn.KindTenant, Tenant: "acme"}))
+	recorder := httptest.NewRecorder()
+	srv.handleSSE(recorder, req)
+
+	if len(provider.seen) == 0 {
+		t.Fatalf("provider never called: %s", recorder.Body.String())
+	}
+	for _, tenant := range provider.seen {
+		if tenant != "acme" {
+			t.Fatalf("SSE ran under tenant %q, want acme (seen %v)", tenant, provider.seen)
+		}
+	}
+	if len(rec.calls) != 1 || rec.calls[0] != [2]string{"mcp", "header"} {
+		t.Fatalf("conflict calls = %v, want [[mcp header]]", rec.calls)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/authn"
 	"github.com/RandomCodeSpace/otelcontext/internal/graph"
 	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
 	"github.com/RandomCodeSpace/otelcontext/internal/httpconst"
@@ -290,12 +291,8 @@ func (s *Server) handleRPC(w http.ResponseWriter, r *http.Request) {
 			rpcErr = &RPCError{Code: ErrInvalidParams, Message: "invalid tools/call params"}
 			break
 		}
-		// Resolve tenant from the MCP HTTP transport: header wins, else default.
 		// Downstream tool handlers pull the tenant off ctx via mcpCtx(r.Context()).
-		tenant := strings.TrimSpace(r.Header.Get(mcpTenantHeader))
-		if tenant == "" {
-			tenant = s.defaultTenant
-		}
+		tenant := s.requestTenant(r)
 		cacheTenant := s.topologyCacheScope(r.Context(), tenant, params.Name)
 
 		// Cache fast-path: cheap, idempotent GraphRAG tools are memoized
@@ -388,11 +385,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	// Send initial endpoint event per MCP Streamable HTTP spec.
 	writeSSE(w, flusher, "endpoint", `{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`)
-	tenant := strings.TrimSpace(r.Header.Get(mcpTenantHeader))
-	if tenant == "" {
-		tenant = s.defaultTenant
-	}
-	ctx := storage.WithTenantContext(r.Context(), tenant)
+	ctx := storage.WithTenantContext(r.Context(), s.requestTenant(r))
 	lastIdentity := topology.Identity{}
 	haveIdentity := false
 	if data, identity, ok := s.topologyNotification(ctx, lastIdentity, haveIdentity); ok {
@@ -542,6 +535,25 @@ func (s *Server) topologyNotification(ctx context.Context, last topology.Identit
 		return "", topology.Identity{}, false
 	}
 	return string(notificationJSON), identity, true
+}
+
+// requestTenant resolves the tenant an MCP request runs under. A bound
+// principal (tenant key or trusted external identity, stashed on the context
+// by the HTTP auth gate) pins the tenant: a contradicting X-Tenant-ID is
+// ignored and counted on the auth conflict counter. Operator and
+// unauthenticated requests keep the header-then-default precedence.
+func (s *Server) requestTenant(r *http.Request) string {
+	asserted := strings.TrimSpace(r.Header.Get(mcpTenantHeader))
+	if bound, ok := authn.BoundTenantFromContext(r.Context()); ok {
+		if asserted != "" && storage.SanitizeTenantID(asserted) != bound {
+			authn.RecordConflict("mcp", "header")
+		}
+		return bound
+	}
+	if asserted == "" {
+		return s.defaultTenant
+	}
+	return asserted
 }
 
 func (s *Server) topologyCacheScope(ctx context.Context, tenant, tool string) string {


### PR DESCRIPTION
Closes production-readiness review blocker 5 (multi-tenant MCP identity correctness), which the epic #243 left unowned.

## Baseline
`internal/mcp/server.go` derived the tenant from the client-controlled `X-Tenant-ID` header on both the JSON-RPC POST and SSE paths and never consulted the principal the HTTP auth gate had already bound, so a tenant-key client could name any tenant.

## Change
One helper, `requestTenant`, used by both paths: a bound principal (`authn.BoundTenantFromContext`) wins; a contradicting header is ignored and counted on `OtelContext_auth_tenant_conflicts_total{surface="mcp",reason="header"}`; operator and unauthenticated requests keep header-then-default precedence. No tool reads a tenant from JSON arguments. The 5s cache already keys on the tenant value, which is now the bound one. One paragraph in CLAUDE.md.

## Verified locally
gofmt, `go vet ./internal/mcp ./internal/authn`, `go test -race -count=1 ./internal/mcp ./internal/authn ./internal/api` (242 passed) including new tests for POST, SSE, cache isolation across two bound tenants, and the unauthenticated regression guard.

## Note
A bound request with a contradicting header is now counted on both the http and mcp surfaces, since the auth gate wraps /mcp. Report-only.

## Compatibility and rollback
No route, field, or config change. Single-tenant deployments are unaffected. Revert the commit.