### PR TITLE
docs: correct the SQLite memory knobs in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,13 +61,14 @@
 # docs/superpowers/specs/2026-05-24-mcp-7tool-sqlite-survival-design.md for
 # per-default rationale and the SQLite PRAGMA stanza applied at startup.
 #
-# The PRAGMA stanza budget-scales its two memory knobs against the detected
-# memory budget (cgroup v2 → cgroup v1 → /proc/meminfo): page cache =
-# budget/32 clamped to [64 MB, 256 MB], mmap window = budget/8 clamped to
-# [256 MB, 1 GB]. A 4 GB host gets 128 MB cache + 512 MB mmap; detection
-# failure falls back to the 256 MB / 1 GB ceilings. Explicit overrides win:
-# SQLITE_CACHE_SIZE_KB=131072    # Page cache in KB (> 0). Pure-Go driver: this is Go-heap memory.
-# SQLITE_MMAP_SIZE_BYTES=536870912 # mmap window in bytes (>= 0; 0 disables mmap).
+# The PRAGMA stanza sets a fixed 64 MB page cache and leaves mmap off. Both are
+# sized to the memory objective, not to the host: the pure-Go driver's page
+# cache is NOT Go-heap memory (modernc's libc allocates it outside the heap,
+# invisible to GOMEMLIMIT) and its allocator holds about twice the configured
+# cache as anonymous RSS, and an mmap window keeps every page a scan touches
+# resident. Explicit overrides win, each costing roughly twice its value in RSS:
+# SQLITE_CACHE_SIZE_KB=65536     # Page cache in KB (> 0). Not Go-heap memory.
+# SQLITE_MMAP_SIZE_BYTES=0       # mmap window in bytes (>= 0; 0 disables mmap).
 
 # ---- Azure Entra (passwordless Postgres) ------------------------------------
 # DB_AZURE_AUTH=false            # Enables DefaultAzureCredential for Postgres. Requires strict TLS


### PR DESCRIPTION
`.env.example` still described the budget-scaled page cache and mmap window that #304 removed, and still called the page cache Go-heap memory, which is the thing that measurement disproved. `CLAUDE.md` was updated with the change; this file was missed.

Now it states the fixed 64 MB cache, mmap off, that the cache is not Go-heap memory, and that each override costs roughly twice its value in resident memory. Comment only; no code and no default changes.