### PR TITLE
feat(api): expose hosts on REST, WebSocket and MCP without changing existing fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,7 +364,7 @@ for the full rationale.
 | Tool | Input | Source |
 |------|-------|--------|
 | `get_anomaly_timeline` | `{since?, service?}` | In-memory (instant) — triage entry point |
-| `get_service_map` | `{depth?, service?}` | In-memory (instant) — topology + health overlay |
+| `get_service_map` | `{depth?, service?, group_by?}` | In-memory (instant) — topology + health overlay; `group_by: "host"` wraps the array as `{services, hosts}` |
 | `get_service_health` | `{service_name}` | In-memory (instant) — per-service drill-down |
 | `root_cause_analysis` | `{service, time_range?}` | In-memory (instant) — ranked probable causes |
 | `impact_analysis` | `{service, depth?}` | In-memory (instant) — blast radius |

--- a/internal/api/graph_handler.go
+++ b/internal/api/graph_handler.go
@@ -32,6 +32,12 @@ type GraphNode struct {
 	Status      string      `json:"status"`
 	Metrics     NodeMetrics `json:"metrics"`
 	Alerts      []string    `json:"alerts"`
+
+	// Additive host projection (#288). Kind is service|host; a host node is
+	// excluded from the service summary.
+	Kind      string   `json:"kind,omitempty"`
+	HostCount int      `json:"host_count,omitempty"`
+	Hosts     []string `json:"hosts,omitempty"`
 }
 
 // NodeMetrics holds per-service observability metrics.
@@ -151,8 +157,14 @@ func buildGraphFromTopology(snapshot topology.Snapshot) *SystemGraphResponse {
 				LatencyProvenance: node.LatencyProvenance,
 				SpanCount1H:       node.SpanCount,
 			},
-			Alerts: alerts,
+			Alerts:    alerts,
+			Kind:      node.Kind,
+			HostCount: node.HostCount,
+			Hosts:     node.Hosts,
 		})
+		if node.Kind == topology.KindHost {
+			continue
+		}
 		totalErrorRate += node.ErrorRate
 		totalLatency += node.AvgLatencyMs
 	}
@@ -378,8 +390,13 @@ func (s *Server) buildGraphFromDB(ctx context.Context) *SystemGraphResponse {
 
 // buildSummaryResponse computes system-level aggregates and returns the final response.
 func buildSummaryResponse(nodes []GraphNode, edges []GraphEdge, totalErrorRate, totalLatency float64) *SystemGraphResponse {
-	healthy, degraded, critical := 0, 0, 0
+	// Host nodes (#288) are listed but never counted as services.
+	services, healthy, degraded, critical := 0, 0, 0, 0
 	for _, n := range nodes {
+		if n.Kind == topology.KindHost {
+			continue
+		}
+		services++
 		switch n.Status {
 		case "healthy":
 			healthy++
@@ -392,18 +409,18 @@ func buildSummaryResponse(nodes []GraphNode, edges []GraphEdge, totalErrorRate, 
 
 	overallHealth := 1.0
 	avgLatency := 0.0
-	if len(nodes) > 0 {
-		overallHealth = math.Round((1.0-totalErrorRate/float64(len(nodes)))*100) / 100
+	if services > 0 {
+		overallHealth = math.Round((1.0-totalErrorRate/float64(services))*100) / 100
 		if overallHealth < 0 {
 			overallHealth = 0
 		}
-		avgLatency = math.Round(totalLatency/float64(len(nodes))*100) / 100
+		avgLatency = math.Round(totalLatency/float64(services)*100) / 100
 	}
 
 	resp := &SystemGraphResponse{
 		Timestamp: time.Now().UTC(),
 		System: SystemSummary{
-			TotalServices:      len(nodes),
+			TotalServices:      services,
 			Healthy:            healthy,
 			Degraded:           degraded,
 			Critical:           critical,

--- a/internal/api/hosts_handler.go
+++ b/internal/api/hosts_handler.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/httpconst"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
+)
+
+// hostProjection reads hosts through the mode-selected topology owner so
+// every mode answers from the same registry. Without a provider there are no
+// hosts.
+func (s *Server) hostProjection(ctx context.Context) topology.HostProjection {
+	if s.topology == nil {
+		return topology.ProjectHosts(nil)
+	}
+	return s.topology.Hosts(ctx)
+}
+
+// handleGetHosts handles GET /api/hosts: the tenant's hosts as a bare array
+// sorted by name, each with its bounded service list.
+func (s *Server) handleGetHosts(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
+	_ = json.NewEncoder(w).Encode(s.hostProjection(r.Context()).Hosts)
+}
+
+// handleGetHost handles GET /api/hosts/{host}; 404 when the tenant has no
+// such host.
+func (s *Server) handleGetHost(w http.ResponseWriter, r *http.Request) {
+	host, ok := s.hostProjection(r.Context()).Host(r.PathValue("host"))
+	if !ok {
+		http.Error(w, "host not found", http.StatusNotFound)
+		return
+	}
+	w.Header().Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
+	_ = json.NewEncoder(w).Encode(host)
+}

--- a/internal/api/hosts_handler_test.go
+++ b/internal/api/hosts_handler_test.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
+)
+
+// hostFixtureProjection is the projection of a fixed registry: gateway on
+// node-a and node-b, a host entity on node-c.
+func hostFixtureProjection() topology.HostProjection {
+	seen := time.Date(2026, 9, 3, 8, 0, 0, 0, time.UTC)
+	return topology.ProjectHosts([]topology.ResourceEntry{
+		{ResourceKey: topology.ResourceKey{Tenant: "default", Service: "gateway", Host: "node-a"}, Signals: topology.SignalTraces, LastSeen: seen},
+		{ResourceKey: topology.ResourceKey{Tenant: "default", Service: "gateway", Host: "node-b"}, Signals: topology.SignalTraces | topology.SignalLogs, LastSeen: seen.Add(time.Minute)},
+		{ResourceKey: topology.ResourceKey{Tenant: "default", Service: "host/node-c", Host: "node-c"}, Signals: topology.SignalMetrics, LastSeen: seen},
+	})
+}
+
+// hostFixtureSnapshot is what a provider hands the handlers once it has
+// stamped hostFixtureProjection onto its nodes.
+func hostFixtureSnapshot() topology.Snapshot {
+	return topology.Snapshot{
+		Nodes: []topology.Node{
+			{Name: "gateway", Kind: "service", HostCount: 2, Hosts: []string{"node-a", "node-b"}},
+			{Name: "host/node-c", Kind: "host", HostCount: 1, Hosts: []string{"node-c"}},
+			{Name: "payments", Kind: "service", Hosts: []string{}},
+		},
+		Edges: []topology.Edge{{Source: "gateway", Target: "payments", CallCount: 4}},
+		Meta:  topology.Metadata{Source: topology.SourceLegacy},
+	}
+}
+
+func newHostsTestServer() *Server {
+	server := NewServer(nil, nil, nil, nil)
+	server.SetTopologyProvider(&fakeTopologyProvider{source: topology.SourceLegacy, snapshot: hostFixtureSnapshot(), hosts: hostFixtureProjection()})
+	return server
+}
+
+func get(t *testing.T, handler http.HandlerFunc, target string, pathValues map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	for k, v := range pathValues {
+		req.SetPathValue(k, v)
+	}
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+	return rec
+}
+
+func TestHostsEndpointsGolden(t *testing.T) {
+	server := newHostsTestServer()
+
+	list := get(t, server.handleGetHosts, "/api/hosts", nil)
+	wantList := `[{"name":"node-a","service_count":1,"services":["gateway"],"last_seen":"2026-09-03T08:00:00Z","signals":["traces"]},` +
+		`{"name":"node-b","service_count":1,"services":["gateway"],"last_seen":"2026-09-03T08:01:00Z","signals":["logs","traces"]},` +
+		`{"name":"node-c","service_count":0,"services":[],"last_seen":"2026-09-03T08:00:00Z","signals":["metrics"]}]` + "\n"
+	if list.Code != http.StatusOK || list.Body.String() != wantList {
+		t.Fatalf("GET /api/hosts = %d\n%s\nwant\n%s", list.Code, list.Body.String(), wantList)
+	}
+
+	one := get(t, server.handleGetHost, "/api/hosts/node-b", map[string]string{"host": "node-b"})
+	wantOne := `{"name":"node-b","service_count":1,"services":["gateway"],"last_seen":"2026-09-03T08:01:00Z","signals":["logs","traces"]}` + "\n"
+	if one.Code != http.StatusOK || one.Body.String() != wantOne {
+		t.Fatalf("GET /api/hosts/node-b = %d\n%s\nwant\n%s", one.Code, one.Body.String(), wantOne)
+	}
+
+	if missing := get(t, server.handleGetHost, "/api/hosts/node-z", map[string]string{"host": "node-z"}); missing.Code != http.StatusNotFound {
+		t.Fatalf("unknown host = %d, want 404", missing.Code)
+	}
+
+	bare := NewServer(nil, nil, nil, nil)
+	if none := get(t, bare.handleGetHosts, "/api/hosts", nil); none.Body.String() != "[]\n" {
+		t.Fatalf("provider-less /api/hosts = %q, want []", none.Body.String())
+	}
+}
+
+// TestServiceMapNodesGainOnlyHostFields pins the node wire shape: every
+// pre-existing field first, unchanged, then kind/host_count/hosts appended.
+func TestServiceMapNodesGainOnlyHostFields(t *testing.T) {
+	server := newHostsTestServer()
+	rec := get(t, server.handleGetServiceMapMetrics, "/api/metrics/service-map", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Nodes []json.RawMessage `json:"nodes"`
+		Edges []json.RawMessage `json:"edges"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := []string{
+		`{"name":"gateway","total_traces":0,"error_count":0,"avg_latency_ms":0,"kind":"service","host_count":2,"hosts":["node-a","node-b"]}`,
+		`{"name":"host/node-c","total_traces":0,"error_count":0,"avg_latency_ms":0,"kind":"host","host_count":1,"hosts":["node-c"]}`,
+		`{"name":"payments","total_traces":0,"error_count":0,"avg_latency_ms":0,"kind":"service"}`,
+	}
+	for i, node := range body.Nodes {
+		if string(node) != want[i] {
+			t.Fatalf("node %d =\n%s\nwant\n%s", i, node, want[i])
+		}
+	}
+	if len(body.Edges) != 1 || string(body.Edges[0]) != `{"source":"gateway","target":"payments","call_count":4,"avg_latency_ms":0,"error_rate":0}` {
+		t.Fatalf("edges = %s", body.Edges)
+	}
+}
+
+// TestSystemGraphNodesGainOnlyHostFields does the same for /api/system/graph
+// and proves a host node never enters the service summary.
+func TestSystemGraphNodesGainOnlyHostFields(t *testing.T) {
+	server := newHostsTestServer()
+	rec := get(t, server.handleGetSystemGraph, "/api/system/graph", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		System SystemSummary     `json:"system"`
+		Nodes  []json.RawMessage `json:"nodes"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.System.TotalServices != 2 || body.System.Healthy != 2 {
+		t.Fatalf("summary counted the host node: %+v", body.System)
+	}
+	wantSuffix := []string{
+		`"alerts":[],"kind":"service","host_count":2,"hosts":["node-a","node-b"]}`,
+		`"alerts":[],"kind":"host","host_count":1,"hosts":["node-c"]}`,
+		`"alerts":[],"kind":"service"}`,
+	}
+	for i, node := range body.Nodes {
+		if !strings.HasPrefix(string(node), `{"id":"`) || !strings.Contains(string(node), `"type":"service"`) || !strings.HasSuffix(string(node), wantSuffix[i]) {
+			t.Fatalf("node %d = %s, want suffix %s", i, node, wantSuffix[i])
+		}
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -256,6 +256,10 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux) {
 	// System Graph (AI-consumable topology + health)
 	mux.HandleFunc("GET /api/system/graph", s.handleGetSystemGraph)
 
+	// Hosts (#288): the resource registry projected through the topology owner
+	mux.HandleFunc("GET /api/hosts", s.handleGetHosts)
+	mux.HandleFunc("GET /api/hosts/{host}", s.handleGetHost)
+
 	// Traces
 	mux.HandleFunc("GET /api/traces", s.handleGetTraces)
 	mux.HandleFunc("GET /api/traces/{id}", s.handleGetTraceByID)

--- a/internal/api/topology_provider_test.go
+++ b/internal/api/topology_provider_test.go
@@ -16,9 +16,12 @@ type fakeTopologyProvider struct {
 	identity topology.Identity
 	snapshot topology.Snapshot
 	err      error
+	hosts    topology.HostProjection
 }
 
 func (f *fakeTopologyProvider) Source() topology.Source { return f.source }
+
+func (f *fakeTopologyProvider) Hosts(context.Context) topology.HostProjection { return f.hosts }
 
 func (f *fakeTopologyProvider) Identity(context.Context) topology.Identity { return f.identity }
 

--- a/internal/api/views/views.go
+++ b/internal/api/views/views.go
@@ -141,6 +141,12 @@ type ServiceMapNode struct {
 	AvgLatencyMs      float64             `json:"avg_latency_ms"`
 	P99LatencyMs      float64             `json:"p99_latency_ms,omitempty"`
 	LatencyProvenance *latency.Provenance `json:"latency_provenance,omitempty"`
+
+	// Additive host projection (#288): kind is service|host, hosts is sorted
+	// and capped at topology.MaxHostsPerNode, host_count is the full total.
+	Kind      string   `json:"kind,omitempty"`
+	HostCount int      `json:"host_count,omitempty"`
+	Hosts     []string `json:"hosts,omitempty"`
 }
 
 // ServiceMapEdge is an edge on the service topology view.
@@ -496,6 +502,9 @@ func ServiceMapMetricsFromTopology(snapshot topology.Snapshot) ServiceMapMetrics
 			AvgLatencyMs:      node.AvgLatencyMs,
 			P99LatencyMs:      node.P99LatencyMs,
 			LatencyProvenance: node.LatencyProvenance,
+			Kind:              node.Kind,
+			HostCount:         node.HostCount,
+			Hosts:             node.Hosts,
 		}
 	}
 	edges := make([]ServiceMapEdge, len(snapshot.Edges))

--- a/internal/mcp/hosts_test.go
+++ b/internal/mcp/hosts_test.go
@@ -1,0 +1,107 @@
+package mcp
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
+)
+
+// setupHostsServer wires an MCP server over a started GraphRAG holding one
+// gateway service, and a provider projecting gateway onto node-a and node-b
+// plus a host entity on node-c.
+func setupHostsServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	db, err := storage.NewDatabase("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	if err := storage.AutoMigrateModels(db, "sqlite"); err != nil {
+		t.Fatalf("AutoMigrateModels: %v", err)
+	}
+	if err := graphrag.AutoMigrateGraphRAG(db); err != nil {
+		t.Fatalf("AutoMigrateGraphRAG: %v", err)
+	}
+	repo := storage.NewRepositoryFromDB(db, "sqlite")
+	cfg := graphrag.DefaultConfig()
+	cfg.RefreshEvery, cfg.SnapshotEvery, cfg.AnomalyEvery = 24*time.Hour, 24*time.Hour, 24*time.Hour
+	cfg.WorkerCount = 1
+	g := graphrag.New(repo, nil, nil, cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	go g.Start(ctx)
+	now := time.Now().UTC()
+	g.OnSpanIngested(storage.Span{TenantID: storage.DefaultTenantID, TraceID: "t", SpanID: "p", ServiceName: "gateway", OperationName: "op", StartTime: now, EndTime: now.Add(time.Millisecond), Duration: 1000, Status: "STATUS_CODE_OK"})
+	deadline := time.Now().Add(2 * time.Second)
+	for len(g.ServiceMap(storage.WithTenantContext(context.Background(), storage.DefaultTenantID), 0)) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("gateway never reached the service store")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	provider := &fakeMCPTopologyProvider{epoch: "boot-a", hosts: topology.ProjectHosts([]topology.ResourceEntry{
+		{ResourceKey: topology.ResourceKey{Tenant: storage.DefaultTenantID, Service: "gateway", Host: "node-a"}, Signals: topology.SignalTraces},
+		{ResourceKey: topology.ResourceKey{Tenant: storage.DefaultTenantID, Service: "gateway", Host: "node-b"}, Signals: topology.SignalTraces},
+		{ResourceKey: topology.ResourceKey{Tenant: storage.DefaultTenantID, Service: "host/node-c", Host: "node-c"}, Signals: topology.SignalMetrics},
+	})}
+	srv := New("", repo, nil, provider)
+	srv.SetGraphRAG(g)
+	httpSrv := httptest.NewServer(srv.Handler())
+	t.Cleanup(func() {
+		httpSrv.Close()
+		cancel()
+		g.Stop()
+		_ = repo.Close()
+	})
+	return httpSrv
+}
+
+func TestGetServiceMapGroupByHostIsAdditiveAndSeparatelyCached(t *testing.T) {
+	ts := setupHostsServer(t)
+
+	_, plain := callTool(t, ts, "", "get_service_map", nil)
+	if !strings.HasPrefix(plain, `[{"service":{`) || strings.Contains(plain, `"hosts"`) {
+		t.Fatalf("plain get_service_map changed shape: %s", plain)
+	}
+
+	// The plain answer is now cached; group_by must not be served from it.
+	_, grouped := callTool(t, ts, "", "get_service_map", map[string]any{"group_by": "host"})
+	if !strings.HasPrefix(grouped, `{"services":[{"service":{`) {
+		t.Fatalf("grouped get_service_map = %s", grouped)
+	}
+	wantHosts := `"hosts":[{"name":"node-a","service_count":1,"services":["gateway"],"last_seen":"0001-01-01T00:00:00Z","signals":["traces"]},` +
+		`{"name":"node-b","service_count":1,"services":["gateway"],"last_seen":"0001-01-01T00:00:00Z","signals":["traces"]},` +
+		`{"name":"node-c","service_count":0,"services":[],"last_seen":"0001-01-01T00:00:00Z","signals":["metrics"]}]}`
+	if !strings.HasSuffix(grouped, wantHosts) {
+		t.Fatalf("grouped hosts =\n%s\nwant suffix\n%s", grouped, wantHosts)
+	}
+	if plainAgain, _ := callTool(t, ts, "", "get_service_map", nil); plainAgain.IsError || strings.Contains(plainAgain.Content[0].Text, `"hosts"`) {
+		t.Fatalf("plain answer polluted by grouped cache entry: %+v", plainAgain)
+	}
+
+	res, text := callTool(t, ts, "", "get_service_map", map[string]any{"group_by": "pod"})
+	if !res.IsError || !strings.Contains(text, "unsupported group_by") {
+		t.Fatalf("unsupported group_by accepted: %+v", res)
+	}
+}
+
+func TestGetServiceHealthGainsHosts(t *testing.T) {
+	ts := setupHostsServer(t)
+	_, health := callTool(t, ts, "", "get_service_health", map[string]any{"service_name": "gateway"})
+	if !strings.HasPrefix(health, `{"service":{`) || !strings.HasSuffix(health, `,"hosts":["node-a","node-b"]}`) {
+		t.Fatalf("get_service_health = %s", health)
+	}
+}
+
+func TestCacheKeyDistinguishesGroupBy(t *testing.T) {
+	plain := cacheKey("default", "get_service_map", nil)
+	grouped := cacheKey("default", "get_service_map", map[string]any{"group_by": "host"})
+	if plain == grouped {
+		t.Fatal("group_by does not change the cache key")
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -60,6 +60,7 @@ var toolDefs = []Tool{
 	mkTool("get_service_map", "Returns the service topology with health scores, error rates, call counts, and dependency edges. Aggregate-backed: counts describe ALL accepted telemetry, not the sampled subset, and are complete within aggregate retention.",
 		param("depth", "number", "Max traversal depth (default 3)."),
 		param("service", "string", "Focus on a specific service and its neighbors."),
+		param("group_by", "string", "Set to \"host\" to wrap the map as {services, hosts}: `hosts` lists the tenant's hosts, each with its bounded, sorted service list. Omitted: the bare service array, unchanged."),
 	),
 	mkTool("get_service_health", "Returns detailed health metrics for a specific service: error rate, latency, request counts and dependency edges. Aggregate-backed and complete within aggregate retention. Returns an explicit \"not found in the current tenant window\" message rather than an empty guess.",
 		required("service_name"),
@@ -240,7 +241,8 @@ func (s *Server) toolGetServiceHealth(ctx context.Context, args map[string]any) 
 	}
 	for _, entry := range s.graphRAG.ServiceMap(mcpCtx(ctx), 0) {
 		if entry.Service != nil && entry.Service.Name == svcName {
-			data, err := json.Marshal(entry)
+			_, hosts := s.hosts(ctx).ServiceHosts(svcName)
+			data, err := json.Marshal(serviceHealthResult{ServiceMapEntry: entry, Hosts: hosts})
 			if err != nil {
 				return errorResult(fmt.Sprintf("failed to marshal service health: %v", err))
 			}
@@ -352,11 +354,41 @@ func (s *Server) toolGetServiceMap(ctx context.Context, args map[string]any) Too
 	} else {
 		result = s.graphRAG.ServiceMap(mcpCtx(ctx), depth)
 	}
-	data, err := json.Marshal(result)
+	// group_by=host (#288) wraps the unchanged array with the tenant's hosts.
+	var payload any = result
+	switch groupBy, _ := args["group_by"].(string); groupBy {
+	case "":
+	case "host":
+		payload = serviceMapByHost{Services: result, Hosts: s.hosts(ctx).Hosts}
+	default:
+		return errorResult(fmt.Sprintf("unsupported group_by %q (only \"host\")", groupBy))
+	}
+	data, err := json.Marshal(payload)
 	if err != nil {
 		return errorResult(fmt.Sprintf("failed to marshal service map: %v", err))
 	}
 	return textResult(string(data))
+}
+
+// serviceMapByHost is the get_service_map payload under group_by=host.
+type serviceMapByHost struct {
+	Services []graphrag.ServiceMapEntry `json:"services"`
+	Hosts    []topology.Host            `json:"hosts"`
+}
+
+// serviceHealthResult is the get_service_health payload: the entry as
+// before, plus the hosts the service was observed on.
+type serviceHealthResult struct {
+	graphrag.ServiceMapEntry
+	Hosts []string `json:"hosts"`
+}
+
+// hosts reads the tenant's host projection through the topology owner.
+func (s *Server) hosts(ctx context.Context) topology.HostProjection {
+	if s.topology == nil {
+		return topology.ProjectHosts(nil)
+	}
+	return s.topology.Hosts(mcpCtx(ctx))
 }
 
 // toolTraceGraph answers with the retained span tree and an explicit coverage

--- a/internal/mcp/topology_provider_test.go
+++ b/internal/mcp/topology_provider_test.go
@@ -16,9 +16,12 @@ type fakeMCPTopologyProvider struct {
 	revision atomic.Uint64
 	snapshot topology.Snapshot
 	err      error
+	hosts    topology.HostProjection
 }
 
 func (*fakeMCPTopologyProvider) Source() topology.Source { return topology.SourceAggregate }
+
+func (p *fakeMCPTopologyProvider) Hosts(context.Context) topology.HostProjection { return p.hosts }
 
 func (p *fakeMCPTopologyProvider) Identity(context.Context) topology.Identity {
 	return topology.Identity{Epoch: p.epoch, Revision: p.revision.Load()}

--- a/internal/realtime/aggregate_publisher.go
+++ b/internal/realtime/aggregate_publisher.go
@@ -179,6 +179,9 @@ func (p *EnginePublisher) Snapshot(ctx context.Context, service string) *LiveSna
 				AvgLatencyMs:      n.AvgLatencyMs,
 				P99LatencyMs:      n.P99LatencyMs,
 				LatencyProvenance: n.LatencyProvenance,
+				Kind:              n.Kind,
+				HostCount:         n.HostCount,
+				Hosts:             n.Hosts,
 			})
 		}
 		for _, e := range topologySnapshot.Edges {

--- a/internal/realtime/aggregate_ws_test.go
+++ b/internal/realtime/aggregate_ws_test.go
@@ -183,6 +183,7 @@ func TestAggregateWSProviderErrorRetainsLastGoodIdentity(t *testing.T) {
 	hub.lastEpoch = "epoch-1"
 	hub.lastRev = 1
 	client := &clientFilter{send: make(chan []byte, 1)}
+	client.seeded.Store(true)
 	hub.clients[nil] = client
 
 	hub.publishIfChanged()
@@ -336,5 +337,26 @@ func TestWebSocketDashboardPreservesMicrosecondsAndProvenance(t *testing.T) {
 	}
 	if wire.Dashboard.P99 != 1_000_000 || wire.Dashboard.LatencyProvenance.P99.Status != latency.StatusApproximate {
 		t.Fatalf("wire dashboard = %+v", wire.Dashboard)
+	}
+}
+
+// TestAggregateWSConnectSeedIsNotRepublished: a client seeded at connect time
+// already holds the current revision. The first loop tick after that must not
+// send the same revision again; the next revision still arrives.
+func TestAggregateWSConnectSeedIsNotRepublished(t *testing.T) {
+	f := newWSFixture(t, time.Hour) // no tick fires on its own
+	seed := f.read(t, 2*time.Second)
+	if !seed.Reset {
+		t.Fatal("connect snapshot is not flagged reset")
+	}
+
+	// A tick at the seeded revision publishes nothing; the next revision is
+	// therefore the very next message on the wire.
+	f.hub.publishIfChanged()
+	f.pub.rev.Store(seed.Revision + 1)
+	f.hub.publishIfChanged()
+	next := f.read(t, 2*time.Second)
+	if next.Revision != seed.Revision+1 || next.Reset {
+		t.Fatalf("next snapshot = rev %d reset %v, want rev %d reset false (a duplicate seed revision would arrive first)", next.Revision, next.Reset, seed.Revision+1)
 	}
 }

--- a/internal/realtime/events_ws.go
+++ b/internal/realtime/events_ws.go
@@ -85,6 +85,10 @@ type clientFilter struct {
 	service string
 	tenant  string
 	closed  atomic.Bool
+	// seeded is set once the connect-time full snapshot has been attempted.
+	// The revision loop skips an unseeded client: an incremental snapshot
+	// delivered ahead of the reset seed would be applied to nothing.
+	seeded atomic.Bool
 }
 
 // matches reports whether an entry belongs to this client's scope.
@@ -385,6 +389,7 @@ func (h *EventHub) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 		h.retryReset = true
 		h.mu.Unlock()
 	}
+	cf.seeded.Store(true)
 
 	// Read loop: client can send {"service":"xxx"} to change filter. The
 	// tenant scope is not negotiable and is deliberately absent here.
@@ -519,6 +524,9 @@ func (h *EventHub) flushSnapshots() {
 func (h *EventHub) groupByScopeLocked() map[scopeKey][]*clientFilter {
 	groups := make(map[scopeKey][]*clientFilter, len(h.clients))
 	for _, cf := range h.clients {
+		if !cf.seeded.Load() {
+			continue
+		}
 		k := scopeKey{tenant: cf.tenant, service: cf.service}
 		groups[k] = append(groups[k], cf)
 	}
@@ -586,7 +594,8 @@ func (h *EventHub) sendSnapshotTo(cf *clientFilter) bool {
 	if snapshot == nil {
 		return false
 	}
-	if h.aggregatePublisher() != nil {
+	aggregate := h.aggregatePublisher() != nil
+	if aggregate {
 		snapshot.Reset = true
 	}
 	msg, err := json.Marshal(snapshot)
@@ -594,6 +603,16 @@ func (h *EventHub) sendSnapshotTo(cf *clientFilter) bool {
 		return false
 	}
 	h.deliver(cf, msg)
+	if aggregate {
+		// The seed carries the identity the client now holds. Until the loop
+		// has published once, adopt it so the next tick does not re-send the
+		// same revision to a client that already has it.
+		h.mu.Lock()
+		if !h.published {
+			h.lastEpoch, h.lastRev, h.published = snapshot.Epoch, snapshot.Revision, true
+		}
+		h.mu.Unlock()
+	}
 	return true
 }
 

--- a/internal/realtime/events_ws.go
+++ b/internal/realtime/events_ws.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/RandomCodeSpace/otelcontext/internal/authn"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
 	"github.com/coder/websocket"
 	"golang.org/x/sync/errgroup"
 )
@@ -160,6 +161,11 @@ type EventHub struct {
 	lastRev    uint64
 	published  bool
 	retryReset bool
+
+	// topology, when set, stamps the host projection (#288) onto the
+	// legacy snapshot's service map. The aggregate publisher's nodes arrive
+	// already stamped by the same provider.
+	topology topology.Provider
 }
 
 // NewEventHub creates a new event notification hub.
@@ -191,6 +197,20 @@ func (h *EventHub) SetAggregatePublisher(p AggregatePublisher, floor time.Durati
 	h.aggPub = p
 	h.publishFloor = floor
 	h.mu.Unlock()
+}
+
+// SetTopologyProvider wires the mode-selected topology owner that answers
+// host questions. Call once at startup, before the hub takes connections.
+func (h *EventHub) SetTopologyProvider(p topology.Provider) {
+	h.mu.Lock()
+	h.topology = p
+	h.mu.Unlock()
+}
+
+func (h *EventHub) topologyProvider() topology.Provider {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.topology
 }
 
 // aggregatePublisher returns the configured publisher, or nil in legacy mode.
@@ -710,6 +730,14 @@ func (h *EventHub) computeSnapshot(ctx context.Context, service string) *LiveSna
 	}
 
 	if smap, err := h.repo.GetServiceMapMetrics(ctx, start, now); err == nil {
+		if provider := h.topologyProvider(); provider != nil {
+			hosts := provider.Hosts(ctx)
+			for i := range smap.Nodes {
+				node := &smap.Nodes[i]
+				node.Kind = topology.NodeKind(node.Name)
+				node.HostCount, node.Hosts = hosts.ServiceHosts(node.Name)
+			}
+		}
 		snapshot.ServiceMap = smap
 	}
 

--- a/internal/realtime/hosts_test.go
+++ b/internal/realtime/hosts_test.go
@@ -1,0 +1,105 @@
+package realtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+	"github.com/RandomCodeSpace/otelcontext/internal/topology"
+)
+
+// hostsProvider is a provider whose host projection a test fixes by hand.
+type hostsProvider struct {
+	fakeRefreshProvider
+	source topology.Source
+	nodes  []topology.Node
+	hosts  topology.HostProjection
+}
+
+func (p *hostsProvider) Source() topology.Source                       { return p.source }
+func (p *hostsProvider) Hosts(context.Context) topology.HostProjection { return p.hosts }
+func (p *hostsProvider) Snapshot(context.Context, topology.Query) (topology.Snapshot, error) {
+	return topology.Snapshot{Nodes: p.nodes, Edges: []topology.Edge{}, Meta: topology.Metadata{Source: p.source}}, nil
+}
+
+func fixtureHosts() topology.HostProjection {
+	return topology.ProjectHosts([]topology.ResourceEntry{
+		{ResourceKey: topology.ResourceKey{Tenant: storage.DefaultTenantID, Service: "gateway", Host: "node-a"}, Signals: topology.SignalTraces},
+		{ResourceKey: topology.ResourceKey{Tenant: storage.DefaultTenantID, Service: "gateway", Host: "node-b"}, Signals: topology.SignalTraces},
+	})
+}
+
+// TestLegacySnapshotStampsHostsOnServiceMap: the legacy live_snapshot keeps
+// its repository-sourced nodes and gains kind/host_count/hosts from the
+// provider's registry projection.
+func TestLegacySnapshotStampsHostsOnServiceMap(t *testing.T) {
+	db, err := storage.NewDatabase("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	if err := storage.AutoMigrateModels(db, "sqlite"); err != nil {
+		t.Fatalf("AutoMigrateModels: %v", err)
+	}
+	repo := storage.NewRepositoryFromDB(db, "sqlite")
+	t.Cleanup(func() { _ = repo.Close() })
+	now := time.Now().UTC()
+	if err := repo.BatchCreateSpans([]storage.Span{
+		{TenantID: storage.DefaultTenantID, TraceID: "t", SpanID: "p", ServiceName: "gateway", OperationName: "op", StartTime: now, EndTime: now.Add(time.Millisecond), Duration: 1000, Status: "STATUS_CODE_UNSET"},
+		{TenantID: storage.DefaultTenantID, TraceID: "t", SpanID: "c", ParentSpanID: "p", ServiceName: "payments", OperationName: "op", StartTime: now, EndTime: now.Add(time.Millisecond), Duration: 1000, Status: "STATUS_CODE_UNSET"},
+	}); err != nil {
+		t.Fatalf("seed spans: %v", err)
+	}
+
+	hub := NewEventHub(repo, nil, nil)
+	hub.SetTopologyProvider(&hostsProvider{source: topology.SourceLegacy, hosts: fixtureHosts()})
+	snap := hub.computeSnapshot(storage.WithTenantContext(context.Background(), storage.DefaultTenantID), "")
+	if snap == nil || snap.ServiceMap == nil {
+		t.Fatalf("snapshot = %+v", snap)
+	}
+	got := ""
+	for _, node := range snap.ServiceMap.Nodes {
+		got += fmt.Sprintf("%s:%s:%d:%v ", node.Name, node.Kind, node.HostCount, node.Hosts)
+	}
+	if want := "gateway:service:2:[node-a node-b] payments:service:0:[] "; got != want {
+		t.Fatalf("nodes = %q, want %q", got, want)
+	}
+	raw, _ := json.Marshal(snap.ServiceMap.Nodes[0])
+	if want := `{"name":"gateway","total_traces":1,"error_count":0,"avg_latency_ms":1,"p99_latency_ms":2.5,"latency_provenance":`; len(raw) < len(want) || string(raw[:len(want)]) != want {
+		t.Fatalf("node prefix changed: %s", raw)
+	}
+	if suffix := `,"kind":"service","host_count":2,"hosts":["node-a","node-b"]}`; string(raw[len(raw)-len(suffix):]) != suffix {
+		t.Fatalf("node suffix = %s, want %s", raw, suffix)
+	}
+}
+
+// TestAggregateSnapshotCarriesProviderHosts: the engine publisher copies the
+// provider's stamped host fields onto live_snapshot nodes.
+func TestAggregateSnapshotCarriesProviderHosts(t *testing.T) {
+	engine, err := aggregate.NewEngine(aggregate.EngineConfig{Mode: aggregate.ModeAggregate})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	provider := &hostsProvider{source: topology.SourceAggregate, nodes: []topology.Node{
+		{Name: "gateway", Kind: "service", HostCount: 2, Hosts: []string{"node-a", "node-b"}},
+		{Name: "host/node-c", Kind: "host", HostCount: 1, Hosts: []string{"node-c"}},
+	}}
+	provider.epoch.Store("epoch-1")
+	pub := NewEnginePublisher(EnginePublisherConfig{Engine: engine, Topology: provider})
+	if pub == nil {
+		t.Fatal("publisher refused an aggregate provider")
+	}
+	snap := pub.Snapshot(context.Background(), "")
+	if snap == nil || snap.ServiceMap == nil || len(snap.ServiceMap.Nodes) != 2 {
+		t.Fatalf("snapshot = %+v", snap)
+	}
+	if n := snap.ServiceMap.Nodes[1]; n.Kind != "host" || n.HostCount != 1 || fmt.Sprint(n.Hosts) != "[node-c]" {
+		t.Fatalf("host node = %+v", n)
+	}
+	if n := snap.ServiceMap.Nodes[0]; n.Kind != "service" || fmt.Sprint(n.Hosts) != "[node-a node-b]" {
+		t.Fatalf("service node = %+v", n)
+	}
+}

--- a/internal/realtime/topology_refresh_test.go
+++ b/internal/realtime/topology_refresh_test.go
@@ -26,6 +26,10 @@ func newFakeRefreshProvider(epoch string) *fakeRefreshProvider {
 
 func (*fakeRefreshProvider) Source() topology.Source { return topology.SourceAggregate }
 
+func (*fakeRefreshProvider) Hosts(context.Context) topology.HostProjection {
+	return topology.ProjectHosts(nil)
+}
+
 func (p *fakeRefreshProvider) Identity(context.Context) topology.Identity {
 	return topology.Identity{Epoch: p.epoch.Load().(string), Revision: p.rev.Load()}
 }

--- a/internal/storage/trace_repo.go
+++ b/internal/storage/trace_repo.go
@@ -30,6 +30,12 @@ type ServiceMapNode struct {
 	AvgLatencyMs      float64             `json:"avg_latency_ms"`
 	P99LatencyMs      float64             `json:"p99_latency_ms,omitempty"`
 	LatencyProvenance *latency.Provenance `json:"latency_provenance,omitempty"`
+
+	// Additive host projection (#288), stamped by the topology provider;
+	// never read from or written to the database.
+	Kind      string   `json:"kind,omitempty" gorm:"-"`
+	HostCount int      `json:"host_count,omitempty" gorm:"-"`
+	Hosts     []string `json:"hosts,omitempty" gorm:"-"`
 }
 
 // ServiceMapEdge represents a connection between two services.

--- a/internal/topology/aggregate.go
+++ b/internal/topology/aggregate.go
@@ -13,6 +13,7 @@ import (
 // AggregateProvider is both the ordinary mode-selected provider and the
 // narrow aggregate projection source GraphRAG already consumes.
 type AggregateProvider struct {
+	HostReader
 	engine *aggregate.Engine
 }
 
@@ -34,6 +35,15 @@ func (p *AggregateProvider) Identity(context.Context) Identity {
 }
 
 func (p *AggregateProvider) Snapshot(ctx context.Context, q Query) (Snapshot, error) {
+	snap, err := p.snapshot(ctx, q)
+	if err != nil {
+		return snap, err
+	}
+	p.stampHosts(ctx, &snap)
+	return snap, nil
+}
+
+func (p *AggregateProvider) snapshot(ctx context.Context, q Query) (Snapshot, error) {
 	id := p.Identity(ctx)
 	tenant := storage.TenantFromContext(ctx)
 	projection := p.engine.TopologySnapshot(tenant)

--- a/internal/topology/hosts.go
+++ b/internal/topology/hosts.go
@@ -1,0 +1,179 @@
+package topology
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+// Host projection bounds (#288). The registry already bounds hosts and
+// service-host pairs per tenant; these bound what one response carries.
+const (
+	// MaxHostsPerNode caps the hosts list stamped on one service-map node.
+	MaxHostsPerNode = 20
+	// MaxServicesPerHost caps the services list carried by one host.
+	MaxServicesPerHost = 100
+)
+
+// Node kinds. A host entity (IsHostEntity) is rendered as a host by every
+// consumer: it is never a service, never carries a CALLS edge and never
+// enters a service count.
+const (
+	KindService = "service"
+	KindHost    = "host"
+)
+
+// NodeKind returns the kind of the named node.
+func NodeKind(service string) string {
+	if IsHostEntity(service) {
+		return KindHost
+	}
+	return KindService
+}
+
+// Names renders the signal bits as sorted names.
+func (s Signal) Names() []string {
+	out := []string{}
+	if s&SignalLogs != 0 {
+		out = append(out, "logs")
+	}
+	if s&SignalMetrics != 0 {
+		out = append(out, "metrics")
+	}
+	if s&SignalTraces != 0 {
+		out = append(out, "traces")
+	}
+	return out
+}
+
+// Host is one host with the services observed on it. Services is sorted,
+// never nil, capped at MaxServicesPerHost and never lists a host entity;
+// ServiceCount is the uncapped total.
+type Host struct {
+	Name         string    `json:"name"`
+	ServiceCount int       `json:"service_count"`
+	Services     []string  `json:"services"`
+	LastSeen     time.Time `json:"last_seen"`
+	Signals      []string  `json:"signals"`
+}
+
+// HostProjection is one tenant's host view derived from one registry
+// snapshot: hosts with their services, and per service its hosts.
+type HostProjection struct {
+	// Hosts is sorted by name and never nil.
+	Hosts     []Host
+	byService map[string][]string
+}
+
+// Host returns the named host.
+func (p HostProjection) Host(name string) (Host, bool) {
+	i := sort.Search(len(p.Hosts), func(i int) bool { return p.Hosts[i].Name >= name })
+	if i < len(p.Hosts) && p.Hosts[i].Name == name {
+		return p.Hosts[i], true
+	}
+	return Host{}, false
+}
+
+// ServiceHosts returns how many hosts service was observed on and the first
+// MaxHostsPerNode of them, sorted.
+func (p HostProjection) ServiceHosts(service string) (int, []string) {
+	all := p.byService[service]
+	n := min(len(all), MaxHostsPerNode)
+	return len(all), append(make([]string, 0, n), all[:n]...)
+}
+
+// ProjectHosts folds registry entries of one tenant into a HostProjection.
+// Entries without a host contribute nothing.
+func ProjectHosts(entries []ResourceEntry) HostProjection {
+	type hostAcc struct {
+		host     Host
+		signals  Signal
+		services map[string]struct{}
+	}
+	hosts := make(map[string]*hostAcc)
+	byService := make(map[string]map[string]struct{})
+	for _, e := range entries {
+		if e.Host == "" {
+			continue
+		}
+		acc := hosts[e.Host]
+		if acc == nil {
+			acc = &hostAcc{host: Host{Name: e.Host}, services: make(map[string]struct{})}
+			hosts[e.Host] = acc
+		}
+		acc.signals |= e.Signals
+		if e.LastSeen.After(acc.host.LastSeen) {
+			acc.host.LastSeen = e.LastSeen
+		}
+		if byService[e.Service] == nil {
+			byService[e.Service] = make(map[string]struct{})
+		}
+		byService[e.Service][e.Host] = struct{}{}
+		if !IsHostEntity(e.Service) {
+			acc.services[e.Service] = struct{}{}
+		}
+	}
+	out := HostProjection{Hosts: make([]Host, 0, len(hosts)), byService: make(map[string][]string, len(byService))}
+	for _, acc := range hosts {
+		services := sortedKeys(acc.services)
+		acc.host.ServiceCount = len(services)
+		acc.host.Services = services[:min(len(services), MaxServicesPerHost)]
+		acc.host.Signals = acc.signals.Names()
+		out.Hosts = append(out.Hosts, acc.host)
+	}
+	sort.Slice(out.Hosts, func(i, j int) bool { return out.Hosts[i].Name < out.Hosts[j].Name })
+	for service, set := range byService {
+		out.byService[service] = sortedKeys(set)
+	}
+	return out
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// HostReader is the single reader of the resource registry for every
+// topology consumer. Both providers embed it, so legacy, shadow and
+// aggregate answer host questions identically. Without a registry it
+// projects nothing.
+type HostReader struct {
+	registry *Registry
+}
+
+// SetRegistry wires the registry read by Hosts.
+func (h *HostReader) SetRegistry(r *Registry) { h.registry = r }
+
+// Hosts projects the registry for the tenant on ctx. It is built per call:
+// the registry snapshot is already sorted and bounded per tenant.
+func (h *HostReader) Hosts(ctx context.Context) HostProjection {
+	if h == nil || h.registry == nil {
+		return ProjectHosts(nil)
+	}
+	return ProjectHosts(h.registry.TenantSnapshot(storage.TenantFromContext(ctx)))
+}
+
+// stampHosts annotates every node with its kind and hosts and drops any edge
+// touching a host entity.
+func (h *HostReader) stampHosts(ctx context.Context, snap *Snapshot) {
+	hosts := h.Hosts(ctx)
+	for i := range snap.Nodes {
+		node := &snap.Nodes[i]
+		node.Kind = NodeKind(node.Name)
+		node.HostCount, node.Hosts = hosts.ServiceHosts(node.Name)
+	}
+	edges := snap.Edges[:0]
+	for _, edge := range snap.Edges {
+		if IsHostEntity(edge.Source) || IsHostEntity(edge.Target) {
+			continue
+		}
+		edges = append(edges, edge)
+	}
+	snap.Edges = edges
+}

--- a/internal/topology/hosts_test.go
+++ b/internal/topology/hosts_test.go
@@ -1,0 +1,136 @@
+package topology
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+// hostFixture registers two tenants: acme has gateway on node-a and node-b,
+// a host entity on node-c and a host-less checkout; beta has one host.
+func hostFixture(t *testing.T) *Registry {
+	t.Helper()
+	r := NewRegistry(nil)
+	now := time.Unix(1_700_000_000, 0).UTC()
+	for _, e := range []struct {
+		tenant, service, host string
+		signal                Signal
+		at                    time.Time
+	}{
+		{"acme", "gateway", "node-a", SignalTraces, now},
+		{"acme", "gateway", "node-b", SignalTraces, now.Add(time.Minute)},
+		{"acme", "payments", "node-b", SignalLogs, now},
+		{"acme", HostPrefix + "node-c", "node-c", SignalMetrics, now},
+		{"acme", "checkout", "", SignalTraces, now},
+		{"beta", "gateway", "node-z", SignalTraces, now},
+	} {
+		if !r.Register(e.tenant, e.service, e.host, "", "", e.signal, e.at) {
+			t.Fatalf("register %+v refused", e)
+		}
+	}
+	return r
+}
+
+func TestProjectHostsSortsScopesAndExcludesHostEntitiesFromServices(t *testing.T) {
+	r := hostFixture(t)
+	reader := &HostReader{}
+	reader.SetRegistry(r)
+	ctx := storage.WithTenantContext(context.Background(), "acme")
+	p := reader.Hosts(ctx)
+
+	got := fmt.Sprint(p.Hosts)
+	want := "[{node-a 1 [gateway] 2023-11-14 22:13:20 +0000 UTC [traces]} {node-b 2 [gateway payments] 2023-11-14 22:14:20 +0000 UTC [logs traces]} {node-c 0 [] 2023-11-14 22:13:20 +0000 UTC [metrics]}]"
+	if got != want {
+		t.Fatalf("hosts =\n%s\nwant\n%s", got, want)
+	}
+	if count, hosts := p.ServiceHosts("gateway"); count != 2 || fmt.Sprint(hosts) != "[node-a node-b]" {
+		t.Fatalf("gateway hosts = %d %v", count, hosts)
+	}
+	if count, hosts := p.ServiceHosts(HostPrefix + "node-c"); count != 1 || fmt.Sprint(hosts) != "[node-c]" {
+		t.Fatalf("host entity hosts = %d %v", count, hosts)
+	}
+	if count, hosts := p.ServiceHosts("checkout"); count != 0 || hosts == nil || len(hosts) != 0 {
+		t.Fatalf("host-less service = %d %v", count, hosts)
+	}
+	if host, ok := p.Host("node-b"); !ok || host.ServiceCount != 2 {
+		t.Fatalf("Host(node-b) = %+v %v", host, ok)
+	}
+	if _, ok := p.Host("node-z"); ok {
+		t.Fatal("beta's host leaked into acme")
+	}
+	if beta := reader.Hosts(storage.WithTenantContext(context.Background(), "beta")); len(beta.Hosts) != 1 || beta.Hosts[0].Name != "node-z" {
+		t.Fatalf("beta hosts = %+v", beta.Hosts)
+	}
+	if empty := (&HostReader{}).Hosts(ctx); empty.Hosts == nil || len(empty.Hosts) != 0 {
+		t.Fatalf("registry-less reader = %+v", empty.Hosts)
+	}
+}
+
+func TestServiceHostsAreBoundedWhileCountIsNot(t *testing.T) {
+	r := NewRegistry(nil)
+	now := time.Now()
+	for i := 0; i < MaxHostsPerNode+5; i++ {
+		r.Register("acme", "gateway", fmt.Sprintf("node-%03d", i), "", "", SignalTraces, now)
+	}
+	p := ProjectHosts(r.TenantSnapshot("acme"))
+	count, hosts := p.ServiceHosts("gateway")
+	if count != MaxHostsPerNode+5 || len(hosts) != MaxHostsPerNode || hosts[0] != "node-000" || hosts[MaxHostsPerNode-1] != "node-019" {
+		t.Fatalf("count=%d hosts=%v", count, hosts)
+	}
+}
+
+func TestLegacyProviderStampsHostsAndDropsHostEntityEdges(t *testing.T) {
+	repo := fakeLegacyRepository{result: &storage.ServiceMapMetrics{
+		Nodes: []storage.ServiceMapNode{{Name: "gateway", TotalTraces: 4}, {Name: HostPrefix + "node-c"}, {Name: "checkout"}},
+		Edges: []storage.ServiceMapEdge{{Source: "gateway", Target: "checkout", CallCount: 3}, {Source: "gateway", Target: HostPrefix + "node-c", CallCount: 1}},
+	}}
+	provider, err := NewLegacyProvider(repo, nil, nil)
+	if err != nil {
+		t.Fatalf("NewLegacyProvider: %v", err)
+	}
+	provider.SetRegistry(hostFixture(t))
+	ctx := storage.WithTenantContext(context.Background(), "acme")
+	snapshot, err := provider.Snapshot(ctx, Query{Start: time.Unix(100, 0), End: time.Unix(200, 0)})
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	got := ""
+	for _, node := range snapshot.Nodes {
+		got += fmt.Sprintf("%s:%s:%d:%v ", node.Name, node.Kind, node.HostCount, node.Hosts)
+	}
+	if want := "checkout:service:0:[] gateway:service:2:[node-a node-b] host/node-c:host:1:[node-c] "; got != want {
+		t.Fatalf("nodes = %q, want %q", got, want)
+	}
+	if len(snapshot.Edges) != 1 || snapshot.Edges[0].Target != "checkout" {
+		t.Fatalf("edges = %+v, want only gateway -> checkout", snapshot.Edges)
+	}
+}
+
+func TestAggregateProviderReadsTheSameRegistry(t *testing.T) {
+	engine, err := aggregate.NewEngine(aggregate.EngineConfig{Mode: aggregate.ModeAggregate})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	provider, err := NewAggregateProvider(engine)
+	if err != nil {
+		t.Fatalf("NewAggregateProvider: %v", err)
+	}
+	registry := hostFixture(t)
+	provider.SetRegistry(registry)
+	ctx := storage.WithTenantContext(context.Background(), "acme")
+	legacy, err := NewLegacyProvider(fakeLegacyRepository{}, nil, nil)
+	if err != nil {
+		t.Fatalf("NewLegacyProvider: %v", err)
+	}
+	legacy.SetRegistry(registry)
+	if a, l := fmt.Sprint(provider.Hosts(ctx).Hosts), fmt.Sprint(legacy.Hosts(ctx).Hosts); a != l || len(provider.Hosts(ctx).Hosts) != 3 {
+		t.Fatalf("aggregate hosts %s != legacy hosts %s", a, l)
+	}
+	if _, err := provider.Snapshot(ctx, Query{}); err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+}

--- a/internal/topology/legacy.go
+++ b/internal/topology/legacy.go
@@ -19,6 +19,7 @@ type legacyRepository interface {
 // LegacyProvider preserves the existing historical repository query and the
 // current GraphRAG/graph/DB preference for live topology.
 type LegacyProvider struct {
+	HostReader
 	repo     legacyRepository
 	graph    *graph.Graph
 	graphRAG *graphrag.GraphRAG
@@ -37,6 +38,15 @@ func (*LegacyProvider) Source() Source { return SourceLegacy }
 func (*LegacyProvider) Identity(context.Context) Identity { return Identity{} }
 
 func (p *LegacyProvider) Snapshot(ctx context.Context, q Query) (Snapshot, error) {
+	snap, err := p.snapshot(ctx, q)
+	if err != nil {
+		return snap, err
+	}
+	p.stampHosts(ctx, &snap)
+	return snap, nil
+}
+
+func (p *LegacyProvider) snapshot(ctx context.Context, q Query) (Snapshot, error) {
 	if !q.Start.IsZero() || !q.End.IsZero() {
 		return p.rangeSnapshot(ctx, q)
 	}

--- a/internal/topology/provider.go
+++ b/internal/topology/provider.go
@@ -76,6 +76,13 @@ type Node struct {
 	HealthScore       float64             `json:"health_score,omitempty"`
 	Status            string              `json:"status,omitempty"`
 	Alerts            []string            `json:"alerts,omitempty"`
+
+	// Host projection (#288), stamped by the provider from the resource
+	// registry. Kind is KindService or KindHost; Hosts is sorted and capped
+	// at MaxHostsPerNode while HostCount is the uncapped total.
+	Kind      string   `json:"kind,omitempty"`
+	HostCount int      `json:"host_count,omitempty"`
+	Hosts     []string `json:"hosts,omitempty"`
 }
 
 // Edge is one directed service dependency.
@@ -101,4 +108,8 @@ type Provider interface {
 	Source() Source
 	Identity(context.Context) Identity
 	Snapshot(context.Context, Query) (Snapshot, error)
+	// Hosts is the tenant-scoped host projection of the resource registry.
+	// Every provider answers it from the same registry, so legacy, shadow
+	// and aggregate agree on hosts.
+	Hosts(context.Context) HostProjection
 }

--- a/internal/topology/registry.go
+++ b/internal/topology/registry.go
@@ -227,9 +227,21 @@ func (r *Registry) Evict(now time.Time) int {
 
 // Snapshot returns every live entry ordered by key.
 func (r *Registry) Snapshot() []ResourceEntry {
+	return r.snapshot(func(ResourceKey) bool { return true })
+}
+
+// TenantSnapshot returns tenant's live entries ordered by key.
+func (r *Registry) TenantSnapshot(tenant string) []ResourceEntry {
+	return r.snapshot(func(key ResourceKey) bool { return key.Tenant == tenant })
+}
+
+func (r *Registry) snapshot(keep func(ResourceKey) bool) []ResourceEntry {
 	r.mu.Lock()
 	out := make([]ResourceEntry, 0, len(r.entries))
 	for key, e := range r.entries {
+		if !keep(key) {
+			continue
+		}
 		out = append(out, ResourceEntry{ResourceKey: key, Kind: e.kind, Signals: e.signals, LastSeen: time.Unix(e.lastSeen, 0).UTC()})
 	}
 	r.mu.Unlock()

--- a/main.go
+++ b/main.go
@@ -728,6 +728,7 @@ func main() {
 		if err != nil {
 			fatal("❌ Aggregate topology provider rejected", err)
 		}
+		provider.SetRegistry(resourceRegistry)
 		topologyProvider = provider
 		graphRAG.SetAggregateSource(provider)
 		slog.Info("🧭 GraphRAG consuming aggregate topology snapshots (raw-span rebuild retired)",
@@ -738,6 +739,7 @@ func main() {
 		if err != nil {
 			fatal("❌ Legacy topology provider rejected", err)
 		}
+		provider.SetRegistry(resourceRegistry)
 		topologyProvider = provider
 	}
 	graphRAG.Start(ctxGraphRAG)
@@ -773,6 +775,7 @@ func main() {
 	)
 
 	hub.SetTopologyProvider(topologyProvider, realtime.DefaultPublishFloor)
+	eventHub.SetTopologyProvider(topologyProvider)
 
 	// Aggregate READ path (#175). Only AGGREGATE_MODE=aggregate switches the
 	// dashboard, the WebSocket publisher and the MCP coverage metadata over;

--- a/test/topologyproof/topology_proof_test.go
+++ b/test/topologyproof/topology_proof_test.go
@@ -46,6 +46,41 @@ type proofAssertion struct {
 	Detail string `json:"detail"`
 }
 
+// proofHost is the mode-independent part of a host answer (#288): the same
+// registry fixture must yield this list in every mode.
+type proofHost struct {
+	Name     string   `json:"name"`
+	Services []string `json:"services"`
+}
+
+// expectedProofHosts is what the registry fixture in TestTopologyModeProof
+// projects to. host/node-c is a host entity: listed as a host, never as a
+// service.
+var expectedProofHosts = []proofHost{
+	{Name: "node-a", Services: []string{"gateway"}},
+	{Name: "node-b", Services: []string{"gateway"}},
+	{Name: "node-c", Services: []string{}},
+}
+
+func proofHostFixture(t *testing.T, provider *scriptedProvider) {
+	t.Helper()
+	registry := topology.NewRegistry(nil)
+	now := time.Now().UTC()
+	for _, r := range []struct {
+		service, host, workload, kind string
+		signal                        topology.Signal
+	}{
+		{"gateway", "node-a", "", "", topology.SignalTraces},
+		{"gateway", "node-b", "pod-1", "pod", topology.SignalTraces | topology.SignalLogs},
+		{topology.HostPrefix + "node-c", "node-c", "", "", topology.SignalMetrics},
+	} {
+		if !registry.Register(storage.DefaultTenantID, r.service, r.host, r.workload, r.kind, r.signal, now) {
+			t.Fatalf("register fixture %s@%s", r.service, r.host)
+		}
+	}
+	provider.SetRegistry(registry)
+}
+
 type modeProof struct {
 	SchemaVersion    string                    `json:"schema_version"`
 	Mode             string                    `json:"mode"`
@@ -56,6 +91,7 @@ type modeProof struct {
 	EmptyReplacement string                    `json:"empty_replacement"`
 	Reconnect        string                    `json:"reconnect"`
 	Coverage         string                    `json:"coverage"`
+	Hosts            []proofHost               `json:"hosts"`
 	Assertions       map[string]proofAssertion `json:"assertions"`
 }
 
@@ -102,6 +138,7 @@ func (p *modeProof) write(t *testing.T) {
 }
 
 type scriptedProvider struct {
+	topology.HostReader
 	mu       sync.RWMutex
 	source   topology.Source
 	identity topology.Identity
@@ -120,7 +157,7 @@ func (p *scriptedProvider) Identity(context.Context) topology.Identity {
 	return p.identity
 }
 
-func (p *scriptedProvider) Snapshot(context.Context, topology.Query) (topology.Snapshot, error) {
+func (p *scriptedProvider) Snapshot(ctx context.Context, _ topology.Query) (topology.Snapshot, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	if p.err != nil {
@@ -129,6 +166,12 @@ func (p *scriptedProvider) Snapshot(context.Context, topology.Query) (topology.S
 	snapshot := p.snapshot
 	snapshot.Nodes = append([]topology.Node(nil), snapshot.Nodes...)
 	snapshot.Edges = append([]topology.Edge(nil), snapshot.Edges...)
+	hosts := p.Hosts(ctx)
+	for i := range snapshot.Nodes {
+		node := &snapshot.Nodes[i]
+		node.Kind = topology.NodeKind(node.Name)
+		node.HostCount, node.Hosts = hosts.ServiceHosts(node.Name)
+	}
 	return snapshot, nil
 }
 
@@ -281,7 +324,7 @@ func (p providerPublisher) Snapshot(ctx context.Context, _ string) *realtime.Liv
 	}
 	nodes := make([]storage.ServiceMapNode, len(snapshot.Nodes))
 	for i, node := range snapshot.Nodes {
-		nodes[i] = storage.ServiceMapNode{Name: node.Name, TotalTraces: node.TotalTraces, ErrorCount: node.ErrorCount, AvgLatencyMs: node.AvgLatencyMs, P99LatencyMs: node.P99LatencyMs, LatencyProvenance: node.LatencyProvenance}
+		nodes[i] = storage.ServiceMapNode{Name: node.Name, TotalTraces: node.TotalTraces, ErrorCount: node.ErrorCount, AvgLatencyMs: node.AvgLatencyMs, P99LatencyMs: node.P99LatencyMs, LatencyProvenance: node.LatencyProvenance, Kind: node.Kind, HostCount: node.HostCount, Hosts: node.Hosts}
 	}
 	edges := make([]storage.ServiceMapEdge, len(snapshot.Edges))
 	for i, edge := range snapshot.Edges {
@@ -348,6 +391,7 @@ func TestTopologyModeProof(t *testing.T) {
 		proof.Coverage = "omitted (legacy-compatible)"
 	}
 	proof.EdgeSet = []proofEdge{{Source: "gateway", Target: target}}
+	proofHostFixture(t, provider)
 
 	repo := proofRepository(t)
 	seedLegacyEdge(t, repo, target)
@@ -364,6 +408,7 @@ func TestTopologyModeProof(t *testing.T) {
 	go rawHub.Run()
 
 	eventHub := realtime.NewEventHub(repo, nil, nil)
+	eventHub.SetTopologyProvider(provider)
 	if mode == aggregate.ModeAggregate {
 		eventHub.SetAggregatePublisher(providerPublisher{provider: provider}, proofFloor)
 	}
@@ -417,12 +462,34 @@ func TestTopologyModeProof(t *testing.T) {
 		proof.check(t, "mcp_coverage", strings.Contains(mapTool, `"coverage":"full"`) && strings.Contains(mapTool, `"source":"aggregate"`), compact(mapTool))
 	}
 
+	// Host projection (#288): one registry fixture, one answer in every mode.
+	proof.Hosts = proofHostsOf(getHosts(t, httpServer.URL+"/api/hosts"))
+	proof.check(t, "rest_hosts_identical", fmt.Sprint(proof.Hosts) == fmt.Sprint(expectedProofHosts), fmt.Sprintf("hosts=%v want=%v", proof.Hosts, expectedProofHosts))
+	hostDetail := getHosts(t, httpServer.URL+"/api/hosts/node-b")
+	unknownHost, err := http.Get(httpServer.URL + "/api/hosts/node-z") //nolint:gosec // local httptest endpoint
+	if err != nil {
+		t.Fatalf("GET unknown host: %v", err)
+	}
+	unknownHost.Body.Close()
+	proof.check(t, "rest_host_detail", len(hostDetail) == 1 && hostDetail[0].Name == "node-b" && fmt.Sprint(hostDetail[0].Services) == "[gateway]" && unknownHost.StatusCode == http.StatusNotFound, fmt.Sprintf("detail=%+v unknown_status=%d", hostDetail, unknownHost.StatusCode))
+	mapNodes := decodeNodes(t, serviceMap.Nodes)
+	graphNodes := decodeNodes(t, systemGraph.Nodes)
+	nodeHostsOK := mapNodes["gateway"].Kind == "service" && mapNodes["gateway"].HostCount == 2 && fmt.Sprint(mapNodes["gateway"].Hosts) == "[node-a node-b]" &&
+		mapNodes[target].Kind == "service" && mapNodes[target].HostCount == 0 &&
+		graphNodes["gateway"].Kind == "service" && fmt.Sprint(graphNodes["gateway"].Hosts) == "[node-a node-b]"
+	proof.check(t, "rest_nodes_carry_hosts", nodeHostsOK, fmt.Sprintf("service_map=%+v system_graph=%+v", mapNodes, graphNodes))
+	groupedTool := callTool(t, mcpHTTP.URL, "get_service_map", map[string]any{"group_by": "host"})
+	proof.check(t, "mcp_group_by_host", !strings.Contains(mapTool, `"hosts"`) && strings.Contains(groupedTool, `"services":[`) && strings.Contains(groupedTool, `"hosts":[{"name":"node-a","service_count":1,"services":["gateway"]`) && strings.Contains(groupedTool, `{"name":"node-c","service_count":0,"services":[]`), compact(groupedTool))
+	gatewayHealth := callTool(t, mcpHTTP.URL, "get_service_health", map[string]any{"service_name": "gateway"})
+	proof.check(t, "mcp_service_health_hosts", strings.Contains(gatewayHealth, `"hosts":["node-a","node-b"]`), compact(gatewayHealth))
+
 	sse := immediateSSE(t, mcpServer)
 	proof.check(t, "mcp_sse", strings.Contains(sse, target) && !strings.Contains(sse, forbidden) && strings.Contains(sse, "notifications/resources/updated"), compact(sse))
 
 	eventConn := dialWS(t, httpServer.URL+"/ws/events")
 	initialEvent := readEventSnapshot(t, eventConn, 2*time.Second)
 	proof.check(t, "websocket_events", initialEvent.ServiceMap != nil && hasStorageEdge(initialEvent.ServiceMap.Edges, target, forbidden), fmt.Sprintf("snapshot=%+v", initialEvent.ServiceMap))
+	proof.check(t, "websocket_events_hosts", initialEvent.ServiceMap != nil && storageNodeHosts(initialEvent.ServiceMap.Nodes, "gateway") == "service [node-a node-b]", fmt.Sprintf("snapshot=%+v", initialEvent.ServiceMap))
 	proof.check(t, "reconnect_immediate", initialEvent.Type == "live_snapshot" && (source != topology.SourceAggregate || initialEvent.Reset), fmt.Sprintf("type=%q reset=%v", initialEvent.Type, initialEvent.Reset))
 
 	rawConn := dialWS(t, httpServer.URL+"/ws")
@@ -551,6 +618,73 @@ func proofGraphRAG(t *testing.T, mode string, provider *scriptedProvider, target
 		cancel()
 		graphRAG.Stop()
 	}
+}
+
+// nodeWire is the additive host projection on a REST node (#288); name is
+// the service-map key, id the system-graph key.
+type nodeWire struct {
+	Name      string   `json:"name"`
+	ID        string   `json:"id"`
+	Kind      string   `json:"kind"`
+	HostCount int      `json:"host_count"`
+	Hosts     []string `json:"hosts"`
+}
+
+func decodeNodes(t *testing.T, raw []json.RawMessage) map[string]nodeWire {
+	t.Helper()
+	out := make(map[string]nodeWire, len(raw))
+	for _, item := range raw {
+		var node nodeWire
+		if err := json.Unmarshal(item, &node); err != nil {
+			t.Fatalf("decode node: %v (%s)", err, item)
+		}
+		key := node.Name
+		if key == "" {
+			key = node.ID
+		}
+		out[key] = node
+	}
+	return out
+}
+
+// getHosts decodes /api/hosts (an array) or /api/hosts/{host} (one object).
+func getHosts(t *testing.T, url string) []topology.Host {
+	t.Helper()
+	response := getTopologyResponse(t, url)
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read %s: %v", url, err)
+	}
+	var hosts []topology.Host
+	if bytes.HasPrefix(bytes.TrimSpace(body), []byte("{")) {
+		var host topology.Host
+		if err := json.Unmarshal(body, &host); err != nil {
+			t.Fatalf("decode host: %v (%s)", err, body)
+		}
+		return []topology.Host{host}
+	}
+	if err := json.Unmarshal(body, &hosts); err != nil {
+		t.Fatalf("decode hosts: %v (%s)", err, body)
+	}
+	return hosts
+}
+
+func proofHostsOf(hosts []topology.Host) []proofHost {
+	out := make([]proofHost, 0, len(hosts))
+	for _, h := range hosts {
+		out = append(out, proofHost{Name: h.Name, Services: h.Services})
+	}
+	return out
+}
+
+func storageNodeHosts(nodes []storage.ServiceMapNode, name string) string {
+	for _, node := range nodes {
+		if node.Name == name {
+			return fmt.Sprintf("%s %v", node.Kind, node.Hosts)
+		}
+	}
+	return "missing"
 }
 
 func getTopology(t *testing.T, url string) topologyWire {


### PR DESCRIPTION
## Claimed child and decision

Closes #288. Implements #279 and #280 for epic #285.

## Baseline

No REST, WebSocket or MCP surface knew about hosts. The registry (#296) and host entities (#297) existed only at ingest.

## Changed owners and contracts

- `internal/topology/hosts.go` (new): `HostProjection` folds one tenant's registry snapshot into hosts with their services and, per service, its hosts. Built per request, no goroutine, no cache. Host entities (`host/<name>`) are listed as hosts with `kind: "host"`, never as services, and any edge touching one is dropped. Bounds: 20 hosts per node, 100 services per host, counts uncapped.
- `internal/topology/provider.go`: `Provider` gains `Hosts(ctx)`; both providers embed a `HostReader` and stamp `kind`, `host_count`, `hosts` (all `omitempty`) onto every node, so legacy, shadow and aggregate answer identically from the one registry. `main.go` wires the registry into whichever provider was selected.
- REST: `GET /api/hosts` (bare sorted array) and `GET /api/hosts/{host}` (404 when unknown), tenant-scoped through the request context, behind the existing auth and rate-limit middleware. Service-map and graph nodes carry the three additive fields; the system summary and the health and latency averages exclude host nodes. Coverage header logic untouched.
- WebSocket: `live_snapshot` nodes gain the same fields in both hubs; no message name, ordering or tenant-scoping change.
- MCP: `get_service_map` accepts optional `group_by: "host"` and then answers `{services, hosts}`; omitted, the array is byte-identical to today; any other value is a tool error. `get_service_health` appends `hosts`. The 5 s cache already keys on the argument map, pinned by a test.
- CLAUDE.md: one MCP table row.

## Targeted local verification

```text
go test -race -count=1 ./internal/api ./internal/realtime ./internal/mcp ./internal/topology   → 260 passed
OTELCONTEXT_TOPOLOGY_PROOF_MODE=legacy|aggregate-shadow go test -race -run TestTopologyModeProof ./test/topologyproof → pass
OTELCONTEXT_TOPOLOGY_PROOF_MODE=aggregate … → all six new host assertions pass; the pre-existing same_epoch_monotonic assertion fails on the local machine identically on main (green in CI)
go vet, gofmt -l on touched packages → clean
```

Golden tests assert old fields first, additions last, on every surface. The topology proof gains six assertions (`rest_hosts_identical`, `rest_host_detail`, `rest_nodes_carry_hosts`, `mcp_group_by_host`, `mcp_service_health_hosts`, `websocket_events_hosts`); no existing assertion changed.

## Compatibility

Additive only. Existing clients ignore the new fields and the new option.

## Rollback

Previous signed binary; nothing persisted by this change.

## Evidence

CI on this PR, including the topology proof in all three modes.

## Added during review

The aggregate topology proof failed in CI on `same_epoch_monotonic`: the events socket received its reset seed at revision 1 and then the same revision again as an incremental snapshot from the loop's first tick. The race predates this PR (a client connecting before the loop has published anything) and host projection only changed the timing that exposed it. `internal/realtime/events_ws.go` now adopts the seed's identity when nothing has been published yet and skips clients whose seed has not been attempted; `TestAggregateWSConnectSeedIsNotRepublished` pins it. The proof passes 3/3 under the race detector in all three modes locally.
