### PR TITLE
feat(ingest): give host-only telemetry a home and allow resource-sourced dims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ most recently published tag.
 
 ### Changed
 
+- Host-only telemetry has a home (#280, #287): a resource carrying `host.name`
+  or `host.id` and no `service.name` is identified as `host/<host.name>`
+  (`host/<host.id>` without a name) in legacy and aggregate modes, so
+  hostmetrics no longer collapse across hosts under `unknown-service`. A
+  resource with neither attribute keeps `unknown-service`. The `host/` prefix
+  is reserved: a client-declared `service.name` inside it is accepted as sent
+  and counted on `otelcontext_ingest_reserved_service_prefix_total{signal}`.
+- `AGGREGATE_METRIC_DIMS` keys fall back to the resource attribute when the
+  point lacks them (#279), so `system.cpu.utilization:host.name` splits per
+  host. A key missing from both point and resource still yields `DimsID=0`;
+  the dim caps and `otelcontext_ingest_metrics_dims_rejected_total` are
+  unchanged.
 - Dashboard, traffic, service-map, and WebSocket reads come from the
   aggregate engine in aggregate mode; the UI shows coverage badges,
   accuracy labels, and epoch-aware WebSocket state.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,10 @@ unbounded bucket.
 
 **Dimensions.** Configured `AGGREGATE_METRIC_DIMS` keys are extracted from each
 point's attributes into the SeriesKey `DimsID`, identically for all three point
-types. Missing any configured key yields `DimsID=0` (all-or-nothing). String,
+types. A key the point lacks falls back to the same key on the resource
+attributes (#279), which is how `system.cpu.utilization:host.name` splits per
+host; a point attribute always outranks the resource one. Missing any
+configured key from both yields `DimsID=0` (all-or-nothing). String,
 int, bool and double attribute values are supported; array and kvlist values
 are refused from identity and counted on
 `otelcontext_ingest_metrics_dims_rejected_total{reason="unsupported_value_type"}`.

--- a/internal/aggregate/dims_config.go
+++ b/internal/aggregate/dims_config.go
@@ -101,14 +101,23 @@ type dimScratch struct {
 	buf   []byte
 }
 
-// resolve extracts the configured tuple for keys out of attrs.
-//
-// It returns ok=false when any configured key is absent or carries an empty
-// value -- the all-or-nothing contract, which exists because a partial tuple is
-// a different series wearing the same name. rejected=true additionally reports
-// that a key WAS present but its value had no scalar rendering, which is worth
-// a counter: the operator configured a dimension that can never bind.
+// resolve extracts the configured tuple for keys out of attrs alone.
 func (s *dimScratch) resolve(keys []string, attrs []*commonpb.KeyValue) (vals []string, rejected, ok bool) {
+	return s.resolveWith(keys, attrs, nil)
+}
+
+// resolveWith extracts the configured tuple for keys out of attrs, falling
+// back to resourceAttrs for every key the point lacks (#279): a host-level
+// dimension such as host.name lives on the resource, never on the point. A
+// point attribute always outranks the resource attribute of the same key.
+//
+// It returns ok=false when any configured key is absent from both or carries
+// an empty value -- the all-or-nothing contract, which exists because a
+// partial tuple is a different series wearing the same name. rejected=true
+// additionally reports that a key WAS present but its value had no scalar
+// rendering, which is worth a counter: the operator configured a dimension
+// that can never bind.
+func (s *dimScratch) resolveWith(keys []string, attrs, resourceAttrs []*commonpb.KeyValue) (vals []string, rejected, ok bool) {
 	n := len(keys)
 	if n == 0 || n > MaxDimensionKeys {
 		return nil, false, false
@@ -117,7 +126,26 @@ func (s *dimScratch) resolve(keys []string, attrs []*commonpb.KeyValue) (vals []
 		s.vals[i] = ""
 		s.found[i] = false
 	}
-	remaining := n
+	remaining, rejected := s.scan(keys, attrs, n)
+	if rejected {
+		return nil, true, false
+	}
+	if remaining != 0 && len(resourceAttrs) > 0 {
+		if remaining, rejected = s.scan(keys, resourceAttrs, remaining); rejected {
+			return nil, true, false
+		}
+	}
+	if remaining != 0 {
+		return nil, false, false
+	}
+	return s.vals[:n], false, true
+}
+
+// scan fills the not-yet-found slots of keys from attrs. It returns how many
+// slots are still empty, and rejected=true on a value with no scalar
+// rendering.
+func (s *dimScratch) scan(keys []string, attrs []*commonpb.KeyValue, remaining int) (int, bool) {
+	n := len(keys)
 	for _, kv := range attrs {
 		if kv == nil || kv.Value == nil || remaining == 0 {
 			continue
@@ -134,7 +162,7 @@ func (s *dimScratch) resolve(keys []string, attrs []*commonpb.KeyValue) (vals []
 		}
 		v, scalar := s.scalarValue(kv.Value)
 		if !scalar {
-			return nil, true, false
+			return remaining, true
 		}
 		if v == "" {
 			// An empty value cannot be interned: the dictionary refuses a
@@ -146,10 +174,7 @@ func (s *dimScratch) resolve(keys []string, attrs []*commonpb.KeyValue) (vals []
 		s.found[idx] = true
 		remaining--
 	}
-	if remaining != 0 {
-		return nil, false, false
-	}
-	return s.vals[:n], false, true
+	return remaining, false
 }
 
 // scalarValue renders an OTLP attribute value as its canonical dimension

--- a/internal/aggregate/dims_resource_test.go
+++ b/internal/aggregate/dims_resource_test.go
@@ -1,0 +1,130 @@
+package aggregate
+
+import (
+	"testing"
+	"time"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+)
+
+// #279: a configured dimension key the point lacks falls back to the same key
+// on the resource attributes. Only a key missing from BOTH yields DimsID 0.
+
+// resourceDimsIDs reduces one point of each shape carrying attrs and
+// resource, and returns the DimsID each landed on.
+func resourceDimsIDs(t *testing.T, r *Reducer, now time.Time, attrs, resource []*commonpb.KeyValue) []uint32 {
+	t.Helper()
+
+	r.ReduceMetricPoint(MetricInput{Tenant: "acme", Service: "checkout", Name: histTestMetric,
+		Value: 1, Timestamp: now, Temporality: TemporalityDelta, Attributes: attrs, ResourceAttributes: resource})
+
+	hist := histPoint(histTestBounds, []uint64{0, 5, 7, 0})
+	hist.Timestamp, hist.Attributes, hist.ResourceAttributes = now, attrs, resource
+	if res := r.ReduceHistogramPoint(hist); res.Rejected() {
+		t.Fatalf("histogram rejected: %v", res.Err)
+	}
+
+	exp := expPointFromValues(SketchDefaultScale, histTestValues)
+	exp.Timestamp, exp.Attributes, exp.ResourceAttributes = now, attrs, resource
+	if res := r.ReduceExponentialHistogramPoint(exp); res.Rejected() {
+		t.Fatalf("exponential rejected: %v", res.Err)
+	}
+
+	ids := make([]uint32, 0, len(r.Deltas()))
+	for swk := range r.Deltas() {
+		ids = append(ids, swk.Key.DimsID)
+	}
+	return ids
+}
+
+func TestDimsFallBackToResourceAttributes(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := dimsEngine(t, now)
+
+	fromPoint := e.NewReducer(now)
+	pointIDs := resourceDimsIDs(t, fromPoint, now,
+		[]*commonpb.KeyValue{attr("http.method", "GET"), intAttr("http.status", 200)}, nil)
+
+	fromResource := e.NewReducer(now)
+	resourceIDs := resourceDimsIDs(t, fromResource, now,
+		[]*commonpb.KeyValue{attr("http.method", "GET")},
+		[]*commonpb.KeyValue{attr("host.name", "node-a"), intAttr("http.status", 200)})
+
+	if len(pointIDs) != 1 || len(resourceIDs) != 1 {
+		t.Fatalf("series = %v / %v, want one each", pointIDs, resourceIDs)
+	}
+	if resourceIDs[0] == 0 {
+		t.Fatal("resource-sourced dimension resolved to DimsID 0")
+	}
+	if resourceIDs[0] != pointIDs[0] {
+		t.Fatalf("resource-sourced tuple interned to %d, point-sourced to %d; the same tuple must be the same series",
+			resourceIDs[0], pointIDs[0])
+	}
+	if got := fromResource.Stats().DimsRejected; got != 0 {
+		t.Errorf("dims rejected = %d, want 0", got)
+	}
+}
+
+func TestDimsPointAttributeOutranksResource(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	e := dimsEngine(t, now)
+
+	ok200 := resourceDimsIDs(t, e.NewReducer(now), now,
+		[]*commonpb.KeyValue{attr("http.method", "GET"), intAttr("http.status", 200)}, nil)
+	both := resourceDimsIDs(t, e.NewReducer(now), now,
+		[]*commonpb.KeyValue{attr("http.method", "GET"), intAttr("http.status", 200)},
+		[]*commonpb.KeyValue{intAttr("http.status", 500)})
+	if len(both) != 1 || both[0] != ok200[0] {
+		t.Fatalf("point+resource tuple = %v, want the point-only identity %v", both, ok200)
+	}
+}
+
+func TestDimsMissingFromPointAndResourceIsZero(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	r := dimsEngine(t, now).NewReducer(now)
+
+	ids := resourceDimsIDs(t, r, now,
+		[]*commonpb.KeyValue{attr("http.method", "GET")},
+		[]*commonpb.KeyValue{attr("host.name", "node-a")})
+	if len(ids) != 1 || ids[0] != 0 {
+		t.Fatalf("tuple missing from both produced %v, want a single DimsID 0", ids)
+	}
+	if got := r.Stats().DimsRejected; got != 0 {
+		t.Errorf("dims rejected = %d, want 0 (absent is not rejected)", got)
+	}
+}
+
+func TestDimsRejectsNonScalarResourceValue(t *testing.T) {
+	now := mustTime(t, "2026-08-21T12:00:00Z")
+	r := dimsEngine(t, now).NewReducer(now)
+
+	arrayAttr := &commonpb.KeyValue{Key: "http.status", Value: &commonpb.AnyValue{
+		Value: &commonpb.AnyValue_ArrayValue{ArrayValue: &commonpb.ArrayValue{}}}}
+	ids := resourceDimsIDs(t, r, now,
+		[]*commonpb.KeyValue{attr("http.method", "GET")},
+		[]*commonpb.KeyValue{arrayAttr})
+	if len(ids) != 1 || ids[0] != 0 {
+		t.Fatalf("array resource dimension produced %v, want a single DimsID 0", ids)
+	}
+	if got := r.Stats().DimsRejected; got != 3 {
+		t.Errorf("dims rejected = %d, want 3 (one per point shape)", got)
+	}
+}
+
+// TestDimsResourceFallbackDoesNotAllocatePerPoint keeps the #199 Q4 hot-path
+// requirement with the resource scan in place.
+func TestDimsResourceFallbackDoesNotAllocatePerPoint(t *testing.T) {
+	keys := []string{"host.name", "http.method"}
+	attrs := []*commonpb.KeyValue{attr("http.method", "GET"), attr("noise", "x")}
+	resource := []*commonpb.KeyValue{attr("service.name", "checkout"), attr("host.name", "node-a")}
+	var s dimScratch
+	s.resolveWith(keys, attrs, resource)
+	allocs := testing.AllocsPerRun(100, func() {
+		if _, _, ok := s.resolveWith(keys, attrs, resource); !ok {
+			t.Fatal("resolveWith failed")
+		}
+	})
+	if allocs != 0 {
+		t.Errorf("resolveWith allocated %v times per point, want 0", allocs)
+	}
+}

--- a/internal/aggregate/histogram.go
+++ b/internal/aggregate/histogram.go
@@ -140,6 +140,9 @@ type HistogramCommon struct {
 
 	Temporality Temporality
 	Attributes  []*commonpb.KeyValue
+	// ResourceAttributes are the RAW OTLP resource attributes; a configured
+	// dimension key the point lacks falls back to them (#279).
+	ResourceAttributes []*commonpb.KeyValue
 
 	Count  uint64
 	Sum    float64

--- a/internal/aggregate/reducer.go
+++ b/internal/aggregate/reducer.go
@@ -147,6 +147,9 @@ type MetricInput struct {
 	// tuple is extracted from them here, against a request-local scratch, so
 	// the hot path never allocates a per-point map (#199 Q4).
 	Attributes []*commonpb.KeyValue
+	// ResourceAttributes are the RAW OTLP resource attributes; a configured
+	// dimension key the point lacks falls back to them (#279).
+	ResourceAttributes []*commonpb.KeyValue
 }
 
 // Reducer collapses one Export request into deltas.
@@ -422,12 +425,14 @@ func (r *Reducer) ReduceLog(in LogInput) {
 	}
 }
 
-// dimsIDFor resolves the DimsID of one metric point from its attributes.
+// dimsIDFor resolves the DimsID of one metric point from its attributes,
+// falling back to the resource attributes for a key the point lacks (#279).
 //
-// Missing any configured key yields 0, the "no configured dims" sentinel and
-// the existing all-or-nothing contract. The scan allocates no per-point map:
-// the configured tuple is bounded, so a request-local scratch holds it.
-func (r *Reducer) dimsIDFor(tenantID uint32, metricName string, attrs []*commonpb.KeyValue) uint32 {
+// Missing any configured key from both yields 0, the "no configured dims"
+// sentinel and the existing all-or-nothing contract. The scan allocates no
+// per-point map: the configured tuple is bounded, so a request-local scratch
+// holds it.
+func (r *Reducer) dimsIDFor(tenantID uint32, metricName string, attrs, resourceAttrs []*commonpb.KeyValue) uint32 {
 	keys := r.eng.dims.Get(metricName)
 	if len(keys) == 0 {
 		return 0
@@ -435,7 +440,7 @@ func (r *Reducer) dimsIDFor(tenantID uint32, metricName string, attrs []*commonp
 	if r.dims == nil {
 		r.dims = &dimScratch{}
 	}
-	values, rejected, ok := r.dims.resolve(keys, attrs)
+	values, rejected, ok := r.dims.resolveWith(keys, attrs, resourceAttrs)
 	if rejected {
 		r.stats.DimsRejected++
 	}
@@ -448,12 +453,12 @@ func (r *Reducer) dimsIDFor(tenantID uint32, metricName string, attrs []*commonp
 // metricSeriesKey builds the metric SeriesKey for one point, including its
 // configured dimension tuple. It is shared by every metric point shape so the
 // three of them cannot drift apart on identity (#199 Q4).
-func (r *Reducer) metricSeriesKey(tenantID uint32, service, name string, attrs []*commonpb.KeyValue) SeriesKey {
+func (r *Reducer) metricSeriesKey(tenantID uint32, service, name string, attrs, resourceAttrs []*commonpb.KeyValue) SeriesKey {
 	return SeriesKey{
 		TenantID:  tenantID,
 		ServiceID: r.eng.cache.Intern(tenantID, KindService, service),
 		NameID:    r.eng.cache.Intern(tenantID, KindMetricName, name),
-		DimsID:    r.dimsIDFor(tenantID, name, attrs),
+		DimsID:    r.dimsIDFor(tenantID, name, attrs, resourceAttrs),
 		Signal:    SignalMetric,
 	}
 }
@@ -539,7 +544,7 @@ func (r *Reducer) reduceFold(c HistogramCommon, fold HistogramFold) MetricPointR
 		r.rejectTenant(SignalMetric)
 		return MetricPointResult{Outcome: MetricPointExcluded}
 	}
-	key := r.metricSeriesKey(tenantID, c.Service, c.Name, c.Attributes)
+	key := r.metricSeriesKey(tenantID, c.Service, c.Name, c.Attributes, c.ResourceAttributes)
 	r.delta(key, window).ObserveHistogram(fold)
 	r.identify(key, window, topoIdentity{Kind: topoMetric, Tenant: c.Tenant, A: c.Service, B: c.Name})
 	r.stats.Accepted[SignalMetric]++
@@ -588,7 +593,7 @@ func (r *Reducer) ReduceMetricPoint(in MetricInput) {
 		r.rejectTenant(SignalMetric)
 		return
 	}
-	key := r.metricSeriesKey(tenantID, in.Service, in.Name, in.Attributes)
+	key := r.metricSeriesKey(tenantID, in.Service, in.Name, in.Attributes, in.ResourceAttributes)
 
 	switch {
 	// Gauges and cumulative non-monotonic sums (UpDownCounter): gauge-like,

--- a/internal/ingest/aggregate_bridge.go
+++ b/internal/ingest/aggregate_bridge.go
@@ -326,27 +326,26 @@ func aggregateEdgeInput(caller string, in aggregate.SpanInput) aggregate.EdgeInp
 	}
 }
 
-// aggregateResourceIdentity extracts the stable resource identity used to
-// derive a metric producer's ProducerID (#166). Only the first-present value
-// per slot is taken: attributes that vary per export would fragment baselines.
-func aggregateResourceIdentity(attrs []*commonpb.KeyValue) aggregate.ResourceIdentity {
-	return scanResourceSlots(attrs).identity()
-}
-
 // resourceSlots is the stable identity slice of one OTLP resource, read once
-// per resource batch and shared by the aggregate producer identity and the
-// resource registry (#279). host is host.id else host.name; workload is
-// k8s.pod.uid else container.id else process.pid; workloadKind names the
-// slot that filled workload (pod|container|process) or "".
+// per resource batch and shared by service identity resolution, the aggregate
+// producer identity and the resource registry (#279, #280). host is host.id
+// else host.name (hostName keeps host.name alone, the preferred host-entity
+// name); workload is k8s.pod.uid else container.id else process.pid;
+// workloadKind names the slot that filled workload (pod|container|process)
+// or "".
 type resourceSlots struct {
 	serviceInstanceID string
 	serviceNamespace  string
 	serviceName       string
 	host              string
+	hostName          string
 	workload          string
 	workloadKind      string
 }
 
+// identity is the stable resource identity used to derive a metric producer's
+// ProducerID (#166). Only the first-present value per slot is taken:
+// attributes that vary per export would fragment baselines.
 func (s resourceSlots) identity() aggregate.ResourceIdentity {
 	return aggregate.ResourceIdentity{
 		ServiceInstanceID: s.serviceInstanceID,
@@ -386,8 +385,9 @@ func scanResourceSlots(attrs []*commonpb.KeyValue) resourceSlots {
 		case "host.id":
 			id.host = kv.Value.GetStringValue()
 		case "host.name":
+			id.hostName = kv.Value.GetStringValue()
 			if id.host == "" {
-				id.host = kv.Value.GetStringValue()
+				id.host = id.hostName
 			}
 		case "k8s.pod.uid":
 			id.workload = kv.Value.GetStringValue()
@@ -464,21 +464,22 @@ func histogramCommonFields(
 	tenant, service, name string,
 	res aggregate.ResourceIdentity,
 	temporality aggregate.Temporality,
-	attrs []*commonpb.KeyValue,
+	attrs, resourceAttrs []*commonpb.KeyValue,
 	timeNanos, startNanos uint64,
 	count uint64,
 	sum, minV, maxV *float64,
 ) aggregate.HistogramCommon {
 	c := aggregate.HistogramCommon{
-		Tenant:      tenant,
-		Service:     service,
-		Name:        name,
-		Resource:    res,
-		Timestamp:   time.Unix(0, int64(timeNanos)),  // #nosec G115 -- OTLP nanos fit int64 until year 2262
-		StartTime:   time.Unix(0, int64(startNanos)), // #nosec G115 -- OTLP nanos fit int64 until year 2262
-		Temporality: temporality,
-		Attributes:  attrs,
-		Count:       count,
+		Tenant:             tenant,
+		Service:            service,
+		Name:               name,
+		Resource:           res,
+		Timestamp:          time.Unix(0, int64(timeNanos)),  // #nosec G115 -- OTLP nanos fit int64 until year 2262
+		StartTime:          time.Unix(0, int64(startNanos)), // #nosec G115 -- OTLP nanos fit int64 until year 2262
+		Temporality:        temporality,
+		Attributes:         attrs,
+		ResourceAttributes: resourceAttrs,
+		Count:              count,
 	}
 	if sum != nil {
 		c.Sum, c.HasSum = *sum, true
@@ -496,12 +497,13 @@ func histogramCommonFields(
 func aggregateHistogramInput(
 	tenant, service, name string,
 	res aggregate.ResourceIdentity,
+	resourceAttrs []*commonpb.KeyValue,
 	temporality aggregate.Temporality,
 	p *metricspb.HistogramDataPoint,
 ) aggregate.HistogramInput {
 	return aggregate.HistogramInput{
 		HistogramCommon: histogramCommonFields(tenant, service, name, res, temporality,
-			p.Attributes, p.TimeUnixNano, p.StartTimeUnixNano, p.Count, p.Sum, p.Min, p.Max),
+			p.Attributes, resourceAttrs, p.TimeUnixNano, p.StartTimeUnixNano, p.Count, p.Sum, p.Min, p.Max),
 		Bounds:       p.ExplicitBounds,
 		BucketCounts: p.BucketCounts,
 	}
@@ -511,12 +513,13 @@ func aggregateHistogramInput(
 func aggregateExpHistogramInput(
 	tenant, service, name string,
 	res aggregate.ResourceIdentity,
+	resourceAttrs []*commonpb.KeyValue,
 	temporality aggregate.Temporality,
 	p *metricspb.ExponentialHistogramDataPoint,
 ) aggregate.ExponentialHistogramInput {
 	return aggregate.ExponentialHistogramInput{
 		HistogramCommon: histogramCommonFields(tenant, service, name, res, temporality,
-			p.Attributes, p.TimeUnixNano, p.StartTimeUnixNano, p.Count, p.Sum, p.Min, p.Max),
+			p.Attributes, resourceAttrs, p.TimeUnixNano, p.StartTimeUnixNano, p.Count, p.Sum, p.Min, p.Max),
 		Scale:     p.Scale,
 		ZeroCount: p.ZeroCount,
 		Positive:  expBuckets(p.Positive),

--- a/internal/ingest/host_entity_test.go
+++ b/internal/ingest/host_entity_test.go
@@ -1,0 +1,233 @@
+package ingest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/RandomCodeSpace/otelcontext/internal/telemetry"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
+	"github.com/RandomCodeSpace/otelcontext/internal/tsdb"
+	"github.com/prometheus/client_golang/prometheus"
+	colmetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+)
+
+// #280: hostmetrics carry host.name and no service.name. They used to land
+// under unknown-service and merge across hosts; they now land under
+// host/<name>, one entity per host, in legacy and aggregate modes alike.
+
+const (
+	hostCPUTime        = "system.cpu.time"
+	hostCPUUtilization = "system.cpu.utilization"
+)
+
+// hostmetricsResource mimics one hostmetrics-receiver resource batch: a
+// cumulative monotonic Sum and a Gauge, per-cpu point attributes, and only
+// the given resource attributes.
+func hostmetricsResource(ts time.Time, attrs ...*commonpb.KeyValue) *metricspb.ResourceMetrics {
+	point := func(v float64) *metricspb.NumberDataPoint {
+		return &metricspb.NumberDataPoint{
+			StartTimeUnixNano: uint64(ts.Add(-time.Hour).UnixNano()), // #nosec G115 -- test timestamps are positive
+			TimeUnixNano:      uint64(ts.UnixNano()),                 // #nosec G115 -- test timestamps are positive
+			Value:             &metricspb.NumberDataPoint_AsDouble{AsDouble: v},
+			Attributes:        []*commonpb.KeyValue{stringAttr("cpu", "cpu0"), stringAttr("state", "user")},
+		}
+	}
+	return &metricspb.ResourceMetrics{
+		Resource: &resourcepb.Resource{Attributes: attrs},
+		ScopeMetrics: []*metricspb.ScopeMetrics{{Metrics: []*metricspb.Metric{
+			{Name: hostCPUTime, Data: &metricspb.Metric_Sum{Sum: &metricspb.Sum{
+				AggregationTemporality: metricspb.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+				IsMonotonic:            true,
+				DataPoints:             []*metricspb.NumberDataPoint{point(1234.5)},
+			}}},
+			{Name: hostCPUUtilization, Data: &metricspb.Metric_Gauge{Gauge: &metricspb.Gauge{
+				DataPoints: []*metricspb.NumberDataPoint{point(0.42)},
+			}}},
+		}}},
+	}
+}
+
+func hostmetricsRequest(ts time.Time, hosts ...string) *colmetricspb.ExportMetricsServiceRequest {
+	req := &colmetricspb.ExportMetricsServiceRequest{}
+	for _, h := range hosts {
+		req.ResourceMetrics = append(req.ResourceMetrics, hostmetricsResource(ts, stringAttr("host.name", h)))
+	}
+	return req
+}
+
+// legacyServiceNames exports req through a legacy-wired MetricsServer and
+// returns the RawMetric count per service name.
+func legacyServiceNames(t *testing.T, req *colmetricspb.ExportMetricsServiceRequest) map[string]int {
+	t.Helper()
+	srv := NewMetricsServer(nil, nil, nil, aggTestConfig())
+	seen := make(map[string]int)
+	srv.SetMetricCallback(func(m tsdb.RawMetric) { seen[m.ServiceName]++ })
+	if _, err := srv.Export(context.Background(), req); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	return seen
+}
+
+func TestHostOnlyResourceLandsUnderHostEntityLegacy(t *testing.T) {
+	seen := legacyServiceNames(t, hostmetricsRequest(time.Now(), "node-a", "node-b"))
+	want := map[string]int{topology.HostPrefix + "node-a": 2, topology.HostPrefix + "node-b": 2}
+	if len(seen) != len(want) {
+		t.Fatalf("services = %v, want %v", seen, want)
+	}
+	for svc, n := range want {
+		if seen[svc] != n {
+			t.Errorf("service %q saw %d metrics, want %d (all: %v)", svc, seen[svc], n, seen)
+		}
+	}
+}
+
+func TestHostIdentityResolution(t *testing.T) {
+	cases := []struct {
+		name  string
+		attrs []*commonpb.KeyValue
+		want  string
+	}{
+		{"service.name wins over host", []*commonpb.KeyValue{stringAttr("host.name", "node-a"), stringAttr("service.name", "checkout")}, "checkout"},
+		{"host.name preferred over host.id", []*commonpb.KeyValue{stringAttr("host.id", "i-0abc"), stringAttr("host.name", "node-a")}, topology.HostPrefix + "node-a"},
+		{"host.id when no host.name", []*commonpb.KeyValue{stringAttr("host.id", "i-0abc")}, topology.HostPrefix + "i-0abc"},
+		{"neither keeps unknown-service", []*commonpb.KeyValue{stringAttr("os.type", "linux")}, "unknown-service"},
+		{"empty resource keeps unknown-service", nil, "unknown-service"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := &colmetricspb.ExportMetricsServiceRequest{ResourceMetrics: []*metricspb.ResourceMetrics{hostmetricsResource(time.Now(), c.attrs...)}}
+			seen := legacyServiceNames(t, req)
+			if len(seen) != 1 || seen[c.want] != 2 {
+				t.Fatalf("services = %v, want %q x2", seen, c.want)
+			}
+		})
+	}
+}
+
+// hostServices returns the set of services the aggregate topology carries
+// for metric name.
+func hostServices(snap aggregate.TopologySnapshot, name string) map[string]bool {
+	out := make(map[string]bool)
+	for _, m := range snap.Metrics {
+		if m.Metric == name {
+			out[m.Service] = true
+		}
+	}
+	return out
+}
+
+func TestHostOnlyResourceLandsUnderHostEntityAggregate(t *testing.T) {
+	now := time.Now().UTC()
+	engine := ackEngine(t, aggregate.ModeAggregate, now)
+	srv := NewMetricsServer(nil, nil, nil, aggTestConfig())
+	srv.SetAggregateEngine(engine)
+
+	if _, err := srv.Export(context.Background(), hostmetricsRequest(now, "node-a", "node-b")); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	snap := engine.TopologySnapshot(storage.DefaultTenantID)
+	got := hostServices(snap, hostCPUUtilization)
+	if len(got) != 2 || !got[topology.HostPrefix+"node-a"] || !got[topology.HostPrefix+"node-b"] {
+		t.Fatalf("%s services = %v, want host/node-a and host/node-b", hostCPUUtilization, got)
+	}
+	for _, m := range snap.Metrics {
+		if m.Service == "unknown-service" {
+			t.Fatalf("metric %q still lands under unknown-service", m.Metric)
+		}
+	}
+}
+
+// hostDimsEngine builds an aggregate-mode engine with the given
+// AGGREGATE_METRIC_DIMS-shaped config.
+func hostDimsEngine(t *testing.T, now time.Time, dims aggregate.DimsConfig) *aggregate.Engine {
+	t.Helper()
+	e, err := aggregate.NewEngine(aggregate.EngineConfig{
+		Mode:       aggregate.ModeAggregate,
+		Now:        func() time.Time { return now },
+		MetricDims: dims,
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	return e
+}
+
+// dimsIDsPerSeries exports two hosts through an engine built with dims and
+// returns the DimsID of every active metric series.
+func dimsIDsPerSeries(t *testing.T, dims aggregate.DimsConfig) []uint32 {
+	t.Helper()
+	now := time.Now().UTC()
+	engine := hostDimsEngine(t, now, dims)
+	srv := NewMetricsServer(nil, nil, nil, aggTestConfig())
+	srv.SetAggregateEngine(engine)
+	if _, err := srv.Export(context.Background(), hostmetricsRequest(now, "node-a", "node-b")); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	var ids []uint32
+	for key := range engine.ActiveSeriesKeys() {
+		if key.Signal == aggregate.SignalMetric {
+			ids = append(ids, key.DimsID)
+		}
+	}
+	return ids
+}
+
+// TestHostDimsSplitPerHostFromResource: with
+// AGGREGATE_METRIC_DIMS=system.cpu.utilization:host.name the point lacks
+// host.name and the resource supplies it, so the gauge series carry one
+// distinct non-zero DimsID per host. Without the config every series is
+// DimsID 0.
+func TestHostDimsSplitPerHostFromResource(t *testing.T) {
+	withDims := dimsIDsPerSeries(t, aggregate.DimsConfig{hostCPUUtilization: {"host.name"}})
+	distinct := make(map[uint32]bool)
+	for _, id := range withDims {
+		if id != 0 {
+			distinct[id] = true
+		}
+	}
+	if len(distinct) != 2 {
+		t.Fatalf("configured host.name dim produced DimsIDs %v, want two distinct non-zero values (one per host)", withDims)
+	}
+
+	for _, id := range dimsIDsPerSeries(t, nil) {
+		if id != 0 {
+			t.Fatalf("no configured dims yet a series carries DimsID %d", id)
+		}
+	}
+}
+
+func TestReservedHostPrefixCounted(t *testing.T) {
+	m := &telemetry.Metrics{
+		IngestionRate: prometheus.NewCounter(prometheus.CounterOpts{Name: "test_ingestion_rate_reserved_prefix"}),
+		GRPCBatchSize: prometheus.NewHistogram(prometheus.HistogramOpts{Name: "test_grpc_batch_size_reserved_prefix"}),
+		IngestReservedServicePrefixTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "test_ingest_reserved_service_prefix_total",
+		}, []string{"signal"}),
+	}
+	srv := NewMetricsServer(nil, m, nil, aggTestConfig())
+	seen := make(map[string]int)
+	srv.SetMetricCallback(func(rm tsdb.RawMetric) { seen[rm.ServiceName]++ })
+
+	now := time.Now()
+	req := &colmetricspb.ExportMetricsServiceRequest{ResourceMetrics: []*metricspb.ResourceMetrics{
+		hostmetricsResource(now, stringAttr("service.name", "host/minted"), stringAttr("host.name", "node-a")),
+		hostmetricsResource(now, stringAttr("host.name", "node-a")),
+		hostmetricsResource(now, stringAttr("service.name", "checkout")),
+	}}
+	if _, err := srv.Export(context.Background(), req); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if seen["host/minted"] != 2 {
+		t.Fatalf("client-declared host/ name was not accepted as sent: %v", seen)
+	}
+	if got := counterAt(t, m.IngestReservedServicePrefixTotal, "metrics"); got != 1 {
+		t.Fatalf("reserved prefix counter = %v, want 1 (only the client-declared host/ name counts)", got)
+	}
+}

--- a/internal/ingest/otlp.go
+++ b/internal/ingest/otlp.go
@@ -284,12 +284,34 @@ func (s *MetricsServer) SetResourceRegistry(r *topology.Registry) {
 
 // registerResource records one resource batch in the registry. now is the
 // Export's arrival time; a nil registry is a no-op.
-func registerResource(reg *topology.Registry, tenant, service string, attrs []*commonpb.KeyValue, signal topology.Signal, now time.Time) {
+func registerResource(reg *topology.Registry, tenant, service string, slots resourceSlots, signal topology.Signal, now time.Time) {
 	if reg == nil {
 		return
 	}
-	slots := scanResourceSlots(attrs)
 	reg.Register(tenant, service, slots.host, slots.workload, slots.workloadKind, signal, now)
+}
+
+// resolveServiceIdentity resolves the service identity of one resource
+// (#280). A declared service.name wins. Without one, a resource carrying
+// host.name or host.id is a host entity named topology.HostPrefix + host.name
+// (host.id when there is no name) and host reports true. A resource with
+// neither keeps unknown-service. A client-declared name inside the reserved
+// host/ namespace is accepted as sent and counted on
+// otelcontext_ingest_reserved_service_prefix_total{signal}.
+func resolveServiceIdentity(slots resourceSlots, metrics *telemetry.Metrics, signal string) (name string, host bool) {
+	if slots.serviceName != "" {
+		if topology.IsHostEntity(slots.serviceName) {
+			metrics.RecordReservedServicePrefix(signal)
+		}
+		return slots.serviceName, false
+	}
+	switch {
+	case slots.hostName != "":
+		return topology.HostPrefix + slots.hostName, true
+	case slots.host != "":
+		return topology.HostPrefix + slots.host, true
+	}
+	return "unknown-service", false
 }
 
 func NewLogsServer(repo *storage.Repository, metrics *telemetry.Metrics, cfg *config.Config) *LogsServer {
@@ -343,27 +365,29 @@ func (s *MetricsServer) Export(ctx context.Context, req *colmetricspb.ExportMetr
 	var rejected metricRejections
 
 	for _, resourceMetrics := range req.ResourceMetrics {
-		serviceName := getServiceName(resourceMetrics.Resource.Attributes)
+		resourceAttrs := resourceMetrics.Resource.Attributes
+		slots := scanResourceSlots(resourceAttrs)
+		serviceName, _ := resolveServiceIdentity(slots, s.metrics, "metrics")
 
 		if !shouldIngestService(serviceName, s.allowedServices, s.excludedServices) {
 			continue
 		}
 
-		tenantID := resolveTenant(ctx, resourceMetrics.Resource.Attributes, s.defaultTenant, s.trustResourceTenant)
-		registerResource(s.resourceRegistry, tenantID, serviceName, resourceMetrics.Resource.Attributes, topology.SignalMetrics, start)
+		tenantID := resolveTenant(ctx, resourceAttrs, s.defaultTenant, s.trustResourceTenant)
+		registerResource(s.resourceRegistry, tenantID, serviceName, slots, topology.SignalMetrics, start)
 
 		var producerIdentity aggregate.ResourceIdentity
 		if reducer != nil {
-			producerIdentity = aggregateResourceIdentity(resourceMetrics.Resource.Attributes)
+			producerIdentity = slots.identity()
 		}
 
 		for _, scopeMetrics := range resourceMetrics.ScopeMetrics {
 			for _, m := range scopeMetrics.Metrics {
 				switch data := m.Data.(type) {
 				case *metricspb.Metric_Gauge:
-					s.exportNumberPoints(reducer, m, data.Gauge.GetDataPoints(), serviceName, tenantID, producerIdentity)
+					s.exportNumberPoints(reducer, m, data.Gauge.GetDataPoints(), serviceName, tenantID, producerIdentity, resourceAttrs)
 				case *metricspb.Metric_Sum:
-					s.exportNumberPoints(reducer, m, data.Sum.GetDataPoints(), serviceName, tenantID, producerIdentity)
+					s.exportNumberPoints(reducer, m, data.Sum.GetDataPoints(), serviceName, tenantID, producerIdentity, resourceAttrs)
 				case *metricspb.Metric_Histogram:
 					// Distribution points have no legacy consumer: the TSDB
 					// ring buffer holds scalars only. They exist for aggregate
@@ -379,7 +403,7 @@ func (s *MetricsServer) Export(ctx context.Context, req *colmetricspb.ExportMetr
 							continue
 						}
 						res := reducer.ReduceHistogramPoint(aggregateHistogramInput(
-							tenantID, serviceName, m.Name, producerIdentity, temporality, p))
+							tenantID, serviceName, m.Name, producerIdentity, resourceAttrs, temporality, p))
 						rejected.record(s.metrics, pointTypeHistogram, res)
 					}
 				case *metricspb.Metric_ExponentialHistogram:
@@ -392,7 +416,7 @@ func (s *MetricsServer) Export(ctx context.Context, req *colmetricspb.ExportMetr
 							continue
 						}
 						res := reducer.ReduceExponentialHistogramPoint(aggregateExpHistogramInput(
-							tenantID, serviceName, m.Name, producerIdentity, temporality, p))
+							tenantID, serviceName, m.Name, producerIdentity, resourceAttrs, temporality, p))
 						rejected.record(s.metrics, pointTypeExpHistogram, res)
 					}
 				case *metricspb.Metric_Summary:
@@ -448,6 +472,7 @@ func (s *MetricsServer) exportNumberPoints(
 	points []*metricspb.NumberDataPoint,
 	serviceName, tenantID string,
 	producerIdentity aggregate.ResourceIdentity,
+	resourceAttrs []*commonpb.KeyValue,
 ) {
 	// In AGGREGATE_MODE=aggregate main.go constructs neither the TSDB
 	// aggregator nor the metric callback, and this collapses to zero: no
@@ -484,6 +509,9 @@ func (s *MetricsServer) exportNumberPoints(
 				Monotonic:   monotonic,
 				Resource:    producerIdentity,
 				Attributes:  p.Attributes,
+				// Resource attributes are the fallback for a configured
+				// dimension the point lacks (#279).
+				ResourceAttributes: resourceAttrs,
 			})
 		}
 
@@ -548,7 +576,8 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 
 	for idx, resourceSpans := range req.ResourceSpans {
 		g.Go(func() error {
-			serviceName := getServiceName(resourceSpans.Resource.Attributes)
+			slots := scanResourceSlots(resourceSpans.Resource.Attributes)
+			serviceName, _ := resolveServiceIdentity(slots, s.metrics, "traces")
 
 			if !shouldIngestService(serviceName, s.allowedServices, s.excludedServices) {
 				slog.Debug("🚫 [TRACES] Dropped service", "service", serviceName)
@@ -558,7 +587,7 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 			tenantID := resolveTenant(ctx, resourceSpans.Resource.Attributes, s.defaultTenant, s.trustResourceTenant)
 			// Pre-sample, like the topology observer: host identity must not
 			// depend on SAMPLING_RATE (#279).
-			registerResource(s.resourceRegistry, tenantID, serviceName, resourceSpans.Resource.Attributes, topology.SignalTraces, start)
+			registerResource(s.resourceRegistry, tenantID, serviceName, slots, topology.SignalTraces, start)
 
 			localSpans := make([]storage.Span, 0)
 			localTraces := make([]storage.Trace, 0)
@@ -1041,7 +1070,8 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 
 	for idx, resourceLogs := range req.ResourceLogs {
 		g.Go(func() error {
-			serviceName := getServiceName(resourceLogs.Resource.Attributes)
+			slots := scanResourceSlots(resourceLogs.Resource.Attributes)
+			serviceName, _ := resolveServiceIdentity(slots, s.metrics, "logs")
 
 			if !shouldIngestService(serviceName, s.allowedServices, s.excludedServices) {
 				slog.Debug("🚫 [LOGS] Dropped service", "service", serviceName)
@@ -1049,7 +1079,7 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 			}
 
 			tenantID := resolveTenant(ctx, resourceLogs.Resource.Attributes, s.defaultTenant, s.trustResourceTenant)
-			registerResource(s.resourceRegistry, tenantID, serviceName, resourceLogs.Resource.Attributes, topology.SignalLogs, start)
+			registerResource(s.resourceRegistry, tenantID, serviceName, slots, topology.SignalLogs, start)
 
 			localLogs := make([]storage.Log, 0)
 			exemplarRes := s.exemplar.NewReservation()
@@ -1339,16 +1369,6 @@ func hasPriorityLog(logs []storage.Log) bool {
 		}
 	}
 	return false
-}
-
-// Helper to extract service.name from attributes
-func getServiceName(attrs []*commonpb.KeyValue) string {
-	for _, kv := range attrs {
-		if kv.Key == "service.name" {
-			return kv.Value.GetStringValue()
-		}
-	}
-	return "unknown-service"
 }
 
 // ParseSeverity is the exported wrapper for parseSeverity. Used by main.go

--- a/internal/ingest/otlp.go
+++ b/internal/ingest/otlp.go
@@ -294,24 +294,24 @@ func registerResource(reg *topology.Registry, tenant, service string, slots reso
 // resolveServiceIdentity resolves the service identity of one resource
 // (#280). A declared service.name wins. Without one, a resource carrying
 // host.name or host.id is a host entity named topology.HostPrefix + host.name
-// (host.id when there is no name) and host reports true. A resource with
-// neither keeps unknown-service. A client-declared name inside the reserved
-// host/ namespace is accepted as sent and counted on
-// otelcontext_ingest_reserved_service_prefix_total{signal}.
-func resolveServiceIdentity(slots resourceSlots, metrics *telemetry.Metrics, signal string) (name string, host bool) {
+// (host.id when there is no name); consumers recognise it with
+// topology.IsHostEntity. A resource with neither keeps unknown-service. A
+// client-declared name inside the reserved host/ namespace is accepted as sent
+// and counted on otelcontext_ingest_reserved_service_prefix_total{signal}.
+func resolveServiceIdentity(slots resourceSlots, metrics *telemetry.Metrics, signal string) string {
 	if slots.serviceName != "" {
 		if topology.IsHostEntity(slots.serviceName) {
 			metrics.RecordReservedServicePrefix(signal)
 		}
-		return slots.serviceName, false
+		return slots.serviceName
 	}
 	switch {
 	case slots.hostName != "":
-		return topology.HostPrefix + slots.hostName, true
+		return topology.HostPrefix + slots.hostName
 	case slots.host != "":
-		return topology.HostPrefix + slots.host, true
+		return topology.HostPrefix + slots.host
 	}
-	return "unknown-service", false
+	return "unknown-service"
 }
 
 func NewLogsServer(repo *storage.Repository, metrics *telemetry.Metrics, cfg *config.Config) *LogsServer {
@@ -367,7 +367,7 @@ func (s *MetricsServer) Export(ctx context.Context, req *colmetricspb.ExportMetr
 	for _, resourceMetrics := range req.ResourceMetrics {
 		resourceAttrs := resourceMetrics.Resource.Attributes
 		slots := scanResourceSlots(resourceAttrs)
-		serviceName, _ := resolveServiceIdentity(slots, s.metrics, "metrics")
+		serviceName := resolveServiceIdentity(slots, s.metrics, "metrics")
 
 		if !shouldIngestService(serviceName, s.allowedServices, s.excludedServices) {
 			continue
@@ -577,7 +577,7 @@ func (s *TraceServer) Export(ctx context.Context, req *coltracepb.ExportTraceSer
 	for idx, resourceSpans := range req.ResourceSpans {
 		g.Go(func() error {
 			slots := scanResourceSlots(resourceSpans.Resource.Attributes)
-			serviceName, _ := resolveServiceIdentity(slots, s.metrics, "traces")
+			serviceName := resolveServiceIdentity(slots, s.metrics, "traces")
 
 			if !shouldIngestService(serviceName, s.allowedServices, s.excludedServices) {
 				slog.Debug("🚫 [TRACES] Dropped service", "service", serviceName)
@@ -1071,7 +1071,7 @@ func (s *LogsServer) Export(ctx context.Context, req *collogspb.ExportLogsServic
 	for idx, resourceLogs := range req.ResourceLogs {
 		g.Go(func() error {
 			slots := scanResourceSlots(resourceLogs.Resource.Attributes)
-			serviceName, _ := resolveServiceIdentity(slots, s.metrics, "logs")
+			serviceName := resolveServiceIdentity(slots, s.metrics, "logs")
 
 			if !shouldIngestService(serviceName, s.allowedServices, s.excludedServices) {
 				slog.Debug("🚫 [LOGS] Dropped service", "service", serviceName)

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -183,6 +183,11 @@ type Metrics struct {
 	// value has no canonical scalar rendering, so it cannot be interned.
 	// The point is still aggregated, under DimsID=0.
 	IngestMetricsDimsRejectedTotal *prometheus.CounterVec
+	// IngestReservedServicePrefixTotal — resources whose client-declared
+	// service.name sits inside the reserved host/ namespace (#280). The name
+	// is accepted as sent; the count tells an operator a client is minting
+	// host entities by hand. Label signal=traces|logs|metrics.
+	IngestReservedServicePrefixTotal *prometheus.CounterVec
 
 	// HTTPOTLPThrottledTotal — count of HTTP 429s issued by the OTLP HTTP
 	// receiver when the async ingest pipeline is full. Mirrors the gRPC
@@ -660,6 +665,10 @@ func New() *Metrics {
 		Name: "otelcontext_ingest_metrics_dims_rejected_total",
 		Help: "Metric points whose configured dimension tuple was refused from series identity. reason=unsupported_value_type. The point is still aggregated under DimsID=0.",
 	}, []string{"reason"})
+	m.IngestReservedServicePrefixTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "otelcontext_ingest_reserved_service_prefix_total",
+		Help: "Resources whose client-declared service.name starts with the reserved host/ prefix. The name is accepted as sent. signal=traces|logs|metrics.",
+	}, []string{"signal"})
 	m.AggregateInputPointsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "otelcontext_aggregate_input_points_total",
 		Help: "Points offered to the aggregate reducer, per signal, counted before sampling and severity gates.",
@@ -894,6 +903,15 @@ func (m *Metrics) RecordMetricDimsRejected(reason string, n uint64) {
 		return
 	}
 	m.IngestMetricsDimsRejectedTotal.WithLabelValues(reason).Add(float64(n))
+}
+
+// RecordReservedServicePrefix counts one resource whose client-declared
+// service.name starts with the reserved host/ prefix. Nil-safe.
+func (m *Metrics) RecordReservedServicePrefix(signal string) {
+	if m == nil || m.IngestReservedServicePrefixTotal == nil {
+		return
+	}
+	m.IngestReservedServicePrefixTotal.WithLabelValues(signal).Inc()
 }
 
 // RecordExemplarEligible implements ingest.ExemplarMetrics.

--- a/internal/topology/registry.go
+++ b/internal/topology/registry.go
@@ -6,6 +6,7 @@ import (
 	"hash/fnv"
 	"log/slog"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -42,6 +43,17 @@ const (
 	RegistryKindPair   = "pair"
 	RegistryKindLength = "length"
 )
+
+// HostPrefix is the reserved service-name namespace of host entities (#280):
+// a resource carrying host.id or host.name and no service.name is identified
+// as HostPrefix + host.name (host.id when there is no name). The registry
+// schema is unchanged; the entity kind is derived from the name.
+const HostPrefix = "host/"
+
+// IsHostEntity reports whether service names a host entity.
+func IsHostEntity(service string) bool {
+	return strings.HasPrefix(service, HostPrefix)
+}
 
 // Signal is one bit of ResourceEntry.Signals.
 type Signal uint8

--- a/internal/topology/registry_test.go
+++ b/internal/topology/registry_test.go
@@ -183,3 +183,14 @@ func TestRegistryRefusesOverLengthValues(t *testing.T) {
 		t.Fatalf("snapshot = %#v", r.Snapshot())
 	}
 }
+
+func TestIsHostEntity(t *testing.T) {
+	if !IsHostEntity(HostPrefix + "node-a") {
+		t.Fatal("host/node-a is not a host entity")
+	}
+	for _, name := range []string{"checkout", "hosted/x", "", "HOST/node-a"} {
+		if IsHostEntity(name) {
+			t.Fatalf("%q reported as a host entity", name)
+		}
+	}
+}


### PR DESCRIPTION
## Claimed child and decision

Closes #287. Implements #280 (host-only telemetry home) and the opt-in dim rule of #279 for epic #285.

## Baseline

A resource with `host.name` and no `service.name` (the hostmetrics receiver's shape) landed under `unknown-service`, so every host's CPU, memory and disk series merged into one. `AGGREGATE_METRIC_DIMS` could only be satisfied from point attributes, so `host.name` could never be a dimension.

## Changed owners and contracts

- `internal/ingest/otlp.go`: `getServiceName` is replaced by `resolveServiceIdentity` over the `resourceSlots` already scanned once per resource batch. A declared `service.name` wins. Without one, `host.name` (else `host.id`) yields `host/<name>`; neither yields `unknown-service`. A client-declared name inside `host/` is accepted as sent and counted on `otelcontext_ingest_reserved_service_prefix_total{signal}`. `topology.HostPrefix` and `topology.IsHostEntity` let consumers recognise host entities; no registry column, no migration.
- `internal/aggregate/dims_config.go`, `reducer.go`: a configured dim key missing from the point falls back to the same key on the resource attributes; a point attribute always outranks the resource one; missing from both still yields `DimsID=0`. The scan reuses the request-local scratch and allocates nothing (pinned by a new alloc test). `MetricInput` and `HistogramCommon` gain an additive `ResourceAttributes` slice, threaded from all three point shapes in `internal/ingest/aggregate_bridge.go`.
- `internal/telemetry`: the reserved-prefix counter.
- CLAUDE.md and CHANGELOG: the dimension rule and the host identity, one paragraph each.

Small intentional change: a resource whose `service.name` is the empty string used to produce an empty service name; it now counts as absent and resolves to host or `unknown-service`.

## Targeted local verification

```text
go test -race -count=1 ./internal/ingest ./internal/aggregate ./internal/topology ./internal/telemetry   → pass
go vet ./internal/ingest ./internal/aggregate ./internal/topology ./internal/telemetry                  → clean
gofmt -l on the same packages                                                                            → empty
```

New tests: hostmetrics-shaped fixture produces `host/node-a` and `host/node-b` in legacy and aggregate modes; `system.cpu.utilization:host.name` splits series per host and without it does not; identity table (service wins, name over id, id fallback, neither); reserved-prefix counter; resource fallback interns to the same DimsID as a point-sourced tuple; non-scalar resource values are rejected.

## Compatibility

No field added, removed or retyped on any response. Partial-success accounting, late-point handling and the delta-only histogram rule are unchanged; no existing test was modified except one appended function.

## Rollback

Previous signed binary. Series named `host/<name>` written by this binary remain readable as ordinary services by the previous one.

## Evidence

CI on this PR; the topology and latency proofs run all three modes.