### PR TITLE
feat(ui): group the map and list by host and add a host panel

### DIFF
--- a/internal/ui/static/app.css
+++ b/internal/ui/static/app.css
@@ -332,7 +332,8 @@ a {
   border-color: var(--line-strong);
 }
 
-.coverage-badge {
+.coverage-badge,
+.coverage-tag {
   padding: 3px 7px;
   border: 1px solid var(--line-strong);
   border-radius: 999px;
@@ -644,6 +645,52 @@ h2 {
   color: var(--text);
 }
 
+.view-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.group-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 5px 10px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.group-toggle[aria-pressed="true"] {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--text);
+}
+
+.group-toggle[aria-disabled="true"] {
+  color: var(--faint);
+  cursor: not-allowed;
+}
+
+/* Host marker: a diamond, so a host never reads as a service dot. */
+.host-mark {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border: 1.5px solid var(--accent);
+  border-radius: 1px;
+  transform: rotate(45deg);
+}
+
+.group-toggle[aria-pressed="true"] .host-mark {
+  background: var(--accent);
+}
+
 .search-field {
   display: flex;
   align-items: center;
@@ -873,6 +920,43 @@ h2 {
   vector-effect: non-scaling-stroke;
 }
 
+.cluster-ring {
+  fill: color-mix(in srgb, var(--accent) 4%, transparent);
+  stroke: color-mix(in srgb, var(--accent) 45%, var(--line));
+  stroke-dasharray: 4 6;
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.cluster-heading {
+  cursor: pointer;
+}
+
+.cluster-label {
+  fill: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 700;
+  paint-order: stroke;
+  stroke: var(--surface);
+  stroke-linejoin: round;
+  stroke-width: 5px;
+}
+
+.cluster-heading:hover .cluster-label,
+.cluster-heading:focus .cluster-label,
+.cluster-heading.is-selected .cluster-label {
+  fill: var(--accent);
+}
+
+.cluster-heading:focus {
+  outline: none;
+}
+
+.cluster-heading:focus-visible .cluster-label {
+  text-decoration: underline;
+}
+
 .graph-edge {
   stroke: color-mix(in srgb, var(--line-strong) 66%, transparent);
   stroke-linecap: round;
@@ -927,7 +1011,8 @@ h2 {
   transition: filter 140ms ease, opacity 140ms ease;
 }
 
-.node-label {
+.node-label,
+.node-sub {
   fill: var(--text);
   font-family: var(--font-mono);
   font-size: 18px;
@@ -937,6 +1022,19 @@ h2 {
   stroke: var(--surface);
   stroke-linejoin: round;
   stroke-width: 5px;
+}
+
+.node-sub {
+  fill: var(--faint);
+  font-size: 13px;
+}
+
+.service-node[data-kind="host"] {
+  --node-color: var(--accent);
+}
+
+.service-node[data-kind="host"] .node-core {
+  fill: color-mix(in srgb, var(--surface) 70%, var(--node-color));
 }
 
 .service-node:hover .node-halo,
@@ -1176,6 +1274,49 @@ h2 {
   display: none;
 }
 
+.host-heading {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 34px;
+  margin: 10px 0 2px;
+  padding: 5px 9px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  text-align: left;
+}
+
+.host-heading:first-child {
+  margin-top: 4px;
+}
+
+button.host-heading:hover,
+.host-heading[aria-current="true"] {
+  border-color: var(--line);
+  background: var(--surface-2);
+}
+
+.host-name {
+  overflow: hidden;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 750;
+  letter-spacing: 0.06em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.host-count {
+  color: var(--faint);
+  font-size: 9px;
+  white-space: nowrap;
+}
+
 .service-row-main {
   min-width: 0;
   margin-left: 8px;
@@ -1324,6 +1465,84 @@ h2 {
   font-family: var(--font-mono);
   font-size: 12px;
   text-overflow: ellipsis;
+}
+
+.stat-card.is-empty strong {
+  color: var(--faint);
+  font-weight: 500;
+}
+
+.resource-grid {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.spark {
+  display: block;
+  width: 100%;
+  height: 24px;
+  margin-top: 6px;
+}
+
+.spark polyline {
+  fill: none;
+  stroke: var(--accent);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.spark circle {
+  fill: var(--accent);
+}
+
+.section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.host-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 30px;
+  padding: 4px 9px;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.host-chip::before {
+  width: 6px;
+  height: 6px;
+  border: 1.5px solid var(--accent);
+  border-radius: 1px;
+  transform: rotate(45deg);
+  content: "";
+}
+
+.host-chip:hover {
+  border-color: var(--accent);
+}
+
+.service-status.host {
+  border: 2px solid var(--accent);
+  border-radius: 1px;
+  background: transparent;
+  transform: rotate(45deg);
 }
 
 .stat-card.is-critical strong {
@@ -1750,6 +1969,10 @@ h2 {
 
   .stat-grid {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .resource-grid {
+    grid-template-columns: repeat(3, 1fr);
   }
 
   .inspector-tabs {

--- a/internal/ui/static/app.js
+++ b/internal/ui/static/app.js
@@ -3,6 +3,13 @@ const GOLDEN_ANGLE = 2.399963229728653;
 const POLL_INTERVAL_MS = 30000;
 const TOOL_CACHE_MS = 300000;
 const HOST_PREFIX = "host/";
+// HOST_NAME_PATTERN bounds what the page accepts as a host name from the URL
+// or a response before it builds a request URL from it.
+const HOST_NAME_PATTERN = /^[A-Za-z0-9._:-]{1,255}$/;
+
+function validHostName(value) {
+  return typeof value === "string" && HOST_NAME_PATTERN.test(value) ? value : null;
+}
 const HOST_METRICS_WINDOW_MS = 3600000;
 // Standard hostmetrics names. The first three always render; the usage pair
 // renders only when the host reports it.
@@ -363,7 +370,7 @@ function updateURL(changes) {
 
 function readURL() {
   const params = new URLSearchParams(window.location.search);
-  state.selectedHost = params.get("host");
+  state.selectedHost = validHostName(params.get("host"));
   state.selected = state.selectedHost ? null : params.get("service");
   state.groupBy = params.get("group") === "host" ? "host" : "service";
   const tab = params.get("tab");
@@ -1433,7 +1440,9 @@ async function fetchSeries(path) {
 
 // loadHostMetrics reads the host's hostmetrics series through the ordinary
 // metrics API. Previous samples stay on screen while a refresh is in flight.
-async function loadHostMetrics(host) {
+async function loadHostMetrics(candidate) {
+  const host = validHostName(candidate);
+  if (!host) return;
   const previous = state.hostMetrics.get(host);
   const entry = {
     series: previous ? previous.series : new Map(),
@@ -1794,7 +1803,9 @@ function openInspector(service) {
   window.setTimeout(() => dom.closeInspector.focus(), 0);
 }
 
-function openHost(host) {
+function openHost(candidate) {
+  const host = validHostName(candidate);
+  if (!host) return;
   state.selected = null;
   state.selectedHost = host;
   updateURL({ host: host, service: null, tab: null });

--- a/internal/ui/static/app.js
+++ b/internal/ui/static/app.js
@@ -2,6 +2,17 @@ const SVG_NS = "http://www.w3.org/2000/svg";
 const GOLDEN_ANGLE = 2.399963229728653;
 const POLL_INTERVAL_MS = 30000;
 const TOOL_CACHE_MS = 300000;
+const HOST_PREFIX = "host/";
+const HOST_METRICS_WINDOW_MS = 3600000;
+// Standard hostmetrics names. The first three always render; the usage pair
+// renders only when the host reports it.
+const HOST_METRICS = [
+  { name: "system.cpu.utilization", label: "CPU", kind: "ratio", always: true },
+  { name: "system.memory.utilization", label: "Memory", kind: "ratio", always: true },
+  { name: "system.filesystem.utilization", label: "Disk", kind: "ratio", always: true },
+  { name: "system.memory.usage", label: "Memory used", kind: "bytes" },
+  { name: "system.filesystem.usage", label: "Disk used", kind: "bytes" },
+];
 
 const byId = (id) => document.getElementById(id);
 const dom = {
@@ -37,8 +48,11 @@ const dom = {
   retry: byId("retry-button"),
   mapView: byId("map-view-button"),
   listView: byId("list-view-button"),
+  hostGroup: byId("host-group-button"),
   map: byId("service-map"),
+  graphDescription: byId("graph-description"),
   rings: byId("graph-rings"),
+  clusters: byId("graph-clusters"),
   edges: byId("graph-edges"),
   nodes: byId("graph-nodes"),
   minimapButton: byId("minimap-button"),
@@ -51,6 +65,7 @@ const dom = {
   fit: byId("fit-button"),
   serviceList: byId("service-list"),
   serviceCount: byId("service-count"),
+  railEyebrow: byId("rail-eyebrow"),
   severity: byId("severity-summary"),
   impactBanner: byId("impact-banner"),
   impactLabel: byId("impact-label"),
@@ -58,6 +73,8 @@ const dom = {
   inspector: byId("inspector"),
   inspectorScrim: byId("inspector-scrim"),
   inspectorTitle: byId("inspector-title"),
+  inspectorEyebrow: byId("inspector-eyebrow"),
+  inspectorTabs: byId("inspector-tabs"),
   inspectorStatus: byId("inspector-status"),
   inspectorHealth: byId("inspector-health"),
   inspectorBody: byId("inspector-body"),
@@ -74,6 +91,11 @@ const state = {
   error: "",
   refreshing: false,
   selected: null,
+  selectedHost: null,
+  groupBy: "service",
+  hosts: null,
+  hostsError: "",
+  hostMetrics: new Map(),
   activeTab: "overview",
   impactRoot: null,
   query: "",
@@ -206,6 +228,81 @@ function formatMB(value) {
   return trimFixed(size, size < 10 ? 1 : 0) + "MB";
 }
 
+function formatBytes(value) {
+  const size = Number(value);
+  if (!Number.isFinite(size)) return "—";
+  if (size < 1048576) return trimFixed(size / 1024, 0) + "KB";
+  return formatMB(size / 1048576);
+}
+
+function isHostNode(node) {
+  return Boolean(node) && (node.kind === "host" || String(node.id).startsWith(HOST_PREFIX));
+}
+
+function hostsAvailable() {
+  return Array.isArray(state.hosts) && state.hosts.length > 0;
+}
+
+function hostGroupReason() {
+  if (hostsAvailable()) return "";
+  if (state.hosts === null) return state.hostsError ? "Host list unavailable: " + state.hostsError : "Loading hosts…";
+  return "No hosts reported yet.";
+}
+
+function hostByName(name) {
+  return (state.hosts || []).find((host) => host.name === name) || null;
+}
+
+// nodeHosts lists the hosts a service was observed on: the node's own stamp
+// when present, else the registry listing (the graph response is cached for
+// a few seconds and can lag the host list).
+function nodeHosts(node) {
+  if (Array.isArray(node.hosts) && node.hosts.length) return node.hosts;
+  const listed = [];
+  for (const host of state.hosts || []) {
+    if (Array.isArray(host.services) && host.services.includes(node.id)) listed.push(host.name);
+  }
+  return listed;
+}
+
+function nodeHostCount(node) {
+  return Math.max(finite(node.host_count, 0), nodeHosts(node).length);
+}
+
+// hostOfNode is the cluster a node belongs to: its own host for a host
+// entity, else the first host it was seen on.
+function hostOfNode(node) {
+  if (isHostNode(node)) {
+    return Array.isArray(node.hosts) && node.hosts.length ? node.hosts[0] : node.id.slice(HOST_PREFIX.length);
+  }
+  return nodeHosts(node)[0];
+}
+
+// hostClusters folds the graph into one cluster per host in host order,
+// with services that no host claims last under a null host.
+function hostClusters() {
+  const byHost = new Map();
+  for (const host of state.hosts || []) byHost.set(host.name, { host: host, members: [] });
+  const unassigned = { host: null, members: [] };
+  for (const node of state.graph ? state.graph.nodes : []) {
+    const cluster = byHost.get(hostOfNode(node));
+    (cluster || unassigned).members.push(node);
+  }
+  const clusters = Array.from(byHost.values());
+  if (unassigned.members.length) clusters.push(unassigned);
+  return clusters;
+}
+
+function clusterServiceCount(cluster) {
+  if (cluster.host) return finite(cluster.host.service_count, 0);
+  return cluster.members.filter((node) => !isHostNode(node)).length;
+}
+
+function clusterLabel(cluster) {
+  const count = clusterServiceCount(cluster);
+  return (cluster.host ? cluster.host.name : "No host") + " · " + count + (count === 1 ? " service" : " services");
+}
+
 function normalizeStatus(node) {
   const raw = String(node && node.status || "").toLowerCase();
   const score = finite(node && node.health_score, 1);
@@ -230,8 +327,10 @@ function statusRank(node) {
   return order[normalizeStatus(node)] === undefined ? 2 : order[normalizeStatus(node)];
 }
 
+// sortedNodes is the worst-first service ranking. Host entities are not
+// services and never enter it.
 function sortedNodes() {
-  const nodes = state.graph && Array.isArray(state.graph.nodes) ? state.graph.nodes.slice() : [];
+  const nodes = state.graph && Array.isArray(state.graph.nodes) ? state.graph.nodes.filter((node) => !isHostNode(node)) : [];
   nodes.sort((a, b) => {
     const statusDiff = statusRank(a) - statusRank(b);
     if (statusDiff !== 0) return statusDiff;
@@ -264,7 +363,9 @@ function updateURL(changes) {
 
 function readURL() {
   const params = new URLSearchParams(window.location.search);
-  state.selected = params.get("service");
+  state.selectedHost = params.get("host");
+  state.selected = state.selectedHost ? null : params.get("service");
+  state.groupBy = params.get("group") === "host" ? "host" : "service";
   const tab = params.get("tab");
   state.activeTab = ["overview", "why", "impact", "dependencies"].includes(tab) ? tab : "overview";
   state.impactRoot = params.get("impact");
@@ -506,11 +607,31 @@ async function refresh(options) {
     renderStates();
   }
 
+  // The host list rides the existing poll only while something shows it; an
+  // idle service view adds no request. Explicit refreshes and the first load
+  // always fetch it so the toggle knows whether hosts exist.
+  const wantHosts = !silent || state.hosts === null || state.groupBy === "host" || Boolean(state.selectedHost);
   const results = await Promise.allSettled([
     fetchJSON("/api/system/graph"),
     fetchJSON("/api/metrics/dashboard"),
     fetchJSON("/api/stats"),
+    wantHosts ? fetchJSON("/api/hosts") : Promise.reject(new Error("skipped")),
   ]);
+
+  if (wantHosts) {
+    if (results[3].status === "fulfilled") {
+      state.hosts = Array.isArray(results[3].value) ? results[3].value.filter((host) => host && typeof host.name === "string") : [];
+      state.hostsError = "";
+    } else if (state.hosts === null) {
+      state.hostsError = results[3].reason && results[3].reason.message ? results[3].reason.message : "Unknown response";
+    }
+  }
+  if (state.selectedHost) {
+    // Silent refreshes arrive with every WebSocket snapshot; the panel's
+    // five series follow the slower poll cadence unless asked explicitly.
+    const loaded = state.hostMetrics.get(state.selectedHost);
+    if (!silent || !loaded || Date.now() - loaded.loadedAt > POLL_INTERVAL_MS) loadHostMetrics(state.selectedHost);
+  }
 
   if (results[0].status === "fulfilled") {
     state.graph = normalizeGraph(results[0].value);
@@ -624,7 +745,7 @@ function summaryItem(status, value, label) {
 
 function renderSeverity() {
   const counts = { healthy: 0, degraded: 0, critical: 0 };
-  for (const node of state.graph ? state.graph.nodes : []) {
+  for (const node of sortedNodes()) {
     const status = normalizeStatus(node);
     if (counts[status] !== undefined) counts[status] += 1;
   }
@@ -654,6 +775,7 @@ function serviceButton(node) {
   const tail = formatP99(metrics.p99_latency_ms, metrics.latency_provenance);
   let detail = tail.value + " " + tail.label.toLowerCase() + " · " + formatRatio(metrics.error_rate, 1) + " error";
   if (state.anomalies.has(node.id)) detail += " · anomaly";
+  if (state.groupBy === "host" && nodeHostCount(node) > 1) detail += " · " + nodeHostCount(node) + " hosts";
   main.appendChild(textElement("span", "service-meta", detail));
   main.title = tail.explanation;
   const health = textElement("span", "service-health", formatRatio(node.health_score, 0));
@@ -668,21 +790,57 @@ function filteredSortedNodes() {
   return sortedNodes().filter((node) => !query || node.id.toLowerCase().includes(query));
 }
 
+function hostHeading(cluster) {
+  const count = clusterServiceCount(cluster);
+  const heading = document.createElement(cluster.host ? "button" : "p");
+  heading.className = "host-heading";
+  if (cluster.host) {
+    heading.type = "button";
+    heading.dataset.host = cluster.host.name;
+    heading.setAttribute("aria-current", cluster.host.name === state.selectedHost ? "true" : "false");
+    heading.setAttribute("aria-label", clusterLabel(cluster) + ", open host panel");
+    heading.addEventListener("click", () => openHost(cluster.host.name));
+  }
+  const mark = document.createElement("i");
+  mark.className = "host-mark";
+  mark.setAttribute("aria-hidden", "true");
+  heading.append(
+    mark,
+    textElement("span", "host-name", cluster.host ? cluster.host.name : "No host"),
+    textElement("span", "host-count", count + (count === 1 ? " service" : " services"))
+  );
+  return heading;
+}
+
+// groupedRows renders the host-mode list: one heading per host, then the
+// worst-first rows of the services whose first host it is.
+function groupedRows(filtered) {
+  const visible = new Set(filtered.map((node) => node.id));
+  const fragment = document.createDocumentFragment();
+  for (const cluster of hostClusters()) {
+    const members = cluster.members.filter((node) => visible.has(node.id));
+    if (state.query && !members.length) continue;
+    fragment.appendChild(hostHeading(cluster));
+    for (const node of filtered) {
+      if (members.includes(node)) fragment.appendChild(serviceButton(node));
+    }
+  }
+  return fragment;
+}
+
 function renderServiceLists() {
   const all = sortedNodes();
   const filtered = filteredSortedNodes();
-  const railFragment = document.createDocumentFragment();
-  const mobileFragment = document.createDocumentFragment();
-  for (const node of filtered) {
-    railFragment.appendChild(serviceButton(node));
-    mobileFragment.appendChild(serviceButton(node));
+  const hostMode = state.groupBy === "host";
+  const fragments = [document.createDocumentFragment(), document.createDocumentFragment()];
+  for (const fragment of fragments) {
+    if (hostMode) fragment.appendChild(groupedRows(filtered));
+    else for (const node of filtered) fragment.appendChild(serviceButton(node));
+    if (filtered.length === 0 && all.length > 0) fragment.appendChild(textElement("p", "quiet", "No services match this search."));
   }
-  if (filtered.length === 0 && all.length > 0) {
-    railFragment.appendChild(textElement("p", "quiet", "No services match this search."));
-    mobileFragment.appendChild(textElement("p", "quiet", "No services match this search."));
-  }
-  dom.serviceList.replaceChildren(railFragment);
-  dom.mobileList.replaceChildren(mobileFragment);
+  dom.serviceList.replaceChildren(fragments[0]);
+  dom.mobileList.replaceChildren(fragments[1]);
+  dom.railEyebrow.textContent = hostMode ? "By host" : "Worst first";
   dom.serviceCount.textContent = String(all.length);
   dom.searchCount.textContent = state.query ? String(filtered.length) + " found" : "";
 }
@@ -743,6 +901,64 @@ function graphLayout(nodes, edges) {
   return positions;
 }
 
+// hostLayout places one golden-angle spiral of cluster centres, then a
+// smaller spiral of members inside each. Deterministic like graphLayout.
+function hostLayout(clusters) {
+  const positions = new Map();
+  const rings = [];
+  const count = clusters.length;
+  const spread = count === 1 ? 0 : 335;
+  const radius = count <= 1 ? 170 : Math.max(50, Math.min(165, 300 / Math.sqrt(count)));
+  clusters.forEach((cluster, index) => {
+    const distance = spread * Math.sqrt((index + 0.4) / count);
+    const angle = index * GOLDEN_ANGLE;
+    const cx = 500 + distance * Math.cos(angle);
+    const cy = 500 + distance * Math.sin(angle);
+    const members = cluster.members.slice().sort((a, b) => a.id.localeCompare(b.id));
+    members.forEach((node, member) => {
+      const inner = members.length === 1 ? 0 : (radius - 30) * Math.sqrt((member + 0.4) / members.length);
+      const turn = member * GOLDEN_ANGLE;
+      positions.set(node.id, { x: cx + inner * Math.cos(turn), y: cy + inner * Math.sin(turn) });
+    });
+    rings.push({ cluster: cluster, x: cx, y: cy, r: radius });
+  });
+  return { positions: positions, rings: rings };
+}
+
+function renderClusterRings(rings) {
+  for (const ring of rings) {
+    dom.rings.appendChild(svgElement("circle", { class: "cluster-ring", cx: ring.x, cy: ring.y, r: ring.r }));
+    const host = ring.cluster.host;
+    const heading = svgElement("g", {
+      class: "cluster-heading",
+      transform: "translate(" + ring.x + " " + (ring.y - ring.r - 10) + ")",
+    });
+    if (host) {
+      heading.setAttribute("tabindex", "0");
+      heading.setAttribute("role", "button");
+      heading.setAttribute("aria-label", clusterLabel(ring.cluster) + ", open host panel");
+      heading.dataset.host = host.name;
+      if (host.name === state.selectedHost) heading.classList.add("is-selected");
+      heading.addEventListener("click", (event) => {
+        event.stopPropagation();
+        openHost(host.name);
+      });
+      heading.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          openHost(host.name);
+        }
+      });
+    } else {
+      heading.setAttribute("aria-hidden", "true");
+    }
+    const text = svgElement("text", { class: "cluster-label", "text-anchor": "middle" });
+    text.textContent = clusterLabel(ring.cluster);
+    heading.appendChild(text);
+    dom.clusters.appendChild(heading);
+  }
+}
+
 function downstreamDepths(root, edges, maxDepth) {
   const outgoing = new Map();
   for (const edge of edges) {
@@ -773,14 +989,29 @@ function graphSearchMatches() {
 
 function renderGraph() {
   dom.rings.replaceChildren();
+  dom.clusters.replaceChildren();
   dom.edges.replaceChildren();
   dom.nodes.replaceChildren();
   dom.minimapEdges.replaceChildren();
   dom.minimapNodes.replaceChildren();
   if (!state.graph || state.graph.nodes.length === 0) return;
 
+  const hostMode = state.groupBy === "host";
+  dom.graphDescription.textContent = hostMode
+    ? "Services are clustered by host. Select a service or a host heading to inspect it."
+    : "Services are arranged by dependency criticality. Select a service to inspect it.";
   const edges = cleanEdges(state.graph.nodes, state.graph.edges);
-  const positions = graphLayout(state.graph.nodes, edges);
+  let positions;
+  if (hostMode) {
+    const layout = hostLayout(hostClusters());
+    positions = layout.positions;
+    renderClusterRings(layout.rings);
+  } else {
+    positions = graphLayout(state.graph.nodes, edges);
+    for (const radius of [100, 200, 300, 400]) {
+      dom.rings.appendChild(svgElement("circle", { class: "graph-ring", cx: 500, cy: 500, r: radius }));
+    }
+  }
   const searchMatches = graphSearchMatches();
   const impact = state.impactRoot ? downstreamDepths(state.impactRoot, edges, 5) : null;
   const selectedNeighbors = new Set();
@@ -790,10 +1021,6 @@ function renderGraph() {
       if (edge.source === state.selected) selectedNeighbors.add(edge.target);
       if (edge.target === state.selected) selectedNeighbors.add(edge.source);
     }
-  }
-
-  for (const radius of [100, 200, 300, 400]) {
-    dom.rings.appendChild(svgElement("circle", { class: "graph-ring", cx: 500, cy: 500, r: radius }));
   }
 
   const edgeFragment = document.createDocumentFragment();
@@ -841,16 +1068,47 @@ function renderGraph() {
   for (const node of state.graph.nodes) {
     const point = positions.get(node.id);
     if (!point) continue;
-    const status = normalizeStatus(node);
+    const hostNode = isHostNode(node);
+    const status = hostNode ? "unknown" : normalizeStatus(node);
     const group = svgElement("g", {
       class: "service-node",
       transform: "translate(" + point.x + " " + point.y + ")",
       tabindex: "0",
       role: "button",
       "data-status": status,
-      "aria-label": node.id + ", " + status + ", health " + formatRatio(node.health_score, 0),
+      "aria-label": hostNode
+        ? node.id + ", host, open host panel"
+        : node.id + ", " + status + ", health " + formatRatio(node.health_score, 0),
     });
     group.dataset.service = node.id;
+    if (hostNode) {
+      // A host entity is a diamond with no edges; activating it opens the host panel.
+      group.dataset.kind = "host";
+      const side = nodeRadius * 1.7;
+      group.appendChild(svgElement("rect", { class: "node-halo", x: -side / 2 - 7, y: -side / 2 - 7, width: side + 14, height: side + 14, transform: "rotate(45)" }));
+      group.appendChild(svgElement("rect", { class: "node-core", x: -side / 2, y: -side / 2, width: side, height: side, transform: "rotate(45)" }));
+      if (showAllLabels || searchMatches && searchMatches.has(node.id)) {
+        const label = svgElement("text", { class: "node-label", x: nodeRadius + 9, y: 6 });
+        label.textContent = node.id.length > 24 ? node.id.slice(0, 23) + "…" : node.id;
+        group.appendChild(label);
+      }
+      const title = svgElement("title");
+      title.textContent = node.id + " — host";
+      group.appendChild(title);
+      const open = () => openHost(hostOfNode(node));
+      group.addEventListener("click", (event) => {
+        event.stopPropagation();
+        open();
+      });
+      group.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          open();
+        }
+      });
+      nodeFragment.appendChild(group);
+      continue;
+    }
     if (node.id === state.selected) group.classList.add("is-selected");
     if (searchMatches && searchMatches.has(node.id)) group.classList.add("is-search-match");
     if (impact && impact.has(node.id)) group.classList.add("is-impact");
@@ -870,6 +1128,11 @@ function renderGraph() {
       });
       label.textContent = node.id.length > 24 ? node.id.slice(0, 23) + "…" : node.id;
       group.appendChild(label);
+      if (hostMode && nodeHostCount(node) > 1) {
+        const sub = svgElement("text", { class: "node-sub", x: nodeRadius + 9, y: 22 });
+        sub.textContent = nodeHostCount(node) + " hosts";
+        group.appendChild(sub);
+      }
     }
     const title = svgElement("title");
     const tail = formatP99(node.metrics.p99_latency_ms, node.metrics.latency_provenance);
@@ -915,6 +1178,38 @@ function renderViewSwitch() {
   const mapMode = state.mobileMode === "map";
   dom.mapView.setAttribute("aria-pressed", mapMode ? "true" : "false");
   dom.listView.setAttribute("aria-pressed", mapMode ? "false" : "true");
+  const reason = hostGroupReason();
+  dom.hostGroup.setAttribute("aria-pressed", state.groupBy === "host" ? "true" : "false");
+  dom.hostGroup.setAttribute("aria-disabled", reason ? "true" : "false");
+  dom.hostGroup.title = reason || "Group services by host";
+}
+
+async function setGroupBy(mode) {
+  if (mode === "host" && !hostsAvailable()) {
+    // Hosts may have appeared since the last explicit refresh; ask once
+    // before refusing, so the toggle never needs a page reload to wake up.
+    try {
+      const hosts = await fetchJSON("/api/hosts");
+      state.hosts = Array.isArray(hosts) ? hosts.filter((host) => host && typeof host.name === "string") : [];
+      state.hostsError = "";
+    } catch (error) {
+      if (state.hosts === null) state.hostsError = error && error.message ? error.message : "Unknown response";
+    }
+    if (!hostsAvailable()) {
+      renderViewSwitch();
+      showToast(hostGroupReason());
+      return;
+    }
+  }
+  state.groupBy = mode;
+  updateURL({ group: mode === "host" ? "host" : null });
+  if (mode === "host" && isMobile()) {
+    state.mobileMode = "list";
+    state.mobileModeChosen = true;
+    updateURL({ flow: "0" });
+  }
+  renderAll();
+  showToast(mode === "host" ? "Grouped by host: " + state.hosts.length + (state.hosts.length === 1 ? " host" : " hosts") : "Grouped by service");
 }
 
 function isMobile() {
@@ -925,7 +1220,7 @@ function chooseInitialMobileMode() {
   if (state.mobileModeChosen || !state.graph) return;
   const requested = new URLSearchParams(window.location.search).get("flow");
   if (requested === "1") state.mobileMode = "map";
-  else if (requested === "0") state.mobileMode = "list";
+  else if (requested === "0" || state.groupBy === "host") state.mobileMode = "list";
   else state.mobileMode = state.graph.nodes.length > 40 ? "list" : "map";
   state.mobileModeChosen = true;
 }
@@ -992,7 +1287,183 @@ function renderOverview(node) {
     section.appendChild(list);
   }
   wrapper.appendChild(section);
+
+  const hosts = nodeHosts(node);
+  if (hosts.length) {
+    const hostSection = document.createElement("section");
+    hostSection.className = "section";
+    const count = nodeHostCount(node);
+    hostSection.appendChild(textElement("h3", "section-title", "Hosts · " + count));
+    const row = document.createElement("div");
+    row.className = "chip-row";
+    for (const host of hosts) {
+      const chip = textElement("button", "host-chip", host);
+      chip.type = "button";
+      chip.dataset.host = host;
+      chip.setAttribute("aria-label", "Open host " + host);
+      chip.addEventListener("click", () => openHost(host));
+      row.appendChild(chip);
+    }
+    if (count > hosts.length) row.appendChild(textElement("span", "quiet", "+" + (count - hosts.length) + " more"));
+    hostSection.appendChild(row);
+    wrapper.appendChild(hostSection);
+  }
   return wrapper;
+}
+
+function sparkline(values) {
+  const svg = svgElement("svg", { class: "spark", viewBox: "0 0 100 28", "aria-hidden": "true" });
+  let min = Infinity;
+  let max = -Infinity;
+  for (const value of values) {
+    min = Math.min(min, value);
+    max = Math.max(max, value);
+  }
+  const span = max - min || 1;
+  const points = values.map((value, index) => {
+    const x = values.length === 1 ? 50 : index / (values.length - 1) * 100;
+    return x.toFixed(1) + "," + (26 - (value - min) / span * 24).toFixed(1);
+  });
+  svg.appendChild(svgElement("polyline", { points: points.join(" ") }));
+  // A lone sample is a point, not a line; make it visible.
+  const last = points[points.length - 1].split(",");
+  svg.appendChild(svgElement("circle", { cx: last[0], cy: last[1], r: 2 }));
+  return svg;
+}
+
+function bucketValue(bucket) {
+  const count = finite(bucket.count, 0);
+  return count > 0 ? finite(bucket.sum, 0) / count : finite(bucket.max, NaN);
+}
+
+function hostMetricCard(spec, buckets) {
+  const card = document.createElement("div");
+  card.className = "stat-card";
+  card.dataset.metric = spec.name;
+  card.append(textElement("span", "stat-label", spec.label));
+  const values = (buckets || []).map(bucketValue).filter(Number.isFinite);
+  if (!buckets) {
+    card.setAttribute("aria-busy", "true");
+    card.append(textElement("strong", "", "…"));
+    return card;
+  }
+  if (!values.length) {
+    card.classList.add("is-empty");
+    card.append(textElement("strong", "", "not reported"));
+    card.title = spec.name + " has no samples in the last hour";
+    return card;
+  }
+  const latest = values[values.length - 1];
+  card.append(textElement("strong", "", spec.kind === "ratio" ? formatRatio(latest, 0) : formatBytes(latest)));
+  card.appendChild(sparkline(values));
+  card.title = spec.name + ": " + values.length + (values.length === 1 ? " bucket" : " buckets") + " in the last hour";
+  return card;
+}
+
+function renderHostPanel(host) {
+  const wrapper = document.createElement("div");
+  const entry = state.hostMetrics.get(state.selectedHost) || null;
+  const resources = document.createElement("section");
+  resources.className = "section";
+  const head = document.createElement("div");
+  head.className = "section-head";
+  head.appendChild(textElement("h3", "section-title", "Resources · last hour"));
+  if (entry && entry.coverage) {
+    const badge = textElement("span", "coverage-tag", entry.coverage + " coverage");
+    badge.title = "Reported by the metrics API";
+    head.appendChild(badge);
+  }
+  resources.appendChild(head);
+  const grid = document.createElement("div");
+  grid.className = "stat-grid resource-grid";
+  for (const spec of HOST_METRICS) {
+    const buckets = entry ? entry.series.get(spec.name) : null;
+    if (!spec.always && !(buckets && buckets.length)) continue;
+    grid.appendChild(hostMetricCard(spec, buckets === undefined ? null : buckets));
+  }
+  resources.appendChild(grid);
+  if (entry && entry.error) resources.appendChild(textElement("p", "quiet", "Metrics unavailable: " + entry.error));
+  wrapper.appendChild(resources);
+
+  const services = document.createElement("section");
+  services.className = "section";
+  const listed = host && Array.isArray(host.services) ? host.services : [];
+  const total = host ? finite(host.service_count, listed.length) : 0;
+  services.appendChild(textElement("h3", "section-title", "Services · " + total));
+  if (!host) {
+    services.appendChild(textElement("p", "quiet", state.selectedHost + " is not in the current host list. It may have stopped reporting."));
+  } else if (!listed.length) {
+    services.appendChild(textElement("p", "quiet", "No services reported on this host."));
+  } else {
+    const list = document.createElement("ul");
+    list.className = "dependency-list";
+    for (const id of listed) {
+      const node = state.graph ? state.graph.nodes.find((candidate) => candidate.id === id) : null;
+      const item = document.createElement("li");
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "dependency-row";
+      button.dataset.service = id;
+      button.append(
+        textElement("strong", "", id),
+        textElement("span", "", node ? normalizeStatus(node) + " · health " + formatRatio(node.health_score, 0) : "not in the current graph")
+      );
+      button.addEventListener("click", () => openInspector(id));
+      item.appendChild(button);
+      list.appendChild(item);
+    }
+    services.appendChild(list);
+    if (total > listed.length) services.appendChild(textElement("p", "quiet", "+" + (total - listed.length) + " more not listed"));
+  }
+  wrapper.appendChild(services);
+  if (host) {
+    const seen = new Date(host.last_seen);
+    const signals = Array.isArray(host.signals) && host.signals.length ? host.signals.join(", ") : "none";
+    wrapper.appendChild(textElement("p", "quiet", "Signals: " + signals + (Number.isNaN(seen.getTime()) ? "" : " · last seen " + seen.toLocaleString())));
+  }
+  return wrapper;
+}
+
+async function fetchSeries(path) {
+  const response = await fetch(path, { headers: { Accept: "application/json" }, cache: "no-cache" });
+  if (!response.ok) throw new Error((await response.text()).trim() || "HTTP " + response.status);
+  const data = await response.json();
+  return { buckets: Array.isArray(data) ? data : [], coverage: response.headers.get("OtelContext-Data-Coverage") || "" };
+}
+
+// loadHostMetrics reads the host's hostmetrics series through the ordinary
+// metrics API. Previous samples stay on screen while a refresh is in flight.
+async function loadHostMetrics(host) {
+  const previous = state.hostMetrics.get(host);
+  const entry = {
+    series: previous ? previous.series : new Map(),
+    coverage: previous ? previous.coverage : "",
+    error: "",
+    loadedAt: Date.now(),
+  };
+  state.hostMetrics.set(host, entry);
+  const end = new Date();
+  const start = new Date(end.getTime() - HOST_METRICS_WINDOW_MS);
+  const query = "&service_name=" + encodeURIComponent(HOST_PREFIX + host)
+    + "&start=" + encodeURIComponent(start.toISOString()) + "&end=" + encodeURIComponent(end.toISOString());
+  const results = await Promise.allSettled(HOST_METRICS.map((spec) => fetchSeries("/api/metrics?name=" + encodeURIComponent(spec.name) + query)));
+  const series = new Map();
+  let coverage = "";
+  let error = "";
+  results.forEach((result, index) => {
+    if (result.status === "fulfilled") {
+      series.set(HOST_METRICS[index].name, result.value.buckets);
+      if (result.value.coverage && coverage !== "sampled") coverage = result.value.coverage;
+    } else {
+      series.set(HOST_METRICS[index].name, []);
+      error = result.reason && result.reason.message ? result.reason.message : "request failed";
+    }
+  });
+  if (state.hostMetrics.get(host) !== entry) return;
+  entry.series = series;
+  entry.coverage = coverage;
+  entry.error = error;
+  if (state.selectedHost === host) renderInspector();
 }
 
 function dependencyRow(id, edge) {
@@ -1265,7 +1736,7 @@ function renderImpact(node) {
 
 function renderInspector() {
   const node = currentNode();
-  if (!state.selected) {
+  if (!state.selected && !state.selectedHost) {
     dom.inspector.setAttribute("aria-hidden", "true");
     dom.inspector.inert = true;
     dom.inspectorScrim.hidden = true;
@@ -1274,6 +1745,17 @@ function renderInspector() {
   dom.inspector.setAttribute("aria-hidden", "false");
   dom.inspector.inert = false;
   dom.inspectorScrim.hidden = !isMobile();
+  dom.inspectorTabs.hidden = Boolean(state.selectedHost);
+  dom.inspectorEyebrow.textContent = state.selectedHost ? "Host inspector" : "Service inspector";
+  if (state.selectedHost) {
+    const host = hostByName(state.selectedHost);
+    dom.inspectorTitle.textContent = state.selectedHost;
+    dom.inspectorStatus.className = "service-status host";
+    dom.inspectorHealth.textContent = host ? formatCount(host.service_count) + (finite(host.service_count, 0) === 1 ? " service" : " services") : "Not reporting";
+    dom.inspectorHealth.style.color = host ? "var(--muted)" : "var(--faint)";
+    dom.inspectorBody.replaceChildren(renderHostPanel(host));
+    return;
+  }
   dom.inspectorTitle.textContent = state.selected;
   dom.inspectorStatus.className = "service-status " + (node ? normalizeStatus(node) : "unknown");
   dom.inspectorHealth.textContent = node ? formatRatio(node.health_score, 0) : "Not reporting";
@@ -1304,24 +1786,38 @@ function renderInspector() {
 
 function openInspector(service) {
   state.selected = service;
-  updateURL({ service: service, tab: state.activeTab === "overview" ? null : state.activeTab });
+  state.selectedHost = null;
+  updateURL({ service: service, host: null, tab: state.activeTab === "overview" ? null : state.activeTab });
   renderGraph();
   renderServiceLists();
   renderInspector();
   window.setTimeout(() => dom.closeInspector.focus(), 0);
 }
 
-function closeInspector() {
-  const selected = state.selected;
+function openHost(host) {
   state.selected = null;
-  updateURL({ service: null, tab: null });
+  state.selectedHost = host;
+  updateURL({ host: host, service: null, tab: null });
   renderGraph();
   renderServiceLists();
   renderInspector();
-  if (selected) {
-    const source = document.querySelector("[data-service=" + CSS.escape(selected) + "]");
-    if (source) source.focus();
-  }
+  loadHostMetrics(host);
+  showToast("Host " + host + " opened.");
+  window.setTimeout(() => dom.closeInspector.focus(), 0);
+}
+
+function closeInspector() {
+  const selected = state.selected;
+  const selectedHost = state.selectedHost;
+  state.selected = null;
+  state.selectedHost = null;
+  updateURL({ service: null, host: null, tab: null });
+  renderGraph();
+  renderServiceLists();
+  renderInspector();
+  const selector = selected ? "[data-service=" + CSS.escape(selected) + "]" : selectedHost ? "[data-host=" + CSS.escape(selectedHost) + "]" : "";
+  const source = selector ? document.querySelector(selector) : null;
+  if (source) source.focus();
 }
 
 function selectTab(tabName, focus) {
@@ -1335,6 +1831,13 @@ function selectTab(tabName, focus) {
 }
 
 function renderAll() {
+  // Host mode cannot outlive its data: once the host list is known to be
+  // empty or unreachable, fall back to the service view and say why.
+  if (state.groupBy === "host" && !hostsAvailable() && (state.hosts !== null || state.hostsError)) {
+    state.groupBy = "service";
+    updateURL({ group: null });
+    showToast("Host grouping turned off: " + hostGroupReason());
+  }
   renderStates();
   renderPulse();
   renderSeverity();
@@ -1561,6 +2064,7 @@ function bindEvents() {
   });
   dom.mapView.addEventListener("click", () => setMobileMode("map"));
   dom.listView.addEventListener("click", () => setMobileMode("list"));
+  dom.hostGroup.addEventListener("click", () => setGroupBy(state.groupBy === "host" ? "service" : "host"));
   dom.zoomIn.addEventListener("click", () => zoomAt(0.8));
   dom.zoomOut.addEventListener("click", () => zoomAt(1.25));
   dom.fit.addEventListener("click", () => setViewBox({ x: 0, y: 0, width: 1000, height: 1000 }));
@@ -1619,7 +2123,12 @@ function bindEvents() {
       setViewBox({ x: 0, y: 0, width: 1000, height: 1000 });
       return;
     }
-    if (event.key === "Escape" && state.selected) {
+    if (event.key.toLowerCase() === "h" && !editable && !event.ctrlKey && !event.metaKey && !event.altKey) {
+      event.preventDefault();
+      setGroupBy(state.groupBy === "host" ? "service" : "host");
+      return;
+    }
+    if (event.key === "Escape" && (state.selected || state.selectedHost)) {
       event.preventDefault();
       closeInspector();
     }
@@ -1631,6 +2140,7 @@ function bindEvents() {
   window.addEventListener("popstate", () => {
     readURL();
     renderAll();
+    if (state.selectedHost) loadHostMetrics(state.selectedHost);
   });
   window.addEventListener("resize", () => {
     renderStates();

--- a/internal/ui/static/index.html
+++ b/internal/ui/static/index.html
@@ -81,9 +81,14 @@
               <p class="eyebrow">Live topology</p>
               <h1 id="map-heading">Service constellation</h1>
             </div>
-            <div class="view-switch" aria-label="View">
-              <button id="map-view-button" type="button" aria-pressed="true">Map</button>
-              <button id="list-view-button" type="button" aria-pressed="false">List</button>
+            <div class="view-controls">
+              <div class="view-switch" aria-label="View">
+                <button id="map-view-button" type="button" aria-pressed="true">Map</button>
+                <button id="list-view-button" type="button" aria-pressed="false">List</button>
+              </div>
+              <button class="group-toggle" id="host-group-button" type="button" aria-pressed="false" aria-disabled="true" title="Loading hosts…">
+                <i class="host-mark" aria-hidden="true"></i>By host
+              </button>
             </div>
             <label class="search-field">
               <span class="sr-only">Find a service</span>
@@ -130,6 +135,7 @@
                 </defs>
                 <g id="graph-viewport">
                   <g id="graph-rings" aria-hidden="true"></g>
+                  <g id="graph-clusters"></g>
                   <g id="graph-edges" aria-hidden="true"></g>
                   <g id="graph-nodes"></g>
                 </g>
@@ -150,6 +156,7 @@
                 <span><i class="status-dot healthy"></i>Healthy</span>
                 <span><i class="status-dot degraded"></i>Degraded</span>
                 <span><i class="status-dot critical"></i>Critical</span>
+                <span><i class="host-mark"></i>Host</span>
               </div>
             </div>
 
@@ -160,7 +167,7 @@
         <aside class="service-rail" aria-labelledby="services-heading">
           <div class="rail-heading">
             <div>
-              <p class="eyebrow">Worst first</p>
+              <p class="eyebrow" id="rail-eyebrow">Worst first</p>
               <h2 id="services-heading">Services</h2>
             </div>
             <span id="service-count">0</span>
@@ -176,7 +183,7 @@
       <header class="inspector-header">
         <span class="service-status" id="inspector-status" aria-hidden="true"></span>
         <div>
-          <p class="eyebrow">Service inspector</p>
+          <p class="eyebrow" id="inspector-eyebrow">Service inspector</p>
           <h2 id="inspector-title">Service</h2>
         </div>
         <span class="health-value" id="inspector-health"></span>
@@ -184,7 +191,7 @@
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m6 6 12 12M18 6 6 18"/></svg>
         </button>
       </header>
-      <div class="inspector-tabs" role="tablist" aria-label="Inspector sections">
+      <div class="inspector-tabs" id="inspector-tabs" role="tablist" aria-label="Inspector sections">
         <button id="tab-overview" role="tab" type="button" aria-selected="true" data-tab="overview">Overview</button>
         <button id="tab-why" role="tab" type="button" aria-selected="false" data-tab="why">Why</button>
         <button id="tab-impact" role="tab" type="button" aria-selected="false" data-tab="impact">Impact</button>
@@ -230,6 +237,7 @@
           <div><dt><kbd>/</kbd></dt><dd>Find a service</dd></div>
           <div><dt><kbd>?</kbd></dt><dd>Show this shortcut sheet</dd></div>
           <div><dt><kbd>F</kbd></dt><dd>Fit the service map</dd></div>
+          <div><dt><kbd>H</kbd></dt><dd>Group by host</dd></div>
           <div><dt><kbd>Enter</kbd></dt><dd>Open a focused service</dd></div>
           <div><dt><kbd>←</kbd> / <kbd>→</kbd></dt><dd>Move between inspector tabs</dd></div>
           <div><dt><kbd>Esc</kbd></dt><dd>Close the open panel</dd></div>

--- a/test/browser/browser_test.go
+++ b/test/browser/browser_test.go
@@ -235,10 +235,15 @@ func waitReady(ctx context.Context, baseURL string) error {
 }
 
 type requestRecord struct {
+	At       string `json:"at"`
 	Phase    string `json:"phase"`
 	Method   string `json:"method"`
 	URL      string `json:"url"`
 	PostData string `json:"post_data,omitempty"`
+}
+
+func stamp() string {
+	return time.Now().Format("15:04:05.000")
 }
 
 type eventRecorder struct {
@@ -251,16 +256,35 @@ type eventRecorder struct {
 	failedRequests     []string
 	unexpectedFailures []string
 	externalRequests   []string
+	requestURLs        map[network.RequestID]string
+	responseStatus     map[network.RequestID]int64
+	phases             []string
 }
 
 func newEventRecorder(rawOrigin string) *eventRecorder {
 	origin, _ := url.Parse(rawOrigin)
-	return &eventRecorder{origin: origin, phase: "setup"}
+	return &eventRecorder{
+		origin:         origin,
+		phase:          "setup",
+		requestURLs:    make(map[network.RequestID]string),
+		responseStatus: make(map[network.RequestID]int64),
+	}
+}
+
+// lenientPhase names the phases whose console errors and failed requests are
+// expected: a forced graph failure, a server restart, and full page reloads.
+func lenientPhase(phase string) bool {
+	switch phase {
+	case "forced-error", "websocket-recovery", "theme-persistence", "host-group-reload":
+		return true
+	}
+	return false
 }
 
 func (r *eventRecorder) setPhase(phase string) {
 	r.mu.Lock()
 	r.phase = phase
+	r.phases = append(r.phases, stamp()+" "+phase)
 	r.mu.Unlock()
 }
 
@@ -273,6 +297,7 @@ func (r *eventRecorder) snapshot() map[string]any {
 		"failed_requests":     append([]string(nil), r.failedRequests...),
 		"unexpected_failures": append([]string(nil), r.unexpectedFailures...),
 		"external_requests":   append([]string(nil), r.externalRequests...),
+		"phases":              append([]string(nil), r.phases...),
 		"requests":            append([]requestRecord(nil), r.requests...),
 	}
 }
@@ -306,6 +331,7 @@ func (r *eventRecorder) listen(ctx context.Context) {
 				}
 			}
 			record := requestRecord{
+				At:       stamp(),
 				Phase:    phase,
 				Method:   event.Request.Method,
 				URL:      event.Request.URL,
@@ -314,6 +340,7 @@ func (r *eventRecorder) listen(ctx context.Context) {
 			if len(r.requests) < 500 {
 				r.requests = append(r.requests, record)
 			}
+			r.requestURLs[event.RequestID] = event.Request.URL
 			if requestURL, err := url.Parse(event.Request.URL); err == nil {
 				switch requestURL.Scheme {
 				case "http", "https", "ws", "wss":
@@ -322,10 +349,18 @@ func (r *eventRecorder) listen(ctx context.Context) {
 					}
 				}
 			}
+		case *network.EventResponseReceived:
+			r.responseStatus[event.RequestID] = event.Response.Status
 		case *network.EventLoadingFailed:
-			message := phase + ": " + event.ErrorText
+			message := phase + ": " + event.ErrorText + " " + r.requestURLs[event.RequestID] + " at " + stamp()
+			// Chrome reports a conditional fetch answered 304 as an aborted
+			// load once it serves the cached body; the page saw a success.
+			revalidated := event.ErrorText == "net::ERR_ABORTED" && r.responseStatus[event.RequestID] == http.StatusNotModified
+			if revalidated {
+				message += " (304 revalidation)"
+			}
 			r.failedRequests = append(r.failedRequests, message)
-			if phase != "forced-error" && phase != "websocket-recovery" && phase != "theme-persistence" {
+			if !revalidated && !lenientPhase(phase) {
 				r.unexpectedFailures = append(r.unexpectedFailures, message)
 			}
 		case *cdpruntime.EventExceptionThrown:
@@ -333,13 +368,13 @@ func (r *eventRecorder) listen(ctx context.Context) {
 		case *cdpruntime.EventConsoleAPICalled:
 			message := fmt.Sprintf("%s: %s", phase, event.Type)
 			r.console = append(r.console, message)
-			if event.Type == cdpruntime.APITypeError && phase != "forced-error" && phase != "websocket-recovery" && phase != "theme-persistence" {
+			if event.Type == cdpruntime.APITypeError && !lenientPhase(phase) {
 				r.unexpectedFailures = append(r.unexpectedFailures, message)
 			}
 		case *cdplog.EventEntryAdded:
 			message := fmt.Sprintf("%s: %s: %s", phase, event.Entry.Level, event.Entry.Text)
 			r.console = append(r.console, message)
-			if event.Entry.Level == cdplog.LevelError && phase != "forced-error" && phase != "websocket-recovery" && phase != "theme-persistence" {
+			if event.Entry.Level == cdplog.LevelError && !lenientPhase(phase) {
 				r.unexpectedFailures = append(r.unexpectedFailures, message)
 			}
 		}
@@ -685,6 +720,33 @@ func tracePayload(service, spanID, parentSpanID string, start, end int64) map[st
 	}
 }
 
+func postOTLP(t *testing.T, endpoint string, payload map[string]any) {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal OTLP payload: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("create OTLP request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	client := &http.Client{Timeout: 10 * time.Second, Transport: &http.Transport{Proxy: nil}}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("export OTLP payload: %v", err)
+	}
+	responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	_ = resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		t.Fatalf("export OTLP payload to %s = %d: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(responseBody)))
+	}
+	if len(bytes.TrimSpace(responseBody)) > 0 {
+		t.Logf("OTLP response from %s: %s", endpoint, strings.TrimSpace(string(responseBody)))
+	}
+}
+
 func injectTopology(t *testing.T, baseURL string) {
 	t.Helper()
 	now := time.Now().UTC().UnixNano()
@@ -692,29 +754,139 @@ func injectTopology(t *testing.T, baseURL string) {
 		tracePayload("gateway", "1111111111111111", "", now, now+int64(12*time.Millisecond)),
 		tracePayload("checkout", "2222222222222222", "1111111111111111", now+int64(time.Millisecond), now+int64(10*time.Millisecond)),
 	}
-	client := &http.Client{Timeout: 10 * time.Second, Transport: &http.Transport{Proxy: nil}}
 	for _, resource := range resources {
-		body, err := json.Marshal(map[string]any{"resourceSpans": []map[string]any{resource}})
-		if err != nil {
-			t.Fatalf("marshal OTLP trace: %v", err)
+		postOTLP(t, baseURL+"/v1/traces", map[string]any{"resourceSpans": []map[string]any{resource}})
+	}
+}
+
+// tracePayloadOnHost is tracePayload with a host.name resource attribute.
+func tracePayloadOnHost(service, host, spanID, parentSpanID string, start, end int64) map[string]any {
+	payload := tracePayload(service, spanID, parentSpanID, start, end)
+	resource := payload["resource"].(map[string]any)
+	resource["attributes"] = append(resource["attributes"].([]map[string]any), map[string]any{
+		"key":   "host.name",
+		"value": map[string]any{"stringValue": host},
+	})
+	return payload
+}
+
+// hostMetricsPayload is a hostmetrics-shaped resource: host.name, no
+// service.name, one gauge point per metric.
+func hostMetricsPayload(host string, now int64, values map[string]float64) map[string]any {
+	names := make([]string, 0, len(values))
+	for name := range values {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	metrics := make([]map[string]any, 0, len(names))
+	for _, name := range names {
+		metrics = append(metrics, map[string]any{
+			"name": name,
+			"gauge": map[string]any{"dataPoints": []map[string]any{{
+				"timeUnixNano": strconv.FormatInt(now, 10),
+				"asDouble":     values[name],
+			}}},
+		})
+	}
+	return map[string]any{"resourceMetrics": []map[string]any{{
+		"resource": map[string]any{
+			"attributes": []map[string]any{{
+				"key":   "host.name",
+				"value": map[string]any{"stringValue": host},
+			}},
+		},
+		"scopeMetrics": []map[string]any{{"metrics": metrics}},
+	}}}
+}
+
+// injectHostFixture seeds the host-grouping fixture: gateway on node-a,
+// checkout on node-a and node-b, and a hostmetrics-only node-c reporting CPU
+// and memory utilization but no filesystem metric.
+func injectHostFixture(t *testing.T, baseURL string) {
+	t.Helper()
+	now := time.Now().UTC().UnixNano()
+	resources := []map[string]any{
+		tracePayloadOnHost("gateway", "node-a", "3333333333333333", "", now, now+int64(12*time.Millisecond)),
+		tracePayloadOnHost("checkout", "node-a", "4444444444444444", "3333333333333333", now+int64(time.Millisecond), now+int64(9*time.Millisecond)),
+		tracePayloadOnHost("checkout", "node-b", "5555555555555555", "3333333333333333", now+int64(2*time.Millisecond), now+int64(10*time.Millisecond)),
+	}
+	for _, resource := range resources {
+		postOTLP(t, baseURL+"/v1/traces", map[string]any{"resourceSpans": []map[string]any{resource}})
+	}
+	postOTLP(t, baseURL+"/v1/metrics", hostMetricsPayload("node-c", now, map[string]float64{
+		"system.cpu.utilization":    0.42,
+		"system.memory.utilization": 0.61,
+	}))
+}
+
+func getJSON(ctx context.Context, rawURL string, target any) (string, error) {
+	client := &http.Client{Timeout: 2 * time.Second, Transport: &http.Transport{Proxy: nil}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	_ = resp.Body.Close()
+	if readErr != nil {
+		return string(body), readErr
+	}
+	return string(body), json.Unmarshal(body, target)
+}
+
+// waitHosts polls /api/hosts until the fixture's three hosts are projected
+// with checkout and gateway both on node-a.
+func waitHosts(ctx context.Context, baseURL string) error {
+	type host struct {
+		Name     string   `json:"name"`
+		Services []string `json:"services"`
+	}
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	var last string
+	for {
+		var hosts []host
+		body, err := getJSON(ctx, baseURL+"/api/hosts", &hosts)
+		last = body
+		if err == nil && len(hosts) == 3 && hosts[0].Name == "node-a" && strings.Join(hosts[0].Services, ",") == "checkout,gateway" &&
+			hosts[1].Name == "node-b" && hosts[2].Name == "node-c" {
+			return nil
 		}
-		req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/traces", bytes.NewReader(body))
-		if err != nil {
-			t.Fatalf("create OTLP request: %v", err)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for host projection: %w; last response: %s", ctx.Err(), last)
+		case <-ticker.C:
 		}
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Accept", "application/json")
-		resp, err := client.Do(req)
-		if err != nil {
-			t.Fatalf("export OTLP trace: %v", err)
+	}
+}
+
+// waitHostMetric polls the metrics API until the TSDB has flushed node-c's
+// CPU gauge into a bucket the host panel can read.
+func waitHostMetric(ctx context.Context, baseURL string) error {
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	var last string
+	for {
+		end := time.Now().UTC()
+		query := url.Values{
+			"name":         {"system.cpu.utilization"},
+			"service_name": {"host/node-c"},
+			"start":        {end.Add(-time.Hour).Format(time.RFC3339)},
+			"end":          {end.Format(time.RFC3339)},
 		}
-		responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
-		_ = resp.Body.Close()
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			t.Fatalf("export OTLP trace = %d: %s", resp.StatusCode, strings.TrimSpace(string(responseBody)))
+		var buckets []map[string]any
+		body, err := getJSON(ctx, baseURL+"/api/metrics?"+query.Encode(), &buckets)
+		last = body
+		if err == nil && len(buckets) > 0 {
+			return nil
 		}
-		if len(bytes.TrimSpace(responseBody)) > 0 {
-			t.Logf("OTLP trace response: %s", strings.TrimSpace(string(responseBody)))
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for host/node-c metric bucket: %w; last response: %s", ctx.Err(), last)
+		case <-ticker.C:
 		}
 	}
 }
@@ -1111,6 +1283,140 @@ func TestProtectedBrowserWorkflow(t *testing.T) {
 	`, 5*time.Second)
 	smoke.screenshot("mobile-map")
 	smoke.complete("mobile-map-list-inspector")
+
+	smoke.phase("host-group")
+	if err := chromedp.Run(ctx, chromedp.EmulateViewport(1280, 900)); err != nil {
+		t.Fatalf("restore desktop viewport: %v", err)
+	}
+	requireJS(t, ctx, `!matchMedia("(max-width: 767px)").matches`, 5*time.Second)
+	injectHostFixture(t, app.baseURL())
+	hostsCtx, hostsCancel := context.WithTimeout(context.Background(), readyTimeout)
+	if err := waitHosts(hostsCtx, app.baseURL()); err != nil {
+		hostsCancel()
+		t.Fatal(err)
+	}
+	hostsCancel()
+	requireJS(t, ctx, `!document.querySelector("#refresh-button").disabled`, 10*time.Second)
+	if err := chromedp.Run(ctx, chromedp.Click("#refresh-button", chromedp.ByQuery)); err != nil {
+		t.Fatalf("refresh host fixture: %v", err)
+	}
+	requireJS(t, ctx, `document.querySelector("#host-group-button").getAttribute("aria-disabled") === "false"`, 10*time.Second)
+	if err := chromedp.Run(ctx, chromedp.Evaluate(`document.querySelector("#host-group-button").focus()`, nil)); err != nil {
+		t.Fatalf("focus host toggle: %v", err)
+	}
+	requireJS(t, ctx, `document.activeElement === document.querySelector("#host-group-button")`, 5*time.Second)
+	if err := chromedp.Run(ctx, chromedp.Click("#host-group-button", chromedp.ByQuery)); err != nil {
+		t.Fatalf("toggle host grouping: %v", err)
+	}
+	requireJS(t, ctx, `
+		(() => {
+			const headings = Array.from(document.querySelectorAll("#service-list .host-heading"));
+			const checkout = document.querySelectorAll('#service-list [data-service="checkout"]');
+			let heading = checkout.length === 1 ? checkout[0].previousElementSibling : null;
+			while (heading && !heading.classList.contains("host-heading")) heading = heading.previousElementSibling;
+			return document.querySelector("#host-group-button").getAttribute("aria-pressed") === "true" &&
+				new URL(location.href).searchParams.get("group") === "host" &&
+				headings.map((item) => item.dataset.host + ":" + item.querySelector(".host-count").textContent).join("|") ===
+					"node-a:2 services|node-b:1 service|node-c:0 services" &&
+				checkout.length === 1 && heading && heading.dataset.host === "node-a" &&
+				checkout[0].querySelector(".service-meta").textContent.includes("2 hosts") &&
+				document.querySelectorAll("#graph-clusters .cluster-heading[data-host]").length === 3 &&
+				document.querySelectorAll("#graph-nodes .service-node").length === 2 &&
+				document.querySelector("#service-count").textContent.trim() === "2" &&
+				document.querySelector("#pulse-services").textContent.trim() === "2";
+		})()
+	`, 10*time.Second)
+	smoke.screenshot("host-group-desktop")
+	if err := chromedp.Run(ctx, chromedp.Evaluate(`
+		(() => {
+			const heading = document.querySelector('#graph-clusters .cluster-heading[data-host="node-c"]');
+			heading.focus();
+			heading.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+		})()
+	`, nil)); err != nil {
+		t.Fatalf("open host panel from map heading: %v", err)
+	}
+	requireJS(t, ctx, `
+		!document.querySelector("#inspector").inert &&
+		document.querySelector("#inspector-title").textContent.trim() === "node-c" &&
+		document.querySelector("#inspector-tabs").hidden &&
+		new URL(location.href).searchParams.get("host") === "node-c" &&
+		document.querySelectorAll('#inspector-body [data-metric]').length === 3 &&
+		document.querySelector("#inspector-body").textContent.includes("Services · 0")
+	`, 5*time.Second)
+	metricCtx, metricCancel := context.WithTimeout(context.Background(), 45*time.Second)
+	if err := waitHostMetric(metricCtx, app.baseURL()); err != nil {
+		metricCancel()
+		t.Fatal(err)
+	}
+	metricCancel()
+	if err := chromedp.Run(ctx, chromedp.Click("#refresh-button", chromedp.ByQuery)); err != nil {
+		t.Fatalf("refresh host metrics: %v", err)
+	}
+	requireJS(t, ctx, `
+		(() => {
+			const value = (name) => document.querySelector('#inspector-body [data-metric="' + name + '"] strong').textContent.trim();
+			return value("system.cpu.utilization") === "42%" &&
+				value("system.memory.utilization") === "61%" &&
+				value("system.filesystem.utilization") === "not reported" &&
+				document.querySelectorAll('#inspector-body [data-metric="system.cpu.utilization"] .spark').length === 1;
+		})()
+	`, 15*time.Second)
+	smoke.screenshot("host-panel-desktop")
+	if err := chromedp.Run(ctx,
+		chromedp.Click("#close-inspector-button", chromedp.ByQuery),
+		chromedp.Click(`#service-list [data-service="checkout"]`, chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("open checkout from grouped list: %v", err)
+	}
+	requireJS(t, ctx, `
+		document.querySelector("#inspector-title").textContent.trim() === "checkout" &&
+		!document.querySelector("#inspector-tabs").hidden &&
+		document.querySelectorAll("#inspector-body .host-chip").length === 2
+	`, 5*time.Second)
+	if err := chromedp.Run(ctx, chromedp.Evaluate(`document.querySelector('#inspector-body .host-chip[data-host="node-b"]').focus()`, nil)); err != nil {
+		t.Fatalf("focus host chip: %v", err)
+	}
+	requireJS(t, ctx, `document.activeElement && document.activeElement.dataset.host === "node-b"`, 5*time.Second)
+	if err := chromedp.Run(ctx, chromedp.Evaluate(`document.activeElement.click()`, nil)); err != nil {
+		t.Fatalf("activate host chip: %v", err)
+	}
+	requireJS(t, ctx, `
+		document.querySelector("#inspector-title").textContent.trim() === "node-b" &&
+		!!document.querySelector('#inspector-body .dependency-row[data-service="checkout"]')
+	`, 5*time.Second)
+	// A fresh load on a phone-sized viewport: the reload cancels in-flight
+	// polling requests, which is expected and scoped to this sub-phase.
+	smoke.phase("host-group-reload")
+	if err := chromedp.Run(ctx, chromedp.EmulateViewport(390, 844)); err != nil {
+		t.Fatalf("set mobile viewport for host grouping: %v", err)
+	}
+	if err := chromedp.Run(ctx, chromedp.Navigate(app.baseURL()+"/?group=host")); err != nil {
+		t.Fatalf("reload host grouping on mobile: %v", err)
+	}
+	requireJS(t, ctx, `document.readyState === "complete" && !!document.querySelector("#host-group-button")`, 10*time.Second)
+	smoke.phase("host-group")
+	requireJS(t, ctx, `
+		matchMedia("(max-width: 767px)").matches &&
+		document.querySelector("#host-group-button").getAttribute("aria-pressed") === "true" &&
+		!document.querySelector("#mobile-list").hidden &&
+		document.querySelectorAll("#mobile-list .host-heading").length === 3 &&
+		document.documentElement.scrollWidth <= document.documentElement.clientWidth &&
+		document.body.scrollWidth <= document.body.clientWidth
+	`, 15*time.Second)
+	smoke.screenshot("host-group-mobile")
+	if err := chromedp.Run(ctx, chromedp.Click(`#mobile-list .host-heading[data-host="node-a"]`, chromedp.ByQuery)); err != nil {
+		t.Fatalf("open mobile host panel: %v", err)
+	}
+	requireJS(t, ctx, `
+		!document.querySelector("#inspector").inert &&
+		document.querySelector("#inspector-title").textContent.trim() === "node-a" &&
+		document.querySelectorAll("#inspector-body .dependency-row").length === 2 &&
+		document.documentElement.scrollWidth <= document.documentElement.clientWidth &&
+		document.body.scrollWidth <= document.body.clientWidth
+	`, 10*time.Second)
+	smoke.screenshot("host-panel-mobile")
+	smoke.complete("host-group")
 
 	smoke.validateInventory()
 	assertNoUnexpectedBrowserEvents(t, recorder)

--- a/test/browser/protected_features.json
+++ b/test/browser/protected_features.json
@@ -82,6 +82,12 @@
       "contract": "At 390 by 844, map and list navigation plus the inspector remain operable without page overflow."
     },
     {
+      "id": "host-grouping-and-panel",
+      "proof": "browser",
+      "phase": "host-group",
+      "contract": "Host mode groups the map and list by host from /api/hosts, keeps host entities out of the service ranking, and the host panel reads CPU, memory and disk through /api/metrics or says not reported; toggle, cluster headings and host chips are keyboard reachable and the grouped list stays readable on mobile."
+    },
+    {
       "id": "node-free-client-source",
       "proof": "source",
       "phase": "source-contract",


### PR DESCRIPTION
## Claimed child and decision

Closes #294. Implements #279 and #280 for epic #285.

## Baseline

The embedded UI rendered services only: constellation, worst-first list, inspector. No host concept, no host metrics.

## What

- **By host toggle** beside Map/List (`aria-pressed`, keyboard `H`, `?group=host`). Disabled with a stated reason when `/api/hosts` is empty or unreachable; re-checks on click; host mode demotes itself with a toast if hosts vanish.
- **Map:** cluster rings on the existing golden-angle spiral with members on an inner spiral; cluster headings are focusable SVG buttons; a service on several hosts appears once under its first host with an `N hosts` sub-label; `kind: "host"` entities render as diamonds with no edges and never enter the ranking, severity counts, service count or command menu.
- **List** (rail and mobile): per-host headings with service counts; rows carry `· N hosts`. Mobile defaults to the list in host mode.
- **Host panel:** the inspector opens on a host from a cluster heading, a host entity, or a host chip on a service's overview, and reads `system.cpu.utilization`, `system.memory.utilization`, `system.filesystem.utilization` (plus the `usage` variants when present) for `host/<name>` through `/api/metrics`, showing the latest value, an inline sparkline over the returned buckets and the existing coverage badge; a missing metric says "not reported", never zero. Fetched on open, explicit refresh, or the existing 30 s poll; nothing new on idle.
- Page weight growth: app.js +22,499 B, app.css +4,029 B, index.html +538 B, total +27,066 B against a 40 KB budget. Still no dependency, bundle or build step.

## Verification

```text
go test -race -count=1 ./internal/ui                                                              → pass
go test -tags=browser -count=1 -run '^TestProtectedBrowserWorkflow$' ./test/browser              → pass, 13 phases, host-group last
go test -tags=browser -count=1 -run TestLatencyLabels ./test/browser                             → pass
node --check, gofmt -l, go vet -tags=browser ./test/browser                                      → clean
```

Existing phases through `mobile-map-list-inspector` are unchanged. The new `host-group` phase seeds host-bearing resources plus a hostmetrics-shaped resource with no `service.name`, toggles host mode, asserts the grouping and the ranking exclusion, opens the host panel, asserts the metric values or "not reported", and screenshots desktop and mobile. `protected_features.json` gains the `host-grouping-and-panel` entry.

The smoke recorder now classifies Chrome's `ERR_ABORTED` after a 304 as a revalidation rather than a failed request; timestamps showed the pre-existing whitelisted aborts were the same thing.

## Caveats

- Host entities never become graph nodes in legacy mode (a metrics-only resource does not reach GraphRAG's service store), so the diamond path is implemented but exercised only through the cluster heading and list in the smoke.
- Mobile is asserted at the smoke's existing 390 px viewport; the layout is fluid with no fixed widths.

## Compatibility and rollback

Additive screens; the default service view is untouched. Rollback: previous binary.

## Evidence

Browser smoke artifacts and screenshots on this PR's CI run.