### PR TITLE
fix: make the rc.2 release gate failures pass on every adapter

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -696,12 +696,15 @@ jobs:
           http_port="$(free_port)"
           grpc_port="$(free_port)"
           started_ms="$(date +%s%3N)"
+          # The hosted runner volume is far above the 8 GiB default data budget,
+          # which would put the disk watchdog into raw_off and fail /ready.
           env \
             AGGREGATE_MODE=legacy \
             APP_ENV=development \
             DB_DRIVER=sqlite \
             DB_DSN="${state}/otelcontext.db" \
             DATA_DISK_PATH="${state}" \
+            DATA_DISK_BUDGET_MB=1000000 \
             DLQ_PATH="${state}/dlq" \
             HTTP_PORT="${http_port}" \
             GRPC_PORT="${grpc_port}" \

--- a/internal/storage/compression_test.go
+++ b/internal/storage/compression_test.go
@@ -25,8 +25,9 @@ func TestCompressedText(t *testing.T) {
 			}
 
 			if tt.text == "" {
-				if value != "" {
-					t.Errorf("Expected empty value for empty text, got %v", value)
+				empty, ok := value.([]byte)
+				if !ok || len(empty) != 0 {
+					t.Errorf("Expected empty []byte for empty text, got %T %v", value, value)
 				}
 				return
 			}

--- a/internal/storage/exemplar_purge.go
+++ b/internal/storage/exemplar_purge.go
@@ -68,7 +68,7 @@ func (r *Repository) PurgeExemplarsBatched(ctx context.Context, cutoff time.Time
 		var traces, spans int64
 		err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 			res := tx.Exec(
-				"DELETE FROM traces WHERE id IN (SELECT id FROM traces WHERE timestamp < ? ORDER BY id LIMIT ?)",
+				batchedDeleteSQL(r.driver, "traces", "timestamp < ?"),
 				cutoff, batchSize,
 			)
 			if res.Error != nil {
@@ -81,7 +81,7 @@ func (r *Repository) PurgeExemplarsBatched(ctx context.Context, cutoff time.Time
 			// yet (Export writes traces and spans separately) is never a
 			// candidate.
 			res = tx.Exec(
-				"DELETE FROM spans WHERE id IN (SELECT id FROM spans WHERE start_time < ? AND trace_id NOT IN (SELECT trace_id FROM traces) ORDER BY id LIMIT ?)",
+				batchedDeleteSQL(r.driver, "spans", "start_time < ? AND trace_id NOT IN (SELECT trace_id FROM traces)"),
 				cutoff, batchSize,
 			)
 			if res.Error != nil {
@@ -111,7 +111,7 @@ func (r *Repository) PurgeExemplarsBatched(ctx context.Context, cutoff time.Time
 		var logs int64
 		err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 			res := tx.Exec(
-				"DELETE FROM logs WHERE id IN (SELECT id FROM logs WHERE timestamp < ? ORDER BY id LIMIT ?)",
+				batchedDeleteSQL(r.driver, "logs", "timestamp < ?"),
 				cutoff, batchSize,
 			)
 			if res.Error != nil {
@@ -141,7 +141,7 @@ func (r *Repository) PurgeExemplarsBatched(ctx context.Context, cutoff time.Time
 			return stats, err
 		}
 		res := r.db.WithContext(ctx).Exec(
-			"DELETE FROM spans WHERE id IN (SELECT id FROM spans WHERE start_time < ? AND trace_id NOT IN (SELECT trace_id FROM traces) ORDER BY id LIMIT ?)",
+			batchedDeleteSQL(r.driver, "spans", "start_time < ? AND trace_id NOT IN (SELECT trace_id FROM traces)"),
 			cutoff, batchSize,
 		)
 		if res.Error != nil {

--- a/internal/storage/log_repo.go
+++ b/internal/storage/log_repo.go
@@ -239,7 +239,7 @@ func (r *Repository) PurgeLogsBatched(ctx context.Context, olderThan time.Time, 
 			return total, err
 		}
 		result := r.db.WithContext(ctx).Exec(
-			"DELETE FROM logs WHERE id IN (SELECT id FROM logs WHERE timestamp < ? ORDER BY id LIMIT ?)",
+			batchedDeleteSQL(driver, "logs", "timestamp < ?"),
 			olderThan, batchSize,
 		)
 		if result.Error != nil {

--- a/internal/storage/metrics_repo.go
+++ b/internal/storage/metrics_repo.go
@@ -379,7 +379,7 @@ func (r *Repository) PurgeMetricBucketsBatched(ctx context.Context, olderThan ti
 			return total, err
 		}
 		result := r.db.WithContext(ctx).Exec(
-			"DELETE FROM metric_buckets WHERE id IN (SELECT id FROM metric_buckets WHERE time_bucket < ? ORDER BY id LIMIT ?)",
+			batchedDeleteSQL(driver, "metric_buckets", "time_bucket < ?"),
 			olderThan, batchSize,
 		)
 		if result.Error != nil {

--- a/internal/storage/models.go
+++ b/internal/storage/models.go
@@ -34,7 +34,9 @@ func (CompressedText) GormDBDataType(db *gorm.DB, _ *schema.Field) string {
 
 func (ct CompressedText) Value() (driver.Value, error) {
 	if ct == "" {
-		return "", nil
+		// The column is binary on every dialect; a string parameter cannot be
+		// bound to varbinary on SQL Server (error 257), so bind empty bytes.
+		return []byte{}, nil
 	}
 	compressed := compress.Compress([]byte(ct))
 	// Prepend magic header to identify compressed data

--- a/internal/storage/purge_sql.go
+++ b/internal/storage/purge_sql.go
@@ -1,0 +1,35 @@
+package storage
+
+import (
+	"fmt"
+	"strings"
+)
+
+// batchedDeleteSQL returns a DELETE that removes at most one batch of rows
+// from table matching predicate, oldest id first. The statement takes the
+// predicate's arguments followed by the batch size, in that order, on every
+// driver.
+//
+// PostgreSQL and SQLite accept a LIMIT inside the id subquery. MySQL refuses a
+// subquery that reads the table being deleted from (error 1093) unless it is
+// wrapped in a derived table. SQL Server has no LIMIT and only allows ORDER BY
+// in a subquery together with OFFSET/FETCH.
+func batchedDeleteSQL(driver, table, predicate string) string {
+	switch strings.ToLower(driver) {
+	case "mysql":
+		return fmt.Sprintf(
+			"DELETE FROM %s WHERE id IN (SELECT id FROM (SELECT id FROM %s WHERE %s ORDER BY id LIMIT ?) AS purge_batch)",
+			table, table, predicate,
+		)
+	case "mssql", "sqlserver":
+		return fmt.Sprintf(
+			"DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE %s ORDER BY id OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY)",
+			table, table, predicate,
+		)
+	default:
+		return fmt.Sprintf(
+			"DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE %s ORDER BY id LIMIT ?)",
+			table, table, predicate,
+		)
+	}
+}

--- a/internal/storage/purge_sql_test.go
+++ b/internal/storage/purge_sql_test.go
@@ -1,0 +1,21 @@
+package storage
+
+import "testing"
+
+func TestBatchedDeleteSQL(t *testing.T) {
+	cases := []struct {
+		driver string
+		want   string
+	}{
+		{"postgres", "DELETE FROM logs WHERE id IN (SELECT id FROM logs WHERE timestamp < ? ORDER BY id LIMIT ?)"},
+		{"sqlite", "DELETE FROM logs WHERE id IN (SELECT id FROM logs WHERE timestamp < ? ORDER BY id LIMIT ?)"},
+		{"mysql", "DELETE FROM logs WHERE id IN (SELECT id FROM (SELECT id FROM logs WHERE timestamp < ? ORDER BY id LIMIT ?) AS purge_batch)"},
+		{"mssql", "DELETE FROM logs WHERE id IN (SELECT id FROM logs WHERE timestamp < ? ORDER BY id OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY)"},
+		{"sqlserver", "DELETE FROM logs WHERE id IN (SELECT id FROM logs WHERE timestamp < ? ORDER BY id OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY)"},
+	}
+	for _, c := range cases {
+		if got := batchedDeleteSQL(c.driver, "logs", "timestamp < ?"); got != c.want {
+			t.Errorf("%s:\n got %s\nwant %s", c.driver, got, c.want)
+		}
+	}
+}

--- a/internal/storage/trace_repo.go
+++ b/internal/storage/trace_repo.go
@@ -539,7 +539,7 @@ func (r *Repository) PurgeTracesBatched(ctx context.Context, olderThan time.Time
 			return total, err
 		}
 		result := r.db.WithContext(ctx).Exec(
-			"DELETE FROM traces WHERE id IN (SELECT id FROM traces WHERE timestamp < ? ORDER BY id LIMIT ?)",
+			batchedDeleteSQL(r.driver, "traces", "timestamp < ?"),
 			olderThan, batchSize,
 		)
 		if result.Error != nil {
@@ -564,7 +564,7 @@ func (r *Repository) PurgeTracesBatched(ctx context.Context, olderThan time.Time
 			return total, err
 		}
 		result := r.db.WithContext(ctx).Exec(
-			"DELETE FROM spans WHERE id IN (SELECT id FROM spans WHERE start_time < ? AND trace_id NOT IN (SELECT trace_id FROM traces) ORDER BY id LIMIT ?)",
+			batchedDeleteSQL(r.driver, "spans", "start_time < ? AND trace_id NOT IN (SELECT trace_id FROM traces)"),
 			olderThan, batchSize,
 		)
 		if result.Error != nil {

--- a/test/dbcontract/dbcontract_test.go
+++ b/test/dbcontract/dbcontract_test.go
@@ -567,8 +567,14 @@ func fingerprintRows(t *testing.T, driver, dsn string, value fixture, stale bool
 	}{
 		"traces": {"trace_id", traceIDs}, "spans": {"span_id", spanIDs}, "logs": {"body", logBodies}, "metric_buckets": {"name", metricNames},
 	} {
+		column := query.column
+		if driver == "mssql" && table == "logs" {
+			// logs.body is a text column on SQL Server, which cannot be
+			// compared with IN; compare its nvarchar cast instead.
+			column = "CAST(body AS NVARCHAR(MAX))"
+		}
 		var count int64
-		if err := db.Table(table).Where(query.column+" IN ?", query.values).Count(&count).Error; err != nil {
+		if err := db.Table(table).Where(column+" IN ?", query.values).Count(&count).Error; err != nil {
 			t.Fatalf("count %s: %v", table, err)
 		}
 		switch table {


### PR DESCRIPTION
## Why

The v0.4.0-rc.2 draft failed its release gate in three places. All three are defects in the candidate or the gate, not in the tag, so the tag stays unpublished and the next candidate is rc.3.

## What

- **linux arm64 smoke.** The hosted runner volume is far above the 8 GiB default data budget, so the disk watchdog entered `raw_off` and `/ready` answered 503. The smoke now sets `DATA_DISK_PATH` to its state directory and `DATA_DISK_BUDGET_MB=1000000`, matching the database-proof harness.
- **MySQL lifecycle.** Every batched purge statement failed with error 1093 (DELETE subquery selects from the target table), so stale rows were never purged. `batchedDeleteSQL` derives the statement per driver; SQL Server gets `OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY` since it has no `LIMIT`.
- **SQL Server lifecycle.** `CompressedText` bound an empty value as a string, and SQL Server refuses the nvarchar-to-varbinary(max) conversion (error 257), so every span and log row with empty `attributes_json` was rejected inside `BatchCreateAll`. The empty value now binds as empty bytes on every dialect. The harness also compared `logs.body` with `IN`, which SQL Server rejects on a text column; it compares the nvarchar cast there.

## Proof

- `go test ./internal/...` green (1493 tests).
- Database lifecycle harness run locally against `mysql:8.4.11` and `mssql/server:2022-CU26` with the fixed binary: both pass, native restore fingerprints match, no failed assertions.
- The hosted CI database gate covers SQLite and Postgres on this PR; MySQL and SQL Server run in the release gate.

Refs #254.