### PR TITLE
feat(latency): return measured percentiles in legacy service-graph paths

### DIFF
--- a/internal/aggregate/latency_provenance_test.go
+++ b/internal/aggregate/latency_provenance_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSketchLatencyProvenanceStates(t *testing.T) {
-	if got := percentileProvenanceFromSketch(nil); got.Status != latency.StatusUnavailable || got.Reason != latency.ReasonNoObservations {
+	if got := PercentileFromSketch(nil); got.Status != latency.StatusUnavailable || got.Reason != latency.ReasonNoObservations {
 		t.Fatalf("nil sketch provenance = %+v", got)
 	}
 
@@ -19,7 +19,7 @@ func TestSketchLatencyProvenanceStates(t *testing.T) {
 	for i := 0; i < 99; i++ {
 		sketch.Observe(10)
 	}
-	got := percentileProvenanceFromSketch(sketch)
+	got := PercentileFromSketch(sketch)
 	if got.Status != latency.StatusApproximate || got.Method != latency.MethodDDSketch || got.SampleCount != 99 || !got.LowSample || got.SketchScale != 2 || math.Abs(got.RelativeErrorBound-sketch.RelativeError()) > 1e-12 {
 		t.Fatalf("ordinary sketch provenance = %+v", got)
 	}
@@ -27,7 +27,7 @@ func TestSketchLatencyProvenanceStates(t *testing.T) {
 	sketch.Observe(10)
 	sketch.collapsed = true
 	sketch.saturations = 3
-	got = percentileProvenanceFromSketch(sketch)
+	got = PercentileFromSketch(sketch)
 	if !got.Degraded || !got.Collapsed || got.Saturations != 3 || got.Reason != latency.ReasonSketchCollapsedSaturated || got.LowSample {
 		t.Fatalf("degraded sketch provenance = %+v", got)
 	}

--- a/internal/aggregate/query.go
+++ b/internal/aggregate/query.go
@@ -148,7 +148,11 @@ func AccuracyFromSketch(s *Sketch) AccuracyMetadata {
 	}
 }
 
-func percentileProvenanceFromSketch(s *Sketch) *latency.Percentile {
+// PercentileFromSketch describes one sketch-derived percentile: approximate
+// with the sketch's own bound, unavailable when the sketch holds nothing.
+// Shared with the legacy GraphRAG ServiceStore (#291), which feeds the same
+// sketch type per service.
+func PercentileFromSketch(s *Sketch) *latency.Percentile {
 	if s == nil || s.Count() == 0 {
 		return &latency.Percentile{
 			Status: latency.StatusUnavailable,
@@ -721,7 +725,7 @@ func (e *Engine) QueryDashboard(q Query) (*DashboardResult, error) {
 		TotalLogs:         asInt64(logs),
 		ActiveServices:    int64(len(services)),
 		Accuracy:          AccuracyFromSketch(merged),
-		LatencyProvenance: latency.Provenance{P99: percentileProvenanceFromSketch(merged)},
+		LatencyProvenance: latency.Provenance{P99: PercentileFromSketch(merged)},
 		Coverage:          CoverageFull,
 		Epoch:             own.Epoch,
 		Revision:          own.Revision,
@@ -896,7 +900,7 @@ func (e *Engine) QueryTopology(q Query) (*TopologyResult, error) {
 		if acc.durCount > 0 {
 			stat.AvgLatencyMs = acc.durSum / float64(acc.durCount) / 1000.0
 		}
-		stat.LatencyProvenance = latency.Provenance{P99: percentileProvenanceFromSketch(acc.sketch)}
+		stat.LatencyProvenance = latency.Provenance{P99: PercentileFromSketch(acc.sketch)}
 		if acc.sketch != nil {
 			stat.P99LatencyMicros = acc.sketch.Quantile(0.99)
 		}

--- a/internal/aggregate/topology.go
+++ b/internal/aggregate/topology.go
@@ -781,7 +781,7 @@ func renderWindows(e *topoEntry, now time.Time) []TopologyWindow {
 		if w.sketch != nil && w.sketch.Count() > 0 {
 			tw.P95Micros = w.sketch.Quantile(0.95)
 			tw.P99Micros = w.sketch.Quantile(0.99)
-			p95 := *percentileProvenanceFromSketch(w.sketch)
+			p95 := *PercentileFromSketch(w.sketch)
 			p99 := p95
 			tw.LatencyProvenance = &latency.Provenance{P95: &p95, P99: &p99}
 		}

--- a/internal/graphrag/anomaly.go
+++ b/internal/graphrag/anomaly.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 )
 
@@ -72,14 +73,19 @@ func (g *GraphRAG) detectAnomaliesForTenant(ctx context.Context, tenant string, 
 			}
 		}
 
-		// Latency degradation: p99-like check using avg * 3 as proxy
-		if svc.AvgLatency > 500 && svc.CallCount > 10 {
+		// Latency degradation: the sketch p99 against the sketch median (#291).
+		// The former check read avg > 500ms with avg*3 standing in for a p99;
+		// the 500ms and >10-call thresholds are unchanged, the tail factor of
+		// 3 is now measured against the service's own typical latency instead
+		// of assumed, so a uniformly slow service is not a degradation.
+		median := stores.service.latencyMedian(svc.Name)
+		if svc.P99Latency > 500 && svc.P99Latency > median*3 && svc.CallCount > 10 {
 			anomaly := AnomalyNode{
 				ID:        fmt.Sprintf("anom_%s_lat", svc.Name), // stable per (service,type); see error-spike note
 				Type:      AnomalyLatencySpike,
-				Severity:  classifyLatencySeverity(svc.AvgLatency),
+				Severity:  classifyLatencySeverity(svc.P99Latency),
 				Service:   svc.Name,
-				Evidence:  fmt.Sprintf("avg latency %.0fms", svc.AvgLatency),
+				Evidence:  fmt.Sprintf("approx. p99 %.0fms vs %.0fms median (%s)", svc.P99Latency, median, sketchAccuracy(svc.LatencyProvenance)),
 				Timestamp: now,
 			}
 			stores.anomalies.AddAnomaly(anomaly)
@@ -151,11 +157,22 @@ func classifyErrorSeverity(errorRate float64) AnomalySeverity {
 	}
 }
 
-func classifyLatencySeverity(avgMs float64) AnomalySeverity {
+// sketchAccuracy words the p99 claim for anomaly evidence.
+func sketchAccuracy(p *latency.Provenance) string {
+	if p == nil || p.P99 == nil {
+		return "DDSketch accuracy unavailable"
+	}
+	if p.P99.Degraded {
+		return "DDSketch degraded"
+	}
+	return fmt.Sprintf("DDSketch ±%.1f%%", p.P99.RelativeErrorBound*100)
+}
+
+func classifyLatencySeverity(ms float64) AnomalySeverity {
 	switch {
-	case avgMs > 2000:
+	case ms > 2000:
 		return SeverityCritical
-	case avgMs > 1000:
+	case ms > 1000:
 		return SeverityWarning
 	default:
 		return SeverityInfo

--- a/internal/graphrag/anomaly.go
+++ b/internal/graphrag/anomaly.go
@@ -73,19 +73,16 @@ func (g *GraphRAG) detectAnomaliesForTenant(ctx context.Context, tenant string, 
 			}
 		}
 
-		// Latency degradation: the sketch p99 against the sketch median (#291).
-		// The former check read avg > 500ms with avg*3 standing in for a p99;
-		// the 500ms and >10-call thresholds are unchanged, the tail factor of
-		// 3 is now measured against the service's own typical latency instead
-		// of assumed, so a uniformly slow service is not a degradation.
-		median := stores.service.latencyMedian(svc.Name)
-		if svc.P99Latency > 500 && svc.P99Latency > median*3 && svc.CallCount > 10 {
+		// Latency degradation on the sketch p99 (#291). The former check read
+		// avg > 500ms with avg*3 standing in for a p99; the 500ms and
+		// >10-call thresholds are unchanged and now apply to the measured tail.
+		if svc.P99Latency > 500 && svc.CallCount > 10 {
 			anomaly := AnomalyNode{
 				ID:        fmt.Sprintf("anom_%s_lat", svc.Name), // stable per (service,type); see error-spike note
 				Type:      AnomalyLatencySpike,
 				Severity:  classifyLatencySeverity(svc.P99Latency),
 				Service:   svc.Name,
-				Evidence:  fmt.Sprintf("approx. p99 %.0fms vs %.0fms median (%s)", svc.P99Latency, median, sketchAccuracy(svc.LatencyProvenance)),
+				Evidence:  fmt.Sprintf("approx. p99 %.0fms (%s)", svc.P99Latency, sketchAccuracy(svc.LatencyProvenance)),
 				Timestamp: now,
 			}
 			stores.anomalies.AddAnomaly(anomaly)

--- a/internal/graphrag/latency_sketch_test.go
+++ b/internal/graphrag/latency_sketch_test.go
@@ -1,0 +1,99 @@
+package graphrag
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+// TestUpsertService_SketchP99 proves the per-service sketch (#291) on a
+// bimodal population where average × 2.5 is nowhere near the tail: 900
+// calls at 10ms and 100 at 500ms have a nearest-rank p99 of 500ms, while
+// the old estimate said 147.5ms (59ms × 2.5, 70% low). The sketch answer
+// lands inside its advertised relative-error bound and says so.
+func TestUpsertService_SketchP99(t *testing.T) {
+	store := newServiceStore()
+	now := time.Now()
+	for i := 0; i < 1000; i++ {
+		ms := 10.0
+		if i%10 == 9 {
+			ms = 500.0
+		}
+		store.UpsertService("bimodal", ms, false, now)
+	}
+	svc := store.Services["bimodal"]
+	const trueP99 = 500.0
+	oldEstimate := svc.AvgLatency * 2.5
+	if svc.AvgLatency != 59 {
+		t.Fatalf("avg = %v, want 59", svc.AvgLatency)
+	}
+	if oldErr := math.Abs(oldEstimate-trueP99) / trueP99; oldErr < 0.5 {
+		t.Fatalf("old estimate %v is within %.0f%% of %v; fixture no longer contradicts the multiplier", oldEstimate, oldErr*100, trueP99)
+	}
+	claim := svc.LatencyProvenance.P99
+	if claim.Status != latency.StatusApproximate || claim.Method != latency.MethodDDSketch ||
+		claim.SampleCount != 1000 || claim.LowSample || claim.Degraded ||
+		claim.SketchScale != aggregate.SketchDefaultScale || claim.RelativeErrorBound <= 0 || claim.EstimateFactor != 0 {
+		t.Fatalf("provenance = %+v", claim)
+	}
+	if err := math.Abs(svc.P99Latency-trueP99) / trueP99; err > claim.RelativeErrorBound {
+		t.Fatalf("sketch p99 %v is %.2f%% from %v, bound %.2f%%", svc.P99Latency, err*100, trueP99, claim.RelativeErrorBound*100)
+	}
+	t.Logf("true p99=%vms old estimate=%vms (avg×2.5) sketch=%.3fms bound=±%.2f%% provenance=%s/%s",
+		trueP99, oldEstimate, svc.P99Latency, claim.RelativeErrorBound*100, claim.Status, claim.Method)
+
+	if size := unsafe.Sizeof(aggregate.Sketch{}); size > 2200 {
+		t.Fatalf("sketch is %d bytes; the store comment promises ~2.1 KiB", size)
+	}
+}
+
+func feedLatencySpan(g *GraphRAG, service string, i int, micros int64) {
+	g.processSpan(&spanEvent{
+		Span: storage.Span{
+			TraceID: "trace-lat", SpanID: fmt.Sprintf("%s-%d", service, i),
+			OperationName: "/op", ServiceName: service, Duration: micros, StartTime: time.Now(),
+		},
+		TraceID: "trace-lat", Status: "STATUS_CODE_UNSET", Tenant: storage.DefaultTenantID,
+	})
+}
+
+// TestDetectAnomalies_LatencyUsesSketch proves the legacy latency check
+// compares the sketch p99 against the sketch median (#291). A service whose
+// tail is 1500ms over a 10ms median fires although its average (159ms) never
+// crossed the old avg > 500ms gate; a uniformly slow 800ms service, which the
+// old gate flagged, is not a degradation of anything.
+func TestDetectAnomalies_LatencyUsesSketch(t *testing.T) {
+	g := New(nil, nil, nil, DefaultConfig())
+	t.Cleanup(g.Stop)
+	for i := 0; i < 100; i++ {
+		micros := int64(10_000)
+		if i%10 == 9 {
+			micros = 1_500_000
+		}
+		feedLatencySpan(g, "tail", i, micros)
+	}
+	for i := 0; i < 20; i++ {
+		feedLatencySpan(g, "slow", i, 800_000)
+	}
+	g.detectAnomalies(context.Background())
+
+	stores := g.storesForTenant(storage.DefaultTenantID)
+	tail, ok := stores.anomalies.Anomalies["anom_tail_lat"]
+	if !ok {
+		t.Fatalf("bimodal tail did not fire: %+v", stores.service.Services["tail"])
+	}
+	if tail.Severity != SeverityWarning {
+		t.Fatalf("severity = %s, want %s for a ~1500ms p99: %s", tail.Severity, SeverityWarning, tail.Evidence)
+	}
+	if _, ok := stores.anomalies.Anomalies["anom_slow_lat"]; ok {
+		t.Fatalf("uniformly slow service fired: %+v", stores.service.Services["slow"])
+	}
+	t.Logf("evidence: %s", tail.Evidence)
+}

--- a/internal/graphrag/latency_sketch_test.go
+++ b/internal/graphrag/latency_sketch_test.go
@@ -65,10 +65,9 @@ func feedLatencySpan(g *GraphRAG, service string, i int, micros int64) {
 }
 
 // TestDetectAnomalies_LatencyUsesSketch proves the legacy latency check
-// compares the sketch p99 against the sketch median (#291). A service whose
-// tail is 1500ms over a 10ms median fires although its average (159ms) never
-// crossed the old avg > 500ms gate; a uniformly slow 800ms service, which the
-// old gate flagged, is not a degradation of anything.
+// gates on the sketch p99 (#291). A service whose tail is 1500ms over a 10ms
+// median fires although its average (159ms) never crossed the old avg > 500ms
+// gate; a uniformly slow 800ms service keeps firing exactly as it did before.
 func TestDetectAnomalies_LatencyUsesSketch(t *testing.T) {
 	g := New(nil, nil, nil, DefaultConfig())
 	t.Cleanup(g.Stop)
@@ -92,8 +91,8 @@ func TestDetectAnomalies_LatencyUsesSketch(t *testing.T) {
 	if tail.Severity != SeverityWarning {
 		t.Fatalf("severity = %s, want %s for a ~1500ms p99: %s", tail.Severity, SeverityWarning, tail.Evidence)
 	}
-	if _, ok := stores.anomalies.Anomalies["anom_slow_lat"]; ok {
-		t.Fatalf("uniformly slow service fired: %+v", stores.service.Services["slow"])
+	if _, ok := stores.anomalies.Anomalies["anom_slow_lat"]; !ok {
+		t.Fatalf("uniformly slow service stopped firing: %+v", stores.service.Services["slow"])
 	}
 	t.Logf("evidence: %s", tail.Evidence)
 }

--- a/internal/graphrag/store.go
+++ b/internal/graphrag/store.go
@@ -95,6 +95,15 @@ type ServiceStore struct {
 	edgesByFrom  map[string][]*Edge          // CALLS edges keyed by FromID
 	edgesByTo    map[string][]*Edge          // CALLS edges keyed by ToID
 	opsByService map[string][]*OperationNode // operations keyed by service
+	// latency holds one bounded duration sketch per service (#291), keyed
+	// like Services and fed wherever UpsertService updates AvgLatency — the
+	// ingest callback and the 60s DB rebuild alike — so it shares the
+	// lifecycle of the other per-service aggregates: it resets when the
+	// tenant slice is re-created (idle eviction, restart), never on its own.
+	// A Sketch is a fixed ~2.1 KiB value (512 uint32 bins plus counters, no
+	// pointers), so the per-tenant memory is 2.1 KiB × len(Services): the
+	// same bound as the ServiceNode map itself.
+	latency map[string]*aggregate.Sketch
 }
 
 func newServiceStore() *ServiceStore {
@@ -105,6 +114,7 @@ func newServiceStore() *ServiceStore {
 		edgesByFrom:  make(map[string][]*Edge),
 		edgesByTo:    make(map[string][]*Edge),
 		opsByService: make(map[string][]*OperationNode),
+		latency:      make(map[string]*aggregate.Sketch),
 	}
 }
 
@@ -194,15 +204,14 @@ func (s *ServiceStore) UpsertService(name string, durationMs float64, isError bo
 		svc.FirstSeen = ts
 	}
 	svc.AvgLatency = svc.TotalMs / float64(svc.CallCount)
-	svc.P99Latency = svc.AvgLatency * 2.5
-	sampleCount := uint64(svc.CallCount) // #nosec G115 -- call count is increment-only.
-	svc.LatencyProvenance = &latency.Provenance{P99: &latency.Percentile{
-		Status:         latency.StatusEstimated,
-		Method:         latency.MethodAverageMultiplier,
-		SampleCount:    sampleCount,
-		LowSample:      sampleCount < latency.LowSampleThreshold,
-		EstimateFactor: 2.5,
-	}}
+	sketch, ok := s.latency[name]
+	if !ok {
+		sketch = aggregate.NewSketch()
+		s.latency[name] = sketch
+	}
+	sketch.Observe(durationMs)
+	svc.P99Latency = sketch.Quantile(0.99)
+	svc.LatencyProvenance = &latency.Provenance{P99: aggregate.PercentileFromSketch(sketch)}
 	svc.ErrorRate = float64(svc.ErrorCount) / float64(svc.CallCount)
 	svc.HealthScore = computeHealth(svc.ErrorRate, svc.AvgLatency)
 }
@@ -247,6 +256,18 @@ func (s *ServiceStore) UpsertOperation(service, operation string, durationMs flo
 			UpdatedAt: ts,
 		}
 	}
+}
+
+// latencyMedian returns the sketch median for a service, the baseline the
+// legacy anomaly detector compares the p99 against. Zero when unknown.
+func (s *ServiceStore) latencyMedian(name string) float64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sketch, ok := s.latency[name]
+	if !ok {
+		return 0
+	}
+	return sketch.Quantile(0.5)
 }
 
 func unavailableOperationLatency() *latency.Provenance {

--- a/internal/graphrag/store.go
+++ b/internal/graphrag/store.go
@@ -258,18 +258,6 @@ func (s *ServiceStore) UpsertOperation(service, operation string, durationMs flo
 	}
 }
 
-// latencyMedian returns the sketch median for a service, the baseline the
-// legacy anomaly detector compares the p99 against. Zero when unknown.
-func (s *ServiceStore) latencyMedian(name string) float64 {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	sketch, ok := s.latency[name]
-	if !ok {
-		return 0
-	}
-	return sketch.Quantile(0.5)
-}
-
 func unavailableOperationLatency() *latency.Provenance {
 	percentile := func() *latency.Percentile {
 		return &latency.Percentile{

--- a/internal/mcp/honesty_test.go
+++ b/internal/mcp/honesty_test.go
@@ -176,7 +176,10 @@ func TestTopologyToolsPreserveLatencyProvenance(t *testing.T) {
 	if err := json.Unmarshal([]byte(mapResult.Content[0].Text), &entries); err != nil {
 		t.Fatal(err)
 	}
-	if len(entries) != 1 || entries[0].Service.LatencyProvenance == nil || entries[0].Service.LatencyProvenance.P99.Status != latency.StatusEstimated || entries[0].Service.P99Latency != 50 {
+	// Legacy GraphRAG p99 is sketch-derived since #291: approximate, within
+	// the sketch bound of the 20ms the fixture emits, no longer avg*2.5.
+	if len(entries) != 1 || entries[0].Service.LatencyProvenance == nil || entries[0].Service.LatencyProvenance.P99.Status != latency.StatusApproximate ||
+		entries[0].Service.P99Latency < 19 || entries[0].Service.P99Latency > 21 {
 		t.Fatalf("service map latency = %+v", entries)
 	}
 	if len(entries[0].Operations) != 1 || entries[0].Operations[0].LatencyProvenance.P99.Status != latency.StatusUnavailable {

--- a/internal/realtime/hosts_test.go
+++ b/internal/realtime/hosts_test.go
@@ -68,7 +68,7 @@ func TestLegacySnapshotStampsHostsOnServiceMap(t *testing.T) {
 		t.Fatalf("nodes = %q, want %q", got, want)
 	}
 	raw, _ := json.Marshal(snap.ServiceMap.Nodes[0])
-	if want := `{"name":"gateway","total_traces":1,"error_count":0,"avg_latency_ms":1,"p99_latency_ms":2.5,"latency_provenance":`; len(raw) < len(want) || string(raw[:len(want)]) != want {
+	if want := `{"name":"gateway","total_traces":1,"error_count":0,"avg_latency_ms":1,"p99_latency_ms":1,"latency_provenance":{"p99":{"status":"measured","method":"ordered_rank",`; len(raw) < len(want) || string(raw[:len(want)]) != want {
 		t.Fatalf("node prefix changed: %s", raw)
 	}
 	if suffix := `,"kind":"service","host_count":2,"hosts":["node-a","node-b"]}`; string(raw[len(raw)-len(suffix):]) != suffix {

--- a/internal/storage/pg_integration_test.go
+++ b/internal/storage/pg_integration_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"gorm.io/gorm"
 )
@@ -527,5 +528,28 @@ func TestPG_AutoMigrate_BlobTypesBecomeBytea(t *testing.T) {
 		if dataType != "bytea" {
 			t.Errorf("%s.%s: data_type = %q, want %q", c.Table, c.Column, dataType, "bytea")
 		}
+	}
+}
+
+// TestPG_ServiceMapMeasuredP99 proves the per-service ordered-rank window
+// query (#291) on PostgreSQL with the same bimodal population the SQLite
+// unit test uses: nearest-rank p99 is exactly 500ms, labelled measured.
+func TestPG_ServiceMapMeasuredP99(t *testing.T) {
+	repo, teardown := setupPGContainer(t)
+	defer teardown()
+	seedBimodalSpans(t, repo, "bimodal", 1000, 10_000, 500_000)
+	start, end := serviceMapFixtureWindow()
+
+	got, err := repo.GetServiceMapMetrics(context.Background(), start, end)
+	if err != nil {
+		t.Fatalf("GetServiceMapMetrics: %v", err)
+	}
+	if len(got.Nodes) != 1 {
+		t.Fatalf("nodes: %+v", got.Nodes)
+	}
+	node := got.Nodes[0]
+	claim := node.LatencyProvenance.P99
+	if node.P99LatencyMs != 500 || claim.Status != latency.StatusMeasured || claim.Method != latency.MethodOrderedRank || claim.SampleCount != 1000 {
+		t.Fatalf("p99=%v provenance=%+v", node.P99LatencyMs, claim)
 	}
 }

--- a/internal/storage/service_map_test.go
+++ b/internal/storage/service_map_test.go
@@ -243,16 +243,19 @@ func TestGetServiceMapMetrics_FixtureValues(t *testing.T) {
 	}
 	sortServiceMap(got)
 
-	estimated := func(count uint64) *latency.Provenance {
+	measured := func(count uint64) *latency.Provenance {
 		return &latency.Provenance{P99: &latency.Percentile{
-			Status: latency.StatusEstimated, Method: latency.MethodAverageMultiplier,
-			SampleCount: count, LowSample: true, EstimateFactor: 2.5,
+			Status: latency.StatusMeasured, Method: latency.MethodOrderedRank,
+			SampleCount: count, LowSample: true,
 		}}
 	}
+	// p99 is the nearest-rank (ceil(0.99·n)) duration per service: the
+	// largest of svc-a's two, the largest of svc-b's four, the largest of
+	// svc-c's two.
 	wantNodes := []ServiceMapNode{
-		{Name: "svc-a", TotalTraces: 2, ErrorCount: 0, AvgLatencyMs: 55, P99LatencyMs: 137.5, LatencyProvenance: estimated(2)},
-		{Name: "svc-b", TotalTraces: 4, ErrorCount: 1, AvgLatencyMs: 25, P99LatencyMs: 62.5, LatencyProvenance: estimated(4)},
-		{Name: "svc-c", TotalTraces: 2, ErrorCount: 1, AvgLatencyMs: 30, P99LatencyMs: 75, LatencyProvenance: estimated(2)},
+		{Name: "svc-a", TotalTraces: 2, ErrorCount: 0, AvgLatencyMs: 55, P99LatencyMs: 100, LatencyProvenance: measured(2)},
+		{Name: "svc-b", TotalTraces: 4, ErrorCount: 1, AvgLatencyMs: 25, P99LatencyMs: 50, LatencyProvenance: measured(4)},
+		{Name: "svc-c", TotalTraces: 2, ErrorCount: 1, AvgLatencyMs: 30, P99LatencyMs: 40, LatencyProvenance: measured(2)},
 	}
 	wantEdges := []ServiceMapEdge{
 		{Source: "svc-a", Target: "svc-b", CallCount: 2, AvgLatencyMs: 40},
@@ -469,5 +472,77 @@ func BenchmarkGetServiceMapMetrics(b *testing.B) {
 		if _, err := repo.GetServiceMapMetrics(ctx, start, end); err != nil {
 			b.Fatalf("GetServiceMapMetrics: %v", err)
 		}
+	}
+}
+
+// seedBimodalSpans inserts a deterministic bimodal population for one
+// service inside the fixture window: 90% at lowMicros, 10% at tailMicros.
+func seedBimodalSpans(t *testing.T, repo *Repository, service string, n int, lowMicros, tailMicros int64) {
+	t.Helper()
+	start, _ := serviceMapFixtureWindow()
+	spans := make([]Span, 0, n)
+	for i := 0; i < n; i++ {
+		dur := lowMicros
+		if i%10 == 9 {
+			dur = tailMicros
+		}
+		spans = append(spans, Span{
+			TenantID: "default", TraceID: fmt.Sprintf("trace-bimodal-%d", i/10),
+			SpanID: fmt.Sprintf("bimodal-%04d", i), OperationName: "op", ServiceName: service,
+			StartTime: start.Add(time.Minute), EndTime: start.Add(time.Minute + time.Duration(dur)*time.Microsecond),
+			Duration: dur, Status: "STATUS_CODE_UNSET",
+		})
+	}
+	if err := repo.BatchCreateSpans(spans); err != nil {
+		t.Fatalf("seedBimodalSpans: %v", err)
+	}
+}
+
+// TestGetServiceMapMetrics_MeasuredP99 proves the ordered-rank path (#291)
+// on a bimodal population where average × 2.5 is nowhere near the tail:
+// 900 spans at 10ms and 100 at 500ms have a nearest-rank p99 of exactly
+// 500ms, while the old estimate said 147.5ms (59ms × 2.5, 70% low). Past
+// the scan cap the same call keeps the estimate and says so.
+func TestGetServiceMapMetrics_MeasuredP99(t *testing.T) {
+	repo := newTestRepo(t)
+	seedBimodalSpans(t, repo, "bimodal", 1000, 10_000, 500_000)
+	start, end := serviceMapFixtureWindow()
+
+	got, err := repo.GetServiceMapMetrics(context.Background(), start, end)
+	if err != nil {
+		t.Fatalf("GetServiceMapMetrics: %v", err)
+	}
+	if len(got.Nodes) != 1 {
+		t.Fatalf("nodes: %+v", got.Nodes)
+	}
+	node := got.Nodes[0]
+	const trueP99, oldEstimate = 500.0, 59 * 2.5
+	if node.AvgLatencyMs != 59 || node.P99LatencyMs != trueP99 {
+		t.Fatalf("avg=%v p99=%v, want avg=59 p99=%v", node.AvgLatencyMs, node.P99LatencyMs, trueP99)
+	}
+	if oldErr := math.Abs(oldEstimate-trueP99) / trueP99; oldErr < 0.5 {
+		t.Fatalf("old estimate %v is within %.0f%% of %v; fixture no longer contradicts the multiplier", oldEstimate, oldErr*100, trueP99)
+	}
+	want := &latency.Provenance{P99: &latency.Percentile{
+		Status: latency.StatusMeasured, Method: latency.MethodOrderedRank, SampleCount: 1000,
+	}}
+	if !reflect.DeepEqual(node.LatencyProvenance, want) {
+		t.Fatalf("provenance = %+v, want %+v", node.LatencyProvenance.P99, want.P99)
+	}
+	t.Logf("true p99=%vms old estimate=%vms (avg×2.5) measured=%vms provenance=%s/%s", trueP99, oldEstimate, node.P99LatencyMs, want.P99.Status, want.P99.Method)
+
+	// Above the row cap: the estimate and its label come back.
+	orig := serviceMapSpanLimit
+	serviceMapSpanLimit = 999
+	t.Cleanup(func() { serviceMapSpanLimit = orig })
+	capped, err := repo.GetServiceMapMetrics(context.Background(), start, end)
+	if err != nil {
+		t.Fatalf("GetServiceMapMetrics above cap: %v", err)
+	}
+	wantCapped := &latency.Provenance{P99: &latency.Percentile{
+		Status: latency.StatusEstimated, Method: latency.MethodAverageMultiplier, SampleCount: 1000, EstimateFactor: 2.5,
+	}}
+	if node := capped.Nodes[0]; node.P99LatencyMs != oldEstimate || !reflect.DeepEqual(node.LatencyProvenance, wantCapped) {
+		t.Fatalf("above cap: p99=%v provenance=%+v", node.P99LatencyMs, node.LatencyProvenance.P99)
 	}
 }

--- a/internal/storage/trace_repo.go
+++ b/internal/storage/trace_repo.go
@@ -419,25 +419,52 @@ func (r *Repository) GetServiceMapMetrics(ctx context.Context, start, end time.T
 		return nil, fmt.Errorf("failed to aggregate service map nodes: %w", err)
 	}
 
+	// Exact per-service p99 (#291): one ordered-rank query over the range,
+	// only while the range fits the same row bound the edge pass scans.
+	// Above it every node keeps the average-multiplier estimate, labelled
+	// as such.
+	var rangeSpans int64
+	for _, nr := range nodeRows {
+		rangeSpans += nr.SpanCount
+	}
+	p99ByService := map[string]int64{}
+	if rangeSpans > 0 && rangeSpans <= int64(serviceMapSpanLimit) {
+		var err error
+		if p99ByService, err = r.serviceP99Durations(ctx, tenant, start, end); err != nil {
+			return nil, fmt.Errorf("failed to rank service map latencies: %w", err)
+		}
+	}
+
 	nodes := make([]ServiceMapNode, 0, len(nodeRows))
 	for _, nr := range nodeRows {
 		avgLatencyMs := math.Round(nr.AvgDuration/1000.0*100) / 100
 		sampleCount := uint64(nr.SpanCount) // #nosec G115 -- grouped database counts cannot be negative.
-		nodes = append(nodes, ServiceMapNode{
+		node := ServiceMapNode{
 			Name:        nr.ServiceName,
 			TotalTraces: nr.SpanCount,
 			ErrorCount:  nr.ErrorCount,
 			// AVG(duration) is microseconds; convert to ms and round to 2dp.
 			AvgLatencyMs: avgLatencyMs,
-			P99LatencyMs: avgLatencyMs * 2.5,
-			LatencyProvenance: &latency.Provenance{P99: &latency.Percentile{
+		}
+		if p99, ok := p99ByService[nr.ServiceName]; ok {
+			node.P99LatencyMs = math.Round(float64(p99)/1000.0*100) / 100
+			node.LatencyProvenance = &latency.Provenance{P99: &latency.Percentile{
+				Status:      latency.StatusMeasured,
+				Method:      latency.MethodOrderedRank,
+				SampleCount: sampleCount,
+				LowSample:   sampleCount < latency.LowSampleThreshold,
+			}}
+		} else {
+			node.P99LatencyMs = avgLatencyMs * 2.5
+			node.LatencyProvenance = &latency.Provenance{P99: &latency.Percentile{
 				Status:         latency.StatusEstimated,
 				Method:         latency.MethodAverageMultiplier,
 				SampleCount:    sampleCount,
 				LowSample:      sampleCount < latency.LowSampleThreshold,
 				EstimateFactor: 2.5,
-			}},
-		})
+			}}
+		}
+		nodes = append(nodes, node)
 	}
 
 	edgeQuery := r.db.WithContext(ctx).Model(&Span{}).
@@ -499,6 +526,48 @@ func (r *Repository) GetServiceMapMetrics(ctx context.Context, start, end time.T
 		Nodes: nodes,
 		Edges: edges,
 	}, nil
+}
+
+// serviceP99Row receives one nearest-rank p99 duration (microseconds) per
+// service from serviceP99Durations.
+type serviceP99Row struct {
+	ServiceName string
+	Duration    int64
+}
+
+// serviceP99Durations returns the nearest-rank p99 duration per service in
+// one statement: rank ceil(0.99·n) within each service's ascending
+// durations, the same convention p99DurationForQuery applies to the
+// dashboard. The rank is picked with integer arithmetic
+// (rank·100 >= n·99 and (rank-1)·100 < n·99) so no dialect-specific CEIL
+// or division is involved.
+//
+// ROW_NUMBER() and COUNT(*) OVER (PARTITION BY …) are accepted verbatim by
+// SQLite (3.25+), PostgreSQL, MySQL 8 and SQL Server, so unlike
+// batchedDeleteSQL this needs no per-driver text.
+func (r *Repository) serviceP99Durations(ctx context.Context, tenant string, start, end time.Time) (map[string]int64, error) {
+	ranked := r.db.WithContext(ctx).Table("spans").
+		Select("service_name, duration, "+
+			"ROW_NUMBER() OVER (PARTITION BY service_name ORDER BY duration) AS rank_in_service, "+
+			"COUNT(*) OVER (PARTITION BY service_name) AS service_count").
+		Where(sqlWhereTenantID, tenant).
+		Where("service_name <> ''")
+	if !start.IsZero() && !end.IsZero() {
+		ranked = ranked.Where("start_time BETWEEN ? AND ?", start, end)
+	}
+	var rows []serviceP99Row
+	err := r.db.WithContext(ctx).Table("(?) AS ranked", ranked).
+		Select("service_name, duration").
+		Where("rank_in_service * 100 >= service_count * 99 AND (rank_in_service - 1) * 100 < service_count * 99").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]int64, len(rows))
+	for _, row := range rows {
+		out[row.ServiceName] = row.Duration
+	}
+	return out, nil
 }
 
 // PurgeTraces deletes traces older than the given timestamp in a single statement.

--- a/test/topologyproof/latency_proof_test.go
+++ b/test/topologyproof/latency_proof_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/RandomCodeSpace/otelcontext/internal/aggregate"
 	"github.com/RandomCodeSpace/otelcontext/internal/api"
+	"github.com/RandomCodeSpace/otelcontext/internal/api/views"
 	"github.com/RandomCodeSpace/otelcontext/internal/graphrag"
 	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/RandomCodeSpace/otelcontext/internal/mcp"
@@ -58,6 +59,7 @@ type latencyContractProof struct {
 	Sentinel      latencySentinel           `json:"sentinel"`
 	Dashboard     latencySurface            `json:"rest_dashboard"`
 	SystemGraph   latencySurface            `json:"rest_system_graph"`
+	ServiceMap    latencySurface            `json:"rest_service_map"`
 	WebSocket     latencySurface            `json:"websocket_dashboard"`
 	GraphRAG      latencySurface            `json:"graphrag_service"`
 	MCPMap        latencySurface            `json:"mcp_get_service_map"`
@@ -218,6 +220,10 @@ func TestLatencyModeProof(t *testing.T) {
 	systemNode := findGraphNode(t, systemGraph.Nodes, latencyService)
 	proof.SystemGraph = latencySurface{Value: systemNode.Metrics.P99LatencyMs, Unit: "milliseconds", Provenance: systemNode.Metrics.LatencyProvenance}
 
+	var serviceMap views.ServiceMapMetrics
+	getProofJSON(t, httpServer.URL+"/api/metrics/service-map", &serviceMap)
+	proof.ServiceMap = findServiceMapNode(t, serviceMap.Nodes, latencyService)
+
 	graphEntry := findServiceEntry(t, graphRAG.ServiceMap(context.Background(), 0), latencyService)
 	proof.GraphRAG = latencySurface{Value: graphEntry.Service.P99Latency, Unit: "milliseconds", Provenance: graphEntry.Service.LatencyProvenance}
 	if len(graphEntry.Operations) == 0 {
@@ -254,18 +260,25 @@ func TestLatencyModeProof(t *testing.T) {
 	if mode == aggregate.ModeAggregate {
 		proof.check(t, "rest_dashboard_approximate", validApproximate(proof.Dashboard, 1000), describeLatency(proof.Dashboard))
 		proof.check(t, "rest_system_graph_approximate", validApproximate(proof.SystemGraph, 1000), describeLatency(proof.SystemGraph))
+		proof.check(t, "rest_service_map_approximate", validApproximate(proof.ServiceMap, 1000), describeLatency(proof.ServiceMap))
 		proof.check(t, "websocket_approximate", validApproximate(proof.WebSocket, latencyTailMicros), describeLatency(proof.WebSocket))
 		proof.check(t, "graphrag_approximate", validApproximate(proof.GraphRAG, 1000), describeLatency(proof.GraphRAG))
 		proof.check(t, "mcp_map_approximate", validApproximate(proof.MCPMap, 1000), describeLatency(proof.MCPMap))
 		proof.check(t, "mcp_health_approximate", validApproximate(proof.MCPHealth, 1000), describeLatency(proof.MCPHealth))
 		proof.check(t, "aggregate_source_owned", systemGraph.Source == "aggregate", fmt.Sprintf("graph=%q", systemGraph.Source))
 	} else {
+		// #291: the legacy database path (service map) ranks the population
+		// exactly and the GraphRAG service store (system graph, GraphRAG, MCP)
+		// answers from its per-service sketch, so no legacy surface may report
+		// the 52.225ms average multiplier any more.
 		proof.check(t, "rest_dashboard_measured", validMeasured(proof.Dashboard, 1000, latency.MethodOrderedRank), describeLatency(proof.Dashboard))
-		proof.check(t, "rest_system_graph_estimated", validEstimated(proof.SystemGraph), describeLatency(proof.SystemGraph))
+		proof.check(t, "rest_system_graph_approximate", validApproximate(proof.SystemGraph, 1000), describeLatency(proof.SystemGraph))
+		proof.check(t, "rest_service_map_measured", validMeasured(proof.ServiceMap, 1000, latency.MethodOrderedRank), describeLatency(proof.ServiceMap))
 		proof.check(t, "websocket_measured", validMeasured(proof.WebSocket, latencyTailMicros, latency.MethodOrderedRank), describeLatency(proof.WebSocket))
-		proof.check(t, "graphrag_estimated", validEstimated(proof.GraphRAG), describeLatency(proof.GraphRAG))
-		proof.check(t, "mcp_map_estimated", validEstimated(proof.MCPMap), describeLatency(proof.MCPMap))
-		proof.check(t, "mcp_health_estimated", validEstimated(proof.MCPHealth), describeLatency(proof.MCPHealth))
+		proof.check(t, "graphrag_approximate", validApproximate(proof.GraphRAG, 1000), describeLatency(proof.GraphRAG))
+		proof.check(t, "mcp_map_approximate", validApproximate(proof.MCPMap, 1000), describeLatency(proof.MCPMap))
+		proof.check(t, "mcp_health_approximate", validApproximate(proof.MCPHealth, 1000), describeLatency(proof.MCPHealth))
+		proof.check(t, "no_legacy_surface_estimated", !anyEstimated(proof), "average × 2.5 is no longer reported by any legacy surface")
 		proof.check(t, "legacy_source_owned", systemGraph.Source == "", fmt.Sprintf("graph=%q", systemGraph.Source))
 	}
 
@@ -279,6 +292,7 @@ func TestLatencyModeProof(t *testing.T) {
 func seedLatencyRepository(t *testing.T, repo *storage.Repository, now time.Time) {
 	t.Helper()
 	traces := make([]storage.Trace, 0, latencyLowCount+latencyTailCount)
+	spans := make([]storage.Span, 0, latencyLowCount+latencyTailCount)
 	for i := 0; i < latencyLowCount+latencyTailCount; i++ {
 		duration := int64(latencyLowMicros)
 		if i >= latencyLowCount {
@@ -289,9 +303,20 @@ func seedLatencyRepository(t *testing.T, repo *storage.Repository, now time.Time
 			ServiceName: latencyService, Duration: duration, Status: "STATUS_CODE_UNSET",
 			Timestamp: now.Add(-time.Minute),
 		})
+		// The same population as spans, so the service-map database path
+		// (#291) ranks exactly what the dashboard ranks.
+		spans = append(spans, storage.Span{
+			TenantID: storage.DefaultTenantID, TraceID: fmt.Sprintf("latency-%04d", i),
+			SpanID: fmt.Sprintf("%016x", i+1), ServiceName: latencyService, OperationName: "GET /latency",
+			StartTime: now.Add(-time.Minute), EndTime: now.Add(-time.Minute + time.Duration(duration)*time.Microsecond),
+			Duration: duration, Status: "STATUS_CODE_UNSET",
+		})
 	}
 	if err := repo.BatchCreateTraces(traces); err != nil {
 		t.Fatalf("seed latency traces: %v", err)
+	}
+	if err := repo.BatchCreateSpans(spans); err != nil {
+		t.Fatalf("seed latency spans: %v", err)
 	}
 }
 
@@ -408,6 +433,17 @@ func findGraphNode(t *testing.T, nodes []api.GraphNode, name string) api.GraphNo
 	return api.GraphNode{}
 }
 
+func findServiceMapNode(t *testing.T, nodes []views.ServiceMapNode, name string) latencySurface {
+	t.Helper()
+	for _, node := range nodes {
+		if node.Name == name {
+			return latencySurface{Value: node.P99LatencyMs, Unit: "milliseconds", Provenance: node.LatencyProvenance}
+		}
+	}
+	t.Fatalf("service map omitted %q", name)
+	return latencySurface{}
+}
+
 func findServiceEntry(t *testing.T, entries []graphrag.ServiceMapEntry, name string) graphrag.ServiceMapEntry {
 	t.Helper()
 	for _, entry := range entries {
@@ -433,11 +469,20 @@ func validMeasured(surface latencySurface, want float64, method string) bool {
 		claim.SampleCount == latencyLowCount+latencyTailCount && !claim.LowSample
 }
 
-func validEstimated(surface latencySurface) bool {
-	claim := p99(surface)
-	return math.Abs(surface.Value-52.225) <= 0.01 && claim != nil &&
-		claim.Status == latency.StatusEstimated && claim.Method == latency.MethodAverageMultiplier &&
-		claim.SampleCount == latencyLowCount+latencyTailCount && claim.EstimateFactor == 2.5
+// anyEstimated reports whether any surface still carries the pre-#291
+// average-multiplier value or claim.
+func anyEstimated(proof *latencyContractProof) bool {
+	for _, surface := range []latencySurface{
+		proof.Dashboard, proof.SystemGraph, proof.ServiceMap, proof.WebSocket,
+		proof.GraphRAG, proof.MCPMap, proof.MCPHealth,
+	} {
+		claim := p99(surface)
+		if claim == nil || claim.Status == latency.StatusEstimated || claim.Method == latency.MethodAverageMultiplier ||
+			claim.EstimateFactor != 0 || math.Abs(surface.Value-52.225) <= 0.01 {
+			return true
+		}
+	}
+	return false
 }
 
 func validApproximate(surface latencySurface, exact float64) bool {
@@ -474,7 +519,7 @@ func unavailableOperation(operation *graphrag.OperationNode) bool {
 
 func allSampleCounts(proof *latencyContractProof, want int) bool {
 	for _, surface := range []latencySurface{
-		proof.Dashboard, proof.SystemGraph, proof.WebSocket,
+		proof.Dashboard, proof.SystemGraph, proof.ServiceMap, proof.WebSocket,
 		proof.GraphRAG, proof.MCPMap, proof.MCPHealth,
 	} {
 		claim := p99(surface)


### PR DESCRIPTION
## Claimed child and decision

Closes #291. Implements #284 (building on #238/#249) for epic #285.

## Baseline

`P99Latency = AvgLatency × 2.5` in GraphRAG's `ServiceStore`, `avg > 500 ms` with `avg × 3` as a p99 stand-in in the anomaly detector, and `× 2.5` on the database service-map fallback, all labelled `estimated` since #249.

## Changed owners and contracts

- `internal/graphrag/store.go`: one bounded DDSketch per tenant and service (the engine's `aggregate.Sketch`, ~2.1 KiB fixed, no pointers, one per `Services` entry), fed wherever `UpsertService` updates the average: ingest callback and the 60 s rebuild alike, sharing the tenant slice's lifecycle. `P99Latency` reads the sketch; provenance is `approximate` with the sketch bound via the exported `aggregate.PercentileFromSketch`.
- `internal/graphrag/anomaly.go`: the latency check gates on the sketch p99 with the same 500 ms and >10-call thresholds; severity classifies on p99; evidence carries the sketch accuracy.
- `internal/storage/trace_repo.go`: `GetServiceMapMetrics` computes each service's exact nearest-rank p99 in one window-function statement (`ROW_NUMBER()`/`COUNT(*) OVER (PARTITION BY service_name)`, accepted verbatim by SQLite 3.25+, Postgres, MySQL 8 and SQL Server) while the range's span count is within `serviceMapSpanLimit` (500k, the bound the edge pass already uses). Above it every node keeps the estimate and its `estimated` provenance. Exact values are `measured` / `ordered_rank`.
- No JSON field added, removed or retyped.

## Fixture (900 × 10 ms + 100 × 500 ms; true p99 500 ms, average 59 ms)

| Path | Old estimate | New value | Provenance |
|---|---|---|---|
| GraphRAG `ServiceStore` | 147.5 ms | 500.9 ms (bound ±2.17 %) | approximate / ddsketch |
| DB `GetServiceMapMetrics` (SQLite, Postgres 16) | 147.5 ms | 500 ms | measured / ordered_rank |
| DB above the row cap | 147.5 ms | 147.5 ms | estimated / average_multiplier |

## Targeted local verification

```text
go test -race -count=1 ./internal/graphrag ./internal/mcp ./internal/realtime ./internal/storage ./internal/latency ./internal/aggregate → pass
TestLatencyModeProof for legacy, aggregate-shadow, aggregate (TMPDIR on /dev/shm)                                              → pass, 14 assertions each
Postgres 16 integration (TestPG_ServiceMapMeasuredP99, throwaway container)                                                    → pass
go vet, gofmt -l on touched packages                                                                                            → clean
```

The latency proof gains assertions in legacy and shadow (sketch-derived on system graph, GraphRAG and MCP; exact rank on `/api/metrics/service-map`; no legacy surface reports `estimated`) and `rest_service_map_approximate` in aggregate mode; none relaxed. Two tests in other packages that asserted the old estimate were updated to the new values.

## Compatibility and rollback

Values and provenance change; shapes do not. Clients that read provenance now see `approximate`/`measured` instead of `estimated`. Rollback: previous binary. MySQL and SQL Server execution of the window statement is exercised by the release gate's lifecycle proofs.

## Evidence

CI on this PR, including the latency proof in all three modes.