### PR TITLE
feat: stabilize storage and query performance for v0.5.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@
 # Copy to `.env` and uncomment the lines you want to override.
 # Booleans accept (case-insensitive): 1 | true | yes | on  (parseTruthy in config.go)
 # Lines shown as `=<default>` document the default applied when the var is unset.
-# Keys marked [REQUIRED IN PROD] must be set for any production deployment.
 # ------------------------------------------------------------------------------
 
 # ---- Application ------------------------------------------------------------
@@ -37,7 +36,7 @@
 
 # ---- Database Pool ----------------------------------------------------------
 # DB_MAX_OPEN_CONNS=50           # Max concurrent DB connections (SQLite default 1; SQLite is single-writer)
-# DB_MAX_IDLE_CONNS=10           # Idle connections kept in pool (SQLite default 1)
+# DB_MAX_IDLE_CONNS=25           # Idle connections kept in pool (SQLite default 1)
 # DB_CONN_MAX_LIFETIME=1h        # Conn recycle window. Internally capped to 30m when DB_AZURE_AUTH=true
 
 # ---- SQLite Tuning (auto-applied when DB_DRIVER=sqlite) ---------------------
@@ -46,7 +45,7 @@
 # explicitly sets the env var. Postgres/MSSQL paths are untouched.
 #
 #   DB_MAX_OPEN_CONNS           50    → 1
-#   DB_MAX_IDLE_CONNS           10    → 1
+#   DB_MAX_IDLE_CONNS           25    → 1
 #   INGEST_PIPELINE_WORKERS     8     → 2
 #   INGEST_PIPELINE_QUEUE_SIZE  50000 → 10000
 #   INGEST_PIPELINE_MAX_BYTES   536870912 → 134217728  (512MB → 128MB byte cap on queued batches;
@@ -55,7 +54,6 @@
 #   STORE_MIN_SEVERITY          ""    → "WARN"   (INFO/DEBUG still flow to GraphRAG/Drain, just not persisted)
 #   SAMPLING_RATE               1.0   → 0.05    (errors and slow spans always kept)
 #   GRPC_MAX_CONCURRENT_STREAMS 1000  → 240     (~2 streams per service at 120 services)
-#   LOG_FTS_ENABLED             false → true    (FTS5 BM25 search; ~30% disk overhead — set false to reclaim)
 #
 # Override by setting the env var explicitly. See
 # docs/superpowers/specs/2026-05-24-mcp-7tool-sqlite-survival-design.md for
@@ -69,6 +67,7 @@
 # resident. Explicit overrides win, each costing roughly twice its value in RSS:
 # SQLITE_CACHE_SIZE_KB=65536     # Page cache in KB (> 0). Not Go-heap memory.
 # SQLITE_MMAP_SIZE_BYTES=0       # mmap window in bytes (>= 0; 0 disables mmap).
+# LOG_FTS_ENABLED=true           # SQLite FTS5 BM25 search defaults on; set false to opt out and use LIKE.
 
 # ---- Azure Entra (passwordless Postgres) ------------------------------------
 # DB_AZURE_AUTH=false            # Enables DefaultAzureCredential for Postgres. Requires strict TLS
@@ -89,9 +88,9 @@
 # TLS_CACHE_DIR=./data/tls
 
 # ---- Auth -------------------------------------------------------------------
-# API_KEY=                       # [REQUIRED IN PROD] Operator bearer token for /api/*, /v1/*, /mcp,
+# API_KEY=                       # Optional operator bearer token for /api/*, /v1/*, /mcp,
 #                                # /ws*, and OTLP gRPC. Authenticates only — tenant selection keeps
-#                                # its X-Tenant-ID precedence. Empty = auth disabled (dev only).
+#                                # its X-Tenant-ID precedence. Empty = auth disabled.
 #                                # For per-tenant identity see API_TENANT_KEYS_FILE below.
 
 # ---- OTLP Ingest Filtering --------------------------------------------------
@@ -103,9 +102,6 @@
 # SAMPLING_RATE=1.0              # 0.0..1.0 probability for non-error, non-slow spans
 # SAMPLING_ALWAYS_ON_ERRORS=true # Keep every error span regardless of rate
 # SAMPLING_LATENCY_THRESHOLD_MS=500  # Keep every span slower than this
-
-# ---- TSDB -------------------------------------------------------------------
-# TSDB_RING_BUFFER_DURATION=1h   # In-memory metric ring buffer window (e.g. 30m, 2h)
 
 # ---- GraphRAG / Cardinality -------------------------------------------------
 # METRIC_ATTRIBUTE_KEYS=         # CSV allowlist of attribute keys included in metric series key
@@ -187,11 +183,6 @@
 # GRPC_REFLECTION=               # gRPC server reflection. Defaults to true outside production and
 #                                # false when APP_ENV=production (reflection enumerates every
 #                                # service and message type to an unauthenticated peer).
-# OTELCONTEXT_ALLOW_INSECURE_GRPC=false
-#                                # Waives the production requirement that the OTLP gRPC listener
-#                                # have both TLS and authentication. Explicit acknowledgement that
-#                                # telemetry crosses the network unprotected and unauthenticated.
-
 # ---- AI Service (optional — Azure OpenAI log insights) ----------------------
 # AI_ENABLED=false               # Master switch. When false, AI workers are not started.
 # AZURE_OPENAI_ENDPOINT=         # e.g. https://my-aoai.openai.azure.com/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ most recently published tag.
 
 ## [Unreleased]
 
+## [v0.5.0] - 2026-09-05
+
 ### Added — aggregate metrics engine (production-readiness epic #194)
 
 - **Aggregate engine** (`internal/aggregate/`, opt-in via
@@ -51,6 +53,25 @@ most recently published tag.
 
 ### Changed
 
+- SQLite log search now enables FTS5 by default. It uses stemmed token-prefix
+  matching with BM25 ranking, while `trace_id` remains an exact filter. Set
+  `LOG_FTS_ENABLED=false` to keep the LIKE path. FTS tables are installed only
+  when `DB_AUTOMIGRATE=true`; an existing database without the index continues
+  to use LIKE until an operator provisions it. Expect the index to add roughly
+  30–40% to log-heavy SQLite database size.
+- SQLite applies its managed PRAGMAs to every physical connection in the pool.
+  The default idle pool now matches the runtime default: 25 connections for
+  non-SQLite databases and one for SQLite.
+- Production mode accepts SQLite without a waiver and treats API
+  authentication and TLS as independent opt-ins. The former
+  `OTELCONTEXT_ALLOW_SQLITE_PROD` and
+  `OTELCONTEXT_ALLOW_INSECURE_GRPC` flags remain accepted as deprecated no-ops.
+  Configured authentication and TLS still take effect.
+- API render caches are capped at 256 entries and 16 MiB each. Cache keys use
+  canonical request parameters and preserve ETag behavior.
+- The unused legacy in-memory metric ring is no longer allocated. Metric
+  queries still use their existing storage paths, and the compatibility ring
+  gauges remain exported at zero.
 - Host-only telemetry has a home (#280, #287): a resource carrying `host.name`
   or `host.id` and no `service.name` is identified as `host/<host.name>`
   (`host/<host.id>` without a name) in legacy and aggregate modes, so
@@ -87,6 +108,14 @@ most recently published tag.
 
 ### Fixed
 
+- Aggregate HTTP, MCP, and realtime reads now propagate request cancellation
+  through their query fan-out.
+- The DLQ refuses a single envelope that exceeds its disk budget before it
+  evicts recoverable entries, and aborts an enqueue when an old entry cannot be
+  removed.
+- FTS log searches with a service filter now qualify `logs.service_name`,
+  avoiding the ambiguous-column error that forced an unnecessary LIKE
+  fallback.
 - **realtime**: WebSocket hub shutdown deadlock and WaitGroup misuse —
   graceful shutdown could hang forever against connection churn.
 - **api**: aggregate reads whose range exceeds the read-range cap are
@@ -405,7 +434,8 @@ committed the built UI to `main`.)
 - bestpractices.dev project [12646](https://www.bestpractices.dev/projects/12646)
   declared at `level: passing` via canonical autofill schema. ([#47])
 
-[Unreleased]: https://github.com/RandomCodeSpace/otelcontext/compare/v0.3.0-beta.1...HEAD
+[Unreleased]: https://github.com/RandomCodeSpace/otelcontext/compare/v0.5.0...HEAD
+[v0.5.0]: https://github.com/RandomCodeSpace/otelcontext/compare/v0.4.0-beta.1...v0.5.0
 [v0.3.0-beta.1]: https://github.com/RandomCodeSpace/otelcontext/compare/v0.2.0-beta.6...v0.3.0-beta.1
 [v0.2.0-beta.6]: https://github.com/RandomCodeSpace/otelcontext/compare/v0.0.11-beta.15...v0.2.0-beta.6
 [#24]: https://github.com/RandomCodeSpace/otelcontext/pull/24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,9 @@
 All notable changes to **otelcontext** are documented in this file.
 
 The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
-and this project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
-once a stable release line exists. While otelcontext remains pre-1.0, every
-commit on `main` is the canonical version identifier (`git rev-parse HEAD`).
-Per-tag pre-release notes are published on
+and this project follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+While otelcontext remains pre-1.0, every commit on `main` is the canonical
+version identifier (`git rev-parse HEAD`). Per-tag release notes are published on
 [GitHub Releases](https://github.com/RandomCodeSpace/otelcontext/releases).
 This file's `Unreleased` section tracks what has landed on `main` since the
 most recently published tag.
@@ -57,8 +56,8 @@ most recently published tag.
   matching with BM25 ranking, while `trace_id` remains an exact filter. Set
   `LOG_FTS_ENABLED=false` to keep the LIKE path. FTS tables are installed only
   when `DB_AUTOMIGRATE=true`; an existing database without the index continues
-  to use LIKE until an operator provisions it. Expect the index to add roughly
-  30–40% to log-heavy SQLite database size.
+  to use LIKE until an operator provisions it. The index adds
+  workload-dependent disk and write overhead.
 - SQLite applies its managed PRAGMAs to every physical connection in the pool.
   The default idle pool now matches the runtime default: 25 connections for
   non-SQLite databases and one for SQLite.

--- a/README.md
+++ b/README.md
@@ -180,19 +180,25 @@ Restore starts the same candidate briefly, waits for `/ready`, and shuts it down
 
 ## Secure a deployment
 
-Set at least one authentication method before exposing OtelContext:
+With no authentication or TLS settings configured, production mode starts without either:
+
+```bash
+APP_ENV=production ./otelcontext
+```
+
+Authentication is optional. Enable it when the deployment boundary requires a credential:
 
 - `API_KEY` for a shared operator credential.
 - `AUTH_TRUST_EXTERNAL=true` when a trusted reverse proxy owns authentication and tenant identity.
 
-Example:
+Authenticated example:
 
 ```bash
 export API_KEY="$(openssl rand -hex 32)"
 ./otelcontext
 ```
 
-Clients then send `Authorization: Bearer <key>`. Production mode also requires protected, authenticated gRPC unless you set an explicit waiver.
+Clients then send `Authorization: Bearer <key>`. Authentication and TLS are independently optional at runtime; configure each one when the deployment boundary requires it.
 
 The browser UI does not currently store an API key. For an authenticated browser deployment, put OtelContext behind a same-origin proxy that authenticates the user and injects the credential for REST, MCP, and WebSocket traffic.
 

--- a/deploy/systemd/otelcontext.env.example
+++ b/deploy/systemd/otelcontext.env.example
@@ -14,7 +14,6 @@ DB_DSN=postgres://otelcontext:replace-me@127.0.0.1:5432/otelcontext?sslmode=requ
 # Comment the PostgreSQL lines above, then uncomment both lines below.
 # DB_DRIVER=sqlite
 # DB_DSN=/var/lib/otelcontext/otelcontext.db
-# OTELCONTEXT_ALLOW_SQLITE_PROD=true
 
 HTTP_PORT=8080
 GRPC_PORT=4317
@@ -29,4 +28,3 @@ HOT_RETENTION_DAYS=7
 # TLS_CERT_FILE=/etc/otelcontext/tls/server.crt
 # TLS_KEY_FILE=/etc/otelcontext/tls/server.key
 # AUTH_TRUST_EXTERNAL=true
-# OTELCONTEXT_ALLOW_INSECURE_GRPC=true

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -18,8 +18,8 @@ What happens:
 - `.env` is loaded if present; otherwise defaults apply.
 - GORM `AutoMigrate` creates tables in `otelcontext.db` in the working directory.
 - `DEFAULT_TENANT=default` is assigned to all rows ingested without an explicit tenant header.
-- `API_KEY` is empty → auth middleware is a **pass-through** (every request allowed). A warning is logged.
-- No TLS is configured → HTTP and gRPC listen in **plaintext**. Dev only.
+- No authentication source is configured → auth middleware is a **pass-through** (every request allowed). A status line is logged.
+- No TLS is configured → HTTP and gRPC listen in **plaintext**.
 - Listeners: HTTP `:8080`, gRPC `:4317`, Prometheus `/metrics`, liveness `/live`, readiness `/ready`.
 
 ### Postgres
@@ -39,7 +39,7 @@ Set `DB_AUTOMIGRATE=false` in production after `otelcontext migrate status` repo
 | Database | Support tier | Intended use |
 |---|---|---|
 | PostgreSQL 16 | Primary | Production deployments |
-| SQLite | Bounded opt-in | One process, at most five services, and a low write rate |
+| SQLite | Bounded | One process, at most five services, and a low write rate |
 | MySQL 8.4 | Preview | Evaluation with weekly lifecycle proof; keep a tested rollback |
 | SQL Server 2022 | Experimental | Evaluation only; keep a tested rollback |
 
@@ -134,12 +134,13 @@ A proxy is optional. When one already fronts the browser, give OtelContext a ded
 
 ## Production Checklist
 
-### Must set
-- `API_KEY` — long random string. Without it, anyone on the network can query or ingest.
-- `DB_DRIVER=postgres` with PostgreSQL 16 for the primary production path. Alternatives retain the support tiers above.
-- `DB_DSN` — with strict TLS when crossing a network boundary.
-- `TLS_CERT_FILE` + `TLS_KEY_FILE` (or `TLS_AUTO_SELFSIGNED=true` for internal-only deployments).
+### Set for the deployment
 - `HOT_RETENTION_DAYS` — pick a value you can defend. Default 7 is reasonable; range is 1..36500.
+- Choose the database and `DB_DSN` from the support tiers above. Use strict database TLS when the connection crosses a network boundary.
+- Configure `API_KEY`, per-tenant keys, or trusted proxy authentication when network access alone is not the intended access control.
+- Configure `TLS_CERT_FILE` + `TLS_KEY_FILE` or `TLS_AUTO_SELFSIGNED=true` when the listener needs transport security.
+
+Older environment files may contain `OTELCONTEXT_ALLOW_SQLITE_PROD`, `OTELCONTEXT_ALLOW_INSECURE_GRPC`, or `TSDB_RING_BUFFER_DURATION`. They remain accepted for compatibility but no longer change runtime behavior.
 
 ### Should set
 - `DB_MAX_OPEN_CONNS` — size to match your Postgres pool and expected ingest concurrency.
@@ -160,7 +161,7 @@ A proxy is optional. When one already fronts the browser, give OtelContext a ded
 - `MCP_MAX_CONCURRENT=32`, `MCP_CALL_TIMEOUT_MS=30000`, `MCP_CACHE_TTL_MS=5000` — MCP HTTP streamable robustness. Concurrent `tools/call` invocations are gated by a counting semaphore (returns JSON-RPC `-32000` "server overloaded" past the cap). Per-call deadlines abort runaway tool handlers (returns JSON-RPC `-32001` "call timeout"). Cheap GraphRAG tools (`get_service_map`, `impact_analysis`, `root_cause_analysis`, `get_anomaly_timeline`, `get_service_health`) are memoized for the TTL window, keyed by `(tenant, tool, args)`. Setting any of these to `0` disables that protection.
 
 ### SQLite in production
-SQLite is rejected at startup when `APP_ENV=production` unless you explicitly opt in with `OTELCONTEXT_ALLOW_SQLITE_PROD=true`. The guard exists because SQLite uses a single writer lock. Keep it to one process, at most five services, and a low write rate. Use PostgreSQL 16 beyond that bound.
+SQLite starts without a production waiver. It uses a single writer lock, so keep it to one process, at most five services, and a low write rate. Use PostgreSQL 16 beyond that bound.
 
 ---
 
@@ -208,7 +209,7 @@ Telemetry:
 
 The FTS5 path uses `tokenize='porter unicode61 remove_diacritics 2'` — case-insensitive, accent-insensitive, English-stemmed (so `panic` matches `panicked`). User input is escaped and prefix-suffixed (`*`) so partial words like `conn` still match `connection`. If FTS5 errors at query time, the repository transparently falls back to LIKE so a misbehaving index does not surface as a 500 to the API.
 
-The FTS5 table is provisioned automatically by `AutoMigrateModels` on every SQLite boot; setup is idempotent. To rebuild after corruption or a manual schema change:
+SQLite FTS5 defaults on. Set `LOG_FTS_ENABLED=false` to opt out and use LIKE. `AutoMigrateModels` provisions the table and triggers when `DB_AUTOMIGRATE=true`, then rebuilds the index from existing log rows. With `DB_AUTOMIGRATE=false`, an existing database without `logs_fts` keeps using the LIKE fallback until an automatic migration runs. To rebuild after corruption or a manual schema change:
 
 ```sql
 INSERT INTO logs_fts(logs_fts) VALUES('rebuild');
@@ -220,7 +221,7 @@ The Postgres `pg_trgm` path requires the extension; if missing, AutoMigrate logs
 CREATE EXTENSION pg_trgm;
 ```
 
-Phase 3b will add Postgres declarative partitioning as an opt-in adapter; at that point the GIN indexes will be created per-partition. There is no migration required to use FTS5 — existing SQLite databases are backfilled the first time the upgraded binary boots.
+Phase 3b will add Postgres declarative partitioning as an opt-in adapter; at that point the GIN indexes will be created per-partition. Existing SQLite databases are backfilled the first time `AutoMigrateModels` runs with FTS enabled.
 
 ---
 

--- a/internal/aggregate/cancellation_test.go
+++ b/internal/aggregate/cancellation_test.go
@@ -1,0 +1,212 @@
+package aggregate
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type countingReadStore struct {
+	*stubStore
+	sumCalls atomic.Int32
+}
+
+func (s *countingReadStore) SumBuckets(ctx context.Context, sel Selector, by GroupBy) ([]SumRow, error) {
+	s.sumCalls.Add(1)
+	return s.stubStore.SumBuckets(ctx, sel, by)
+}
+
+func TestQueryDashboardCancelledBeforePlanningDoesNotReadStore(t *testing.T) {
+	f := newQueryFixture(t)
+	store := &countingReadStore{stubStore: newStubStore()}
+	f.engine.SetStore(store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := f.engine.QueryDashboard(ctx, f.rangeQuery())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("QueryDashboard error = %v, want context.Canceled", err)
+	}
+	if got := store.sumCalls.Load(); got != 0 {
+		t.Fatalf("SumBuckets calls = %d, want 0", got)
+	}
+}
+
+type joinedFanoutStore struct {
+	*stubStore
+	want       int32
+	failStart  int64
+	failure    error
+	allStarted chan struct{}
+	started    atomic.Int32
+	finished   atomic.Int32
+}
+
+func newJoinedFanoutStore(sel Selector, failure error) *joinedFanoutStore {
+	return &joinedFanoutStore{
+		stubStore:  newStubStore(),
+		want:       int32(len(splitSelector(sel))),
+		failStart:  sel.Start,
+		failure:    failure,
+		allStarted: make(chan struct{}),
+	}
+}
+
+func (s *joinedFanoutStore) run(ctx context.Context, sel Selector) error {
+	if s.started.Add(1) == s.want {
+		close(s.allStarted)
+	}
+	defer s.finished.Add(1)
+
+	select {
+	case <-s.allStarted:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	if sel.Start == s.failStart {
+		return s.failure
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (s *joinedFanoutStore) SumBuckets(ctx context.Context, sel Selector, _ GroupBy) ([]SumRow, error) {
+	return nil, s.run(ctx, sel)
+}
+
+func (s *joinedFanoutStore) VisitSketches(ctx context.Context, sel Selector, _ func(uint32, *Sketch) error) error {
+	return s.run(ctx, sel)
+}
+
+func wideFanoutSelector() Selector {
+	return Selector{
+		TenantID: 1,
+		Start:    0,
+		End:      int64(storeReadFanout*storeReadChunkMinWindows) * int64(WindowSize/time.Second),
+	}
+}
+
+func assertFanoutJoined(t *testing.T, store *joinedFanoutStore) {
+	t.Helper()
+	if got := store.started.Load(); got != store.want {
+		t.Fatalf("started workers = %d, want %d", got, store.want)
+	}
+	if got := store.finished.Load(); got != store.want {
+		t.Fatalf("finished workers at return = %d, want %d", got, store.want)
+	}
+}
+
+func TestSumStoreCancelsAndJoinsSiblingReads(t *testing.T) {
+	sel := wideFanoutSelector()
+	boom := errors.New("sum failed")
+	store := newJoinedFanoutStore(sel, boom)
+	e := testEngine(t, time.Unix(sel.End, 0))
+	e.SetStore(store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := e.sumStore(ctx, sel, 0)
+	if !errors.Is(err, boom) {
+		t.Fatalf("sumStore error = %v, want %v", err, boom)
+	}
+	assertFanoutJoined(t, store)
+}
+
+func TestVisitStoreSketchesCancelsAndJoinsSiblingReads(t *testing.T) {
+	sel := wideFanoutSelector()
+	boom := errors.New("sketch scan failed")
+	store := newJoinedFanoutStore(sel, boom)
+	e := testEngine(t, time.Unix(sel.End, 0))
+	e.SetStore(store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := e.visitStoreSketches(ctx, sel, nil, func(uint32, *Sketch) {})
+	if !errors.Is(err, boom) {
+		t.Fatalf("visitStoreSketches error = %v, want %v", err, boom)
+	}
+	assertFanoutJoined(t, store)
+}
+
+func TestSQLiteSumBucketsPoolWaitHonorsCancellation(t *testing.T) {
+	store := newTestStoreAt(t, filepath.Join(t.TempDir(), "aggregate.db"), StoreConfig{ReadPoolSize: 1})
+	held, err := store.reader.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("hold reader connection: %v", err)
+	}
+	defer func() { _ = held.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := store.SumBuckets(ctx, Selector{TenantID: 1, Start: 300, End: 600}, 0)
+		result <- err
+	}()
+
+	waitDeadline := time.NewTimer(2 * time.Second)
+	defer waitDeadline.Stop()
+	waitTick := time.NewTicker(time.Millisecond)
+	defer waitTick.Stop()
+	for store.reader.Stats().WaitCount == 0 {
+		select {
+		case <-waitTick.C:
+		case <-waitDeadline.C:
+			t.Fatal("SumBuckets did not wait for the exhausted read pool")
+		}
+	}
+
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("SumBuckets error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SumBuckets did not release the pool waiter after cancellation")
+	}
+
+	if err := held.Close(); err != nil {
+		t.Fatalf("release held connection: %v", err)
+	}
+	pingCtx, pingCancel := context.WithTimeout(context.Background(), time.Second)
+	defer pingCancel()
+	if err := store.reader.PingContext(pingCtx); err != nil {
+		t.Fatalf("read pool after cancellation: %v", err)
+	}
+}
+
+func TestSQLiteVisitSketchesCancellationStopsIterationAndReleasesConnection(t *testing.T) {
+	store := newTestStoreAt(t, filepath.Join(t.TempDir(), "aggregate.db"), StoreConfig{ReadPoolSize: 1})
+	if err := store.CommitGroup(&GroupBatch{
+		Series: []SeriesRow{{ID: 1, Key: storeKey(1)}, {ID: 2, Key: storeKey(2)}},
+		Deltas: []DeltaRow{
+			{SeriesID: 1, WindowStart: 300, Delta: spanDelta(1, 100)},
+			{SeriesID: 2, WindowStart: 300, Delta: spanDelta(1, 200)},
+		},
+	}); err != nil {
+		t.Fatalf("CommitGroup: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	visits := 0
+	err := store.VisitSketches(ctx, Selector{TenantID: 1, Start: 300, End: 600}, func(uint32, *Sketch) error {
+		visits++
+		cancel()
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("VisitSketches error = %v, want context.Canceled", err)
+	}
+	if visits != 1 {
+		t.Fatalf("visitor calls = %d, want 1", visits)
+	}
+
+	pingCtx, pingCancel := context.WithTimeout(context.Background(), time.Second)
+	defer pingCancel()
+	if err := store.reader.PingContext(pingCtx); err != nil {
+		t.Fatalf("read pool after canceled sketch scan: %v", err)
+	}
+}

--- a/internal/aggregate/commit_failure_test.go
+++ b/internal/aggregate/commit_failure_test.go
@@ -1,6 +1,7 @@
 package aggregate
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -342,7 +343,7 @@ func seedTraceWindow(t *testing.T, f *cumulativeFixture, spans int) int64 {
 // the request/span basis, so the span counter is the honest assertion here.
 func dashboardSpans(t *testing.T, e *Engine, from, to time.Time) int64 {
 	t.Helper()
-	res, err := e.QueryDashboard(Query{Tenant: "acme", Start: from, End: to})
+	res, err := e.QueryDashboard(context.Background(), Query{Tenant: "acme", Start: from, End: to})
 	if err != nil {
 		t.Fatalf("QueryDashboard: %v", err)
 	}

--- a/internal/aggregate/query.go
+++ b/internal/aggregate/query.go
@@ -1,13 +1,14 @@
 package aggregate
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"sort"
-	"sync"
 	"time"
 
 	"github.com/RandomCodeSpace/otelcontext/internal/latency"
+	"golang.org/x/sync/errgroup"
 )
 
 // The engine's query facade (#164, #175).
@@ -325,11 +326,14 @@ type visitFunc func(windowStart int64, key SeriesKey, d *AggregateDelta)
 //	generic rows   -> ReadBuckets: keeps its row cap and says so.
 //
 // hasStore is false when memory owns the whole range or no store is attached.
-func (e *Engine) plan(q Query, visit visitFunc) (Ownership, Selector, bool, error) {
+func (e *Engine) plan(ctx context.Context, q Query, visit visitFunc) (Ownership, Selector, bool, error) {
 	var (
 		own Ownership
 		sel Selector
 	)
+	if err := ctx.Err(); err != nil {
+		return own, sel, false, err
+	}
 	if q.Tenant == "" {
 		return own, sel, false, fmt.Errorf("%w: tenant is required", ErrSelectorUnbounded)
 	}
@@ -352,7 +356,10 @@ func (e *Engine) plan(q Query, visit visitFunc) (Ownership, Selector, bool, erro
 
 	// Memory first, under the ownership read lock, so the shard contents and
 	// the snapshot describe the same instant.
-	own = e.readMutable(tenantID, start, end, q.Signal, visit)
+	own, err := e.readMutable(ctx, tenantID, start, end, q.Signal, visit)
+	if err != nil {
+		return own, sel, false, err
+	}
 
 	// Everything below the oldest memory-owned window in range belongs to the
 	// store. The mutable set is a contiguous suffix by construction, so this
@@ -371,18 +378,28 @@ func (e *Engine) plan(q Query, visit visitFunc) (Ownership, Selector, bool, erro
 
 // readMutable visits the memory-owned windows in [start, end) and returns the
 // ownership snapshot it read under.
-func (e *Engine) readMutable(tenantID uint32, start, end int64, signal Signal, visit visitFunc) Ownership {
+func (e *Engine) readMutable(ctx context.Context, tenantID uint32, start, end int64, signal Signal, visit visitFunc) (Ownership, error) {
 	e.own.mu.RLock()
 	defer e.own.mu.RUnlock()
 	own := e.ownershipLocked()
 	for _, w := range own.Mutable {
+		if err := ctx.Err(); err != nil {
+			return own, err
+		}
 		if w < start || w >= end {
 			continue
 		}
 		for i := range e.shards {
+			if err := ctx.Err(); err != nil {
+				return own, err
+			}
 			sh := &e.shards[i]
 			sh.mu.Lock()
 			for key, d := range sh.windows[w] {
+				if err := ctx.Err(); err != nil {
+					sh.mu.Unlock()
+					return own, err
+				}
 				if key.TenantID != tenantID {
 					continue
 				}
@@ -394,7 +411,7 @@ func (e *Engine) readMutable(tenantID uint32, start, end int64, signal Signal, v
 			sh.mu.Unlock()
 		}
 	}
-	return own
+	return own, nil
 }
 
 // Store reads over a wide range fan out across the read pool (#290). A
@@ -439,30 +456,33 @@ func splitSelector(sel Selector) []Selector {
 
 // sumStore runs the SQL aggregation over the store-owned sub-range, one
 // chunk per connection, and re-sums the grouped rows the chunks return.
-func (e *Engine) sumStore(sel Selector, by GroupBy) ([]SumRow, error) {
+func (e *Engine) sumStore(ctx context.Context, sel Selector, by GroupBy) ([]SumRow, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	st := e.Store()
 	if st == nil {
 		return nil, nil
 	}
 	chunks := splitSelector(sel)
 	if len(chunks) == 1 {
-		return st.SumBuckets(sel, by)
+		return st.SumBuckets(ctx, sel, by)
 	}
 	results := make([][]SumRow, len(chunks))
-	errs := make([]error, len(chunks))
-	var wg sync.WaitGroup
+	g, groupCtx := errgroup.WithContext(ctx)
 	for i, chunk := range chunks {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			results[i], errs[i] = st.SumBuckets(chunk, by)
-		}()
+		i, chunk := i, chunk
+		g.Go(func() error {
+			rows, err := st.SumBuckets(groupCtx, chunk, by)
+			results[i] = rows
+			return err
+		})
 	}
-	wg.Wait()
-	for _, err := range errs {
-		if err != nil {
-			return nil, err
-		}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 	type groupKey struct {
 		window        int64
@@ -473,6 +493,9 @@ func (e *Engine) sumStore(sel Selector, by GroupBy) ([]SumRow, error) {
 	var out []SumRow
 	for _, rows := range results {
 		for _, r := range rows {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			key := groupKey{r.WindowStart, r.ServiceID, r.NameID, r.Signal}
 			i, ok := merged[key]
 			if !ok {
@@ -508,7 +531,10 @@ func (e *Engine) sumStore(sel Selector, by GroupBy) ([]SumRow, error) {
 // are merged across chunks and handed to visit once per service, so the
 // visitor runs on the calling goroutine and sees one sketch per service
 // instead of one per stored row.
-func (e *Engine) visitStoreSketches(sel Selector, filter map[string]struct{}, visit func(uint32, *Sketch)) error {
+func (e *Engine) visitStoreSketches(ctx context.Context, sel Selector, filter map[string]struct{}, visit func(uint32, *Sketch)) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	st := e.Store()
 	if st == nil {
 		return nil
@@ -517,25 +543,28 @@ func (e *Engine) visitStoreSketches(sel Selector, filter map[string]struct{}, vi
 	sel.SketchOnly = true
 	chunks := splitSelector(sel)
 	perChunk := make([]map[uint32]*Sketch, len(chunks))
-	errs := make([]error, len(chunks))
-	var wg sync.WaitGroup
+	g, groupCtx := errgroup.WithContext(ctx)
 	for i, chunk := range chunks {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			perChunk[i], errs[i] = e.collectStoreSketches(st, chunk, filter)
-		}()
-	}
-	wg.Wait()
-	for _, err := range errs {
-		if err != nil {
+		i, chunk := i, chunk
+		g.Go(func() error {
+			rows, err := e.collectStoreSketches(groupCtx, st, chunk, filter)
+			perChunk[i] = rows
 			return err
-		}
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	byService := make(map[uint32]*Sketch)
 	var order []uint32
 	for _, m := range perChunk {
 		for serviceID, sk := range m {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			acc := byService[serviceID]
 			if acc == nil {
 				byService[serviceID] = sk
@@ -546,6 +575,9 @@ func (e *Engine) visitStoreSketches(sel Selector, filter map[string]struct{}, vi
 		}
 	}
 	for _, serviceID := range order {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		visit(serviceID, byService[serviceID])
 	}
 	return nil
@@ -554,13 +586,16 @@ func (e *Engine) visitStoreSketches(sel Selector, filter map[string]struct{}, vi
 // collectStoreSketches streams one chunk's sketch rows and folds them into one
 // sketch per service, applying the service filter with one memoized
 // dictionary lookup per distinct service ID.
-func (e *Engine) collectStoreSketches(st Store, sel Selector, filter map[string]struct{}) (map[uint32]*Sketch, error) {
+func (e *Engine) collectStoreSketches(ctx context.Context, st Store, sel Selector, filter map[string]struct{}) (map[uint32]*Sketch, error) {
 	var verdict map[uint32]bool
 	if filter != nil {
 		verdict = make(map[uint32]bool, len(filter))
 	}
 	out := make(map[uint32]*Sketch)
-	err := st.VisitSketches(sel, func(serviceID uint32, sk *Sketch) error {
+	err := st.VisitSketches(ctx, sel, func(serviceID uint32, sk *Sketch) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if filter != nil {
 			ok, seen := verdict[serviceID]
 			if !seen {
@@ -582,8 +617,8 @@ func (e *Engine) collectStoreSketches(st Store, sel Selector, filter map[string]
 	return out, err
 }
 
-func (e *Engine) mergeStoreSketches(sel Selector, filter map[string]struct{}, merge func(*Sketch)) error {
-	return e.visitStoreSketches(sel, filter, func(_ uint32, sk *Sketch) { merge(sk) })
+func (e *Engine) mergeStoreSketches(ctx context.Context, sel Selector, filter map[string]struct{}, merge func(*Sketch)) error {
+	return e.visitStoreSketches(ctx, sel, filter, func(_ uint32, sk *Sketch) { merge(sk) })
 }
 
 // serviceName resolves a series' service through the dictionary. An
@@ -657,7 +692,7 @@ func (c *trafficCounters) addSum(r SumRow) {
 // The store half is a SQL GROUP BY: the result is one row per window (per
 // service when a service filter forces it), so the 20,000-row read cap cannot
 // reach it. That is #194 blocker 4 for this query class.
-func (e *Engine) QueryBuckets(q Query) (*BucketsResult, error) {
+func (e *Engine) QueryBuckets(ctx context.Context, q Query) (*BucketsResult, error) {
 	if q.Signal == SignalUnspecified {
 		q.Signal = SignalTraceOp
 	}
@@ -672,7 +707,7 @@ func (e *Engine) QueryBuckets(q Query) (*BucketsResult, error) {
 		return c
 	}
 
-	own, sel, hasStore, err := e.plan(q, func(windowStart int64, key SeriesKey, d *AggregateDelta) {
+	own, sel, hasStore, err := e.plan(ctx, q, func(windowStart int64, key SeriesKey, d *AggregateDelta) {
 		if filter != nil {
 			if _, ok := filter[e.serviceName(key)]; !ok {
 				return
@@ -690,7 +725,7 @@ func (e *Engine) QueryBuckets(q Query) (*BucketsResult, error) {
 		if filter != nil {
 			by |= GroupByService
 		}
-		sums, err := e.sumStore(sel, by)
+		sums, err := e.sumStore(ctx, sel, by)
 		if err != nil {
 			return nil, err
 		}
@@ -774,7 +809,7 @@ func (a *dashAccum) addSum(r SumRow) {
 // quantile sketch is not SUMmable, so the sketch-bearing rows are streamed
 // once and merged in Go (#219). Doing both through one capped read is exactly
 // what made the old dashboard quietly wrong past 20,000 rows.
-func (e *Engine) QueryDashboard(q Query) (*DashboardResult, error) {
+func (e *Engine) QueryDashboard(ctx context.Context, q Query) (*DashboardResult, error) {
 	q.Signal = SignalUnspecified // the scan covers traces and logs in one pass
 	filter := serviceFilter(q.Services)
 
@@ -808,7 +843,7 @@ func (e *Engine) QueryDashboard(q Query) (*DashboardResult, error) {
 		acc.addSum(r)
 	}
 
-	own, sel, hasStore, err := e.plan(q, func(_ int64, key SeriesKey, d *AggregateDelta) {
+	own, sel, hasStore, err := e.plan(ctx, q, func(_ int64, key SeriesKey, d *AggregateDelta) {
 		name := e.serviceName(key)
 		if filter != nil {
 			if _, ok := filter[name]; !ok {
@@ -839,7 +874,7 @@ func (e *Engine) QueryDashboard(q Query) (*DashboardResult, error) {
 		// sorted by the GROUP BY just to be discarded here (#290).
 		sumSel := sel
 		sumSel.Signals = []Signal{SignalTraceOp, SignalLog}
-		sums, err := e.sumStore(sumSel, GroupByService|GroupBySignal)
+		sums, err := e.sumStore(ctx, sumSel, GroupByService|GroupBySignal)
 		if err != nil {
 			return nil, err
 		}
@@ -858,7 +893,7 @@ func (e *Engine) QueryDashboard(q Query) (*DashboardResult, error) {
 			}
 		}
 
-		if err := e.mergeStoreSketches(sel, filter, mergeSketch); err != nil {
+		if err := e.mergeStoreSketches(ctx, sel, filter, mergeSketch); err != nil {
 			return nil, err
 		}
 	}
@@ -935,7 +970,7 @@ func topFailing(perSvc map[string]*dashAccum, limit int) []ServiceStat {
 // A Services filter selects a SUBGRAPH: an edge survives only when both of its
 // ends survive, so the result is never a graph with edges hanging off nodes it
 // does not contain.
-func (e *Engine) QueryTopology(q Query) (*TopologyResult, error) {
+func (e *Engine) QueryTopology(ctx context.Context, q Query) (*TopologyResult, error) {
 	// No signal filter: the trace-op series carry the nodes and the
 	// service-edge series carry the edges, and both must be read through the
 	// one plan that pins tenant, range and ownership.
@@ -971,7 +1006,7 @@ func (e *Engine) QueryTopology(q Query) (*TopologyResult, error) {
 		return acc
 	}
 
-	own, sel, hasStore, err := e.plan(q, func(_ int64, key SeriesKey, d *AggregateDelta) {
+	own, sel, hasStore, err := e.plan(ctx, q, func(_ int64, key SeriesKey, d *AggregateDelta) {
 		switch key.Signal {
 		case SignalTraceOp:
 			name := e.serviceName(key)
@@ -993,7 +1028,7 @@ func (e *Engine) QueryTopology(q Query) (*TopologyResult, error) {
 	if hasStore {
 		nodeSel := sel
 		nodeSel.Signal = SignalTraceOp
-		sums, err := e.sumStore(nodeSel, GroupByService)
+		sums, err := e.sumStore(ctx, nodeSel, GroupByService)
 		if err != nil {
 			return nil, err
 		}
@@ -1004,7 +1039,7 @@ func (e *Engine) QueryTopology(q Query) (*TopologyResult, error) {
 			}
 			at(name).addSum(r)
 		}
-		if err := e.visitStoreSketches(sel, filter, func(serviceID uint32, sk *Sketch) {
+		if err := e.visitStoreSketches(ctx, sel, filter, func(serviceID uint32, sk *Sketch) {
 			name := e.serviceNameByID(serviceID)
 			if keep(name) {
 				at(name).mergeSketch(sk)
@@ -1018,7 +1053,7 @@ func (e *Engine) QueryTopology(q Query) (*TopologyResult, error) {
 		// selector — the only shape in which a NameID means one namespace.
 		edgeSel := sel
 		edgeSel.Signal = SignalServiceEdge
-		edgeSums, err := e.sumStore(edgeSel, GroupByService|GroupByName)
+		edgeSums, err := e.sumStore(ctx, edgeSel, GroupByService|GroupByName)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/aggregate/query_test.go
+++ b/internal/aggregate/query_test.go
@@ -1,6 +1,7 @@
 package aggregate
 
 import (
+	"context"
 	"math"
 	"slices"
 	"sort"
@@ -81,7 +82,10 @@ func (s *stubStore) matching(sel Selector) []Bucket {
 	return out
 }
 
-func (s *stubStore) ReadBuckets(sel Selector) (BucketPage, error) {
+func (s *stubStore) ReadBuckets(ctx context.Context, sel Selector) (BucketPage, error) {
+	if err := ctx.Err(); err != nil {
+		return BucketPage{}, err
+	}
 	limit, err := sel.Validate()
 	if err != nil {
 		return BucketPage{}, err
@@ -100,14 +104,20 @@ func (s *stubStore) ReadBuckets(sel Selector) (BucketPage, error) {
 	return page, nil
 }
 
-func (s *stubStore) VisitSketches(sel Selector, visit func(uint32, *Sketch) error) error {
+func (s *stubStore) VisitSketches(ctx context.Context, sel Selector, visit func(uint32, *Sketch) error) error {
 	if _, err := sel.Validate(); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 	s.reads++
 	s.readRanges = append(s.readRanges, [2]int64{sel.Start, sel.End})
 	sel.SketchOnly = true
 	for _, b := range s.matching(sel) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err := visit(s.infos[b.SeriesID].ServiceID, b.Delta.Sketch); err != nil {
 			return err
 		}
@@ -115,8 +125,11 @@ func (s *stubStore) VisitSketches(sel Selector, visit func(uint32, *Sketch) erro
 	return nil
 }
 
-func (s *stubStore) SumBuckets(sel Selector, by GroupBy) ([]SumRow, error) {
+func (s *stubStore) SumBuckets(ctx context.Context, sel Selector, by GroupBy) ([]SumRow, error) {
 	if _, err := sel.Validate(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	groups := make(map[SumRow]*SumRow)
@@ -291,7 +304,7 @@ func TestQueryDashboardFromMutableMemory(t *testing.T) {
 	logs.ObserveLog(f.now, false)
 	f.apply(f.logKey("checkout", "payment failed <*>"), f.window(), logs)
 
-	res, err := f.engine.QueryDashboard(f.rangeQuery())
+	res, err := f.engine.QueryDashboard(context.Background(), f.rangeQuery())
 	if err != nil {
 		t.Fatalf("QueryDashboard: %v", err)
 	}
@@ -340,7 +353,7 @@ func TestQueryDashboardPercentileWithinReportedBound(t *testing.T) {
 	}
 	f.apply(f.traceKey("checkout", "POST /pay"), f.window(), d)
 
-	res, err := f.engine.QueryDashboard(f.rangeQuery())
+	res, err := f.engine.QueryDashboard(context.Background(), f.rangeQuery())
 	if err != nil {
 		t.Fatalf("QueryDashboard: %v", err)
 	}
@@ -386,7 +399,7 @@ func TestAccuracyMetadataTracksDownscaledMerge(t *testing.T) {
 	f.apply(f.traceKey("a", "op"), f.window(), fine)
 	f.apply(f.traceKey("b", "op"), f.window(), coarse)
 
-	res, err := f.engine.QueryDashboard(f.rangeQuery())
+	res, err := f.engine.QueryDashboard(context.Background(), f.rangeQuery())
 	if err != nil {
 		t.Fatalf("QueryDashboard: %v", err)
 	}
@@ -425,7 +438,7 @@ func TestQueryBucketsOnePointPerWindow(t *testing.T) {
 	f.apply(f.traceKey("checkout", "op"), prev, spanDelta(3, 1000))
 	f.apply(f.traceKey("checkout", "op"), cur, spanDelta(6, 1000))
 
-	res, err := f.engine.QueryBuckets(f.rangeQuery())
+	res, err := f.engine.QueryBuckets(context.Background(), f.rangeQuery())
 	if err != nil {
 		t.Fatalf("QueryBuckets: %v", err)
 	}
@@ -452,7 +465,7 @@ func TestQueryTopologyNodesFromAggregates(t *testing.T) {
 	f.apply(f.traceKey("cart", "op"), f.window(), spanDelta(3, 2000))
 	f.apply(f.traceKey("checkout", "op"), f.window(), spanDelta(6, 1000))
 
-	res, err := f.engine.QueryTopology(f.rangeQuery())
+	res, err := f.engine.QueryTopology(context.Background(), f.rangeQuery())
 	if err != nil {
 		t.Fatalf("QueryTopology: %v", err)
 	}
@@ -486,7 +499,7 @@ func TestOwnershipIsExclusivePerWindow(t *testing.T) {
 	// must not add a second count.
 	st.put(1, key, w, spanDelta(10, 1000))
 
-	res, err := f.engine.QueryDashboard(f.rangeQuery())
+	res, err := f.engine.QueryDashboard(context.Background(), f.rangeQuery())
 	if err != nil {
 		t.Fatalf("QueryDashboard: %v", err)
 	}
@@ -515,7 +528,7 @@ func TestOwnershipIsExclusivePerWindow(t *testing.T) {
 		t.Errorf("FinalizedWatermark = %d, want %d", own.FinalizedWatermark, w)
 	}
 
-	res, err = f.engine.QueryDashboard(f.rangeQuery())
+	res, err = f.engine.QueryDashboard(context.Background(), f.rangeQuery())
 	if err != nil {
 		t.Fatalf("QueryDashboard after finalize: %v", err)
 	}
@@ -528,10 +541,10 @@ func TestOwnershipIsExclusivePerWindow(t *testing.T) {
 // facade: a query without a forward range is refused, not clamped silently.
 func TestQueryRejectsUnboundedRange(t *testing.T) {
 	f := newQueryFixture(t)
-	if _, err := f.engine.QueryDashboard(Query{Tenant: "default"}); err == nil {
+	if _, err := f.engine.QueryDashboard(context.Background(), Query{Tenant: "default"}); err == nil {
 		t.Fatal("QueryDashboard accepted an empty range")
 	}
-	if _, err := f.engine.QueryDashboard(Query{Start: f.now.Add(-time.Hour), End: f.now}); err == nil {
+	if _, err := f.engine.QueryDashboard(context.Background(), Query{Start: f.now.Add(-time.Hour), End: f.now}); err == nil {
 		t.Fatal("QueryDashboard accepted a query with no tenant")
 	}
 }
@@ -598,7 +611,7 @@ func TestQueryTopologyEdgesShareTheNodeQuery(t *testing.T) {
 		Signal:    SignalServiceEdge,
 	}, old, spanDelta(30, 1000))
 
-	res, err := f.engine.QueryTopology(f.rangeQuery())
+	res, err := f.engine.QueryTopology(context.Background(), f.rangeQuery())
 	if err != nil {
 		t.Fatalf("QueryTopology: %v", err)
 	}
@@ -641,7 +654,7 @@ func TestQueryTopologyServiceFilterKeepsTheGraphClosed(t *testing.T) {
 
 	q := f.rangeQuery()
 	q.Services = []string{"checkout"}
-	res, err := f.engine.QueryTopology(q)
+	res, err := f.engine.QueryTopology(context.Background(), q)
 	if err != nil {
 		t.Fatalf("QueryTopology: %v", err)
 	}

--- a/internal/aggregate/read_contract_test.go
+++ b/internal/aggregate/read_contract_test.go
@@ -1,6 +1,7 @@
 package aggregate
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -318,7 +319,7 @@ func TestReadsAreCompleteBeyondTheRowCap(t *testing.T) {
 	}
 
 	t.Run("dashboard totals match the reference", func(t *testing.T) {
-		res, err := f.engine.QueryDashboard(f.query())
+		res, err := f.engine.QueryDashboard(context.Background(), f.query())
 		if err != nil {
 			t.Fatalf("QueryDashboard: %v", err)
 		}
@@ -332,7 +333,7 @@ func TestReadsAreCompleteBeyondTheRowCap(t *testing.T) {
 			names = append(names, n)
 		}
 		ref := buildReference(func(s string) bool { _, ok := keep[s]; return ok })
-		res, err := f.engine.QueryDashboard(f.query(names...))
+		res, err := f.engine.QueryDashboard(context.Background(), f.query(names...))
 		if err != nil {
 			t.Fatalf("QueryDashboard(filtered): %v", err)
 		}
@@ -340,7 +341,7 @@ func TestReadsAreCompleteBeyondTheRowCap(t *testing.T) {
 
 		// A filter matching nothing must produce zeros, not the unfiltered
 		// answer — the cheapest way for a pushed-down filter to be wrong.
-		empty, err := f.engine.QueryDashboard(f.query("no-such-service"))
+		empty, err := f.engine.QueryDashboard(context.Background(), f.query("no-such-service"))
 		if err != nil {
 			t.Fatalf("QueryDashboard(empty filter): %v", err)
 		}
@@ -350,7 +351,7 @@ func TestReadsAreCompleteBeyondTheRowCap(t *testing.T) {
 	})
 
 	t.Run("traffic totals match the reference per window", func(t *testing.T) {
-		res, err := f.engine.QueryBuckets(f.query())
+		res, err := f.engine.QueryBuckets(context.Background(), f.query())
 		if err != nil {
 			t.Fatalf("QueryBuckets: %v", err)
 		}
@@ -371,7 +372,7 @@ func TestReadsAreCompleteBeyondTheRowCap(t *testing.T) {
 	})
 
 	t.Run("topology nodes match the reference", func(t *testing.T) {
-		res, err := f.engine.QueryTopology(f.query())
+		res, err := f.engine.QueryTopology(context.Background(), f.query())
 		if err != nil {
 			t.Fatalf("QueryTopology: %v", err)
 		}
@@ -391,7 +392,7 @@ func TestReadsAreCompleteBeyondTheRowCap(t *testing.T) {
 
 	t.Run("generic reads page to completion and say when they do not", func(t *testing.T) {
 		sel := f.selector()
-		first, err := f.store.ReadBuckets(sel)
+		first, err := f.store.ReadBuckets(context.Background(), sel)
 		if err != nil {
 			t.Fatalf("ReadBuckets: %v", err)
 		}
@@ -417,7 +418,7 @@ func TestReadsAreCompleteBeyondTheRowCap(t *testing.T) {
 				break
 			}
 			sel.After = page.Next
-			if page, err = f.store.ReadBuckets(sel); err != nil {
+			if page, err = f.store.ReadBuckets(context.Background(), sel); err != nil {
 				t.Fatalf("ReadBuckets(page %d): %v", pages, err)
 			}
 			pages++
@@ -508,7 +509,7 @@ func TestPercentilePathReadsEverySketchBearingRow(t *testing.T) {
 	var merged *Sketch
 	visited := 0
 	sel := Selector{TenantID: tenantID, Start: base, End: base + 3*windowSecs}
-	if err := e.mergeStoreSketches(sel, nil, func(sk *Sketch) {
+	if err := e.mergeStoreSketches(context.Background(), sel, nil, func(sk *Sketch) {
 		visited++
 		if sk == nil {
 			t.Error("sketch stream delivered a nil sketch")
@@ -535,14 +536,14 @@ func TestPercentilePathReadsEverySketchBearingRow(t *testing.T) {
 	// filter naming the seeded service must observe everything; a filter
 	// naming an absent service must observe nothing.
 	var kept uint64
-	if err := e.mergeStoreSketches(sel, map[string]struct{}{"svc": {}}, func(sk *Sketch) { kept += sk.Count() }); err != nil {
+	if err := e.mergeStoreSketches(context.Background(), sel, map[string]struct{}{"svc": {}}, func(sk *Sketch) { kept += sk.Count() }); err != nil {
 		t.Fatalf("mergeStoreSketches(filter=svc): %v", err)
 	}
 	if kept != want {
 		t.Fatalf("filter for the seeded service observed %d of %d observations", kept, want)
 	}
 	dropped := 0
-	if err := e.mergeStoreSketches(sel, map[string]struct{}{"absent": {}}, func(*Sketch) { dropped++ }); err != nil {
+	if err := e.mergeStoreSketches(context.Background(), sel, map[string]struct{}{"absent": {}}, func(*Sketch) { dropped++ }); err != nil {
 		t.Fatalf("mergeStoreSketches(filter=absent): %v", err)
 	}
 	if dropped != 0 {
@@ -700,7 +701,7 @@ func TestStoreRefusesAV2FileAndRebuildsOnDemand(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("commit into rebuilt store: %v", err)
 	}
-	sums, err := rebuilt.SumBuckets(Selector{TenantID: 1, Start: 600, End: 900}, 0)
+	sums, err := rebuilt.SumBuckets(context.Background(), Selector{TenantID: 1, Start: 600, End: 900}, 0)
 	if err != nil {
 		t.Fatalf("SumBuckets: %v", err)
 	}

--- a/internal/aggregate/recovery_test.go
+++ b/internal/aggregate/recovery_test.go
@@ -1,6 +1,7 @@
 package aggregate
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -120,7 +121,7 @@ func TestRecoveryFinalizesDowntimeExpiredWindows(t *testing.T) {
 	if stats.FinalizedWindows != 1 || stats.ReplayedRows != 0 {
 		t.Fatalf("recovery stats = %+v, want 1 finalized / 0 replayed", stats)
 	}
-	page, err := store.ReadBuckets(Selector{
+	page, err := store.ReadBuckets(context.Background(), Selector{
 		TenantID: 1,
 		Start:    WindowStart(clock.Now()) - int64(4*(WindowSize+AllowedLateness)/time.Second),
 		End:      WindowStart(clock.Now()) + 1,

--- a/internal/aggregate/store.go
+++ b/internal/aggregate/store.go
@@ -1,6 +1,7 @@
 package aggregate
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -581,13 +582,13 @@ type Store interface {
 	// store-side. The read asks the database for limit+1 rows and reports
 	// Truncated rather than trimming in silence; a caller that needs every row
 	// pages with Selector.After until Truncated is false.
-	ReadBuckets(sel Selector) (BucketPage, error)
+	ReadBuckets(ctx context.Context, sel Selector) (BucketPage, error)
 
 	// SumBuckets aggregates the same row set as ReadBuckets in SQL, grouped by
 	// by. NO row cap applies: the result is bounded by the grouping — windows,
 	// services, signals — not by the number of rows scanned, which is what
 	// makes a scalar dashboard total structurally impossible to truncate.
-	SumBuckets(sel Selector, by GroupBy) ([]SumRow, error)
+	SumBuckets(ctx context.Context, sel Selector, by GroupBy) ([]SumRow, error)
 
 	// VisitSketches streams every sketch-bearing row matching sel — from
 	// BOTH durable tables, like ReadBuckets — to visit, in no particular
@@ -606,7 +607,7 @@ type Store interface {
 	// The visited sketch is valid only for the duration of the call: the
 	// store decodes every row into one scratch value, so a visitor must
 	// merge or copy it, never retain the pointer.
-	VisitSketches(sel Selector, visit func(serviceID uint32, sk *Sketch) error) error
+	VisitSketches(ctx context.Context, sel Selector, visit func(serviceID uint32, sk *Sketch) error) error
 
 	// ReplayMutable returns the delta-log rows for windows at or after since —
 	// the mutable set only. Finalized history never hydrates into RAM (#160).

--- a/internal/aggregate/store_finalize_test.go
+++ b/internal/aggregate/store_finalize_test.go
@@ -1,6 +1,7 @@
 package aggregate
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -67,7 +68,7 @@ func TestDeltaLogRowsScaleWithSeriesNotCommits(t *testing.T) {
 
 	// Merging is not the same as sampling: every observation has to be in the
 	// bucket. spanDelta(2, _) contributes 2 points and 1 error per commit.
-	page, err := store.ReadBuckets(Selector{TenantID: 1, Start: window, End: window + 300})
+	page, err := store.ReadBuckets(context.Background(), Selector{TenantID: 1, Start: window, End: window + 300})
 	if err != nil {
 		t.Fatalf("ReadBuckets: %v", err)
 	}

--- a/internal/aggregate/store_sqlite.go
+++ b/internal/aggregate/store_sqlite.go
@@ -1266,9 +1266,12 @@ func (s *SQLiteStore) Analyze() error {
 // resume cursor. A caller that needs completeness pages with Selector.After
 // until Truncated is false; a caller that wants a scalar total should not be
 // here at all and should call SumBuckets.
-func (s *SQLiteStore) ReadBuckets(sel Selector) (BucketPage, error) {
+func (s *SQLiteStore) ReadBuckets(ctx context.Context, sel Selector) (BucketPage, error) {
 	limit, err := sel.Validate()
 	if err != nil {
+		return BucketPage{}, err
+	}
+	if err := ctx.Err(); err != nil {
 		return BucketPage{}, err
 	}
 	page := BucketPage{Limit: limit}
@@ -1295,13 +1298,19 @@ func (s *SQLiteStore) ReadBuckets(sel Selector) (BucketPage, error) {
 	sb.WriteString(` ORDER BY window_start, series_id, src LIMIT ?`)
 	args = append(args, limit+1)
 
-	rows, err := s.reader.Query(sb.String(), args...)
+	rows, err := s.reader.QueryContext(ctx, sb.String(), args...)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return BucketPage{}, ctxErr
+		}
 		return BucketPage{}, fmt.Errorf("aggregate store: read buckets: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	out := make([]Bucket, 0, 64)
 	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return BucketPage{}, err
+		}
 		var window, id, src int64
 		d, err := scanDelta(func(dst ...any) error {
 			return rows.Scan(append([]any{&window, &id, &src}, dst...)...)
@@ -1323,6 +1332,9 @@ func (s *SQLiteStore) ReadBuckets(sel Selector) (BucketPage, error) {
 			Delta:       d,
 			Source:      BucketSource(src), // #nosec G115 -- src is a literal 0/1 in the query
 		})
+	}
+	if err := ctx.Err(); err != nil {
+		return BucketPage{}, err
 	}
 	if err := rows.Err(); err != nil {
 		return BucketPage{}, fmt.Errorf("aggregate store: read buckets: %w", err)
@@ -1346,8 +1358,11 @@ const sumColumnList = `point_count, error_count, request_count, error_request_co
 // the cardinality limiter — and never by the number of rows scanned. That is
 // the structural difference from ReadBuckets, whose result size IS the row
 // count.
-func (s *SQLiteStore) SumBuckets(sel Selector, by GroupBy) ([]SumRow, error) {
+func (s *SQLiteStore) SumBuckets(ctx context.Context, sel Selector, by GroupBy) ([]SumRow, error) {
 	if _, err := sel.Validate(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	var (
@@ -1420,13 +1435,19 @@ func (s *SQLiteStore) SumBuckets(sel Selector, by GroupBy) ([]SumRow, error) {
 		sb.WriteString(` GROUP BY ` + strings.Join(group, ", "))
 	}
 
-	rows, err := s.reader.Query(sb.String(), args...)
+	rows, err := s.reader.QueryContext(ctx, sb.String(), args...)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		return nil, fmt.Errorf("aggregate store: sum buckets: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	var out []SumRow
 	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		var (
 			r                              SumRow
 			window, service, name, signal  int64
@@ -1451,6 +1472,9 @@ func (s *SQLiteStore) SumBuckets(sel Selector, by GroupBy) ([]SumRow, error) {
 		r.DurationSum = durSum
 		out = append(out, r)
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return out, rows.Err()
 }
 
@@ -1461,12 +1485,15 @@ func (s *SQLiteStore) SumBuckets(sel Selector, by GroupBy) ([]SumRow, error) {
 // per page and a re-scan per keyset resume; a wide dashboard range paid that
 // price hundreds of times over (#219). A sketch merge is order-independent,
 // so this path pays it zero times.
-func (s *SQLiteStore) VisitSketches(sel Selector, visit func(serviceID uint32, sk *Sketch) error) error {
+func (s *SQLiteStore) VisitSketches(ctx context.Context, sel Selector, visit func(serviceID uint32, sk *Sketch) error) error {
 	if _, err := sel.Validate(); err != nil {
 		return err
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	for _, src := range bucketSources {
-		if err := s.visitTableSketches(src.table, sel, visit); err != nil {
+		if err := s.visitTableSketches(ctx, src.table, sel, visit); err != nil {
 			return err
 		}
 	}
@@ -1474,7 +1501,7 @@ func (s *SQLiteStore) VisitSketches(sel Selector, visit func(serviceID uint32, s
 }
 
 // visitTableSketches streams one table's sketch-bearing rows to visit.
-func (s *SQLiteStore) visitTableSketches(table string, sel Selector, visit func(uint32, *Sketch) error) error {
+func (s *SQLiteStore) visitTableSketches(ctx context.Context, table string, sel Selector, visit func(uint32, *Sketch) error) error {
 	var (
 		sb   strings.Builder
 		args []any
@@ -1484,8 +1511,11 @@ func (s *SQLiteStore) visitTableSketches(table string, sel Selector, visit func(
 		JOIN aggregate_series s ON s.id = t.series_id WHERE `, table)
 	sel.SketchOnly = true
 	args = appendBucketFilter(&sb, sel, args)
-	rows, err := s.reader.Query(sb.String(), args...)
+	rows, err := s.reader.QueryContext(ctx, sb.String(), args...)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		return fmt.Errorf("aggregate store: visit sketches: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
@@ -1499,6 +1529,9 @@ func (s *SQLiteStore) visitTableSketches(table string, sel Selector, visit func(
 		blob    sql.RawBytes
 	)
 	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err := rows.Scan(&service, &blob); err != nil {
 			return fmt.Errorf("aggregate store: visit sketches: %w", err)
 		}
@@ -1508,6 +1541,9 @@ func (s *SQLiteStore) visitTableSketches(table string, sel Selector, visit func(
 		if err := visit(uint32(service), &scratch); err != nil { // #nosec G115 -- dictionary IDs are uint32
 			return err
 		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("aggregate store: visit sketches: %w", err)

--- a/internal/aggregate/store_sqlite.go
+++ b/internal/aggregate/store_sqlite.go
@@ -1298,7 +1298,9 @@ func (s *SQLiteStore) ReadBuckets(ctx context.Context, sel Selector) (BucketPage
 	sb.WriteString(` ORDER BY window_start, series_id, src LIMIT ?`)
 	args = append(args, limit+1)
 
-	rows, err := s.reader.QueryContext(ctx, sb.String(), args...)
+	// The query structure comes only from bucketSources and fixed clauses in
+	// appendBucketUnion. Selector values and the limit stay bound in args.
+	rows, err := s.reader.QueryContext(ctx, sb.String(), args...) // NOSONAR
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return BucketPage{}, ctxErr
@@ -1435,7 +1437,9 @@ func (s *SQLiteStore) SumBuckets(ctx context.Context, sel Selector, by GroupBy) 
 		sb.WriteString(` GROUP BY ` + strings.Join(group, ", "))
 	}
 
-	rows, err := s.reader.QueryContext(ctx, sb.String(), args...)
+	// Group columns come from the fixed GroupBy table above, bucketSources owns
+	// both table names, and appendBucketFilter binds every selector value.
+	rows, err := s.reader.QueryContext(ctx, sb.String(), args...) // NOSONAR
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
@@ -1511,7 +1515,9 @@ func (s *SQLiteStore) visitTableSketches(ctx context.Context, table string, sel 
 		JOIN aggregate_series s ON s.id = t.series_id WHERE `, table)
 	sel.SketchOnly = true
 	args = appendBucketFilter(&sb, sel, args)
-	rows, err := s.reader.QueryContext(ctx, sb.String(), args...)
+	// table is one of the bucketSources literals and appendBucketFilter binds
+	// every selector value. No caller input becomes SQL structure.
+	rows, err := s.reader.QueryContext(ctx, sb.String(), args...) // NOSONAR
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return ctxErr

--- a/internal/aggregate/store_test.go
+++ b/internal/aggregate/store_test.go
@@ -1,6 +1,7 @@
 package aggregate
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -297,7 +298,7 @@ func TestFinalizeWindowMaterializesAndDeletes(t *testing.T) {
 	assertCount(t, store, "aggregate_delta_log", 0)
 	assertCount(t, store, "aggregate_buckets", 2)
 
-	page, err := store.ReadBuckets(Selector{TenantID: 1, Start: 300, End: 900})
+	page, err := store.ReadBuckets(context.Background(), Selector{TenantID: 1, Start: 300, End: 900})
 	if err != nil {
 		t.Fatalf("ReadBuckets: %v", err)
 	}
@@ -344,7 +345,7 @@ func TestFinalizeWindowMergesIntoExistingBucket(t *testing.T) {
 	if _, err := store.FinalizeWindow(600); err != nil {
 		t.Fatalf("second finalize: %v", err)
 	}
-	page, err := store.ReadBuckets(Selector{TenantID: 1, Start: 600, End: 900})
+	page, err := store.ReadBuckets(context.Background(), Selector{TenantID: 1, Start: 600, End: 900})
 	if err != nil {
 		t.Fatalf("ReadBuckets: %v", err)
 	}
@@ -392,7 +393,7 @@ func TestReadBucketsEnforcesBounds(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := store.ReadBuckets(tc.sel); !errors.Is(err, ErrSelectorUnbounded) {
+			if _, err := store.ReadBuckets(context.Background(), tc.sel); !errors.Is(err, ErrSelectorUnbounded) {
 				t.Fatalf("ReadBuckets(%+v) = %v, want ErrSelectorUnbounded", tc.sel, err)
 			}
 		})
@@ -417,7 +418,7 @@ func TestReadBucketsClampsLimitAndScopesTenant(t *testing.T) {
 		t.Fatalf("FinalizeWindow: %v", err)
 	}
 
-	got, err := store.ReadBuckets(Selector{TenantID: 1, Start: 600, End: 900})
+	got, err := store.ReadBuckets(context.Background(), Selector{TenantID: 1, Start: 600, End: 900})
 	if err != nil {
 		t.Fatalf("ReadBuckets: %v", err)
 	}
@@ -428,7 +429,7 @@ func TestReadBucketsClampsLimitAndScopesTenant(t *testing.T) {
 		t.Fatal("an unlimited read of 3 rows reported truncation")
 	}
 
-	limited, err := store.ReadBuckets(Selector{TenantID: 1, Start: 600, End: 900, Limit: 2})
+	limited, err := store.ReadBuckets(context.Background(), Selector{TenantID: 1, Start: 600, End: 900, Limit: 2})
 	if err != nil {
 		t.Fatalf("ReadBuckets(limit): %v", err)
 	}
@@ -444,7 +445,7 @@ func TestReadBucketsClampsLimitAndScopesTenant(t *testing.T) {
 		t.Fatalf("resume cursor %+v does not point at the last returned row %+v", limited.Next, last)
 	}
 
-	signalScoped, err := store.ReadBuckets(Selector{TenantID: 1, Start: 600, End: 900, Signal: SignalLog})
+	signalScoped, err := store.ReadBuckets(context.Background(), Selector{TenantID: 1, Start: 600, End: 900, Signal: SignalLog})
 	if err != nil {
 		t.Fatalf("ReadBuckets(signal): %v", err)
 	}
@@ -608,7 +609,7 @@ func TestSumBucketsGroupsByNameWithinASignal(t *testing.T) {
 		t.Fatalf("CommitGroup: %v", err)
 	}
 
-	sums, err := store.SumBuckets(Selector{
+	sums, err := store.SumBuckets(context.Background(), Selector{
 		TenantID: 1,
 		Start:    window,
 		End:      window + 4*int64(WindowSize/time.Second),

--- a/internal/aggregate/wide_range_timing_test.go
+++ b/internal/aggregate/wide_range_timing_test.go
@@ -1,6 +1,7 @@
 package aggregate
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -76,7 +77,7 @@ func TestManualWideRangeTiming(t *testing.T) {
 	newStart := time.Now()
 	var newMerged *Sketch
 	newRows := 0
-	if err := e.mergeStoreSketches(sel, nil, func(sk *Sketch) {
+	if err := e.mergeStoreSketches(context.Background(), sel, nil, func(sk *Sketch) {
 		newRows++
 		if newMerged == nil {
 			newMerged = NewSketchAtScaleUnchecked(sk.Scale())
@@ -95,7 +96,7 @@ func TestManualWideRangeTiming(t *testing.T) {
 	var oldMerged *Sketch
 	oldRows := 0
 	for {
-		page, err := store.ReadBuckets(pagedSel)
+		page, err := store.ReadBuckets(context.Background(), pagedSel)
 		if err != nil {
 			t.Fatalf("ReadBuckets: %v", err)
 		}
@@ -182,7 +183,7 @@ func BenchmarkQueryDashboardSevenDay(b *testing.B) {
 	b.ReportMetric(float64(seriesN*windowsN), "rows/query")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		result, err := e.QueryDashboard(q)
+		result, err := e.QueryDashboard(context.Background(), q)
 		if err != nil {
 			b.Fatalf("QueryDashboard: %v", err)
 		}

--- a/internal/api/admin_handlers.go
+++ b/internal/api/admin_handlers.go
@@ -4,11 +4,10 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
-	"os"
 	"strconv"
-	"strings"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/config"
 	"github.com/RandomCodeSpace/otelcontext/internal/httpconst"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 )
@@ -99,16 +98,9 @@ func (s *Server) handleVacuum(w http.ResponseWriter, _ *http.Request) {
 // VACUUM blocks writes for ~10-60 minutes on a multi-GB DB. Run this during
 // a maintenance window.
 func (s *Server) handleDropFTS(w http.ResponseWriter, r *http.Request) {
-	if v, ok := os.LookupEnv("LOG_FTS_ENABLED"); ok {
-		if b, err := strconv.ParseBool(strings.TrimSpace(v)); err == nil && b {
-			http.Error(w, "drop_fts refused: LOG_FTS_ENABLED is currently true; set it to false and restart before dropping", http.StatusMethodNotAllowed)
-			return
-		}
-		switch strings.ToLower(strings.TrimSpace(v)) {
-		case "yes", "y", "on":
-			http.Error(w, "drop_fts refused: LOG_FTS_ENABLED is currently true; set it to false and restart before dropping", http.StatusMethodNotAllowed)
-			return
-		}
+	if config.LogFTSEnabledFromEnv() {
+		http.Error(w, "drop_fts refused: LOG_FTS_ENABLED is currently true; set it to false and restart before dropping", http.StatusMethodNotAllowed)
+		return
 	}
 
 	started := time.Now()

--- a/internal/api/admin_handlers_test.go
+++ b/internal/api/admin_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -76,22 +77,37 @@ func TestHandleDropFTS_Reclaims(t *testing.T) {
 // endpoint refuses (405) if LOG_FTS_ENABLED is currently truthy, because
 // dropping the triggers mid-operation would silently break FTS5 sync.
 func TestHandleDropFTS_RefusesWhenEnabled(t *testing.T) {
-	t.Setenv("LOG_FTS_ENABLED", "true")
-	repo := newAPITestRepoWithFTS(t)
-
-	srv := &Server{repo: repo}
-	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/admin/drop_fts", srv.handleDropFTS)
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/admin/drop_fts", nil)
-	mux.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusMethodNotAllowed {
-		t.Fatalf("want 405 with LOG_FTS_ENABLED=true, got %d body=%q", rec.Code, rec.Body.String())
-	}
-	// FTS5 table must still be present.
-	if err := repo.DB().Exec("SELECT 1 FROM logs_fts LIMIT 1").Error; err != nil {
-		t.Fatalf("logs_fts should remain queryable when refused: %v", err)
+	for _, tc := range []struct {
+		name  string
+		value *string
+	}{
+		{name: "unset defaults on"},
+		{name: "explicit true", value: stringPtrAPI("true")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("LOG_FTS_ENABLED", "")
+			if tc.value == nil {
+				if err := os.Unsetenv("LOG_FTS_ENABLED"); err != nil {
+					t.Fatalf("unset LOG_FTS_ENABLED: %v", err)
+				}
+			} else {
+				t.Setenv("LOG_FTS_ENABLED", *tc.value)
+			}
+			repo := newAPITestRepoWithFTS(t)
+			srv := &Server{repo: repo}
+			mux := http.NewServeMux()
+			mux.HandleFunc("POST /api/admin/drop_fts", srv.handleDropFTS)
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/api/admin/drop_fts", nil)
+			mux.ServeHTTP(rec, req)
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("want 405 with FTS enabled, got %d body=%q", rec.Code, rec.Body.String())
+			}
+			if err := repo.DB().Exec("SELECT 1 FROM logs_fts LIMIT 1").Error; err != nil {
+				t.Fatalf("logs_fts should remain queryable when refused: %v", err)
+			}
+		})
 	}
 }
+
+func stringPtrAPI(v string) *string { return &v }

--- a/internal/api/aggregate_reads_test.go
+++ b/internal/api/aggregate_reads_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,6 +16,17 @@ import (
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"gorm.io/gorm"
 )
+
+var errAPIAggregateReadLostContext = errors.New("aggregate API read lost request context")
+
+type apiReadContextStore struct{ aggregate.Store }
+
+func (apiReadContextStore) SumBuckets(ctx context.Context, _ aggregate.Selector, _ aggregate.GroupBy) ([]aggregate.SumRow, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return nil, errAPIAggregateReadLostContext
+}
 
 // rawTableCounter counts GORM reads that touch the raw telemetry tables. It is
 // how "no raw trace/log table scans behind the dashboard in aggregate mode"
@@ -78,6 +90,20 @@ func aggregateTestServer(t *testing.T, withEngine bool) (*Server, *rawTableCount
 	counter := &rawTableCounter{}
 	counter.install(t, db)
 	return s, counter, engine
+}
+
+func TestDashboardViewPropagatesRequestCancellation(t *testing.T) {
+	server, _, engine := aggregateTestServer(t, true)
+	engine.SetStore(apiReadContextStore{})
+
+	ctx := storage.WithTenantContext(context.Background(), "default")
+	ctx, cancel := context.WithCancel(ctx)
+	cancel()
+	req := httptest.NewRequest(http.MethodGet, "/api/metrics/dashboard", nil).WithContext(ctx)
+	_, err := server.dashboardView(req, time.Now().Add(-time.Hour), time.Now(), nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("dashboardView error = %v, want context.Canceled", err)
+	}
 }
 
 // seedAggregate folds one service's worth of spans and logs into the engine's

--- a/internal/api/etag.go
+++ b/internal/api/etag.go
@@ -16,10 +16,11 @@ import (
 // map lookup plus an ETag compare instead of a SQLite query + JSON encode.
 const hotPollCacheTTL = 10 * time.Second
 
-// maxCacheKeyQueryLen bounds cache-key cardinality for endpoints whose key
-// includes the raw query string: anything longer skips the cache rather
-// than letting a hostile client grow the map.
-const maxCacheKeyQueryLen = 256
+const (
+	maxCacheKeyLen    = 256
+	apiCacheEntries   = 256
+	apiCacheByteLimit = int64(16 << 20)
+)
 
 // cachedJSON is a fully rendered JSON response body plus its strong ETag.
 // Marshalling and hashing happen once per cache fill; clients that echo
@@ -28,6 +29,8 @@ type cachedJSON struct {
 	body []byte
 	etag string
 }
+
+func (c *cachedJSON) CacheSizeBytes() int64 { return int64(len(c.body)) }
 
 func newCachedJSON(v any) (*cachedJSON, error) {
 	b, err := json.Marshal(v)
@@ -49,5 +52,28 @@ func (c *cachedJSON) write(w http.ResponseWriter, r *http.Request, xCache string
 		return
 	}
 	h.Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
+	_, _ = w.Write(c.body) //nolint:gosec // G705 false positive: body is json.Marshal output of server-built values, served as application/json
+}
+
+// cachedBody preserves the service-map endpoint's existing JSON encoding and
+// headers while retaining one rendered copy for cache hits and byte charging.
+type cachedBody struct {
+	body []byte
+}
+
+func newCachedBody(v any) (*cachedBody, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	b = append(b, '\n')
+	return &cachedBody{body: b}, nil
+}
+
+func (c *cachedBody) CacheSizeBytes() int64 { return int64(len(c.body)) }
+
+func (c *cachedBody) write(w http.ResponseWriter, xCache string) {
+	w.Header().Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
+	w.Header().Set("X-Cache", xCache)
 	_, _ = w.Write(c.body) //nolint:gosec // G705 false positive: body is json.Marshal output of server-built values, served as application/json
 }

--- a/internal/api/etag_cache_test.go
+++ b/internal/api/etag_cache_test.go
@@ -23,7 +23,7 @@ func newCachedTestServer(t *testing.T) *Server {
 		t.Fatalf("AutoMigrateModels: %v", err)
 	}
 	repo := storage.NewRepositoryFromDB(db, "sqlite")
-	c := cache.New()
+	c := cache.NewBounded(apiCacheEntries, apiCacheByteLimit)
 	t.Cleanup(func() {
 		c.Stop()
 		_ = repo.Close()
@@ -101,9 +101,7 @@ func TestHandleGetSystemGraph_CacheAndETag(t *testing.T) {
 	pollCacheFlow(t, s.handleGetSystemGraph, "/api/system/graph")
 }
 
-// TestHandleGetDashboardStats_QueryScopedKey proves distinct query strings
-// never share a cache entry.
-func TestHandleGetDashboardStats_QueryScopedKey(t *testing.T) {
+func TestHandleGetDashboardStats_CanonicalKey(t *testing.T) {
 	s := newCachedTestServer(t)
 
 	do := func(path string) *httptest.ResponseRecorder {
@@ -113,14 +111,84 @@ func TestHandleGetDashboardStats_QueryScopedKey(t *testing.T) {
 		return rec
 	}
 
-	if got := do("/api/metrics/dashboard?service_name=a").Header().Get("X-Cache"); got != "MISS" {
-		t.Errorf("first ?service_name=a: X-Cache = %q, want MISS", got)
+	first := "/api/metrics/dashboard?start=2026-06-11T00:00:00Z&end=2026-06-11T01:00:00Z&service_name=b&service_name=a&ignored=one"
+	if got := do(first).Header().Get("X-Cache"); got != "MISS" {
+		t.Fatalf("first request X-Cache = %q, want MISS", got)
 	}
-	if got := do("/api/metrics/dashboard?service_name=b").Header().Get("X-Cache"); got != "MISS" {
-		t.Errorf("first ?service_name=b: X-Cache = %q, want MISS (different query must not share entry)", got)
+
+	equivalent := "/api/metrics/dashboard?service_name=%61&ignored=two&end=2026-06-11T02:00:00%2B01:00&service_name=b&service_name=b&start=2026-06-11T01:00:00%2B01:00"
+	if got := do(equivalent).Header().Get("X-Cache"); got != "HIT" {
+		t.Errorf("equivalent request X-Cache = %q, want HIT", got)
 	}
-	if got := do("/api/metrics/dashboard?service_name=a").Header().Get("X-Cache"); got != "HIT" {
-		t.Errorf("second ?service_name=a: X-Cache = %q, want HIT", got)
+}
+
+func TestHandleGetDashboardStats_CacheKeyPreservesEmptyFilterAndPartialRanges(t *testing.T) {
+	s := newCachedTestServer(t)
+	do := func(path string) string {
+		rec := httptest.NewRecorder()
+		s.handleGetDashboardStats(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		return rec.Header().Get("X-Cache")
+	}
+
+	if got := do("/api/metrics/dashboard"); got != "MISS" {
+		t.Fatalf("unfiltered X-Cache = %q, want MISS", got)
+	}
+	if got := do("/api/metrics/dashboard?service_name="); got != "MISS" {
+		t.Errorf("explicit empty service filter X-Cache = %q, want MISS", got)
+	}
+
+	stamp := "2026-06-11T00:00:00Z"
+	if got := do("/api/metrics/dashboard?start=" + stamp); got != "MISS" {
+		t.Fatalf("explicit start X-Cache = %q, want MISS", got)
+	}
+	if got := do("/api/metrics/dashboard?end=" + stamp); got != "MISS" {
+		t.Errorf("explicit end collided with explicit start: X-Cache = %q, want MISS", got)
+	}
+}
+
+func TestHandleGetDashboardStats_CacheKeySeparatesSemantics(t *testing.T) {
+	s := newCachedTestServer(t)
+	do := func(path, tenant string) string {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req = req.WithContext(storage.WithTenantContext(req.Context(), tenant))
+		rec := httptest.NewRecorder()
+		s.handleGetDashboardStats(rec, req)
+		return rec.Header().Get("X-Cache")
+	}
+
+	base := "/api/metrics/dashboard?start=2026-06-11T00:00:00Z&end=2026-06-11T01:00:00Z&service_name=a"
+	if got := do(base, "tenant-a"); got != "MISS" {
+		t.Fatalf("base X-Cache = %q, want MISS", got)
+	}
+	for name, request := range map[string]struct {
+		path   string
+		tenant string
+	}{
+		"tenant":  {base, "tenant-b"},
+		"range":   {"/api/metrics/dashboard?start=2026-06-11T00:00:00Z&end=2026-06-11T02:00:00Z&service_name=a", "tenant-a"},
+		"service": {"/api/metrics/dashboard?start=2026-06-11T00:00:00Z&end=2026-06-11T01:00:00Z&service_name=b", "tenant-a"},
+	} {
+		if got := do(request.path, request.tenant); got != "MISS" {
+			t.Errorf("different %s X-Cache = %q, want MISS", name, got)
+		}
+	}
+}
+
+func TestHandleGetDashboardStats_RollingAndIgnoredParametersReuseKey(t *testing.T) {
+	s := newCachedTestServer(t)
+	do := func(path string) string {
+		rec := httptest.NewRecorder()
+		s.handleGetDashboardStats(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		return rec.Header().Get("X-Cache")
+	}
+	if got := do("/api/metrics/dashboard"); got != "MISS" {
+		t.Fatalf("first rolling request X-Cache = %q, want MISS", got)
+	}
+	if got := do("/api/metrics/dashboard?ignored=" + strings.Repeat("x", 300)); got != "HIT" {
+		t.Errorf("ignored parameter changed rolling key: X-Cache = %q, want HIT", got)
+	}
+	if got := do("/api/metrics/dashboard?start=invalid"); got != "HIT" {
+		t.Errorf("ignored invalid start changed effective rolling key: X-Cache = %q, want HIT", got)
 	}
 }
 
@@ -140,6 +208,24 @@ func TestHandleGetDashboardStats_LongQueryBypassesCache(t *testing.T) {
 		}
 		if got := rec.Header().Get("X-Cache"); got == "HIT" {
 			t.Errorf("request %d: oversized query must bypass the cache, got X-Cache HIT", i)
+		}
+	}
+}
+
+func TestHandleGetDashboardStats_OversizedPayloadBypassesCache(t *testing.T) {
+	s := newCachedTestServer(t)
+	tiny := cache.NewBounded(1, 1)
+	t.Cleanup(tiny.Stop)
+	s.cache = tiny
+
+	for i := range 2 {
+		rec := httptest.NewRecorder()
+		s.handleGetDashboardStats(rec, httptest.NewRequest(http.MethodGet, "/api/metrics/dashboard", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("request %d: status = %d body=%q", i, rec.Code, rec.Body.String())
+		}
+		if got := rec.Header().Get("X-Cache"); got != "MISS" {
+			t.Errorf("request %d: X-Cache = %q, want MISS", i, got)
 		}
 	}
 }

--- a/internal/api/metrics_handlers.go
+++ b/internal/api/metrics_handlers.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
+	"net/url"
 	"sort"
 	"time"
 
@@ -39,7 +40,7 @@ func (s *Server) handleGetTrafficMetrics(w http.ResponseWriter, r *http.Request)
 	// travels in the response header instead (#164).
 	if s.aggregateReads() {
 		start = clampAggregateRange(w, start, end)
-		res, err := s.aggregateEngine.QueryBuckets(aggregate.Query{
+		res, err := s.aggregateEngine.QueryBuckets(r.Context(), aggregate.Query{
 			Tenant:   storage.TenantFromContext(r.Context()),
 			Start:    start,
 			End:      end,
@@ -127,27 +128,30 @@ func (s *Server) handleGetLatencyHeatmap(w http.ResponseWriter, r *http.Request)
 }
 
 // handleGetDashboardStats handles GET /api/metrics/dashboard.
-// The rendered JSON is cached for 10s per (tenant, query) with an ETag —
+// The rendered JSON is cached for 10s per normalized request with an ETag —
 // same pattern as handleGetSystemGraph — so steady-state dashboard polling
 // becomes a hash compare instead of a SQLite aggregate + JSON encode. The
-// key includes the raw query string so explicit start/end/service_name
-// windows never share an entry; oversized queries skip the cache (see
-// maxCacheKeyQueryLen).
+// keys retain only the supported tenant, time-range, and service semantics.
 func (s *Server) handleGetDashboardStats(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
 	// Default to last 30 minutes if not specified
 	end := time.Now()
 	start := end.Add(-30 * time.Minute)
 
-	if startStr := r.URL.Query().Get("start"); startStr != "" {
+	var explicitStart, explicitEnd *time.Time
+	if startStr := query.Get("start"); startStr != "" {
 		if t, err := time.Parse(time.RFC3339, startStr); err == nil {
 			start = t
+			explicitStart = &t
 		}
 	}
-	if endStr := r.URL.Query().Get("end"); endStr != "" {
+	if endStr := query.Get("end"); endStr != "" {
 		if t, err := time.Parse(time.RFC3339, endStr); err == nil {
 			end = t
+			explicitEnd = &t
 		}
 	}
+	serviceNames := query["service_name"]
 	// Clamp BEFORE the cache lookup so the clamp headers are stamped on
 	// cache hits too — the cached payload was produced from the clamped
 	// range, and the headers must say so every time it is served (#217).
@@ -155,16 +159,13 @@ func (s *Server) handleGetDashboardStats(w http.ResponseWriter, r *http.Request)
 		start = clampAggregateRange(w, start, end)
 	}
 
-	var cacheKey string
-	if len(r.URL.RawQuery) <= maxCacheKeyQueryLen {
-		cacheKey = "dashboard_stats:" + storage.TenantFromContext(r.Context()) + "?" + r.URL.RawQuery
+	cacheKey := dashboardCacheKey(storage.TenantFromContext(r.Context()), explicitStart, explicitEnd, serviceNames)
+	if cacheKey != "" {
 		if cached, ok := s.cache.Get(cacheKey); ok {
 			cached.(*cachedJSON).write(w, r, "HIT")
 			return
 		}
 	}
-
-	serviceNames := r.URL.Query()["service_name"]
 
 	view, err := s.dashboardView(r, start, end, serviceNames)
 	if err != nil {
@@ -184,6 +185,32 @@ func (s *Server) handleGetDashboardStats(w http.ResponseWriter, r *http.Request)
 	cj.write(w, r, "MISS")
 }
 
+func dashboardCacheKey(tenant string, start, end *time.Time, services []string) string {
+	values := make(url.Values, 4)
+	values.Set("tenant", tenant)
+	values.Set("start", "rolling")
+	if start != nil {
+		values.Set("start", start.UTC().Format(time.RFC3339Nano))
+	}
+	values.Set("end", "rolling")
+	if end != nil {
+		values.Set("end", end.UTC().Format(time.RFC3339Nano))
+	}
+
+	canonicalServices := append([]string(nil), services...)
+	sort.Strings(canonicalServices)
+	for i, service := range canonicalServices {
+		if i == 0 || service != canonicalServices[i-1] {
+			values.Add("service_name", service)
+		}
+	}
+	key := "dashboard_stats?" + values.Encode()
+	if len(key) > maxCacheKeyLen {
+		return ""
+	}
+	return key
+}
+
 // dashboardView produces the dashboard payload from whichever source owns the
 // numbers in this mode. In aggregate mode every figure comes from engine
 // queries — no COUNT/AVG/DISTINCT scan of the trace or log tables, and no
@@ -191,7 +218,7 @@ func (s *Server) handleGetDashboardStats(w http.ResponseWriter, r *http.Request)
 // bound that sketch justifies.
 func (s *Server) dashboardView(r *http.Request, start, end time.Time, serviceNames []string) (views.DashboardStats, error) {
 	if s.aggregateReads() {
-		res, err := s.aggregateEngine.QueryDashboard(aggregate.Query{
+		res, err := s.aggregateEngine.QueryDashboard(r.Context(), aggregate.Query{
 			Tenant:   storage.TenantFromContext(r.Context()),
 			Start:    start,
 			End:      end,
@@ -244,9 +271,7 @@ func (s *Server) handleGetServiceMapMetrics(w http.ResponseWriter, r *http.Reque
 	}
 
 	if cached, ok := s.cache.Get(cacheKey); ok {
-		w.Header().Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
-		w.Header().Set("X-Cache", "HIT")
-		_ = json.NewEncoder(w).Encode(cached)
+		cached.(*cachedBody).write(w, "HIT")
 		return
 	}
 
@@ -256,10 +281,13 @@ func (s *Server) handleGetServiceMapMetrics(w http.ResponseWriter, r *http.Reque
 		http.Error(w, err.Error(), aggregateReadStatus(err))
 		return
 	}
-	s.cache.Set(cacheKey, resp, cacheTTL)
-	w.Header().Set(httpconst.HeaderContentType, httpconst.ContentTypeJSON)
-	w.Header().Set("X-Cache", "MISS")
-	_ = json.NewEncoder(w).Encode(resp)
+	body, err := newCachedBody(resp)
+	if err != nil {
+		http.Error(w, "failed to encode service map metrics", http.StatusInternalServerError)
+		return
+	}
+	s.cache.Set(cacheKey, body, cacheTTL)
+	body.write(w, "MISS")
 }
 
 // serviceMapView produces the topology payload.
@@ -285,7 +313,7 @@ func (s *Server) serviceMapView(r *http.Request, start, end time.Time) (views.Se
 		}
 		return views.ServiceMapMetricsFromModel(metrics), nil
 	}
-	res, err := s.aggregateEngine.QueryTopology(aggregate.Query{
+	res, err := s.aggregateEngine.QueryTopology(r.Context(), aggregate.Query{
 		Tenant: storage.TenantFromContext(r.Context()),
 		Start:  start,
 		End:    end,

--- a/internal/api/range_clamp_test.go
+++ b/internal/api/range_clamp_test.go
@@ -59,6 +59,18 @@ func TestOverCapRangeClampsInsteadOfFailing(t *testing.T) {
 			if got := rr.Header().Get(EffectiveStartHeader); got != wantEffective {
 				t.Errorf("%s = %q, want %q", EffectiveStartHeader, got, wantEffective)
 			}
+			if name == "dashboard" || name == "service-map" {
+				hit := doClampGet(t, h, "/api/metrics/"+name+q)
+				if got := hit.Header().Get("X-Cache"); got != "HIT" {
+					t.Errorf("cached response X-Cache = %q, want HIT", got)
+				}
+				if got, want := hit.Header().Get(RequestedStartHeader), start.Format(time.RFC3339); got != want {
+					t.Errorf("cached %s = %q, want %q", RequestedStartHeader, got, want)
+				}
+				if got := hit.Header().Get(EffectiveStartHeader); got != wantEffective {
+					t.Errorf("cached %s = %q, want %q", EffectiveStartHeader, got, wantEffective)
+				}
+			}
 		})
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -148,7 +148,7 @@ func NewServer(repo *storage.Repository, hub *realtime.Hub, eventHub *realtime.E
 		hub:      hub,
 		eventHub: eventHub,
 		metrics:  metrics,
-		cache:    cache.New(),
+		cache:    cache.NewBounded(apiCacheEntries, apiCacheByteLimit),
 	}
 	metrics.RegisterReadCache("api_ttl", s.cache.Len)
 	return s

--- a/internal/api/service_map_cache_test.go
+++ b/internal/api/service_map_cache_test.go
@@ -23,7 +23,7 @@ func newServiceMapTestServer(t *testing.T) *Server {
 		t.Fatalf("AutoMigrateModels: %v", err)
 	}
 	repo := storage.NewRepositoryFromDB(db, "sqlite")
-	c := cache.New()
+	c := cache.NewBounded(apiCacheEntries, apiCacheByteLimit)
 	t.Cleanup(func() {
 		c.Stop()
 		_ = repo.Close()

--- a/internal/cache/ttl.go
+++ b/internal/cache/ttl.go
@@ -8,23 +8,50 @@ import (
 type entry struct {
 	value     any
 	expiresAt time.Time
+	charge    int64
+}
+
+const entryChargeBytes int64 = 64
+
+type retainedSizer interface {
+	CacheSizeBytes() int64
 }
 
 // TTLCache is a simple in-memory cache with per-entry TTL expiry.
 // Safe for concurrent use. Background goroutine evicts stale entries every 30s.
 // Call Stop() to shut down the background goroutine.
 type TTLCache struct {
-	mu     sync.RWMutex
-	items  map[string]entry
-	stopCh chan struct{}
-	wg     sync.WaitGroup
+	mu           sync.RWMutex
+	items        map[string]entry
+	maxEntries   int
+	maxBytes     int64
+	chargedBytes int64
+	stopCh       chan struct{}
+	wg           sync.WaitGroup
 }
 
 // New creates a new TTLCache and starts the background eviction loop.
 func New() *TTLCache {
+	return newCache(0, 0)
+}
+
+// NewBounded creates a cache limited by entry count and retained bytes.
+// Values admitted to a bounded cache must implement CacheSizeBytes. The byte
+// charge includes that payload size, the key length, and a fixed per-entry
+// charge for cache bookkeeping. It is an accounting bound, not an RSS bound.
+func NewBounded(maxEntries int, maxBytes int64) *TTLCache {
+	if maxEntries <= 0 || maxBytes <= 0 {
+		panic("cache: bounded limits must be positive")
+	}
+	return newCache(maxEntries, maxBytes)
+}
+
+func newCache(maxEntries int, maxBytes int64) *TTLCache {
 	c := &TTLCache{
-		items:  make(map[string]entry),
-		stopCh: make(chan struct{}),
+		items:      make(map[string]entry),
+		maxEntries: maxEntries,
+		maxBytes:   maxBytes,
+		stopCh:     make(chan struct{}),
 	}
 	c.wg.Add(1)
 	go c.evictLoop()
@@ -37,11 +64,42 @@ func (c *TTLCache) Stop() {
 	c.wg.Wait()
 }
 
-// Set stores value under key with the given TTL.
-func (c *TTLCache) Set(key string, value any, ttl time.Duration) {
+// Set stores value under key with the given TTL. It returns false when a
+// bounded cache cannot account for or admit the value.
+func (c *TTLCache) Set(key string, value any, ttl time.Duration) bool {
+	var charge int64
+	if c.maxEntries > 0 {
+		sized, ok := value.(retainedSizer)
+		if !ok {
+			c.Delete(key)
+			return false
+		}
+		payloadBytes := sized.CacheSizeBytes()
+		keyBytes := int64(len(key))
+		if payloadBytes < 0 || payloadBytes > c.maxBytes || keyBytes > c.maxBytes-entryChargeBytes || payloadBytes > c.maxBytes-entryChargeBytes-keyBytes {
+			c.Delete(key)
+			return false
+		}
+		charge = entryChargeBytes + keyBytes + payloadBytes
+	}
+
+	now := time.Now()
 	c.mu.Lock()
-	c.items[key] = entry{value: value, expiresAt: time.Now().Add(ttl)}
-	c.mu.Unlock()
+	defer c.mu.Unlock()
+	c.deleteExpiredLocked(now)
+	c.deleteLocked(key)
+	if c.maxEntries > 0 && charge > c.maxBytes {
+		return false
+	}
+	for c.maxEntries > 0 && (len(c.items) >= c.maxEntries || c.chargedBytes+charge > c.maxBytes) {
+		for victim := range c.items {
+			c.deleteLocked(victim)
+			break
+		}
+	}
+	c.items[key] = entry{value: value, expiresAt: now.Add(ttl), charge: charge}
+	c.chargedBytes += charge
+	return true
 }
 
 // Get returns the cached value and true if it exists and has not expired.
@@ -49,7 +107,15 @@ func (c *TTLCache) Get(key string) (any, bool) {
 	c.mu.RLock()
 	e, ok := c.items[key]
 	c.mu.RUnlock()
-	if !ok || time.Now().After(e.expiresAt) {
+	if !ok {
+		return nil, false
+	}
+	if !time.Now().Before(e.expiresAt) {
+		c.mu.Lock()
+		if current, exists := c.items[key]; exists && !time.Now().Before(current.expiresAt) {
+			c.deleteLocked(key)
+		}
+		c.mu.Unlock()
 		return nil, false
 	}
 	return e.value, true
@@ -63,11 +129,34 @@ func (c *TTLCache) Len() int {
 	return len(c.items)
 }
 
+// Usage reports the current entry count and charged retained bytes. Unbounded
+// caches report zero charged bytes.
+func (c *TTLCache) Usage() (entries int, chargedBytes int64) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.items), c.chargedBytes
+}
+
 // Delete removes a key immediately.
 func (c *TTLCache) Delete(key string) {
 	c.mu.Lock()
-	delete(c.items, key)
+	c.deleteLocked(key)
 	c.mu.Unlock()
+}
+
+func (c *TTLCache) deleteLocked(key string) {
+	if e, ok := c.items[key]; ok {
+		delete(c.items, key)
+		c.chargedBytes -= e.charge
+	}
+}
+
+func (c *TTLCache) deleteExpiredLocked(now time.Time) {
+	for key, e := range c.items {
+		if !now.Before(e.expiresAt) {
+			c.deleteLocked(key)
+		}
+	}
 }
 
 // evictLoop removes expired entries every 30 seconds.
@@ -80,11 +169,7 @@ func (c *TTLCache) evictLoop() {
 		case <-ticker.C:
 			now := time.Now()
 			c.mu.Lock()
-			for k, e := range c.items {
-				if now.After(e.expiresAt) {
-					delete(c.items, k)
-				}
-			}
+			c.deleteExpiredLocked(now)
 			c.mu.Unlock()
 		case <-c.stopCh:
 			return

--- a/internal/cache/ttl_test.go
+++ b/internal/cache/ttl_test.go
@@ -1,0 +1,138 @@
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+type sizedValue []byte
+
+func (v sizedValue) CacheSizeBytes() int64 { return int64(len(v)) }
+
+func TestBoundedCacheLimitsDistinctKeyChurn(t *testing.T) {
+	const (
+		maxEntries = 256
+		maxBytes   = int64(16 << 20)
+	)
+	c := NewBounded(maxEntries, maxBytes)
+	t.Cleanup(c.Stop)
+
+	maxObservedEntries := 0
+	var maxObservedBytes int64
+	for i := range 300 {
+		if !c.Set(fmt.Sprintf("key-%d", i), sizedValue(make([]byte, 40)), time.Minute) {
+			t.Fatalf("Set(%d) rejected an admissible value", i)
+		}
+		entries, bytes := c.Usage()
+		maxObservedEntries = max(maxObservedEntries, entries)
+		maxObservedBytes = max(maxObservedBytes, bytes)
+		if entries > maxEntries || bytes > maxBytes {
+			t.Fatalf("usage after Set(%d) = %d entries/%d bytes, limits %d/%d", i, entries, bytes, maxEntries, maxBytes)
+		}
+	}
+	t.Logf("maximum observed usage: %d entries, %d charged bytes", maxObservedEntries, maxObservedBytes)
+}
+
+func TestBoundedCacheByteLimitEvicts(t *testing.T) {
+	c := NewBounded(10, 256)
+	t.Cleanup(c.Stop)
+
+	if !c.Set("first", sizedValue(make([]byte, 80)), time.Minute) || !c.Set("second", sizedValue(make([]byte, 80)), time.Minute) {
+		t.Fatal("Set rejected values that fit individually")
+	}
+	if _, ok := c.Get("first"); ok {
+		t.Fatal("byte pressure retained the older entry")
+	}
+	if _, ok := c.Get("second"); !ok {
+		t.Fatal("byte pressure evicted the admitted entry")
+	}
+	if entries, bytes := c.Usage(); entries != 1 || bytes > 256 {
+		t.Fatalf("usage after byte eviction = %d entries/%d bytes", entries, bytes)
+	}
+}
+
+func TestBoundedCacheReplacementAndOversize(t *testing.T) {
+	c := NewBounded(2, 256)
+	t.Cleanup(c.Stop)
+
+	if !c.Set("same", sizedValue(make([]byte, 16)), time.Minute) {
+		t.Fatal("initial Set rejected")
+	}
+	_, before := c.Usage()
+	if !c.Set("same", sizedValue(make([]byte, 80)), time.Minute) {
+		t.Fatal("replacement Set rejected")
+	}
+	entries, after := c.Usage()
+	if entries != 1 || after <= before {
+		t.Fatalf("replacement usage = %d entries/%d bytes, initial bytes %d", entries, after, before)
+	}
+
+	if c.Set("same", sizedValue(make([]byte, 1024)), time.Minute) {
+		t.Fatal("oversized replacement was admitted")
+	}
+	if _, ok := c.Get("same"); ok {
+		t.Fatal("rejected replacement left the prior value cached")
+	}
+	if entries, bytes := c.Usage(); entries != 0 || bytes != 0 {
+		t.Fatalf("usage after rejected replacement = %d entries/%d bytes", entries, bytes)
+	}
+}
+
+func TestBoundedCacheExpiryReleasesCharge(t *testing.T) {
+	c := NewBounded(1, 256)
+	t.Cleanup(c.Stop)
+
+	if !c.Set("expired", sizedValue("payload"), -time.Second) {
+		t.Fatal("Set rejected")
+	}
+	if _, ok := c.Get("expired"); ok {
+		t.Fatal("expired value returned as a hit")
+	}
+	if entries, bytes := c.Usage(); entries != 0 || bytes != 0 {
+		t.Fatalf("expired usage = %d entries/%d bytes", entries, bytes)
+	}
+}
+
+func TestBoundedCacheConcurrentInsertsStayWithinLimits(t *testing.T) {
+	const (
+		maxEntries = 8
+		maxBytes   = 1024
+	)
+	c := NewBounded(maxEntries, maxBytes)
+	t.Cleanup(c.Stop)
+
+	var wg sync.WaitGroup
+	for i := range 200 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.Set(fmt.Sprintf("key-%d", i), sizedValue(make([]byte, 32)), time.Minute)
+		}()
+	}
+	wg.Wait()
+	entries, bytes := c.Usage()
+	if entries > maxEntries || bytes > maxBytes {
+		t.Fatalf("concurrent usage = %d entries/%d bytes, limits %d/%d", entries, bytes, maxEntries, maxBytes)
+	}
+}
+
+func TestUnboundedCacheStillAcceptsUnsizedValues(t *testing.T) {
+	c := New()
+	t.Cleanup(c.Stop)
+	if !c.Set("key", struct{}{}, time.Minute) {
+		t.Fatal("unbounded cache rejected an unsized value")
+	}
+	if _, ok := c.Get("key"); !ok {
+		t.Fatal("unbounded cache missed stored value")
+	}
+}
+
+func TestBoundedCacheRejectsUnsizedValues(t *testing.T) {
+	c := NewBounded(1, 256)
+	t.Cleanup(c.Stop)
+	if c.Set("key", struct{}{}, time.Minute) {
+		t.Fatal("bounded cache admitted a value without retained-size accounting")
+	}
+}

--- a/internal/config/authn_config_test.go
+++ b/internal/config/authn_config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -15,31 +16,34 @@ func productionConfig(t *testing.T) *Config {
 	return c
 }
 
-// The production startup matrix from the #198 resolution: plaintext OR
-// unauthenticated gRPC is refused, and each waiver flag admits it with a
-// message that names the flag.
-func TestValidate_ProductionRequiresTransportAndAuth(t *testing.T) {
+// Production does not implicitly enable or require transport protection or
+// authentication. Each remains independently opt-in.
+func TestValidate_ProductionAllowsOptionalTransportAndAuth(t *testing.T) {
 	certFile, keyFile := writeTLSPair(t)
 
 	cases := []struct {
-		name    string
-		mutate  func(*Config)
-		wantErr string
+		name   string
+		mutate func(*Config)
 	}{
 		{
-			name:    "plaintext and unauthenticated refused",
-			mutate:  func(*Config) {},
-			wantErr: "transport protection",
+			name:   "plaintext and unauthenticated",
+			mutate: func(*Config) {},
 		},
 		{
-			name:    "TLS without authentication refused",
-			mutate:  func(c *Config) { c.TLSCertFile, c.TLSKeyFile = certFile, keyFile },
-			wantErr: "requires authentication",
+			name:   "TLS without authentication",
+			mutate: func(c *Config) { c.TLSCertFile, c.TLSKeyFile = certFile, keyFile },
 		},
 		{
-			name:    "self-signed TLS counts as transport protection",
-			mutate:  func(c *Config) { c.TLSAutoSelfsigned = true },
-			wantErr: "requires authentication",
+			name:   "self-signed TLS without authentication",
+			mutate: func(c *Config) { c.TLSAutoSelfsigned = true },
+		},
+		{
+			name:   "API key without TLS",
+			mutate: func(c *Config) { c.APIKey = "secret" },
+		},
+		{
+			name:   "tenant keys without TLS",
+			mutate: func(c *Config) { c.APITenantKeysFile = "/etc/otelcontext/keys.json" },
 		},
 		{
 			name: "TLS plus API_KEY admitted",
@@ -56,39 +60,75 @@ func TestValidate_ProductionRequiresTransportAndAuth(t *testing.T) {
 			},
 		},
 		{
-			name:   "AUTH_TRUST_EXTERNAL waives both",
+			name:   "external trusted authentication",
 			mutate: func(c *Config) { c.AuthTrustExternal = true; c.AuthExternalTenantHeader = "X-OtelContext-Tenant" },
 		},
 		{
-			name:   "OTELCONTEXT_ALLOW_INSECURE_GRPC waives both",
+			name:   "deprecated insecure flag true",
 			mutate: func(c *Config) { c.AllowInsecureGRPC = true },
+		},
+		{
+			name:   "deprecated insecure flag false",
+			mutate: func(c *Config) { c.AllowInsecureGRPC = false },
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := productionConfig(t)
 			tc.mutate(c)
-			err := c.Validate()
-			if tc.wantErr == "" {
-				if err != nil {
-					t.Fatalf("want admitted, got %v", err)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatal("want refusal, got nil")
-			}
-			if !strings.Contains(err.Error(), tc.wantErr) {
-				t.Fatalf("error %q should mention %q", err, tc.wantErr)
-			}
-			// Every refusal names both waivers so the operator can see the
-			// acknowledgement they would be making.
-			for _, flag := range []string{"AUTH_TRUST_EXTERNAL", "OTELCONTEXT_ALLOW_INSECURE_GRPC"} {
-				if !strings.Contains(err.Error(), flag) {
-					t.Errorf("refusal %q does not name %s", err, flag)
-				}
+			if err := c.Validate(); err != nil {
+				t.Fatalf("production opt-in combination refused: %v", err)
 			}
 		})
+	}
+}
+
+func TestValidate_ProductionRejectsInvalidExplicitTLS(t *testing.T) {
+	c := productionConfig(t)
+	c.TLSCertFile = "/tmp/cert-without-key.crt"
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "TLS_CERT_FILE and TLS_KEY_FILE") {
+		t.Fatalf("invalid explicit TLS pair must be rejected, got %v", err)
+	}
+}
+
+func TestLoad_ProductionDefaultsAllowSQLiteWithoutAuthOrTLS(t *testing.T) {
+	for _, key := range []string{
+		"API_KEY",
+		"API_TENANT_KEYS_FILE",
+		"AUTH_TRUST_EXTERNAL",
+		"TLS_CERT_FILE",
+		"TLS_KEY_FILE",
+		"TLS_AUTO_SELFSIGNED",
+		"OTELCONTEXT_ALLOW_INSECURE_GRPC",
+		"OTELCONTEXT_ALLOW_SQLITE_PROD",
+		"LOG_FTS_ENABLED",
+	} {
+		t.Setenv(key, "")
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("unset %s: %v", key, err)
+		}
+	}
+	t.Setenv("APP_ENV", "production")
+	t.Setenv("DB_DRIVER", "sqlite")
+
+	c, err := Load("__no_such_env_file__")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.AuthEnabled() || c.TLSEnabled() {
+		t.Fatalf("production defaults unexpectedly enabled auth or TLS: auth=%t tls=%t", c.AuthEnabled(), c.TLSEnabled())
+	}
+	if c.AllowInsecureGRPC || c.AllowSqliteProd {
+		t.Fatalf("deprecated compatibility flags unexpectedly enabled: grpc=%t sqlite=%t", c.AllowInsecureGRPC, c.AllowSqliteProd)
+	}
+	if !c.LogFTSEnabled {
+		t.Fatal("SQLite FTS must default on")
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if err := c.ValidateDBForEnv(); err != nil {
+		t.Fatalf("ValidateDBForEnv: %v", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,8 +76,9 @@ type Config struct {
 	// POST /api/admin/vacuum. Ignored on non-SQLite drivers.
 	RetentionFullVacuum bool
 
-	// TSDB
-	TSDBRingBufferDuration string // e.g. "1h"
+	// TSDBRingBufferDuration is retained for configuration compatibility.
+	// Deprecated: the runtime no longer creates the legacy metric ring buffer.
+	TSDBRingBufferDuration string
 
 	// Smart Observability — Adaptive Sampling
 	SamplingRate               float64
@@ -133,8 +134,8 @@ type Config struct {
 	// LogFTSEnabled toggles SQLite FTS5 provisioning + querying. The FTS5
 	// inverted index typically consumes 30-40% of SQLite DB disk for
 	// log-heavy workloads, while the LIKE fallback (log_repo.go:105) keeps
-	// search_logs functional without it. Default false; opt in with
-	// LOG_FTS_ENABLED=true. Only meaningful on SQLite; Postgres uses pg_trgm
+	// search_logs functional without it. Default true; opt out with
+	// LOG_FTS_ENABLED=false. Only meaningful on SQLite; Postgres uses pg_trgm
 	// independently of this flag.
 	LogFTSEnabled bool
 
@@ -259,9 +260,8 @@ type Config struct {
 	// and message type to an unauthenticated peer.
 	GRPCReflection bool
 
-	// AllowInsecureGRPC waives the production requirement for TLS and
-	// authentication on the OTLP gRPC listener. Explicit acknowledgement that
-	// telemetry crosses the network unprotected and unauthenticated.
+	// AllowInsecureGRPC is retained for configuration compatibility.
+	// Deprecated: TLS and authentication are independently opt-in in every environment.
 	AllowInsecureGRPC bool
 
 	// DevMode disables origin checks for WebSocket and enables dev-friendly defaults.
@@ -272,9 +272,8 @@ type Config struct {
 	GRPCMaxRecvMB            int
 	GRPCMaxConcurrentStreams int
 
-	// AllowSqliteProd lets operators explicitly acknowledge that SQLite is
-	// being used outside dev/test. Without it, a production Env + SQLite
-	// combination refuses to start.
+	// AllowSqliteProd is retained for configuration compatibility.
+	// Deprecated: SQLite is allowed in every environment.
 	AllowSqliteProd bool
 
 	// WSMaxClients caps simultaneous WebSocket connections to /ws*
@@ -522,7 +521,7 @@ func Load(customPath string) (*Config, error) {
 
 		// DB Connection Pool
 		DBMaxOpenConns:    getEnvInt("DB_MAX_OPEN_CONNS", 50),
-		DBMaxIdleConns:    getEnvInt("DB_MAX_IDLE_CONNS", 10),
+		DBMaxIdleConns:    getEnvInt("DB_MAX_IDLE_CONNS", 25),
 		DBConnMaxLifetime: getEnv("DB_CONN_MAX_LIFETIME", "1h"),
 
 		// Postgres partitioning (opt-in). Default empty = legacy unpartitioned.
@@ -535,7 +534,7 @@ func Load(customPath string) (*Config, error) {
 		RetentionBatchSleepMs: getEnvInt("RETENTION_BATCH_SLEEP_MS", 1),
 		RetentionFullVacuum:   getEnvBool("RETENTION_FULL_VACUUM", false),
 
-		// TSDB
+		// Deprecated compatibility input; the runtime no longer creates the ring.
 		TSDBRingBufferDuration: getEnv("TSDB_RING_BUFFER_DURATION", "1h"),
 
 		// Adaptive Sampling
@@ -567,8 +566,8 @@ func Load(customPath string) (*Config, error) {
 		// Compression
 		CompressionLevel: getEnv("COMPRESSION_LEVEL", "default"),
 
-		// Log search FTS5 toggle (SQLite only). Default off — see field comment.
-		LogFTSEnabled: parseTruthy(getEnv("LOG_FTS_ENABLED", "")),
+		// Log search FTS5 toggle (SQLite only). Default on; explicit values win.
+		LogFTSEnabled: LogFTSEnabledFromEnv(),
 
 		// GraphRAG
 		GraphRAGWorkerCount:       getEnvInt("GRAPHRAG_WORKER_COUNT", 16),
@@ -615,7 +614,7 @@ func Load(customPath string) (*Config, error) {
 		GRPCMaxRecvMB:            getEnvInt("GRPC_MAX_RECV_MB", 16),
 		GRPCMaxConcurrentStreams: getEnvInt("GRPC_MAX_CONCURRENT_STREAMS", 1000),
 
-		// Production safety guard for SQLite
+		// Deprecated compatibility input; SQLite no longer requires a waiver.
 		AllowSqliteProd: parseTruthy(getEnv("OTELCONTEXT_ALLOW_SQLITE_PROD", "")),
 
 		// Aggregate Engine Configuration
@@ -766,7 +765,6 @@ var sqliteOverrides = []struct {
 	{"METRIC_MAX_CARDINALITY", func(c *Config) { c.MetricMaxCardinality = 3000 }},
 	{"SAMPLING_RATE", func(c *Config) { c.SamplingRate = 0.05 }},
 	{"GRPC_MAX_CONCURRENT_STREAMS", func(c *Config) { c.GRPCMaxConcurrentStreams = 240 }},
-	{"LOG_FTS_ENABLED", func(c *Config) { c.LogFTSEnabled = true }},
 	// Each queued event embeds a storage.Span/Log by value (~0.5–2 KB); the
 	// 100k Postgres default is ~100 MB+ of standing buffer. On SQLite the
 	// single writer starves the workers anyway — drop sooner (metered via
@@ -788,6 +786,25 @@ func applyDriverDefaults(cfg *Config) {
 			ov.apply(cfg)
 		}
 	}
+}
+
+// LogFTSEnabledFromEnv is the authoritative LOG_FTS_ENABLED resolver used by
+// configuration, SQLite migration, queries, and the administrative drop gate.
+// An unset variable enables FTS5. Explicit empty, false, and invalid values
+// disable it; strconv boolean values plus yes/y/on enable it.
+func LogFTSEnabledFromEnv() bool {
+	v, ok := os.LookupEnv("LOG_FTS_ENABLED")
+	if !ok {
+		return true
+	}
+	if b, err := strconv.ParseBool(strings.TrimSpace(v)); err == nil {
+		return b
+	}
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "yes", "y", "on":
+		return true
+	}
+	return false
 }
 
 func getEnv(key, fallback string) string {
@@ -994,18 +1011,6 @@ func (c *Config) Validate() error {
 		}
 		if strings.EqualFold(c.AuthExternalTenantHeader, "X-Tenant-ID") {
 			return fmt.Errorf("AUTH_EXTERNAL_TENANT_HEADER must not be X-Tenant-ID — that header stays client-controlled; use a dedicated header your proxy strips and re-injects")
-		}
-	}
-
-	// Production fail-closed: the OTLP gRPC listener must be both protected in
-	// transport and authenticated. Two waivers, each named in the refusal so
-	// the operator knows exactly which acknowledgement they are making.
-	if c.IsProduction() && !c.AuthTrustExternal && !c.AllowInsecureGRPC {
-		if !c.TLSEnabled() {
-			return fmt.Errorf("APP_ENV=production requires transport protection on the OTLP gRPC listener: set TLS_CERT_FILE/TLS_KEY_FILE, or TLS_AUTO_SELFSIGNED=true, or waive with AUTH_TRUST_EXTERNAL=true (proxy-terminated TLS) or OTELCONTEXT_ALLOW_INSECURE_GRPC=true")
-		}
-		if !c.AuthEnabled() {
-			return fmt.Errorf("APP_ENV=production requires authentication on the OTLP gRPC listener: set API_KEY or API_TENANT_KEYS_FILE, or waive with AUTH_TRUST_EXTERNAL=true (proxy-authenticated identity) or OTELCONTEXT_ALLOW_INSECURE_GRPC=true")
 		}
 	}
 
@@ -1270,21 +1275,10 @@ func checkReadable(path string) error {
 	return f.Close()
 }
 
-// ValidateDBForEnv refuses the combination of SQLite driver + production
-// environment unless AllowSqliteProd is explicitly set. SQLite's single-writer
-// lock caps sustained throughput to ~5 services; using it in production will
-// silently throttle ingestion.
-//
-// Call once during startup after Load + Validate.
+// ValidateDBForEnv is retained for callers that perform a separate environment
+// compatibility check after Validate. All supported drivers are valid in every
+// environment; operators choose a driver based on their workload.
 func (c *Config) ValidateDBForEnv() error {
-	if !strings.EqualFold(c.DBDriver, "sqlite") {
-		return nil
-	}
-	if strings.EqualFold(c.Env, "production") && !c.AllowSqliteProd {
-		return fmt.Errorf("SQLite is unsuitable for APP_ENV=production " +
-			"(single-writer lock caps throughput at ~5 services). " +
-			"Use DB_DRIVER=postgres, or set OTELCONTEXT_ALLOW_SQLITE_PROD=true to acknowledge")
-	}
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,7 +35,7 @@ func baseValid() *Config {
 		SamplingRate:             1.0,
 		APIRateLimitRPS:          100,
 		DBMaxOpenConns:           50,
-		DBMaxIdleConns:           10,
+		DBMaxIdleConns:           25,
 		CompressionLevel:         "default",
 		GRPCMaxRecvMB:            16,
 		GRPCMaxConcurrentStreams: 1000,
@@ -324,24 +324,15 @@ func TestTLSAutoSelfsigned_IgnoredWhenCertFilesSet(t *testing.T) {
 	}
 }
 
-func TestValidateDBForEnv_RefusesSQLiteInProduction(t *testing.T) {
-	c := baseValid()
-	c.DBDriver = "sqlite"
-	c.Env = "production"
-	c.AllowSqliteProd = false
-	err := c.ValidateDBForEnv()
-	if err == nil || !strings.Contains(err.Error(), "SQLite is unsuitable") {
-		t.Fatalf("expected SQLite-in-prod rejection, got %v", err)
-	}
-}
-
-func TestValidateDBForEnv_AllowsSQLiteWhenOptIn(t *testing.T) {
-	c := baseValid()
-	c.DBDriver = "sqlite"
-	c.Env = "production"
-	c.AllowSqliteProd = true
-	if err := c.ValidateDBForEnv(); err != nil {
-		t.Fatalf("opt-in should allow SQLite in prod, got %v", err)
+func TestValidateDBForEnv_AllowsSQLiteInProductionRegardlessOfDeprecatedFlag(t *testing.T) {
+	for _, allow := range []bool{false, true} {
+		c := baseValid()
+		c.DBDriver = "sqlite"
+		c.Env = "production"
+		c.AllowSqliteProd = allow
+		if err := c.ValidateDBForEnv(); err != nil {
+			t.Fatalf("AllowSqliteProd=%t: SQLite in production must pass, got %v", allow, err)
+		}
 	}
 }
 

--- a/internal/config/driver_defaults_test.go
+++ b/internal/config/driver_defaults_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 // sqliteEnvKeys is the set of env vars whose defaults applyDriverDefaults
-// flips when the driver is SQLite. Cleared via t.Setenv before each test so a
+// changes when the driver is SQLite. Cleared via t.Setenv before each test so a
 // stray host-env value doesn't leak in.
 var sqliteEnvKeys = []string{
 	"DB_MAX_OPEN_CONNS",
@@ -17,7 +17,6 @@ var sqliteEnvKeys = []string{
 	"METRIC_MAX_CARDINALITY",
 	"SAMPLING_RATE",
 	"GRPC_MAX_CONCURRENT_STREAMS",
-	"LOG_FTS_ENABLED",
 	"GRAPHRAG_EVENT_QUEUE_SIZE",
 	"GRAPHRAG_TRACE_TTL",
 }
@@ -49,7 +48,7 @@ func postgresDefaultsConfig(driver string) *Config {
 	return &Config{
 		DBDriver:                 driver,
 		DBMaxOpenConns:           50,        // Postgres default
-		DBMaxIdleConns:           10,        // Postgres default
+		DBMaxIdleConns:           25,        // Postgres default
 		IngestPipelineWorkers:    8,         // Postgres default
 		IngestPipelineQueueSize:  50000,     // Postgres default
 		IngestPipelineMaxBytes:   512 << 20, // Postgres default
@@ -58,15 +57,15 @@ func postgresDefaultsConfig(driver string) *Config {
 		SamplingRate:             1.0,       // keep-all default
 		GRPCMaxConcurrentStreams: 1000,      // Postgres default
 		GraphRAGEventQueueSize:   100000,    // Postgres default
-		LogFTSEnabled:            false,     // FTS5 opt-in default
+		LogFTSEnabled:            true,      // global default; only meaningful for SQLite
 		GraphRAGTraceTTL:         "1h",      // Postgres default
 	}
 }
 
-// TestApplyDriverDefaults_SQLite_FlipsAllWhenNoEnv proves the post-Load()
+// TestApplyDriverDefaults_SQLite_AppliesWhenNoEnv proves the post-Load()
 // override fires when the driver is SQLite and the operator did not set
 // any of the overridable env vars.
-func TestApplyDriverDefaults_SQLite_FlipsAllWhenNoEnv(t *testing.T) {
+func TestApplyDriverDefaults_SQLite_AppliesWhenNoEnv(t *testing.T) {
 	clearSQLiteEnv(t)
 	cfg := postgresDefaultsConfig("sqlite")
 	applyDriverDefaults(cfg)
@@ -92,6 +91,62 @@ func TestApplyDriverDefaults_SQLite_FlipsAllWhenNoEnv(t *testing.T) {
 		if c.got != c.want {
 			t.Errorf("%s: SQLite override = %v, want %v", c.name, c.got, c.want)
 		}
+	}
+}
+
+func TestLoad_SQLiteLogFTSDefaultsOnAndRespectsOverride(t *testing.T) {
+	t.Setenv("DB_DRIVER", "sqlite")
+	for _, tc := range []struct {
+		name  string
+		value *string
+		want  bool
+	}{
+		{name: "unset", want: true},
+		{name: "explicit empty", value: stringPtr(""), want: false},
+		{name: "explicit false", value: stringPtr("false"), want: false},
+		{name: "explicit zero", value: stringPtr("0"), want: false},
+		{name: "invalid", value: stringPtr("sometimes"), want: false},
+		{name: "explicit true", value: stringPtr("true"), want: true},
+		{name: "explicit one", value: stringPtr("1"), want: true},
+		{name: "yes", value: stringPtr("yes"), want: true},
+		{name: "y", value: stringPtr("Y"), want: true},
+		{name: "on", value: stringPtr("ON"), want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("LOG_FTS_ENABLED", "")
+			if tc.value == nil {
+				if err := os.Unsetenv("LOG_FTS_ENABLED"); err != nil {
+					t.Fatalf("unset LOG_FTS_ENABLED: %v", err)
+				}
+			} else {
+				t.Setenv("LOG_FTS_ENABLED", *tc.value)
+			}
+			cfg, err := Load("__no_such_env_file__")
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.LogFTSEnabled != tc.want {
+				t.Fatalf("LogFTSEnabled = %t, want %t", cfg.LogFTSEnabled, tc.want)
+			}
+		})
+	}
+}
+
+func stringPtr(v string) *string { return &v }
+
+func TestLoad_PostgresIdlePoolDefaultMatchesStorage(t *testing.T) {
+	t.Setenv("DB_DRIVER", "postgres")
+	t.Setenv("DB_MAX_IDLE_CONNS", "")
+	if err := os.Unsetenv("DB_MAX_IDLE_CONNS"); err != nil {
+		t.Fatalf("unset DB_MAX_IDLE_CONNS: %v", err)
+	}
+
+	cfg, err := Load("__no_such_env_file__")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.DBMaxIdleConns != 25 {
+		t.Fatalf("DBMaxIdleConns = %d, want storage default 25", cfg.DBMaxIdleConns)
 	}
 }
 

--- a/internal/mcp/fts_search_test.go
+++ b/internal/mcp/fts_search_test.go
@@ -1,0 +1,84 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/RandomCodeSpace/otelcontext/internal/storage"
+)
+
+func TestSearchLogsDefaultFTSPreservesMCPFiltersAndPagination(t *testing.T) {
+	t.Setenv("LOG_FTS_ENABLED", "")
+	if err := os.Unsetenv("LOG_FTS_ENABLED"); err != nil {
+		t.Fatalf("unset LOG_FTS_ENABLED: %v", err)
+	}
+	db, err := storage.NewDatabase("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+	if err := storage.AutoMigrateModels(db, "sqlite"); err != nil {
+		t.Fatalf("AutoMigrateModels: %v", err)
+	}
+	var ftsTableCount int64
+	if err := db.Raw("SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'logs_fts'").Scan(&ftsTableCount).Error; err != nil {
+		t.Fatalf("inspect logs_fts: %v", err)
+	}
+	if ftsTableCount != 1 {
+		t.Fatalf("default migration created %d logs_fts tables, want 1", ftsTableCount)
+	}
+
+	repo := storage.NewRepositoryFromDB(db, "sqlite")
+	t.Cleanup(func() { _ = repo.Close() })
+	now := time.Now().UTC().Truncate(time.Second)
+	rows := []storage.Log{
+		{TenantID: "alpha", Severity: "ERROR", Body: "worker connected alpha first", ServiceName: "checkout", TraceID: "trace-target", Timestamp: now.Add(-2 * time.Minute)},
+		{TenantID: "alpha", Severity: "ERROR", Body: "worker connected alpha second", ServiceName: "checkout", TraceID: "trace-target", Timestamp: now.Add(-time.Minute)},
+		{TenantID: "beta", Severity: "ERROR", Body: "worker connected beta", ServiceName: "checkout", TraceID: "trace-target", Timestamp: now.Add(-time.Minute)},
+		{TenantID: "alpha", Severity: "ERROR", Body: "worker connected wrong service", ServiceName: "payments", TraceID: "trace-target", Timestamp: now.Add(-time.Minute)},
+		{TenantID: "alpha", Severity: "WARN", Body: "worker connected wrong severity", ServiceName: "checkout", TraceID: "trace-target", Timestamp: now.Add(-time.Minute)},
+		{TenantID: "alpha", Severity: "ERROR", Body: "worker connected wrong trace", ServiceName: "checkout", TraceID: "trace-other", Timestamp: now.Add(-time.Minute)},
+		{TenantID: "alpha", Severity: "ERROR", Body: "worker connected too old", ServiceName: "checkout", TraceID: "trace-target", Timestamp: now.Add(-25 * time.Hour)},
+	}
+	if err := repo.DB().Create(&rows).Error; err != nil {
+		t.Fatalf("seed logs: %v", err)
+	}
+
+	srv := New("", repo, nil, nil)
+	ctx := storage.WithTenantContext(context.Background(), "alpha")
+	result := srv.toolSearchLogs(ctx, map[string]any{
+		"query": "connections", "severity": "ERROR", "service": "checkout", "trace_id": "trace-target",
+		"start": now.Add(-2 * time.Hour).Format(time.RFC3339), "end": now.Format(time.RFC3339),
+		"limit": float64(1), "page": float64(1),
+	})
+	if result.IsError || len(result.Content) != 1 || result.Content[0].Resource == nil {
+		t.Fatalf("search_logs result changed shape or errored: %+v", result)
+	}
+	var body struct {
+		Total   int64 `json:"total"`
+		Page    int   `json:"page"`
+		Limit   int   `json:"limit"`
+		Count   int   `json:"count"`
+		Entries []struct {
+			Severity    string `json:"severity"`
+			ServiceName string `json:"service_name"`
+			Body        string `json:"body"`
+			TraceID     string `json:"trace_id"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal([]byte(result.Content[0].Resource.Text), &body); err != nil {
+		t.Fatalf("decode search_logs resource: %v", err)
+	}
+	if body.Total != 2 || body.Page != 1 || body.Limit != 1 || body.Count != 1 || len(body.Entries) != 1 {
+		t.Fatalf("filtered page metadata = %+v, want total=2 page=1 limit=1 count=1", body)
+	}
+	entry := body.Entries[0]
+	if entry.Severity != "ERROR" || entry.ServiceName != "checkout" || entry.TraceID != "trace-target" {
+		t.Fatalf("search_logs filters changed: %+v", entry)
+	}
+	if entry.Body != "worker connected alpha first" && entry.Body != "worker connected alpha second" {
+		t.Fatalf("unexpected paged FTS entry: %+v", entry)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -81,7 +81,7 @@ var toolDefs = []Tool{
 		param("trace_id", "string", "The trace ID to visualize."),
 	),
 	mkTool("search_logs", "Searches log entries by severity, service, body text, trace ID, and time range. Returns id, timestamp, severity, service_name, body, trace_id. **Limited to the last 24 hours** — windows entirely outside the 24h cap are rejected. Strongly recommend setting `service` and/or `severity` to scope the search; unscoped keyword queries scan large row counts when FTS5 is disabled. Use severity=ERROR to find errors, query= for full-text search, trace_id= to correlate with a trace. Use page= for pagination.",
-		param("query", "string", "Full-text search in log body."),
+		param("query", "string", "Full-text search in log body. SQLite uses stemmed token-prefix matching and BM25 ranking when FTS5 is enabled; use trace_id for exact trace lookup."),
 		param("severity", "string", "Filter by severity level: ERROR, WARN, INFO, DEBUG."),
 		param("service", "string", "Filter by service name (exact match)."),
 		param("trace_id", "string", "Filter logs belonging to a specific trace ID."),

--- a/internal/queue/dlq.go
+++ b/internal/queue/dlq.go
@@ -54,6 +54,7 @@ type DeadLetterQueue struct {
 	evicted      atomic.Int64
 	evictedBytes atomic.Int64
 	metricsTel   *telemetry.Metrics // nil-safe; enables otelcontext_dlq_evicted_* counters
+	removeFile   func(string) error
 }
 
 // NewDLQ creates a new Dead Letter Queue.
@@ -79,6 +80,7 @@ func NewDLQWithLimits(dir string, interval time.Duration, replayFn func(data []b
 		maxDiskMB:  maxDiskMB,
 		maxRetries: maxRetries,
 		retries:    make(map[string]int),
+		removeFile: os.Remove,
 	}
 
 	dlq.wg.Add(1)
@@ -158,7 +160,9 @@ func (d *DeadLetterQueue) Enqueue(batch any) error {
 	}
 
 	// Enforce limits before writing a new file.
-	d.enforceLimits(int64(len(data)))
+	if err := d.enforceLimits(int64(len(data))); err != nil {
+		return fmt.Errorf("DLQ: cannot enforce limits: %w", err)
+	}
 
 	// batch_<nanos>_*.json — CreateTemp replaces `*` with a unique suffix so
 	// two goroutines in the same nanosecond still get distinct files.
@@ -206,14 +210,23 @@ func (d *DeadLetterQueue) Enqueue(batch any) error {
 
 // enforceLimits removes oldest files to stay within maxFiles and maxDiskMB.
 // Must be called with d.mu held.
-func (d *DeadLetterQueue) enforceLimits(incomingBytes int64) {
+func (d *DeadLetterQueue) enforceLimits(incomingBytes int64) error {
 	if d.maxFiles == 0 && d.maxDiskMB == 0 {
-		return
+		return nil
+	}
+
+	const bytesPerMiB int64 = 1024 * 1024
+	if d.maxDiskMB > math.MaxInt64/bytesPerMiB {
+		return fmt.Errorf("disk limit exceeds supported range")
+	}
+	maxBytes := d.maxDiskMB * bytesPerMiB
+	if maxBytes > 0 && incomingBytes > maxBytes {
+		return fmt.Errorf("incoming envelope is %d bytes, exceeds %d-byte disk limit", incomingBytes, maxBytes)
 	}
 
 	entries, err := os.ReadDir(d.dir)
 	if err != nil {
-		return
+		return fmt.Errorf("read DLQ directory: %w", err)
 	}
 
 	// Collect JSON files sorted by name (timestamp-prefixed → chronological).
@@ -227,13 +240,17 @@ func (d *DeadLetterQueue) enforceLimits(incomingBytes int64) {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
 			continue
 		}
-		if info, err := e.Info(); err == nil {
-			files = append(files, fileInfo{e.Name(), info.Size()})
-			totalBytes += info.Size()
+		info, err := e.Info()
+		if err != nil {
+			return fmt.Errorf("stat DLQ file %s: %w", e.Name(), err)
 		}
+		if info.Size() > math.MaxInt64-totalBytes {
+			return fmt.Errorf("DLQ file sizes exceed supported range")
+		}
+		files = append(files, fileInfo{e.Name(), info.Size()})
+		totalBytes += info.Size()
 	}
 
-	maxBytes := d.maxDiskMB * 1024 * 1024
 	var evictedThisCall int
 	var evictedBytesThisCall int64
 	i := 0
@@ -247,8 +264,10 @@ func (d *DeadLetterQueue) enforceLimits(incomingBytes int64) {
 
 		// Evict oldest file.
 		path := filepath.Join(d.dir, files[i].name)
+		if err := d.removeFile(path); err != nil {
+			return fmt.Errorf("remove DLQ file %s: %w", files[i].name, err)
+		}
 		totalBytes -= files[i].size
-		_ = os.Remove(path)
 		delete(d.retries, files[i].name)
 		slog.Warn("🗑️  DLQ FIFO eviction", "file", files[i].name)
 		d.evicted.Add(1)
@@ -274,6 +293,7 @@ func (d *DeadLetterQueue) enforceLimits(incomingBytes int64) {
 			"max_disk_mb", d.maxDiskMB,
 		)
 	}
+	return nil
 }
 
 // Size returns the number of files currently in the DLQ directory.

--- a/internal/queue/dlq_limits_test.go
+++ b/internal/queue/dlq_limits_test.go
@@ -1,0 +1,210 @@
+package queue
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const testMiB = 1024 * 1024
+
+func TestDLQDiskLimitRejectsOversizedEnvelopeWithoutEviction(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		seedFile bool
+	}{
+		{name: "empty queue"},
+		{name: "nonempty queue", seedFile: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			oldPath := filepath.Join(dir, "batch_1_old.json")
+			oldData := []byte(`{"old":"recoverable"}`)
+			if tc.seedFile {
+				if err := os.WriteFile(oldPath, oldData, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			q, err := NewDLQWithLimits(dir, time.Hour, func([]byte) error { return nil }, 0, 1, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(q.Stop)
+			enqueued := 0
+			q.SetMetrics(func() { enqueued++ }, nil, nil, nil)
+
+			// JSON string encoding adds two quote bytes.
+			oversized := strings.Repeat("x", testMiB-1)
+			if err := q.Enqueue(oversized); err == nil {
+				t.Fatal("Enqueue oversized envelope succeeded")
+			}
+			if got := q.EvictedCount(); got != 0 {
+				t.Fatalf("EvictedCount=%d, want 0", got)
+			}
+			if got := q.EvictedBytesCount(); got != 0 {
+				t.Fatalf("EvictedBytesCount=%d, want 0", got)
+			}
+			if enqueued != 0 {
+				t.Fatalf("enqueue callback count=%d, want 0", enqueued)
+			}
+
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantFiles := 0
+			if tc.seedFile {
+				wantFiles = 1
+			}
+			if len(entries) != wantFiles {
+				t.Fatalf("files=%d, want %d", len(entries), wantFiles)
+			}
+			if tc.seedFile {
+				got, err := os.ReadFile(oldPath)
+				if err != nil {
+					t.Fatalf("read old envelope: %v", err)
+				}
+				if !bytes.Equal(got, oldData) {
+					t.Fatalf("old envelope changed: got %q, want %q", got, oldData)
+				}
+			}
+		})
+	}
+}
+
+func TestDLQDiskLimitAcceptsExactBoundary(t *testing.T) {
+	dir := t.TempDir()
+	q, err := NewDLQWithLimits(dir, time.Hour, func([]byte) error { return nil }, 0, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(q.Stop)
+
+	// JSON string encoding adds two quote bytes.
+	if err := q.Enqueue(strings.Repeat("x", testMiB-2)); err != nil {
+		t.Fatalf("Enqueue exact-boundary envelope: %v", err)
+	}
+	if got := q.DiskBytes(); got != testMiB {
+		t.Fatalf("DiskBytes=%d, want %d", got, testMiB)
+	}
+}
+
+func TestDLQDiskLimitEvictsOldestFile(t *testing.T) {
+	dir := t.TempDir()
+	oldestPath := filepath.Join(dir, "batch_1_oldest.json")
+	newerPath := filepath.Join(dir, "batch_2_newer.json")
+	if err := os.WriteFile(oldestPath, bytes.Repeat([]byte("a"), 700*1024), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newerPath, bytes.Repeat([]byte("b"), 300*1024), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	q, err := NewDLQWithLimits(dir, time.Hour, func([]byte) error { return nil }, 0, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(q.Stop)
+
+	// The incoming JSON string is exactly 100 KiB. Removing the 700 KiB
+	// oldest file leaves the newer 300 KiB file and the incoming envelope.
+	if err := q.Enqueue(strings.Repeat("x", 100*1024-2)); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := os.Stat(oldestPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("oldest file still exists or stat failed: %v", err)
+	}
+	if _, err := os.Stat(newerPath); err != nil {
+		t.Fatalf("newer file was not preserved: %v", err)
+	}
+	if got := q.EvictedCount(); got != 1 {
+		t.Fatalf("EvictedCount=%d, want 1", got)
+	}
+	if got := q.EvictedBytesCount(); got != 700*1024 {
+		t.Fatalf("EvictedBytesCount=%d, want %d", got, 700*1024)
+	}
+	if got := q.DiskBytes(); got != 400*1024 {
+		t.Fatalf("DiskBytes=%d, want %d", got, 400*1024)
+	}
+}
+
+func TestDLQDiskLimitRemovalFailureRefusesIncoming(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "batch_1_old.json")
+	oldData := bytes.Repeat([]byte("a"), 700*1024)
+	if err := os.WriteFile(oldPath, oldData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	q, err := NewDLQWithLimits(dir, time.Hour, func([]byte) error { return nil }, 0, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(q.Stop)
+	removeErr := errors.New("injected remove failure")
+	q.removeFile = func(string) error { return removeErr }
+
+	if err := q.Enqueue(strings.Repeat("x", 400*1024-2)); !errors.Is(err, removeErr) {
+		t.Fatalf("Enqueue error=%v, want removal failure", err)
+	}
+	if got := q.EvictedCount(); got != 0 {
+		t.Fatalf("EvictedCount=%d, want 0", got)
+	}
+	if got := q.EvictedBytesCount(); got != 0 {
+		t.Fatalf("EvictedBytesCount=%d, want 0", got)
+	}
+	got, err := os.ReadFile(oldPath)
+	if err != nil {
+		t.Fatalf("read old envelope: %v", err)
+	}
+	if !bytes.Equal(got, oldData) {
+		t.Fatal("old envelope changed after removal failure")
+	}
+	if entries, err := os.ReadDir(dir); err != nil || len(entries) != 1 {
+		t.Fatalf("files after removal failure=%d, err=%v; want one old file", len(entries), err)
+	}
+}
+
+func TestDLQDiskLimitDirectoryReadFailureRefusesIncoming(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "dlq")
+	q, err := NewDLQWithLimits(dir, time.Hour, func([]byte) error { return nil }, 0, 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(q.Stop)
+	if err := os.Remove(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := q.Enqueue("fits"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Enqueue error=%v, want missing-directory error", err)
+	}
+	if got := q.EvictedCount(); got != 0 {
+		t.Fatalf("EvictedCount=%d, want 0", got)
+	}
+	if _, err := os.Stat(dir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("DLQ directory was recreated or stat failed: %v", err)
+	}
+}
+
+func TestDLQDiskLimitZeroIsUnlimited(t *testing.T) {
+	dir := t.TempDir()
+	q, err := NewDLQWithLimits(dir, time.Hour, func([]byte) error { return nil }, 0, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(q.Stop)
+
+	if err := q.Enqueue(strings.Repeat("x", testMiB)); err != nil {
+		t.Fatalf("Enqueue with unlimited disk: %v", err)
+	}
+	if got := q.DiskBytes(); got != testMiB+2 {
+		t.Fatalf("DiskBytes=%d, want %d", got, testMiB+2)
+	}
+}

--- a/internal/realtime/aggregate_publisher.go
+++ b/internal/realtime/aggregate_publisher.go
@@ -124,7 +124,7 @@ func (p *EnginePublisher) Snapshot(ctx context.Context, service string) *LiveSna
 		snap.CoverageNote = coverage.Note()
 	}
 
-	if dash, err := p.engine.QueryDashboard(q); err == nil {
+	if dash, err := p.engine.QueryDashboard(ctx, q); err == nil {
 		provenance := dash.LatencyProvenance
 		snap.Dashboard = &storage.DashboardStats{
 			// Headline trio on the REQUEST basis, restated by name alongside
@@ -156,7 +156,7 @@ func (p *EnginePublisher) Snapshot(ctx context.Context, service string) *LiveSna
 		slog.Debug("aggregate snapshot: dashboard query failed", "error", err)
 	}
 
-	if traffic, err := p.engine.QueryBuckets(q); err == nil {
+	if traffic, err := p.engine.QueryBuckets(ctx, q); err == nil {
 		points := make([]storage.TrafficPoint, 0, len(traffic.Points))
 		for _, pt := range traffic.Points {
 			points = append(points, trafficPointFromAggregate(pt))

--- a/internal/realtime/aggregate_ws_test.go
+++ b/internal/realtime/aggregate_ws_test.go
@@ -22,6 +22,44 @@ type fakePublisher struct {
 	fail  atomic.Bool
 }
 
+type cancellationPublisher struct{ started chan struct{} }
+
+func (p *cancellationPublisher) Epoch() string    { return "epoch-1" }
+func (p *cancellationPublisher) Revision() uint64 { return 1 }
+func (p *cancellationPublisher) Snapshot(ctx context.Context, _ string) *LiveSnapshot {
+	close(p.started)
+	<-ctx.Done()
+	return nil
+}
+
+func TestRunAggregatePropagatesShutdownContextToSnapshot(t *testing.T) {
+	hub := NewEventHub(nil, nil, nil)
+	pub := &cancellationPublisher{started: make(chan struct{})}
+	hub.SetAggregatePublisher(pub, time.Millisecond)
+	client := &clientFilter{send: make(chan []byte, 1)}
+	client.seeded.Store(true)
+	hub.clients[nil] = client
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		hub.runAggregate(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-pub.started:
+	case <-time.After(time.Second):
+		t.Fatal("aggregate loop did not start a snapshot")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("aggregate loop did not stop its in-flight snapshot")
+	}
+}
+
 func newFakePublisher(epoch string) *fakePublisher {
 	p := &fakePublisher{}
 	p.epoch.Store(epoch)
@@ -139,7 +177,7 @@ func TestAggregateWSSameEpochRevisionNeverDecreases(t *testing.T) {
 	hub.lastEpoch = "epoch-1"
 	hub.lastRev = 7
 
-	hub.publishIfChanged()
+	hub.publishIfChanged(context.Background())
 
 	if hub.lastRev != 7 {
 		t.Fatalf("published revision regressed to %d", hub.lastRev)
@@ -157,17 +195,17 @@ func TestAggregateWSPublishesOnlyOnRevisionChange(t *testing.T) {
 	hub.SetAggregatePublisher(pub, time.Hour)
 
 	pub.rev.Store(3)
-	hub.publishIfChanged()
+	hub.publishIfChanged(context.Background())
 	first := pub.calls.Load()
 
-	hub.publishIfChanged()
-	hub.publishIfChanged()
+	hub.publishIfChanged(context.Background())
+	hub.publishIfChanged(context.Background())
 	if got := pub.calls.Load(); got != first {
 		t.Fatalf("snapshot built %d times for an unchanged revision, want %d", got, first)
 	}
 
 	pub.rev.Store(4)
-	hub.publishIfChanged()
+	hub.publishIfChanged(context.Background())
 	if hub.lastRev != 4 {
 		t.Fatalf("lastRev = %d after a change, want 4", hub.lastRev)
 	}
@@ -186,7 +224,7 @@ func TestAggregateWSProviderErrorRetainsLastGoodIdentity(t *testing.T) {
 	client.seeded.Store(true)
 	hub.clients[nil] = client
 
-	hub.publishIfChanged()
+	hub.publishIfChanged(context.Background())
 	if hub.lastRev != 1 {
 		t.Fatalf("provider error advanced last good revision to %d", hub.lastRev)
 	}
@@ -202,7 +240,7 @@ func TestAggregateWSReconnectRetriesObservedRevisionAfterProviderRecovery(t *tes
 	pub.fail.Store(true)
 	hub.SetAggregatePublisher(pub, 20*time.Millisecond)
 	// Observe the revision while idle, without rendering it.
-	hub.publishIfChanged()
+	hub.publishIfChanged(context.Background())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go hub.Start(ctx, time.Hour, time.Hour)
@@ -352,9 +390,9 @@ func TestAggregateWSConnectSeedIsNotRepublished(t *testing.T) {
 
 	// A tick at the seeded revision publishes nothing; the next revision is
 	// therefore the very next message on the wire.
-	f.hub.publishIfChanged()
+	f.hub.publishIfChanged(context.Background())
 	f.pub.rev.Store(seed.Revision + 1)
-	f.hub.publishIfChanged()
+	f.hub.publishIfChanged(context.Background())
 	next := f.read(t, 2*time.Second)
 	if next.Revision != seed.Revision+1 || next.Reset {
 		t.Fatalf("next snapshot = rev %d reset %v, want rev %d reset false (a duplicate seed revision would arrive first)", next.Revision, next.Reset, seed.Revision+1)

--- a/internal/realtime/events_ws.go
+++ b/internal/realtime/events_ws.go
@@ -249,7 +249,7 @@ func (h *EventHub) Start(ctx context.Context, snapshotInterval, batchInterval ti
 			slog.Info("🌐 EventHub stopping via signal...")
 			return
 		case <-snapshotTicker.C:
-			h.flushSnapshots()
+			h.flushSnapshots(ctx)
 		case <-batchTicker.C:
 			h.flushBatches()
 		case entry := <-h.logsCh:
@@ -382,7 +382,7 @@ func (h *EventHub) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// Send immediate FULL snapshot so the client has data right away. In
 	// aggregate mode it carries {epoch, revision} and reset=true: a fresh
 	// client has nothing to merge into and must adopt the snapshot whole.
-	if !h.sendSnapshotTo(cf) && h.aggregatePublisher() != nil {
+	if !h.sendSnapshotTo(r.Context(), cf) && h.aggregatePublisher() != nil {
 		// A failed reconnect seed must remain retryable even when the revision
 		// was observed earlier while no clients were connected.
 		h.mu.Lock()
@@ -466,7 +466,7 @@ func (h *EventHub) updateClientFilter(c *websocket.Conn, service string) {
 // matching clients. A scope is (tenant, service filter): two clients on
 // different tenants never share a computed snapshot, so a snapshot cannot
 // carry another tenant's rows.
-func (h *EventHub) flushSnapshots() {
+func (h *EventHub) flushSnapshots(ctx context.Context) {
 	h.mu.Lock()
 	if !h.pending {
 		h.mu.Unlock()
@@ -482,13 +482,13 @@ func (h *EventHub) flushSnapshots() {
 	h.mu.Unlock()
 
 	// Compute snapshots in parallel using errgroup
-	g, _ := errgroup.WithContext(context.Background())
+	g, groupCtx := errgroup.WithContext(ctx)
 	snapshotMap := make(map[scopeKey]*LiveSnapshot)
 	var snapMu sync.Mutex
 
 	for scope := range groups {
 		g.Go(func() error {
-			snap := h.snapshotFor(scope)
+			snap := h.snapshotFor(groupCtx, scope)
 			if snap != nil {
 				snapMu.Lock()
 				snapshotMap[scope] = snap
@@ -589,8 +589,8 @@ func (h *EventHub) sendBatch(cf *clientFilter, batchType string, data any) {
 
 // sendSnapshotTo sends a snapshot to a single client and reports whether a
 // full replacement was queued.
-func (h *EventHub) sendSnapshotTo(cf *clientFilter) bool {
-	snapshot := h.snapshotFor(scopeKey{tenant: cf.tenant, service: cf.service})
+func (h *EventHub) sendSnapshotTo(ctx context.Context, cf *clientFilter) bool {
+	snapshot := h.snapshotFor(ctx, scopeKey{tenant: cf.tenant, service: cf.service})
 	if snapshot == nil {
 		return false
 	}
@@ -619,8 +619,7 @@ func (h *EventHub) sendSnapshotTo(cf *clientFilter) bool {
 // snapshotFor produces the payload for one scope from whichever source owns
 // the numbers in this mode. The tenant travels on the context, which is what
 // scopes both the repository queries and the aggregate publisher.
-func (h *EventHub) snapshotFor(scope scopeKey) *LiveSnapshot {
-	ctx := context.Background()
+func (h *EventHub) snapshotFor(ctx context.Context, scope scopeKey) *LiveSnapshot {
 	if scope.tenant != "" {
 		ctx = storage.WithTenantContext(ctx, scope.tenant)
 	}
@@ -654,7 +653,7 @@ func (h *EventHub) runAggregate(ctx context.Context) {
 			slog.Info("🌐 EventHub stopping via signal...")
 			return
 		case <-tick.C:
-			h.publishIfChanged()
+			h.publishIfChanged(ctx)
 		}
 	}
 }
@@ -663,7 +662,7 @@ func (h *EventHub) runAggregate(ctx context.Context) {
 // the engine's {epoch, revision} identity has moved since the last
 // publication. It is exported behaviour only through the loop; tests drive it
 // directly so the 2 s floor does not become a 2 s test.
-func (h *EventHub) publishIfChanged() {
+func (h *EventHub) publishIfChanged(ctx context.Context) {
 	pub := h.aggregatePublisher()
 	if pub == nil {
 		return
@@ -691,7 +690,7 @@ func (h *EventHub) publishIfChanged() {
 
 	messages := make(map[scopeKey][]byte, len(groups))
 	for scope := range groups {
-		snap := h.snapshotFor(scope)
+		snap := h.snapshotFor(ctx, scope)
 		if snap == nil {
 			// A provider error is not an empty topology. Keep the last good
 			// identity so the same revision is retried on the next tick.

--- a/internal/realtime/hosts_test.go
+++ b/internal/realtime/hosts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,6 +12,21 @@ import (
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 	"github.com/RandomCodeSpace/otelcontext/internal/topology"
 )
+
+type realtimeReadContextStore struct {
+	aggregate.Store
+	calls atomic.Int32
+}
+
+func (s *realtimeReadContextStore) SumBuckets(context.Context, aggregate.Selector, aggregate.GroupBy) ([]aggregate.SumRow, error) {
+	s.calls.Add(1)
+	return nil, nil
+}
+
+func (s *realtimeReadContextStore) VisitSketches(context.Context, aggregate.Selector, func(uint32, *aggregate.Sketch) error) error {
+	s.calls.Add(1)
+	return nil
+}
 
 // hostsProvider is a provider whose host projection a test fixes by hand.
 type hostsProvider struct {
@@ -101,5 +117,30 @@ func TestAggregateSnapshotCarriesProviderHosts(t *testing.T) {
 	}
 	if n := snap.ServiceMap.Nodes[0]; n.Kind != "service" || fmt.Sprint(n.Hosts) != "[node-a node-b]" {
 		t.Fatalf("service node = %+v", n)
+	}
+}
+
+func TestEnginePublisherPropagatesSnapshotCancellation(t *testing.T) {
+	engine, err := aggregate.NewEngine(aggregate.EngineConfig{Mode: aggregate.ModeAggregate})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	store := &realtimeReadContextStore{}
+	engine.SetStore(store)
+	provider := &hostsProvider{source: topology.SourceAggregate}
+	pub := NewEnginePublisher(EnginePublisherConfig{Engine: engine, Topology: provider})
+	if pub == nil {
+		t.Fatal("publisher refused an aggregate provider")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	hub := NewEventHub(nil, nil, nil)
+	hub.SetAggregatePublisher(pub, time.Second)
+	if snap := hub.snapshotFor(ctx, scopeKey{}); snap == nil {
+		t.Fatal("Snapshot returned nil after the topology provider completed")
+	}
+	if got := store.calls.Load(); got != 0 {
+		t.Fatalf("store calls = %d, want 0", got)
 	}
 }

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -2,14 +2,17 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/config"
 	"github.com/glebarez/sqlite"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
@@ -25,6 +28,7 @@ import (
 // Applies per-driver optimizations (WAL for SQLite, connection pooling for others).
 func NewDatabase(driver, dsn string) (*gorm.DB, error) {
 	var dialector gorm.Dialector
+	var sqliteDB *sql.DB
 
 	switch strings.ToLower(driver) {
 	case "postgres", "postgresql":
@@ -62,7 +66,16 @@ func NewDatabase(driver, dsn string) (*gorm.DB, error) {
 			driver = "sqlite"
 			log.Println("DB_DRIVER not set, defaulting to sqlite (OtelContext.db)")
 		}
-		dialector = sqlite.Open(dsn)
+		cacheKB, mmapBytes := sqliteMemorySizes()
+		dsn, err := sqliteTunedDSN(dsn, cacheKB, mmapBytes)
+		if err != nil {
+			return nil, fmt.Errorf("sqlite DSN: %w", err)
+		}
+		sqliteDB, err = sql.Open(sqlite.DriverName, dsn)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open sqlite database: %w", err)
+		}
+		dialector = &sqlite.Dialector{DSN: dsn, Conn: sqliteDB}
 
 	default:
 		return nil, fmt.Errorf("unsupported database driver: %s", driver)
@@ -91,17 +104,18 @@ func NewDatabase(driver, dsn string) (*gorm.DB, error) {
 		DisableForeignKeyConstraintWhenMigrating: true,
 	})
 	if err != nil {
+		if sqliteDB != nil {
+			_ = sqliteDB.Close()
+		}
 		// Never surface the DSN in error wraps — pgx occasionally embeds connection
 		// string fragments (user:password@host) in its errors. Sanitize before returning.
 		return nil, fmt.Errorf("failed to connect to database (%s): %s", driver, scrubDSN(err.Error()))
 	}
 
-	// SQLite pragmas — set via Exec because glebarez/sqlite doesn't honour
-	// _pragma DSN params. Applied fail-closed: any PRAGMA failure aborts
-	// startup with a wrapped error so an unexpected SQLite build that doesn't
-	// support, e.g. mmap_size cannot silently regress the platform to
-	// default-tuned behaviour. The set was hardened on 2026-05-24 to make
-	// the platform survivable at 120 services on SQLite.
+	// The SQLite driver applies the PRAGMA parameters in sqliteTunedDSN to every
+	// physical connection and rejects a connection if initialization fails.
+	// The set was hardened on 2026-05-24 to make the platform survivable at 120
+	// services on SQLite.
 	//
 	// cache_size is fixed to the memory objective and mmap is opt-in — see
 	// sqliteMemorySizes for the rationale and the override rules.
@@ -109,31 +123,6 @@ func NewDatabase(driver, dsn string) (*gorm.DB, error) {
 	// journal_size_limit=67108864 = hard-cap the WAL file at 64 MB.
 	if strings.ToLower(driver) == "sqlite" || driver == "" {
 		cacheKB, mmapBytes := sqliteMemorySizes()
-		// Best-effort, deliberately NOT fail-closed, and ordered BEFORE the
-		// stanza below: auto_vacuum only takes effect on databases this
-		// process creates, and the journal_mode=WAL switch initializes the
-		// file header — after which the stored auto_vacuum mode is frozen
-		// (pre-existing files keep theirs either way). INCREMENTAL lets the
-		// retention scheduler reclaim pages via PRAGMA incremental_vacuum
-		// instead of a full daily VACUUM.
-		if err := db.Exec("PRAGMA auto_vacuum=INCREMENTAL").Error; err != nil {
-			log.Printf("⚠️  PRAGMA auto_vacuum=INCREMENTAL failed (best-effort, continuing): %v", err)
-		}
-		pragmas := []string{
-			"PRAGMA journal_mode=WAL",
-			"PRAGMA synchronous=NORMAL",
-			fmt.Sprintf("PRAGMA cache_size=-%d", cacheKB),
-			"PRAGMA temp_store=MEMORY",
-			fmt.Sprintf("PRAGMA mmap_size=%d", mmapBytes),
-			"PRAGMA wal_autocheckpoint=10000",
-			"PRAGMA journal_size_limit=67108864",
-			"PRAGMA busy_timeout=5000",
-		}
-		for _, p := range pragmas {
-			if err := db.Exec(p).Error; err != nil {
-				return nil, fmt.Errorf("sqlite pragma %q failed: %w", p, err)
-			}
-		}
 		log.Printf("📊 SQLite memory tuning: cache=%d KB, mmap=%d MB", cacheKB, mmapBytes/(1<<20))
 	}
 
@@ -179,6 +168,51 @@ func NewDatabase(driver, dsn string) (*gorm.DB, error) {
 	}
 
 	return db, nil
+}
+
+var sqliteManagedPragmas = map[string]struct{}{
+	"auto_vacuum":        {},
+	"busy_timeout":       {},
+	"cache_size":         {},
+	"journal_mode":       {},
+	"journal_size_limit": {},
+	"mmap_size":          {},
+	"synchronous":        {},
+	"temp_store":         {},
+	"wal_autocheckpoint": {},
+}
+
+func sqliteTunedDSN(dsn string, cacheKB, mmapBytes int64) (string, error) {
+	path, rawQuery, _ := strings.Cut(dsn, "?")
+	q, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return "", err
+	}
+
+	kept := q["_pragma"][:0]
+	for _, pragma := range q["_pragma"] {
+		name := strings.TrimSpace(pragma)
+		if end := strings.IndexAny(name, " (=\t"); end >= 0 {
+			name = name[:end]
+		}
+		if _, managed := sqliteManagedPragmas[strings.ToLower(name)]; !managed {
+			kept = append(kept, pragma)
+		}
+	}
+
+	q["_pragma"] = append([]string{
+		"auto_vacuum(INCREMENTAL)",
+		"journal_mode(WAL)",
+		"synchronous(NORMAL)",
+		fmt.Sprintf("cache_size(-%d)", cacheKB),
+		"temp_store(MEMORY)",
+		fmt.Sprintf("mmap_size(%d)", mmapBytes),
+		"wal_autocheckpoint(10000)",
+		"journal_size_limit(67108864)",
+		"busy_timeout(5000)",
+	}, kept...)
+
+	return path + "?" + q.Encode(), nil
 }
 
 func getEnvPoolInt(key string, fallback int) int {
@@ -389,12 +423,12 @@ func AutoMigrateModelsWithOptions(db *gorm.DB, driver string, opts MigrateOption
 	// Search routes through bm25() ranking on this driver; LIKE remains the fallback
 	// if FTS5 is unavailable (older SQLite builds without FTS5 compiled in).
 	//
-	// Gated on LOG_FTS_ENABLED (default false) — FTS5's inverted index typically
+	// Gated on LOG_FTS_ENABLED (default true) — FTS5's inverted index typically
 	// consumes 30-40% of SQLite DB disk for log-heavy workloads. When disabled,
 	// search_logs falls back transparently to LIKE via the existing branch in
 	// log_repo.go:105.
 	if driver == "sqlite" || driver == "" {
-		if logFTSEnabledFromEnv() {
+		if config.LogFTSEnabledFromEnv() {
 			if err := setupSQLiteFTS5(db); err != nil {
 				log.Printf("⚠️  SQLite FTS5 setup failed (%v) — log search will fall back to LIKE", err)
 			}

--- a/internal/storage/factory_test.go
+++ b/internal/storage/factory_test.go
@@ -1,10 +1,15 @@
 package storage
 
 import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 )
 
@@ -200,6 +205,131 @@ func TestNewDatabase_SQLiteAutoVacuumIncremental(t *testing.T) {
 
 	if got := pragmaInt64(t, db, "auto_vacuum"); got != 2 {
 		t.Fatalf("auto_vacuum=%d want 2 (INCREMENTAL) on a fresh database", got)
+	}
+}
+
+func TestNewDatabase_SQLitePragmasSurviveConnectionReplacement(t *testing.T) {
+	tests := []struct {
+		name      string
+		cacheKB   string
+		mmapBytes string
+		wantCache int64
+		wantMmap  int64
+	}{
+		{name: "defaults", wantCache: -65536},
+		{name: "overrides", cacheKB: "12345", mmapBytes: "33554432", wantCache: -12345, wantMmap: 33554432},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SQLITE_CACHE_SIZE_KB", tt.cacheKB)
+			t.Setenv("SQLITE_MMAP_SIZE_BYTES", tt.mmapBytes)
+
+			db, err := NewDatabase("sqlite", filepath.Join(t.TempDir(), "replacement.db"))
+			if err != nil {
+				t.Fatalf("sqlite: %v", err)
+			}
+			defer closeDB(db)
+			sqlDB, err := db.DB()
+			if err != nil {
+				t.Fatalf("database handle: %v", err)
+			}
+
+			assertSQLiteConnectionPragmas(t, sqlDB, tt.wantCache, tt.wantMmap)
+			conn, err := sqlDB.Conn(context.Background())
+			if err != nil {
+				t.Fatalf("acquire initial connection: %v", err)
+			}
+			if err := conn.Raw(func(any) error { return driver.ErrBadConn }); err != driver.ErrBadConn {
+				t.Fatalf("retire initial connection: %v", err)
+			}
+			_ = conn.Close()
+			assertSQLiteConnectionPragmas(t, sqlDB, tt.wantCache, tt.wantMmap)
+		})
+	}
+}
+
+func assertSQLiteConnectionPragmas(t *testing.T, db *sql.DB, wantCache, wantMmap int64) {
+	t.Helper()
+	for pragma, want := range map[string]int64{
+		"cache_size": wantCache, "mmap_size": wantMmap, "synchronous": 1,
+		"temp_store": 2, "wal_autocheckpoint": 10000,
+		"journal_size_limit": 67108864, "busy_timeout": 5000,
+	} {
+		var got int64
+		if err := db.QueryRow("PRAGMA " + pragma).Scan(&got); err != nil || got != want {
+			t.Fatalf("PRAGMA %s=%d err=%v want %d", pragma, got, err, want)
+		}
+	}
+	var mode string
+	if err := db.QueryRow("PRAGMA journal_mode").Scan(&mode); err != nil || !strings.EqualFold(mode, "wal") {
+		t.Fatalf("journal_mode=%q err=%v want wal", mode, err)
+	}
+}
+
+func TestSQLiteTunedDSN_PreservesSupportedFormsAndParameters(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "escaped # name.db")
+	tests := []string{
+		base,
+		(&url.URL{Scheme: "file", Path: base, RawQuery: "mode=rwc&cache=shared&custom=value"}).String(),
+		":memory:",
+		"file::memory:?cache=shared",
+		"file:named-memory?mode=memory&cache=shared",
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			dsn, err := sqliteTunedDSN(input, 12345, 0)
+			if err != nil {
+				t.Fatalf("sqliteTunedDSN: %v", err)
+			}
+			if strings.Contains(input, "custom=value") && !strings.Contains(dsn, "custom=value") {
+				t.Fatalf("existing parameter lost: %q", dsn)
+			}
+			db, err := sql.Open(sqlite.DriverName, dsn)
+			if err != nil {
+				t.Fatalf("open %q: %v", dsn, err)
+			}
+			defer db.Close()
+			if err := db.Ping(); err != nil {
+				t.Fatalf("ping %q: %v", dsn, err)
+			}
+		})
+	}
+}
+
+func TestSQLiteTunedDSN_ReplacesOnlyManagedPragmas(t *testing.T) {
+	dsn, err := sqliteTunedDSN("test.db?custom=value&_pragma=foreign_keys(ON)&_pragma=cache_size(-1)", 12345, 0)
+	if err != nil {
+		t.Fatalf("sqliteTunedDSN: %v", err)
+	}
+	_, rawQuery, _ := strings.Cut(dsn, "?")
+	q, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		t.Fatalf("parse tuned query: %v", err)
+	}
+	if q.Get("custom") != "value" {
+		t.Fatalf("custom parameter lost: %q", dsn)
+	}
+	var foreignKeys, cacheSizes []string
+	for _, pragma := range q["_pragma"] {
+		switch {
+		case strings.HasPrefix(pragma, "foreign_keys"):
+			foreignKeys = append(foreignKeys, pragma)
+		case strings.HasPrefix(pragma, "cache_size"):
+			cacheSizes = append(cacheSizes, pragma)
+		}
+	}
+	if len(foreignKeys) != 1 || foreignKeys[0] != "foreign_keys(ON)" {
+		t.Fatalf("unmanaged PRAGMA changed: %v", foreignKeys)
+	}
+	if len(cacheSizes) != 1 || cacheSizes[0] != "cache_size(-12345)" {
+		t.Fatalf("managed PRAGMA conflict remains: %v", cacheSizes)
+	}
+}
+
+func TestNewDatabase_SQLiteInvalidInitializationFails(t *testing.T) {
+	_, err := NewDatabase("sqlite", filepath.Join(t.TempDir(), "invalid.db")+"?_pragma=definitely_not_a_pragma(")
+	if err == nil {
+		t.Fatal("invalid required connection initialization must fail")
 	}
 }
 

--- a/internal/storage/fts5.go
+++ b/internal/storage/fts5.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
-	"os"
-	"strconv"
 	"strings"
 
+	"github.com/RandomCodeSpace/otelcontext/internal/config"
 	"gorm.io/gorm"
 )
 
@@ -118,32 +117,14 @@ func fts5MatchExpr(input string) string {
 // fts5Available reports whether the given driver should use the FTS5 path.
 // FTS5 is only enabled when (a) the driver is SQLite (Postgres has its own
 // pg_trgm GIN path; MySQL/SQL Server are out of scope) and (b) LOG_FTS_ENABLED
-// is truthy. Default off — FTS5's inverted index typically consumes 30-40% of
+// is enabled. Default on; FTS5's inverted index typically consumes 30-40% of
 // SQLite DB disk for log-heavy workloads, and the LIKE fallback at
 // log_repo.go:105 keeps search_logs functional without it.
 func fts5Available(driver string) bool {
 	if !strings.EqualFold(driver, "sqlite") {
 		return false
 	}
-	return logFTSEnabledFromEnv()
-}
-
-// logFTSEnabledFromEnv reads LOG_FTS_ENABLED and reports whether the FTS5
-// virtual table + triggers should be installed and queried. Defaults to
-// false; opt in with LOG_FTS_ENABLED=true (also accepts yes/on/1).
-func logFTSEnabledFromEnv() bool {
-	v, ok := os.LookupEnv("LOG_FTS_ENABLED")
-	if !ok {
-		return false
-	}
-	if b, err := strconv.ParseBool(strings.TrimSpace(v)); err == nil {
-		return b
-	}
-	switch strings.ToLower(strings.TrimSpace(v)) {
-	case "yes", "y", "on":
-		return true
-	}
-	return false
+	return config.LogFTSEnabledFromEnv()
 }
 
 // DropLogsFTS removes the FTS5 virtual table and its sync triggers, then runs

--- a/internal/storage/fts5_test.go
+++ b/internal/storage/fts5_test.go
@@ -72,13 +72,15 @@ func TestFTS5Available_FlagGate(t *testing.T) {
 		flag string
 		want bool
 	}{
-		{"", false},      // empty value present = unparsable = false
+		{"", false}, // empty value present = unparsable = false
+		{"invalid", false},
 		{"false", false}, // explicit off
 		{"0", false},
 		{"no", false},
 		{"true", true},
 		{"1", true},
 		{"yes", true},
+		{"y", true},
 		{"on", true},
 		{"YES", true},
 		{"TRUE", true},
@@ -93,11 +95,11 @@ func TestFTS5Available_FlagGate(t *testing.T) {
 	}
 }
 
-// TestFTS5Available_DefaultOff verifies the absence of LOG_FTS_ENABLED yields
-// false. Uses os.Unsetenv directly because t.Setenv only sets values, never
+// TestFTS5Available_DefaultOn verifies the absence of LOG_FTS_ENABLED yields
+// true. Uses os.Unsetenv directly because t.Setenv only sets values, never
 // unsets — and the test's whole point is to assert behavior when the env var
 // is unset.
-func TestFTS5Available_DefaultOff(t *testing.T) {
+func TestFTS5Available_DefaultOn(t *testing.T) {
 	prev, hadPrev := os.LookupEnv("LOG_FTS_ENABLED")
 	if err := os.Unsetenv("LOG_FTS_ENABLED"); err != nil {
 		t.Fatalf("unsetenv: %v", err)
@@ -109,8 +111,8 @@ func TestFTS5Available_DefaultOff(t *testing.T) {
 			_ = os.Unsetenv("LOG_FTS_ENABLED")
 		}
 	})
-	if fts5Available("sqlite") {
-		t.Fatal("FTS5 must default off when LOG_FTS_ENABLED is unset")
+	if !fts5Available("sqlite") {
+		t.Fatal("FTS5 must default on when LOG_FTS_ENABLED is unset")
 	}
 }
 

--- a/internal/storage/log_repo.go
+++ b/internal/storage/log_repo.go
@@ -130,7 +130,7 @@ func (r *Repository) GetLogsV2(ctx context.Context, filter LogFilter) ([]Log, in
 // applied here — the two callers handle it differently (FTS5 MATCH vs LIKE).
 func applyLogFilterCriteria(base *gorm.DB, filter LogFilter) *gorm.DB {
 	if filter.ServiceName != "" {
-		base = base.Where("service_name = ?", filter.ServiceName)
+		base = base.Where("logs.service_name = ?", filter.ServiceName)
 	}
 	if filter.Severity != "" {
 		base = base.Where(sqlWhereSeverity, filter.Severity)

--- a/internal/storage/testhelpers_test.go
+++ b/internal/storage/testhelpers_test.go
@@ -11,8 +11,8 @@ import (
 // newTestRepo builds a Repository backed by an in-memory SQLite DB with all models migrated.
 // Tests live in the same package so they can poke unexported fields.
 //
-// FTS5 is force-enabled here so the existing FTS5 + BM25 + trigger tests
-// keep working after LOG_FTS_ENABLED defaulted to false in production.
+// FTS5 is explicitly enabled here so tests are isolated from the host
+// environment even though LOG_FTS_ENABLED defaults to true.
 // t.Setenv applies for the lifetime of the test that called this helper.
 func newTestRepo(t *testing.T) *Repository {
 	t.Helper()

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -112,13 +112,14 @@ type Metrics struct {
 	// GraphRAGStoreEntities — live node counts per entity kind across tenants
 	// (tenants|services|operations|traces|spans|log_clusters|metrics|anomalies).
 	// GraphRAGStoreEdges — live edge counts per store (service|trace|signal|anomaly).
-	// Together with the ring/drain gauges these attribute RSS growth to a
+	// Together with the Drain gauge these attribute RSS growth to a
 	// specific structure before a heap profile is needed.
 	GraphRAGStoreEntities *prometheus.GaugeVec
 	GraphRAGStoreEdges    *prometheus.GaugeVec
+	// TSDBRingSeriesActive and TSDBRingSeriesRejected remain registered for
+	// metric-name compatibility. Production does not instantiate the legacy
+	// ring, so both collectors remain zero.
 	TSDBRingSeriesActive  prometheus.Gauge
-	// TSDBRingSeriesRejected — points refused a NEW ring series at the
-	// tenant-scoped series cap (existing series keep recording).
 	TSDBRingSeriesRejected prometheus.Counter
 	DrainTemplatesActive   prometheus.Gauge
 
@@ -582,11 +583,11 @@ func New() *Metrics {
 		}, []string{"store"}),
 		TSDBRingSeriesActive: promauto.NewGauge(prometheus.GaugeOpts{
 			Name: "otelcontext_tsdb_ring_series_active",
-			Help: "Distinct metric series currently held in TSDB ring buffers.",
+			Help: "Legacy compatibility metric; always zero because the unused TSDB ring buffer is disabled.",
 		}),
 		TSDBRingSeriesRejected: promauto.NewCounter(prometheus.CounterOpts{
 			Name: "otelcontext_tsdb_ring_series_rejected_total",
-			Help: "Metric points refused a new TSDB ring series at the cardinality cap (existing series keep recording).",
+			Help: "Legacy compatibility metric; always zero because the unused TSDB ring buffer is disabled.",
 		}),
 		DrainTemplatesActive: promauto.NewGauge(prometheus.GaugeOpts{
 			Name: "otelcontext_drain_templates_active",

--- a/internal/telemetry/metrics_pool_test.go
+++ b/internal/telemetry/metrics_pool_test.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"database/sql"
+	"strings"
 	"testing"
 	"time"
 
@@ -86,6 +87,33 @@ func TestSampleDBPoolStats(t *testing.T) {
 		// telemetry.Metrics through to the OTLP servers.
 		var m2 *Metrics
 		m2.ObserveIngestDuration("traces", time.Millisecond)
+	})
+
+	t.Run("DisabledRingMetricsRemainCompatibleAndZero", func(t *testing.T) {
+		activeDesc := m.TSDBRingSeriesActive.Desc().String()
+		if !strings.Contains(activeDesc, `fqName: "otelcontext_tsdb_ring_series_active"`) ||
+			!strings.Contains(activeDesc, "always zero") {
+			t.Fatalf("active ring metric descriptor = %s", activeDesc)
+		}
+		rejectedDesc := m.TSDBRingSeriesRejected.Desc().String()
+		if !strings.Contains(rejectedDesc, `fqName: "otelcontext_tsdb_ring_series_rejected_total"`) ||
+			!strings.Contains(rejectedDesc, "always zero") {
+			t.Fatalf("rejected ring metric descriptor = %s", rejectedDesc)
+		}
+
+		var active, rejected dto.Metric
+		if err := m.TSDBRingSeriesActive.Write(&active); err != nil {
+			t.Fatalf("active ring gauge write: %v", err)
+		}
+		if err := m.TSDBRingSeriesRejected.Write(&rejected); err != nil {
+			t.Fatalf("rejected ring counter write: %v", err)
+		}
+		if got := active.GetGauge().GetValue(); got != 0 {
+			t.Fatalf("active ring series = %v, want 0", got)
+		}
+		if got := rejected.GetCounter().GetValue(); got != 0 {
+			t.Fatalf("rejected ring series = %v, want 0", got)
+		}
 	})
 }
 

--- a/internal/topology/aggregate.go
+++ b/internal/topology/aggregate.go
@@ -60,7 +60,7 @@ func (p *AggregateProvider) snapshot(ctx context.Context, q Query) (Snapshot, er
 	}
 	meta.Start, meta.End = q.Start, q.End
 
-	result, err := p.engine.QueryTopology(aggregate.Query{
+	result, err := p.engine.QueryTopology(ctx, aggregate.Query{
 		Tenant:   tenant,
 		Start:    q.Start,
 		End:      q.End,

--- a/internal/topology/provider_test.go
+++ b/internal/topology/provider_test.go
@@ -2,6 +2,8 @@ package topology
 
 import (
 	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -9,6 +11,42 @@ import (
 	"github.com/RandomCodeSpace/otelcontext/internal/latency"
 	"github.com/RandomCodeSpace/otelcontext/internal/storage"
 )
+
+type topologyReadContextStore struct {
+	aggregate.Store
+	calls atomic.Int32
+}
+
+func (s *topologyReadContextStore) SumBuckets(ctx context.Context, _ aggregate.Selector, _ aggregate.GroupBy) ([]aggregate.SumRow, error) {
+	s.calls.Add(1)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return nil, errors.New("aggregate topology read lost caller context")
+}
+
+func TestAggregateProviderPropagatesCallerCancellation(t *testing.T) {
+	engine, err := aggregate.NewEngine(aggregate.EngineConfig{Mode: aggregate.ModeAggregate})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	store := &topologyReadContextStore{}
+	engine.SetStore(store)
+	provider, err := NewAggregateProvider(engine)
+	if err != nil {
+		t.Fatalf("NewAggregateProvider: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(storage.WithTenantContext(context.Background(), "default"))
+	cancel()
+	_, err = provider.Snapshot(ctx, Query{Start: time.Now().Add(-time.Hour), End: time.Now()})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Snapshot error = %v, want context.Canceled", err)
+	}
+	if got := store.calls.Load(); got != 0 {
+		t.Fatalf("store calls = %d, want 0", got)
+	}
+}
 
 type fakeLegacyRepository struct {
 	result *storage.ServiceMapMetrics

--- a/legacy_metric_path_test.go
+++ b/legacy_metric_path_test.go
@@ -7,10 +7,9 @@ import (
 )
 
 // TestLegacyMetricPathByMode pins the wiring decision behind #194 finding 10:
-// aggregate mode constructs no TSDB aggregator, no ring buffer and no metric
-// callback, while legacy and shadow keep all three. Shadow especially — it runs
-// both paths side by side, and dropping the legacy one would leave nothing to
-// shadow.
+// aggregate mode constructs no TSDB aggregator or metric callback, while legacy
+// and shadow keep both. Shadow especially — it runs both paths side by side,
+// and dropping the legacy one would leave nothing to shadow.
 func TestLegacyMetricPathByMode(t *testing.T) {
 	for _, tc := range []struct {
 		mode string

--- a/main.go
+++ b/main.go
@@ -385,19 +385,16 @@ func main() {
 	// needs the publisher wired before the first tick.
 	ctxEvents, cancelEvents := context.WithCancel(context.Background())
 
-	// 4c. Initialize TSDB Aggregator + Ring Buffer.
+	// 4c. Initialize the legacy TSDB aggregator.
 	//
 	// Retired outright in AGGREGATE_MODE=aggregate (#194 finding 10). There the
-	// aggregate engine owns every metric read, so the ring buffer, the 30s
-	// flush into metric_buckets, the per-point RawMetric allocation and the
-	// metric callback are all pure waste on the hot path. Legacy keeps the path
-	// because it IS the metric store; shadow keeps it because shadow's whole
-	// job is running both paths side by side.
+	// aggregate engine owns every metric read, so the 30s flush into
+	// metric_buckets, the per-point RawMetric allocation and the metric callback
+	// are all pure waste on the hot path. Legacy keeps the path because it IS the
+	// metric store; shadow keeps it because shadow's whole job is running both
+	// paths side by side.
 	legacyTSDB := legacyMetricPath(cfg.AggregateMode)
-	var (
-		tsdbAgg *tsdb.Aggregator
-		ringBuf *tsdb.RingBuffer
-	)
+	var tsdbAgg *tsdb.Aggregator
 	ctxTSDB, cancelTSDB := context.WithCancel(context.Background())
 	if legacyTSDB {
 		tsdbAgg = tsdb.NewAggregator(repo, 30*time.Second)
@@ -419,9 +416,9 @@ func main() {
 			func() { metrics.TSDBIngestTotal.Inc() },
 			func() { metrics.TSDBBatchesDropped.Inc() },
 		)
-		ringBuf = tsdb.NewRingBuffer(120, 30*time.Second, cfg.MetricMaxCardinality, metrics.TSDBRingSeriesRejected.Inc)
-		tsdbAgg.SetRingBuffer(ringBuf)
-		slog.Info("📈 TSDB ring buffer attached (120 slots × 30s = 1h retention)")
+		slog.Info("📈 TSDB ring buffer disabled",
+			"note", "no runtime query consumes the legacy ring; compatibility metrics remain zero",
+		)
 
 		go tsdbAgg.Start(ctxTSDB)
 		slog.Info("📈 TSDB Aggregator started (30s window)")
@@ -490,7 +487,7 @@ func main() {
 	if idle, err := time.ParseDuration(cfg.GraphRAGTenantIdleTTL); err == nil && idle > 0 {
 		graphRAGCfg.TenantIdleTTL = idle
 	}
-	graphRAG := graphrag.New(repo, tsdbAgg, ringBuf, graphRAGCfg)
+	graphRAG := graphrag.New(repo, tsdbAgg, nil, graphRAGCfg)
 	graphRAG.SetMetrics(metrics)
 	ctxGraphRAG, cancelGraphRAG := context.WithCancel(context.Background())
 
@@ -1169,7 +1166,7 @@ func main() {
 		),
 	}
 	// OTLP gRPC authentication. Installed only when a credential source is
-	// configured, so an unauthenticated development deployment is untouched.
+	// configured. Without one, the interceptors remain disabled.
 	// Auth runs AFTER the metrics interceptor so rejected calls still show up
 	// in the request counters.
 	if authUnary, authStream := ingest.NewGRPCAuthInterceptors(ingest.GRPCAuthOptions{
@@ -1188,7 +1185,7 @@ func main() {
 			"operator_key", cfg.APIKey != "",
 			"trust_external", cfg.AuthTrustExternal)
 	} else {
-		slog.Warn("🔓 gRPC OTLP unauthenticated — tenant identity is client-controlled; set API_KEY or API_TENANT_KEYS_FILE")
+		slog.Info("gRPC OTLP authentication disabled", "tenant_identity", "client-controlled")
 	}
 	slog.Info("📡 gRPC server tuned",
 		"max_recv_mb", recvBytes,
@@ -1210,7 +1207,7 @@ func main() {
 		grpcOpts = append(grpcOpts, grpc.Creds(creds))
 		slog.Info("🔒 gRPC TLS enabled", "mode", tlsModeSelfSigned, "cache_dir", cfg.TLSCacheDir)
 	default:
-		slog.Info("🔓 gRPC plaintext — not for production; set TLS_CERT_FILE/TLS_KEY_FILE or TLS_AUTO_SELFSIGNED=true")
+		slog.Info("gRPC transport security disabled", "mode", "plaintext")
 	}
 	grpcServer := grpc.NewServer(grpcOpts...)
 	coltracepb.RegisterTraceServiceServer(grpcServer, traceServer)
@@ -1312,7 +1309,7 @@ func main() {
 		slog.Warn("🔑 Authentication delegated to the front proxy (AUTH_TRUST_EXTERNAL=true) — the deployment contract in CLAUDE.md is mandatory",
 			"identity_header", cfg.AuthExternalTenantHeader)
 	default:
-		slog.Warn("API authentication disabled — set API_KEY or API_TENANT_KEYS_FILE for production")
+		slog.Info("API authentication disabled", "tenant_identity", "client-controlled")
 	}
 	if cfg.EnforceWSOrigin() {
 		slog.Info("🔒 WebSocket origin policy enforced",
@@ -1397,9 +1394,6 @@ func main() {
 				edg.WithLabelValues("trace").Set(float64(c.TraceEdges))
 				edg.WithLabelValues("signal").Set(float64(c.SignalEdges))
 				edg.WithLabelValues("anomaly").Set(float64(c.AnomalyEdges))
-				if ringBuf != nil {
-					metrics.TSDBRingSeriesActive.Set(float64(ringBuf.MetricCount()))
-				}
 				metrics.DrainTemplatesActive.Set(float64(graphRAG.DrainTemplateCount()))
 			}
 		}
@@ -1461,7 +1455,7 @@ func main() {
 				fatal("HTTPS server failed", err)
 			}
 		} else {
-			slog.Info("🌐 HTTP server started (plaintext — not for production)", "port", cfg.HTTPPort)
+			slog.Info("HTTP server started", "port", cfg.HTTPPort, "mode", "plaintext")
 			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 				fatal("HTTP server failed", err)
 			}
@@ -1773,8 +1767,8 @@ func sqliteMainDBPath(cfg *config.Config) string {
 }
 
 // legacyMetricPath reports whether the legacy metric path — the TSDB
-// aggregator, its ring buffer, the 30s flush into metric_buckets and the
-// per-point metric callback — is constructed for a given AGGREGATE_MODE.
+// aggregator, its 30s flush into metric_buckets and the per-point metric
+// callback — is constructed for a given AGGREGATE_MODE.
 //
 // Only AGGREGATE_MODE=aggregate retires it (#194 finding 10). Legacy has no
 // other metric store, and shadow's entire purpose is running both paths at


### PR DESCRIPTION
## Summary

- make SQLite FTS5 log search the default, keep explicit opt-out and missing-index fallback behavior, and apply managed SQLite PRAGMAs to every pooled connection
- propagate cancellation through aggregate HTTP, MCP, and realtime reads, cap API render caches, and remove the unused legacy metric ring allocation
- allow SQLite in production without a waiver, keep authentication and TLS independently configurable, and reject DLQ envelopes that cannot fit without discarding recoverable entries

## Operator notes

`LOG_FTS_ENABLED` now defaults to enabled for SQLite. The FTS schema is installed only when `DB_AUTOMIGRATE=true`; an existing database without the index continues to use LIKE until it is provisioned. Set `LOG_FTS_ENABLED=false` to stay on LIKE. The index adds workload-dependent disk and write overhead.

The former `OTELCONTEXT_ALLOW_SQLITE_PROD` and `OTELCONTEXT_ALLOW_INSECURE_GRPC` flags are deprecated no-ops. Configured API authentication and TLS still work as before.

## Validation

- focused config checks passed, 12 cases
- focused SQLite FTS, BM25, filter, fallback, and trigger checks passed, 30 cases
- focused admin checks passed, 4 cases
- MCP FTS regression and migration contract checks passed
- focused aggregate, realtime, API cache, and race checks passed
- `git diff --check` passed

The hosted protected-branch workflows remain the full regression and release gate.
