### PR TITLE
test(browser): activate the host chip in one evaluation

### DIFF
--- a/test/browser/browser_test.go
+++ b/test/browser/browser_test.go
@@ -1374,13 +1374,20 @@ func TestProtectedBrowserWorkflow(t *testing.T) {
 		!document.querySelector("#inspector-tabs").hidden &&
 		document.querySelectorAll("#inspector-body .host-chip").length === 2
 	`, 5*time.Second)
-	if err := chromedp.Run(ctx, chromedp.Evaluate(`document.querySelector('#inspector-body .host-chip[data-host="node-b"]').focus()`, nil)); err != nil {
-		t.Fatalf("focus host chip: %v", err)
-	}
-	requireJS(t, ctx, `document.activeElement && document.activeElement.dataset.host === "node-b"`, 5*time.Second)
-	if err := chromedp.Run(ctx, chromedp.Evaluate(`document.activeElement.click()`, nil)); err != nil {
-		t.Fatalf("activate host chip: %v", err)
-	}
+	// Focus and activate the chip in one evaluation. A live snapshot can
+	// re-render the inspector body between two round-trips; the replaced
+	// chip then no longer holds focus and a click on document.activeElement
+	// lands on <body>.
+	requireJS(t, ctx, `
+		(() => {
+			const chip = document.querySelector('#inspector-body .host-chip[data-host="node-b"]');
+			if (!chip) return false;
+			chip.focus();
+			if (document.activeElement !== chip) return false;
+			chip.click();
+			return true;
+		})()
+	`, 5*time.Second)
 	requireJS(t, ctx, `
 		document.querySelector("#inspector-title").textContent.trim() === "node-b" &&
 		!!document.querySelector('#inspector-body .dependency-row[data-service="checkout"]')


### PR DESCRIPTION
## Why

The v0.5.0-rc.1 release run failed `browser smoke · release binary` in the `host-group` phase: after focusing the `node-b` host chip in the checkout inspector, the test clicked `document.activeElement` in a second round-trip, and the inspector stayed on checkout. Between the two evaluations a live snapshot re-rendered the inspector body; the replaced chip no longer held focus, so the click landed on `<body>`. The DOM snapshot in the run's artifact shows the inspector title still `checkout`. The same phase passed on `main` at the same commit, which is what a race looks like.

## What

Focus and activate the chip inside one evaluation that the polling helper retries until it succeeds. The keyboard-focus semantics the phase asserts are unchanged. Test-only; no application code touched.

## Verification

```text
go vet -tags browser ./test/browser                                              → clean
OTELCONTEXT_BINARY=<release-shaped build> go test -tags=browser -run '^TestProtectedBrowserWorkflow$' ./test/browser → ok (44.7 s)
```

Part of #295 for epic #285. The candidate that carries this commit will be `v0.5.0-rc.2`; `v0.5.0-rc.1` is not reused.