### PR TITLE
fix(release): archive the systemd files under their own paths

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,10 +35,12 @@ archives:
     files:
       - LICENSE.md
       - README.md
-      - src: deploy/systemd/otelcontext.service
-        dst: deploy/systemd
-      - src: deploy/systemd/otelcontext.env.example
-        dst: deploy/systemd
+      # Plain paths keep their directory inside the archive. A src/dst pair
+      # treats dst as the destination file name, which collapsed both files
+      # into one entry called deploy/systemd (caught by verify-assets on
+      # v0.4.0-rc.1).
+      - deploy/systemd/otelcontext.service
+      - deploy/systemd/otelcontext.env.example
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
Corrective commit for the failed candidate `v0.4.0-rc.1` (issue #254, run 33746978223).

## Baseline
`.goreleaser.yaml` listed the two systemd files as `src`/`dst` pairs with `dst: deploy/systemd`. GoReleaser treats `dst` as the destination file name, so every archive contained one 610-byte entry named `deploy/systemd` and neither real file. `verify signed assets` refused the draft and all downstream proofs were skipped, as designed.

## Change
Plain path entries, which keep their directory inside the archive. One config file, no product change.

## Verified locally
`goreleaser check`; `goreleaser release --snapshot --skip=sign,sbom,publish,validate` then `tar -tzf` on all four archives: each lists exactly `LICENSE.md README.md deploy/systemd/otelcontext.env.example deploy/systemd/otelcontext.service otelcontext`.

## Rollback
Revert. The rc.1 draft stays unpublished as evidence; the next candidate is `v0.4.0-rc.2`.