### PR TITLE
feat(ui): render hosts as nodes with dashed runs-on edges

### DIFF
--- a/internal/ui/static/app.css
+++ b/internal/ui/static/app.css
@@ -11,6 +11,8 @@
   --faint: #737e90;
   --accent: #8b95ff;
   --accent-soft: #8b95ff1f;
+  --edge-runs-on: color-mix(in srgb, var(--accent) 55%, transparent);
+  --edge-runs-on-dash: 5 5;
   --healthy: #39d59b;
   --degraded: #f7bd45;
   --critical: #ff7078;
@@ -920,41 +922,12 @@ h2 {
   vector-effect: non-scaling-stroke;
 }
 
-.cluster-ring {
-  fill: color-mix(in srgb, var(--accent) 4%, transparent);
-  stroke: color-mix(in srgb, var(--accent) 45%, var(--line));
-  stroke-dasharray: 4 6;
+.runs-on-edge {
+  stroke: var(--edge-runs-on);
+  stroke-dasharray: var(--edge-runs-on-dash);
+  stroke-linecap: round;
   stroke-width: 1;
   vector-effect: non-scaling-stroke;
-}
-
-.cluster-heading {
-  cursor: pointer;
-}
-
-.cluster-label {
-  fill: var(--muted);
-  font-family: var(--font-mono);
-  font-size: 15px;
-  font-weight: 700;
-  paint-order: stroke;
-  stroke: var(--surface);
-  stroke-linejoin: round;
-  stroke-width: 5px;
-}
-
-.cluster-heading:hover .cluster-label,
-.cluster-heading:focus .cluster-label,
-.cluster-heading.is-selected .cluster-label {
-  fill: var(--accent);
-}
-
-.cluster-heading:focus {
-  outline: none;
-}
-
-.cluster-heading:focus-visible .cluster-label {
-  text-decoration: underline;
 }
 
 .graph-edge {

--- a/internal/ui/static/app.js
+++ b/internal/ui/static/app.js
@@ -59,7 +59,6 @@ const dom = {
   map: byId("service-map"),
   graphDescription: byId("graph-description"),
   rings: byId("graph-rings"),
-  clusters: byId("graph-clusters"),
   edges: byId("graph-edges"),
   nodes: byId("graph-nodes"),
   minimapButton: byId("minimap-button"),
@@ -908,61 +907,54 @@ function graphLayout(nodes, edges) {
   return positions;
 }
 
-// hostLayout places one golden-angle spiral of cluster centres, then a
-// smaller spiral of members inside each. Deterministic like graphLayout.
-function hostLayout(clusters) {
-  const positions = new Map();
-  const rings = [];
-  const count = clusters.length;
-  const spread = count === 1 ? 0 : 335;
-  const radius = count <= 1 ? 170 : Math.max(50, Math.min(165, 300 / Math.sqrt(count)));
-  clusters.forEach((cluster, index) => {
-    const distance = spread * Math.sqrt((index + 0.4) / count);
-    const angle = index * GOLDEN_ANGLE;
-    const cx = 500 + distance * Math.cos(angle);
-    const cy = 500 + distance * Math.sin(angle);
-    const members = cluster.members.slice().sort((a, b) => a.id.localeCompare(b.id));
-    members.forEach((node, member) => {
-      const inner = members.length === 1 ? 0 : (radius - 30) * Math.sqrt((member + 0.4) / members.length);
-      const turn = member * GOLDEN_ANGLE;
-      positions.set(node.id, { x: cx + inner * Math.cos(turn), y: cy + inner * Math.sin(turn) });
-    });
-    rings.push({ cluster: cluster, x: cx, y: cy, r: radius });
-  });
-  return { positions: positions, rings: rings };
+// hostNodes synthesizes one host node per registry host the graph does not
+// already carry as a host entity, so host mode draws every host once.
+function hostNodes(nodes) {
+  const present = new Set(nodes.filter(isHostNode).map(hostOfNode));
+  const output = [];
+  for (const host of state.hosts || []) {
+    if (!present.has(host.name)) output.push({ id: HOST_PREFIX + host.name, kind: "host", hosts: [host.name] });
+  }
+  return output;
 }
 
-function renderClusterRings(rings) {
-  for (const ring of rings) {
-    dom.rings.appendChild(svgElement("circle", { class: "cluster-ring", cx: ring.x, cy: ring.y, r: ring.r }));
-    const host = ring.cluster.host;
-    const heading = svgElement("g", {
-      class: "cluster-heading",
-      transform: "translate(" + ring.x + " " + (ring.y - ring.r - 10) + ")",
-    });
-    if (host) {
-      heading.setAttribute("tabindex", "0");
-      heading.setAttribute("role", "button");
-      heading.setAttribute("aria-label", clusterLabel(ring.cluster) + ", open host panel");
-      heading.dataset.host = host.name;
-      if (host.name === state.selectedHost) heading.classList.add("is-selected");
-      heading.addEventListener("click", (event) => {
-        event.stopPropagation();
-        openHost(host.name);
-      });
-      heading.addEventListener("keydown", (event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          openHost(host.name);
-        }
-      });
-    } else {
-      heading.setAttribute("aria-hidden", "true");
+// runsOnEdges is one placement edge per (service, host) pair. They exist
+// for drawing and layout only and never enter the call-edge traversals.
+function runsOnEdges(nodes) {
+  const hostIds = new Set(nodes.filter(isHostNode).map((node) => node.id));
+  const output = [];
+  for (const node of nodes) {
+    if (isHostNode(node)) continue;
+    for (const host of nodeHosts(node)) {
+      const target = HOST_PREFIX + host;
+      if (hostIds.has(target)) output.push({ source: node.id, target: target, kind: "runs_on" });
     }
-    const text = svgElement("text", { class: "cluster-label", "text-anchor": "middle" });
-    text.textContent = clusterLabel(ring.cluster);
-    heading.appendChild(text);
-    dom.clusters.appendChild(heading);
+  }
+  return output;
+}
+
+function hostNodeLabel(name) {
+  const host = hostByName(name);
+  if (!host) return name + ", host";
+  const count = finite(host.service_count, 0);
+  return name + ", " + count + (count === 1 ? " service" : " services");
+}
+
+function renderRunsOnEdges(placements, positions, fragment) {
+  for (const edge of placements) {
+    const source = positions.get(edge.source);
+    const target = positions.get(edge.target);
+    if (!source || !target) continue;
+    fragment.appendChild(svgElement("line", {
+      class: "runs-on-edge",
+      "data-kind": edge.kind,
+      "data-source": edge.source,
+      "data-target": edge.target,
+      x1: source.x,
+      y1: source.y,
+      x2: target.x,
+      y2: target.y,
+    }));
   }
 }
 
@@ -996,7 +988,6 @@ function graphSearchMatches() {
 
 function renderGraph() {
   dom.rings.replaceChildren();
-  dom.clusters.replaceChildren();
   dom.edges.replaceChildren();
   dom.nodes.replaceChildren();
   dom.minimapEdges.replaceChildren();
@@ -1005,19 +996,16 @@ function renderGraph() {
 
   const hostMode = state.groupBy === "host";
   dom.graphDescription.textContent = hostMode
-    ? "Services are clustered by host. Select a service or a host heading to inspect it."
+    ? "Hosts share the map with services; a dashed edge links a service to each host it runs on. Select a service or a host to inspect it."
     : "Services are arranged by dependency criticality. Select a service to inspect it.";
+  const nodes = hostMode ? state.graph.nodes.concat(hostNodes(state.graph.nodes)) : state.graph.nodes;
   const edges = cleanEdges(state.graph.nodes, state.graph.edges);
-  let positions;
-  if (hostMode) {
-    const layout = hostLayout(hostClusters());
-    positions = layout.positions;
-    renderClusterRings(layout.rings);
-  } else {
-    positions = graphLayout(state.graph.nodes, edges);
-    for (const radius of [100, 200, 300, 400]) {
-      dom.rings.appendChild(svgElement("circle", { class: "graph-ring", cx: 500, cy: 500, r: radius }));
-    }
+  // Placement edges enter the layout scoring only, so a host ranks with the
+  // services it carries; every traversal below reads the call edges alone.
+  const placements = hostMode ? runsOnEdges(nodes) : [];
+  const positions = graphLayout(nodes, edges.concat(placements));
+  for (const radius of [100, 200, 300, 400]) {
+    dom.rings.appendChild(svgElement("circle", { class: "graph-ring", cx: 500, cy: 500, r: radius }));
   }
   const searchMatches = graphSearchMatches();
   const impact = state.impactRoot ? downstreamDepths(state.impactRoot, edges, 5) : null;
@@ -1031,6 +1019,7 @@ function renderGraph() {
   }
 
   const edgeFragment = document.createDocumentFragment();
+  renderRunsOnEdges(placements, positions, edgeFragment);
   for (const edge of edges) {
     const source = positions.get(edge.source);
     const target = positions.get(edge.target);
@@ -1068,14 +1057,15 @@ function renderGraph() {
   }
   dom.edges.appendChild(edgeFragment);
 
-  const count = state.graph.nodes.length;
+  const count = nodes.length;
   const nodeRadius = count > 140 ? 7 : count > 70 ? 9 : count > 30 ? 11 : 14;
   const showAllLabels = count <= 42;
   const nodeFragment = document.createDocumentFragment();
-  for (const node of state.graph.nodes) {
+  for (const node of nodes) {
     const point = positions.get(node.id);
     if (!point) continue;
     const hostNode = isHostNode(node);
+    const hostName = hostNode ? hostOfNode(node) : "";
     const status = hostNode ? "unknown" : normalizeStatus(node);
     const group = svgElement("g", {
       class: "service-node",
@@ -1084,25 +1074,27 @@ function renderGraph() {
       role: "button",
       "data-status": status,
       "aria-label": hostNode
-        ? node.id + ", host, open host panel"
+        ? hostNodeLabel(hostName)
         : node.id + ", " + status + ", health " + formatRatio(node.health_score, 0),
     });
     group.dataset.service = node.id;
     if (hostNode) {
-      // A host entity is a diamond with no edges; activating it opens the host panel.
+      // A host is a diamond; activating it opens the host panel.
       group.dataset.kind = "host";
+      group.dataset.host = hostName;
+      if (hostName === state.selectedHost) group.classList.add("is-selected");
       const side = nodeRadius * 1.7;
       group.appendChild(svgElement("rect", { class: "node-halo", x: -side / 2 - 7, y: -side / 2 - 7, width: side + 14, height: side + 14, transform: "rotate(45)" }));
       group.appendChild(svgElement("rect", { class: "node-core", x: -side / 2, y: -side / 2, width: side, height: side, transform: "rotate(45)" }));
       if (showAllLabels || searchMatches && searchMatches.has(node.id)) {
         const label = svgElement("text", { class: "node-label", x: nodeRadius + 9, y: 6 });
-        label.textContent = node.id.length > 24 ? node.id.slice(0, 23) + "…" : node.id;
+        label.textContent = hostName.length > 24 ? hostName.slice(0, 23) + "…" : hostName;
         group.appendChild(label);
       }
       const title = svgElement("title");
-      title.textContent = node.id + " — host";
+      title.textContent = hostName + " — host";
       group.appendChild(title);
-      const open = () => openHost(hostOfNode(node));
+      const open = () => openHost(hostName);
       group.addEventListener("click", (event) => {
         event.stopPropagation();
         open();

--- a/internal/ui/static/index.html
+++ b/internal/ui/static/index.html
@@ -135,7 +135,6 @@
                 </defs>
                 <g id="graph-viewport">
                   <g id="graph-rings" aria-hidden="true"></g>
-                  <g id="graph-clusters"></g>
                   <g id="graph-edges" aria-hidden="true"></g>
                   <g id="graph-nodes"></g>
                 </g>

--- a/test/browser/browser_test.go
+++ b/test/browser/browser_test.go
@@ -1320,8 +1320,13 @@ func TestProtectedBrowserWorkflow(t *testing.T) {
 					"node-a:2 services|node-b:1 service|node-c:0 services" &&
 				checkout.length === 1 && heading && heading.dataset.host === "node-a" &&
 				checkout[0].querySelector(".service-meta").textContent.includes("2 hosts") &&
-				document.querySelectorAll("#graph-clusters .cluster-heading[data-host]").length === 3 &&
-				document.querySelectorAll("#graph-nodes .service-node").length === 2 &&
+				document.querySelectorAll('#graph-nodes .service-node[data-kind="host"]').length === 3 &&
+				document.querySelectorAll('#graph-nodes .service-node:not([data-kind="host"])').length === 2 &&
+				Array.from(document.querySelectorAll('#graph-edges .runs-on-edge[data-kind="runs_on"]'))
+					.map((edge) => edge.dataset.source + ">" + edge.dataset.target).sort().join("|") ===
+					"checkout>host/node-a|checkout>host/node-b|gateway>host/node-a" &&
+				document.querySelectorAll("#graph-edges .graph-edge").length === 1 &&
+				document.querySelector('#graph-nodes .service-node[data-kind="host"][data-host="node-a"]').getAttribute("aria-label") === "node-a, 2 services" &&
 				document.querySelector("#service-count").textContent.trim() === "2" &&
 				document.querySelector("#pulse-services").textContent.trim() === "2";
 		})()
@@ -1329,12 +1334,23 @@ func TestProtectedBrowserWorkflow(t *testing.T) {
 	smoke.screenshot("host-group-desktop")
 	if err := chromedp.Run(ctx, chromedp.Evaluate(`
 		(() => {
-			const heading = document.querySelector('#graph-clusters .cluster-heading[data-host="node-c"]');
-			heading.focus();
-			heading.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+			const node = document.querySelector('#graph-nodes .service-node[data-kind="host"][data-host="node-b"]');
+			node.focus();
+			node.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
 		})()
 	`, nil)); err != nil {
-		t.Fatalf("open host panel from map heading: %v", err)
+		t.Fatalf("open host panel from map host node: %v", err)
+	}
+	requireJS(t, ctx, `
+		!document.querySelector("#inspector").inert &&
+		document.querySelector("#inspector-title").textContent.trim() === "node-b" &&
+		document.querySelector("#inspector-tabs").hidden &&
+		new URL(location.href).searchParams.get("host") === "node-b" &&
+		document.querySelector("#inspector-body").textContent.includes("Services · 1") &&
+		document.querySelector('#graph-nodes .service-node[data-kind="host"][data-host="node-b"]').classList.contains("is-selected")
+	`, 5*time.Second)
+	if err := chromedp.Run(ctx, chromedp.Click(`#graph-nodes .service-node[data-kind="host"][data-host="node-c"]`, chromedp.ByQuery)); err != nil {
+		t.Fatalf("open host panel by clicking map host node: %v", err)
 	}
 	requireJS(t, ctx, `
 		!document.querySelector("#inspector").inert &&
@@ -1398,14 +1414,19 @@ func TestProtectedBrowserWorkflow(t *testing.T) {
 	if err := chromedp.Run(ctx, chromedp.EmulateViewport(390, 844)); err != nil {
 		t.Fatalf("set mobile viewport for host grouping: %v", err)
 	}
-	if err := chromedp.Run(ctx, chromedp.Navigate(app.baseURL()+"/?group=host")); err != nil {
+	if err := chromedp.Run(ctx, chromedp.Navigate(app.baseURL()+"/?group=host&impact=gateway")); err != nil {
 		t.Fatalf("reload host grouping on mobile: %v", err)
 	}
 	requireJS(t, ctx, `document.readyState === "complete" && !!document.querySelector("#host-group-button")`, 10*time.Second)
 	smoke.phase("host-group")
+	// Runs-on edges are not calls: the blast radius of gateway still counts
+	// checkout alone, not the hosts it is drawn against.
 	requireJS(t, ctx, `
 		matchMedia("(max-width: 767px)").matches &&
 		document.querySelector("#host-group-button").getAttribute("aria-pressed") === "true" &&
+		!document.querySelector("#impact-banner").hidden &&
+		document.querySelector("#impact-banner").textContent.includes("Blast radius of gateway — 1 downstream") &&
+		document.querySelectorAll('#graph-edges .runs-on-edge').length === 3 &&
 		!document.querySelector("#mobile-list").hidden &&
 		document.querySelectorAll("#mobile-list .host-heading").length === 3 &&
 		document.documentElement.scrollWidth <= document.documentElement.clientWidth &&

--- a/test/browser/protected_features.json
+++ b/test/browser/protected_features.json
@@ -85,7 +85,7 @@
       "id": "host-grouping-and-panel",
       "proof": "browser",
       "phase": "host-group",
-      "contract": "Host mode groups the map and list by host from /api/hosts, keeps host entities out of the service ranking, and the host panel reads CPU, memory and disk through /api/metrics or says not reported; toggle, cluster headings and host chips are keyboard reachable and the grouped list stays readable on mobile."
+      "contract": "Host mode draws every host from /api/hosts as a diamond node in the service layout with one dashed runs-on edge per service placement, excluded from call traversals so the blast radius is unchanged; the list groups by host, host entities stay out of the service ranking, and the host panel reads CPU, memory and disk through /api/metrics or says not reported; toggle, host nodes and host chips are keyboard reachable and the grouped list stays readable on mobile."
     },
     {
       "id": "node-free-client-source",


### PR DESCRIPTION
Closes #309. Follow-up to #294 from epic #285.

## What

In "By host" mode every host from `/api/hosts` is a diamond node in the same golden-angle layout as the services, rendered by the existing `data-kind="host"` branch, and every (service, host) placement is one dashed `runs_on` edge drawn beneath the call edges with no arrowhead and no flow animation. A multi-host service now shows every placement (checkout → node-a and node-b in the smoke fixture) instead of being drawn inside one ring. Cluster rings, headings, their CSS and the `#graph-clusters` group are removed.

Runs-on edges never enter `state.graph.edges`, which is what blast radius, impact, why, dependency rows, related-highlighting and the arrow cap all read, so nothing is filtered per consumer and blast radius of gateway stays "1 downstream". Host nodes open the host panel on click, Enter and Space, carry `data-host`, an accessible name such as "node-a, 2 services", and `is-selected` while their panel is open. The list keeps its host headings.

Outside host mode nothing changes except that a metrics-only host entity is labelled by its bare host name instead of `host/<name>`, since one renderer now serves both cases.

## Proof

`test/browser` phase `host-group`: three host nodes, two service nodes, runs-on pairs `checkout>host/node-a`, `checkout>host/node-b`, `gateway>host/node-a`, exactly one call edge, the node-b host node opening the panel by keyboard ("Services · 1", `?host=node-b`), the node-c metric assertions and the host-chip path unchanged, and the mobile reload asserting the blast-radius banner with the three runs-on edges present. `protected_features.json` contract rewritten for host nodes.

## Verification

```text
go test -race -count=1 ./internal/ui ./internal/api                                  → pass
TestProtectedBrowserWorkflow against a release-shaped binary, three runs             → PASS (43 s each)
TestLatencyLabels                                                                    → PASS
go vet ./...; go vet -tags browser ./test/browser; gofmt -l                          → clean
```

Not part of a published candidate; the next `v0.5.0-rc.N` carries it.